### PR TITLE
Add OpenAI model provider

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ add_executable(agent_main
     src/http_client.cpp
     src/openrouter_client.cpp
     src/openrouter_codec.cpp
+    src/openai_client.cpp
+    src/openai_codec.cpp
     src/minimax_tts.cpp
     src/minimax_codec.cpp
     src/tool_dispatch.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ add_executable(agent_main
     src/openrouter_codec.cpp
     src/openai_client.cpp
     src/openai_codec.cpp
+    src/llm_api_url.cpp
     src/minimax_tts.cpp
     src/minimax_codec.cpp
     src/tool_dispatch.cpp

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -57,6 +57,8 @@ bool load_config(const char* path, AgentConfig& config) {
                 copy_str(config.model.api_key, sizeof(config.model.api_key), val);
             else if (strcmp(key, "model") == 0)
                 copy_str(config.model.model, sizeof(config.model.model), val);
+            else if (strcmp(key, "base_url") == 0)
+                copy_str(config.model.base_url, sizeof(config.model.base_url), val);
         }
         else if (strcmp(current_section, "tts") == 0) {
             if (strcmp(key, "provider") == 0)

--- a/src/config.h
+++ b/src/config.h
@@ -6,11 +6,13 @@ struct ModelConfig {
     char provider[32];
     char api_key[256];
     char model[128];
+    char base_url[256];
 
     ModelConfig() {
         provider[0] = '\0';
         api_key[0] = '\0';
         model[0] = '\0';
+        base_url[0] = '\0';
     }
 };
 

--- a/src/llm_api_url.cpp
+++ b/src/llm_api_url.cpp
@@ -1,0 +1,21 @@
+#include "llm_api_url.h"
+
+namespace aiden {
+
+static std::string strip_trailing_slashes(const std::string& url) {
+    std::string normalized = url;
+    while (!normalized.empty() && normalized[normalized.size() - 1] == '/') {
+        normalized.erase(normalized.size() - 1);
+    }
+    return normalized;
+}
+
+std::string build_chat_completions_url(const char* configured_base_url,
+                                       const char* default_base_url) {
+    const char* raw_base = configured_base_url && configured_base_url[0] != '\0'
+        ? configured_base_url
+        : default_base_url;
+    return strip_trailing_slashes(raw_base ? raw_base : "") + "/chat/completions";
+}
+
+}

--- a/src/llm_api_url.h
+++ b/src/llm_api_url.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <string>
+
+namespace aiden {
+
+std::string build_chat_completions_url(const char* configured_base_url,
+                                       const char* default_base_url);
+
+}

--- a/src/openai_client.cpp
+++ b/src/openai_client.cpp
@@ -1,5 +1,6 @@
 #include "openai_client.h"
 #include "http_client.h"
+#include "llm_api_url.h"
 #include "openai_codec.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -7,8 +8,9 @@
 namespace aiden {
 
 OpenAIClient::OpenAIClient(const char* api_key, const char* llm_model,
+                           const char* base_url,
                            const char* additional_prompt)
-    : api_key_(api_key), llm_model_(llm_model) {
+    : api_key_(api_key), llm_model_(llm_model), base_url_(base_url ? base_url : "") {
     std::string system_prompt =
         "You are an AI assistant controlling a device via keyboard and touchscreen. "
         "Use the provided tools to interact. Touch coordinates: 0-32767 absolute range.";
@@ -23,14 +25,15 @@ OpenAIClient::OpenAIClient(const char* api_key, const char* llm_model,
 
 bool OpenAIClient::chat(const uint8_t* wav_data, size_t wav_len,
                         std::string& response, std::vector<ToolCall>& tool_calls) {
-    std::string b64_audio = openai::base64_encode(wav_data, wav_len);
-    std::string conversation_with_user = openai::append_user_audio_wav(conversation_, b64_audio);
+    std::string conversation_with_user =
+        openai::append_user_audio_wav_if_present(conversation_, wav_data, wav_len);
     std::string request_body = openai::build_chat_request(conversation_with_user, llm_model_);
+    std::string url = build_chat_completions_url(base_url_.c_str(), "https://api.openai.com/v1");
 
     HttpClient http;
     std::string http_response;
     bool success = http.post_json(
-        "https://api.openai.com/v1/chat/completions",
+        url.c_str(),
         api_key_.c_str(),
         request_body.c_str(),
         http_response);

--- a/src/openai_client.cpp
+++ b/src/openai_client.cpp
@@ -1,0 +1,61 @@
+#include "openai_client.h"
+#include "http_client.h"
+#include "openai_codec.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+namespace aiden {
+
+OpenAIClient::OpenAIClient(const char* api_key, const char* llm_model,
+                           const char* additional_prompt)
+    : api_key_(api_key), llm_model_(llm_model) {
+    std::string system_prompt =
+        "You are an AI assistant controlling a device via keyboard and touchscreen. "
+        "Use the provided tools to interact. Touch coordinates: 0-32767 absolute range.";
+
+    if (additional_prompt && additional_prompt[0] != '\0') {
+        system_prompt += "\n\n";
+        system_prompt += additional_prompt;
+    }
+
+    conversation_ = openai::init_conversation(system_prompt);
+}
+
+bool OpenAIClient::chat(const uint8_t* wav_data, size_t wav_len,
+                        std::string& response, std::vector<ToolCall>& tool_calls) {
+    std::string b64_audio = openai::base64_encode(wav_data, wav_len);
+    std::string conversation_with_user = openai::append_user_audio_wav(conversation_, b64_audio);
+    std::string request_body = openai::build_chat_request(conversation_with_user, llm_model_);
+
+    HttpClient http;
+    std::string http_response;
+    bool success = http.post_json(
+        "https://api.openai.com/v1/chat/completions",
+        api_key_.c_str(),
+        request_body.c_str(),
+        http_response);
+    if (!success) {
+        fprintf(stderr, "[error] HTTP request failed\n");
+        fprintf(stderr, "[error] Response: %s\n", http_response.c_str());
+        return false;
+    }
+
+    openai::ChatResult result = openai::parse_chat_response(http_response);
+    if (!result.ok) {
+        fprintf(stderr, "[error] Failed to parse OpenAI response: %s\n", result.error.c_str());
+        fprintf(stderr, "[error] Raw response: %s\n", http_response.c_str());
+        return false;
+    }
+
+    response = result.content;
+    tool_calls = result.tool_calls;
+    conversation_ = openai::append_assistant_message(conversation_with_user,
+                                                     result.assistant_message_json);
+    return true;
+}
+
+void OpenAIClient::add_tool_result(const char* tool_call_id, const char* result) {
+    conversation_ = openai::append_tool_result(conversation_, tool_call_id, result);
+}
+
+}

--- a/src/openai_client.h
+++ b/src/openai_client.h
@@ -9,6 +9,7 @@ namespace aiden {
 class OpenAIClient : public LlmClient {
 public:
     OpenAIClient(const char* api_key, const char* llm_model,
+                 const char* base_url = "",
                  const char* additional_prompt = "");
 
     bool chat(const uint8_t* wav_data, size_t wav_len,
@@ -19,6 +20,7 @@ public:
 private:
     std::string api_key_;
     std::string llm_model_;
+    std::string base_url_;
     std::string conversation_;
 };
 

--- a/src/openai_client.h
+++ b/src/openai_client.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "provider_interfaces.h"
+#include <string>
+#include <vector>
+#include <cstdint>
+
+namespace aiden {
+
+class OpenAIClient : public LlmClient {
+public:
+    OpenAIClient(const char* api_key, const char* llm_model,
+                 const char* additional_prompt = "");
+
+    bool chat(const uint8_t* wav_data, size_t wav_len,
+              std::string& response, std::vector<ToolCall>& tool_calls) override;
+
+    void add_tool_result(const char* tool_call_id, const char* result) override;
+
+private:
+    std::string api_key_;
+    std::string llm_model_;
+    std::string conversation_;
+};
+
+}

--- a/src/openai_codec.cpp
+++ b/src/openai_codec.cpp
@@ -236,6 +236,14 @@ std::string append_user_audio_wav(const std::string& conversation_json,
     return result;
 }
 
+std::string append_user_audio_wav_if_present(const std::string& conversation_json,
+                                             const uint8_t* wav_data,
+                                             size_t wav_len) {
+    if (!wav_data || wav_len == 0)
+        return conversation_json;
+    return append_user_audio_wav(conversation_json, base64_encode(wav_data, wav_len));
+}
+
 std::string append_assistant_message(const std::string& conversation_json,
                                      const std::string& assistant_message_json) {
     cJSON* messages = parse_conversation_or_empty(conversation_json);

--- a/src/openai_codec.cpp
+++ b/src/openai_codec.cpp
@@ -1,0 +1,289 @@
+#include "openai_codec.h"
+#include "cJSON/cJSON.h"
+#include <stdlib.h>
+
+namespace aiden {
+namespace openai {
+
+static const char* BASE64_CHARS =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+std::string base64_encode(const uint8_t* data, size_t len) {
+    std::string result;
+    result.reserve((len + 2) / 3 * 4);
+
+    for (size_t i = 0; i < len; i += 3) {
+        uint32_t val = data[i] << 16;
+        if (i + 1 < len) val |= data[i + 1] << 8;
+        if (i + 2 < len) val |= data[i + 2];
+
+        result += BASE64_CHARS[(val >> 18) & 0x3F];
+        result += BASE64_CHARS[(val >> 12) & 0x3F];
+        result += (i + 1 < len) ? BASE64_CHARS[(val >> 6) & 0x3F] : '=';
+        result += (i + 2 < len) ? BASE64_CHARS[val & 0x3F] : '=';
+    }
+
+    return result;
+}
+
+static cJSON* create_tool_definitions() {
+    cJSON* tools = cJSON_CreateArray();
+
+    cJSON* kb_tap = cJSON_CreateObject();
+    cJSON_AddStringToObject(kb_tap, "type", "function");
+    cJSON* kb_tap_func = cJSON_CreateObject();
+    cJSON_AddStringToObject(kb_tap_func, "name", "keyboard_tap");
+    cJSON_AddStringToObject(kb_tap_func, "description", "Tap keyboard keys in sequence");
+    cJSON* kb_tap_params = cJSON_CreateObject();
+    cJSON_AddStringToObject(kb_tap_params, "type", "object");
+    cJSON* kb_tap_props = cJSON_CreateObject();
+    cJSON* kb_tap_keys = cJSON_CreateObject();
+    cJSON_AddStringToObject(kb_tap_keys, "type", "array");
+    cJSON* kb_tap_items = cJSON_CreateObject();
+    cJSON_AddStringToObject(kb_tap_items, "type", "string");
+    cJSON_AddItemToObject(kb_tap_keys, "items", kb_tap_items);
+    cJSON_AddItemToObject(kb_tap_props, "keys", kb_tap_keys);
+    cJSON_AddItemToObject(kb_tap_params, "properties", kb_tap_props);
+    cJSON* kb_tap_req = cJSON_CreateArray();
+    cJSON_AddItemToArray(kb_tap_req, cJSON_CreateString("keys"));
+    cJSON_AddItemToObject(kb_tap_params, "required", kb_tap_req);
+    cJSON_AddItemToObject(kb_tap_func, "parameters", kb_tap_params);
+    cJSON_AddItemToObject(kb_tap, "function", kb_tap_func);
+    cJSON_AddItemToArray(tools, kb_tap);
+
+    cJSON* kb_text = cJSON_CreateObject();
+    cJSON_AddStringToObject(kb_text, "type", "function");
+    cJSON* kb_text_func = cJSON_CreateObject();
+    cJSON_AddStringToObject(kb_text_func, "name", "keyboard_text");
+    cJSON_AddStringToObject(kb_text_func, "description", "Type text string via keyboard");
+    cJSON* kb_text_params = cJSON_CreateObject();
+    cJSON_AddStringToObject(kb_text_params, "type", "object");
+    cJSON* kb_text_props = cJSON_CreateObject();
+    cJSON* kb_text_text = cJSON_CreateObject();
+    cJSON_AddStringToObject(kb_text_text, "type", "string");
+    cJSON_AddItemToObject(kb_text_props, "text", kb_text_text);
+    cJSON_AddItemToObject(kb_text_params, "properties", kb_text_props);
+    cJSON* kb_text_req = cJSON_CreateArray();
+    cJSON_AddItemToArray(kb_text_req, cJSON_CreateString("text"));
+    cJSON_AddItemToObject(kb_text_params, "required", kb_text_req);
+    cJSON_AddItemToObject(kb_text_func, "parameters", kb_text_params);
+    cJSON_AddItemToObject(kb_text, "function", kb_text_func);
+    cJSON_AddItemToArray(tools, kb_text);
+
+    cJSON* touch_click = cJSON_CreateObject();
+    cJSON_AddStringToObject(touch_click, "type", "function");
+    cJSON* touch_click_func = cJSON_CreateObject();
+    cJSON_AddStringToObject(touch_click_func, "name", "touch_click");
+    cJSON_AddStringToObject(touch_click_func, "description", "Send a left click at absolute coordinates");
+    cJSON* touch_click_params = cJSON_CreateObject();
+    cJSON_AddStringToObject(touch_click_params, "type", "object");
+    cJSON* touch_click_props = cJSON_CreateObject();
+    cJSON* touch_click_x = cJSON_CreateObject();
+    cJSON_AddStringToObject(touch_click_x, "type", "integer");
+    cJSON_AddItemToObject(touch_click_props, "x", touch_click_x);
+    cJSON* touch_click_y = cJSON_CreateObject();
+    cJSON_AddStringToObject(touch_click_y, "type", "integer");
+    cJSON_AddItemToObject(touch_click_props, "y", touch_click_y);
+    cJSON_AddItemToObject(touch_click_params, "properties", touch_click_props);
+    cJSON* touch_click_req = cJSON_CreateArray();
+    cJSON_AddItemToArray(touch_click_req, cJSON_CreateString("x"));
+    cJSON_AddItemToArray(touch_click_req, cJSON_CreateString("y"));
+    cJSON_AddItemToObject(touch_click_params, "required", touch_click_req);
+    cJSON_AddItemToObject(touch_click_func, "parameters", touch_click_params);
+    cJSON_AddItemToObject(touch_click, "function", touch_click_func);
+    cJSON_AddItemToArray(tools, touch_click);
+
+    cJSON* touch_swipe = cJSON_CreateObject();
+    cJSON_AddStringToObject(touch_swipe, "type", "function");
+    cJSON* touch_swipe_func = cJSON_CreateObject();
+    cJSON_AddStringToObject(touch_swipe_func, "name", "touch_swipe");
+    cJSON_AddStringToObject(touch_swipe_func, "description", "Swipe on touchscreen from one point to another");
+    cJSON* touch_swipe_params = cJSON_CreateObject();
+    cJSON_AddStringToObject(touch_swipe_params, "type", "object");
+    cJSON* touch_swipe_props = cJSON_CreateObject();
+    cJSON* touch_swipe_x1 = cJSON_CreateObject();
+    cJSON_AddStringToObject(touch_swipe_x1, "type", "integer");
+    cJSON_AddItemToObject(touch_swipe_props, "x1", touch_swipe_x1);
+    cJSON* touch_swipe_y1 = cJSON_CreateObject();
+    cJSON_AddStringToObject(touch_swipe_y1, "type", "integer");
+    cJSON_AddItemToObject(touch_swipe_props, "y1", touch_swipe_y1);
+    cJSON* touch_swipe_x2 = cJSON_CreateObject();
+    cJSON_AddStringToObject(touch_swipe_x2, "type", "integer");
+    cJSON_AddItemToObject(touch_swipe_props, "x2", touch_swipe_x2);
+    cJSON* touch_swipe_y2 = cJSON_CreateObject();
+    cJSON_AddStringToObject(touch_swipe_y2, "type", "integer");
+    cJSON_AddItemToObject(touch_swipe_props, "y2", touch_swipe_y2);
+    cJSON_AddItemToObject(touch_swipe_params, "properties", touch_swipe_props);
+    cJSON* touch_swipe_req = cJSON_CreateArray();
+    cJSON_AddItemToArray(touch_swipe_req, cJSON_CreateString("x1"));
+    cJSON_AddItemToArray(touch_swipe_req, cJSON_CreateString("y1"));
+    cJSON_AddItemToArray(touch_swipe_req, cJSON_CreateString("x2"));
+    cJSON_AddItemToArray(touch_swipe_req, cJSON_CreateString("y2"));
+    cJSON_AddItemToObject(touch_swipe_params, "required", touch_swipe_req);
+    cJSON_AddItemToObject(touch_swipe_func, "parameters", touch_swipe_params);
+    cJSON_AddItemToObject(touch_swipe, "function", touch_swipe_func);
+    cJSON_AddItemToArray(tools, touch_swipe);
+
+    return tools;
+}
+
+std::string build_tool_definitions_json() {
+    cJSON* tools = create_tool_definitions();
+    char* json = cJSON_PrintUnformatted(tools);
+    std::string result = json ? json : "[]";
+    free(json);
+    cJSON_Delete(tools);
+    return result;
+}
+
+ChatResult parse_chat_response(const std::string& http_response) {
+    ChatResult result;
+    cJSON* resp_json = cJSON_Parse(http_response.c_str());
+    if (!resp_json) {
+        result.error = "failed to parse response JSON";
+        return result;
+    }
+
+    cJSON* choices = cJSON_GetObjectItem(resp_json, "choices");
+    if (!choices || choices->type != cJSON_Array || cJSON_GetArraySize(choices) == 0) {
+        result.error = "no choices in response";
+        cJSON_Delete(resp_json);
+        return result;
+    }
+
+    cJSON* choice = cJSON_GetArrayItem(choices, 0);
+    cJSON* message = cJSON_GetObjectItem(choice, "message");
+    if (!message) {
+        result.error = "no message in choice";
+        cJSON_Delete(resp_json);
+        return result;
+    }
+
+    cJSON* content = cJSON_GetObjectItem(message, "content");
+    if (content && content->type == cJSON_String)
+        result.content = content->valuestring;
+
+    cJSON* tool_calls_json = cJSON_GetObjectItem(message, "tool_calls");
+    if (tool_calls_json && tool_calls_json->type == cJSON_Array) {
+        int count = cJSON_GetArraySize(tool_calls_json);
+        for (int i = 0; i < count; i++) {
+            cJSON* tc = cJSON_GetArrayItem(tool_calls_json, i);
+            cJSON* id = cJSON_GetObjectItem(tc, "id");
+            cJSON* func = cJSON_GetObjectItem(tc, "function");
+            if (!func) continue;
+
+            cJSON* name = cJSON_GetObjectItem(func, "name");
+            cJSON* args = cJSON_GetObjectItem(func, "arguments");
+
+            ToolCall call;
+            if (id && id->type == cJSON_String) call.id = id->valuestring;
+            if (name && name->type == cJSON_String) call.name = name->valuestring;
+            if (args && args->type == cJSON_String) call.arguments = args->valuestring;
+            result.tool_calls.push_back(call);
+        }
+    }
+
+    char* assistant_json = cJSON_PrintUnformatted(message);
+    result.assistant_message_json = assistant_json ? assistant_json : "{}";
+    free(assistant_json);
+
+    result.ok = true;
+    cJSON_Delete(resp_json);
+    return result;
+}
+
+std::string init_conversation(const std::string& system_prompt) {
+    cJSON* messages = cJSON_CreateArray();
+    cJSON* sys_msg = cJSON_CreateObject();
+    cJSON_AddStringToObject(sys_msg, "role", "system");
+    cJSON_AddStringToObject(sys_msg, "content", system_prompt.c_str());
+    cJSON_AddItemToArray(messages, sys_msg);
+
+    char* json = cJSON_PrintUnformatted(messages);
+    std::string result = json ? json : "[]";
+    free(json);
+    cJSON_Delete(messages);
+    return result;
+}
+
+static cJSON* parse_conversation_or_empty(const std::string& conversation_json) {
+    cJSON* messages = cJSON_Parse(conversation_json.c_str());
+    if (messages && messages->type == cJSON_Array) return messages;
+    if (messages) cJSON_Delete(messages);
+    return cJSON_CreateArray();
+}
+
+std::string append_user_audio_wav(const std::string& conversation_json,
+                                  const std::string& base64_wav) {
+    cJSON* messages = parse_conversation_or_empty(conversation_json);
+    cJSON* user_msg = cJSON_CreateObject();
+    cJSON_AddStringToObject(user_msg, "role", "user");
+    cJSON* content_array = cJSON_CreateArray();
+    cJSON* audio_content = cJSON_CreateObject();
+    cJSON_AddStringToObject(audio_content, "type", "input_audio");
+    cJSON* input_audio = cJSON_CreateObject();
+    cJSON_AddStringToObject(input_audio, "data", base64_wav.c_str());
+    cJSON_AddStringToObject(input_audio, "format", "wav");
+    cJSON_AddItemToObject(audio_content, "input_audio", input_audio);
+    cJSON_AddItemToArray(content_array, audio_content);
+    cJSON_AddItemToObject(user_msg, "content", content_array);
+    cJSON_AddItemToArray(messages, user_msg);
+
+    char* json = cJSON_PrintUnformatted(messages);
+    std::string result = json ? json : "[]";
+    free(json);
+    cJSON_Delete(messages);
+    return result;
+}
+
+std::string append_assistant_message(const std::string& conversation_json,
+                                     const std::string& assistant_message_json) {
+    cJSON* messages = parse_conversation_or_empty(conversation_json);
+    cJSON* message = cJSON_Parse(assistant_message_json.c_str());
+    if (!message) {
+        cJSON_Delete(messages);
+        return conversation_json;
+    }
+
+    cJSON_AddItemToArray(messages, message);
+    char* json = cJSON_PrintUnformatted(messages);
+    std::string result = json ? json : conversation_json;
+    free(json);
+    cJSON_Delete(messages);
+    return result;
+}
+
+std::string append_tool_result(const std::string& conversation_json,
+                               const std::string& tool_call_id,
+                               const std::string& result_text) {
+    cJSON* messages = parse_conversation_or_empty(conversation_json);
+    cJSON* tool_msg = cJSON_CreateObject();
+    cJSON_AddStringToObject(tool_msg, "role", "tool");
+    cJSON_AddStringToObject(tool_msg, "tool_call_id", tool_call_id.c_str());
+    cJSON_AddStringToObject(tool_msg, "content", result_text.c_str());
+    cJSON_AddItemToArray(messages, tool_msg);
+
+    char* json = cJSON_PrintUnformatted(messages);
+    std::string result = json ? json : conversation_json;
+    free(json);
+    cJSON_Delete(messages);
+    return result;
+}
+
+std::string build_chat_request(const std::string& conversation_json,
+                               const std::string& model) {
+    cJSON* messages = parse_conversation_or_empty(conversation_json);
+    cJSON* request = cJSON_CreateObject();
+    cJSON_AddStringToObject(request, "model", model.c_str());
+    cJSON_AddItemToObject(request, "messages", messages);
+    cJSON_AddItemToObject(request, "tools", create_tool_definitions());
+
+    char* json = cJSON_PrintUnformatted(request);
+    std::string result = json ? json : "{}";
+    free(json);
+    cJSON_Delete(request);
+    return result;
+}
+
+}
+}

--- a/src/openai_codec.h
+++ b/src/openai_codec.h
@@ -24,6 +24,9 @@ ChatResult parse_chat_response(const std::string& http_response);
 std::string init_conversation(const std::string& system_prompt);
 std::string append_user_audio_wav(const std::string& conversation_json,
                                   const std::string& base64_wav);
+std::string append_user_audio_wav_if_present(const std::string& conversation_json,
+                                             const uint8_t* wav_data,
+                                             size_t wav_len);
 std::string append_assistant_message(const std::string& conversation_json,
                                      const std::string& assistant_message_json);
 std::string append_tool_result(const std::string& conversation_json,

--- a/src/openai_codec.h
+++ b/src/openai_codec.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "provider_interfaces.h"
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace aiden {
+namespace openai {
+
+struct ChatResult {
+    std::string content;
+    std::vector<ToolCall> tool_calls;
+    std::string assistant_message_json;
+    bool ok;
+    std::string error;
+
+    ChatResult() : ok(false) {}
+};
+
+std::string base64_encode(const uint8_t* data, size_t len);
+std::string build_tool_definitions_json();
+ChatResult parse_chat_response(const std::string& http_response);
+
+std::string init_conversation(const std::string& system_prompt);
+std::string append_user_audio_wav(const std::string& conversation_json,
+                                  const std::string& base64_wav);
+std::string append_assistant_message(const std::string& conversation_json,
+                                     const std::string& assistant_message_json);
+std::string append_tool_result(const std::string& conversation_json,
+                               const std::string& tool_call_id,
+                               const std::string& result);
+std::string build_chat_request(const std::string& conversation_json,
+                               const std::string& model);
+
+}
+}

--- a/src/openrouter_client.cpp
+++ b/src/openrouter_client.cpp
@@ -1,5 +1,6 @@
 #include "openrouter_client.h"
 #include "http_client.h"
+#include "llm_api_url.h"
 #include "openrouter_codec.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -7,8 +8,9 @@
 namespace aiden {
 
 OpenRouterClient::OpenRouterClient(const char* api_key, const char* llm_model,
+                                   const char* base_url,
                                    const char* additional_prompt)
-    : api_key_(api_key), llm_model_(llm_model) {
+    : api_key_(api_key), llm_model_(llm_model), base_url_(base_url ? base_url : "") {
     std::string system_prompt =
         "You are an AI assistant controlling a device via keyboard and touchscreen. "
         "Use the provided tools to interact. Touch coordinates: 0-32767 absolute range.";
@@ -23,14 +25,15 @@ OpenRouterClient::OpenRouterClient(const char* api_key, const char* llm_model,
 
 bool OpenRouterClient::chat(const uint8_t* wav_data, size_t wav_len,
                             std::string& response, std::vector<ToolCall>& tool_calls) {
-    std::string b64_audio = openrouter::base64_encode(wav_data, wav_len);
-    std::string conversation_with_user = openrouter::append_user_audio_wav(conversation_, b64_audio);
+    std::string conversation_with_user =
+        openrouter::append_user_audio_wav_if_present(conversation_, wav_data, wav_len);
     std::string request_body = openrouter::build_chat_request(conversation_with_user, llm_model_);
+    std::string url = build_chat_completions_url(base_url_.c_str(), "https://openrouter.ai/api/v1");
 
     HttpClient http;
     std::string http_response;
     bool success = http.post_json(
-        "https://openrouter.ai/api/v1/chat/completions",
+        url.c_str(),
         api_key_.c_str(),
         request_body.c_str(),
         http_response);

--- a/src/openrouter_client.h
+++ b/src/openrouter_client.h
@@ -9,6 +9,7 @@ namespace aiden {
 class OpenRouterClient : public LlmClient {
 public:
     OpenRouterClient(const char* api_key, const char* llm_model,
+                     const char* base_url = "",
                      const char* additional_prompt = "");
 
     bool chat(const uint8_t* wav_data, size_t wav_len,
@@ -19,6 +20,7 @@ public:
 private:
     std::string api_key_;
     std::string llm_model_;
+    std::string base_url_;
     std::string conversation_;
 };
 

--- a/src/openrouter_codec.cpp
+++ b/src/openrouter_codec.cpp
@@ -236,6 +236,14 @@ std::string append_user_audio_wav(const std::string& conversation_json,
     return result;
 }
 
+std::string append_user_audio_wav_if_present(const std::string& conversation_json,
+                                             const uint8_t* wav_data,
+                                             size_t wav_len) {
+    if (!wav_data || wav_len == 0)
+        return conversation_json;
+    return append_user_audio_wav(conversation_json, base64_encode(wav_data, wav_len));
+}
+
 std::string append_assistant_message(const std::string& conversation_json,
                                      const std::string& assistant_message_json) {
     cJSON* messages = parse_conversation_or_empty(conversation_json);

--- a/src/openrouter_codec.h
+++ b/src/openrouter_codec.h
@@ -24,6 +24,9 @@ ChatResult parse_chat_response(const std::string& http_response);
 std::string init_conversation(const std::string& system_prompt);
 std::string append_user_audio_wav(const std::string& conversation_json,
                                   const std::string& base64_wav);
+std::string append_user_audio_wav_if_present(const std::string& conversation_json,
+                                             const uint8_t* wav_data,
+                                             size_t wav_len);
 std::string append_assistant_message(const std::string& conversation_json,
                                      const std::string& assistant_message_json);
 std::string append_tool_result(const std::string& conversation_json,

--- a/src/provider_factory.cpp
+++ b/src/provider_factory.cpp
@@ -18,6 +18,11 @@ ProviderCheckResult check_llm_provider(const char* provider) {
         result.normalized = "openrouter";
         return result;
     }
+    if (strcmp(provider, "openai") == 0) {
+        result.ok = true;
+        result.normalized = "openai";
+        return result;
+    }
     result.error = std::string("unsupported model provider: ") + provider;
     return result;
 }
@@ -41,15 +46,15 @@ ProviderCheckResult check_llm_config(const ModelConfig& config) {
     ProviderCheckResult llm = check_llm_provider(config.provider);
     if (!llm.ok) return llm;
 
-    if (llm.normalized == "openrouter") {
+    if (llm.normalized == "openrouter" || llm.normalized == "openai") {
         if (is_empty(config.api_key)) {
             ProviderCheckResult result;
-            result.error = "model provider openrouter requires api_key";
+            result.error = std::string("model provider ") + llm.normalized + " requires api_key";
             return result;
         }
         if (is_empty(config.model)) {
             ProviderCheckResult result;
-            result.error = "model provider openrouter requires model";
+            result.error = std::string("model provider ") + llm.normalized + " requires model";
             return result;
         }
     }

--- a/src/provider_factory_runtime.cpp
+++ b/src/provider_factory_runtime.cpp
@@ -14,12 +14,14 @@ std::unique_ptr<LlmClient> create_llm_client(const AgentConfig& config, std::str
 
     if (check.normalized == "openrouter") {
         return std::unique_ptr<LlmClient>(
-            new OpenRouterClient(config.model.api_key, config.model.model, config.additional_prompt));
+            new OpenRouterClient(config.model.api_key, config.model.model,
+                                 config.model.base_url, config.additional_prompt));
     }
 
     if (check.normalized == "openai") {
         return std::unique_ptr<LlmClient>(
-            new OpenAIClient(config.model.api_key, config.model.model, config.additional_prompt));
+            new OpenAIClient(config.model.api_key, config.model.model,
+                             config.model.base_url, config.additional_prompt));
     }
 
     error = std::string("unsupported model provider: ") + config.model.provider;

--- a/src/provider_factory_runtime.cpp
+++ b/src/provider_factory_runtime.cpp
@@ -1,5 +1,6 @@
 #include "provider_factory.h"
 #include "openrouter_client.h"
+#include "openai_client.h"
 #include "minimax_tts.h"
 
 namespace aiden {
@@ -14,6 +15,11 @@ std::unique_ptr<LlmClient> create_llm_client(const AgentConfig& config, std::str
     if (check.normalized == "openrouter") {
         return std::unique_ptr<LlmClient>(
             new OpenRouterClient(config.model.api_key, config.model.model, config.additional_prompt));
+    }
+
+    if (check.normalized == "openai") {
+        return std::unique_ptr<LlmClient>(
+            new OpenAIClient(config.model.api_key, config.model.model, config.additional_prompt));
     }
 
     error = std::string("unsupported model provider: ") + config.model.provider;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(AIDEN_TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/src/tool_dispatch.cpp
     ${CMAKE_SOURCE_DIR}/src/wav_codec.cpp
     ${CMAKE_SOURCE_DIR}/src/provider_factory.cpp
+    ${CMAKE_SOURCE_DIR}/src/llm_api_url.cpp
     ${CMAKE_SOURCE_DIR}/src/cJSON/cJSON.c
 )
 
@@ -28,6 +29,7 @@ add_executable(aiden_tests
     tool_dispatch_test.cpp
     wav_codec_test.cpp
     provider_factory_test.cpp
+    llm_api_url_test.cpp
     ${AIDEN_TEST_SOURCES}
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(AIDEN_TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/src/config.cpp
     ${CMAKE_SOURCE_DIR}/src/vad.cpp
     ${CMAKE_SOURCE_DIR}/src/openrouter_codec.cpp
+    ${CMAKE_SOURCE_DIR}/src/openai_codec.cpp
     ${CMAKE_SOURCE_DIR}/src/minimax_codec.cpp
     ${CMAKE_SOURCE_DIR}/src/tool_dispatch.cpp
     ${CMAKE_SOURCE_DIR}/src/wav_codec.cpp
@@ -22,6 +23,7 @@ add_executable(aiden_tests
     config_test.cpp
     vad_test.cpp
     openrouter_codec_test.cpp
+    openai_codec_test.cpp
     minimax_codec_test.cpp
     tool_dispatch_test.cpp
     wav_codec_test.cpp

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -31,6 +31,7 @@ TEST_CASE("load_config parses role-based sections") {
         "provider = openrouter\n"
         "api_key = sk-test\n"
         "model = openai/gpt-4o-audio-preview\n"
+        "base_url = https://proxy.example/v1\n"
         "\n"
         "[tts]\n"
         "provider = minimax\n"
@@ -53,6 +54,7 @@ TEST_CASE("load_config parses role-based sections") {
     CHECK(std::string(cfg.model.provider) == "openrouter");
     CHECK(std::string(cfg.model.api_key) == "sk-test");
     CHECK(std::string(cfg.model.model) == "openai/gpt-4o-audio-preview");
+    CHECK(std::string(cfg.model.base_url) == "https://proxy.example/v1");
 
     CHECK(std::string(cfg.tts.provider) == "minimax");
     CHECK(std::string(cfg.tts.api_key) == "mm-test");
@@ -218,6 +220,7 @@ TEST_CASE("load_config keeps optional fields at defaults when omitted") {
     REQUIRE(aiden::load_config(f.path.c_str(), cfg));
     CHECK(std::string(cfg.model.provider).empty());
     CHECK(std::string(cfg.model.model).empty());
+    CHECK(std::string(cfg.model.base_url).empty());
     CHECK(std::string(cfg.tts.api_key).empty());
     CHECK(std::string(cfg.tts.voice_id).empty());
     CHECK(std::string(cfg.hid_binary).empty());

--- a/tests/llm_api_url_test.cpp
+++ b/tests/llm_api_url_test.cpp
@@ -1,0 +1,20 @@
+#include "doctest.h"
+#include "llm_api_url.h"
+#include <string>
+
+using aiden::build_chat_completions_url;
+
+TEST_CASE("build_chat_completions_url uses default base when config is empty") {
+    CHECK(build_chat_completions_url("", "https://api.openai.com/v1") ==
+          "https://api.openai.com/v1/chat/completions");
+}
+
+TEST_CASE("build_chat_completions_url uses configured base_url") {
+    CHECK(build_chat_completions_url("https://proxy.example/v1", "https://api.openai.com/v1") ==
+          "https://proxy.example/v1/chat/completions");
+}
+
+TEST_CASE("build_chat_completions_url trims trailing slash from base_url") {
+    CHECK(build_chat_completions_url("https://proxy.example/v1/", "https://api.openai.com/v1") ==
+          "https://proxy.example/v1/chat/completions");
+}

--- a/tests/openai_codec_test.cpp
+++ b/tests/openai_codec_test.cpp
@@ -7,6 +7,7 @@ using aiden::openai::build_chat_request;
 using aiden::openai::parse_chat_response;
 using aiden::openai::init_conversation;
 using aiden::openai::append_user_audio_wav;
+using aiden::openai::append_user_audio_wav_if_present;
 using aiden::openai::append_assistant_message;
 using aiden::openai::append_tool_result;
 using aiden::openai::ChatResult;
@@ -75,6 +76,12 @@ TEST_CASE("openai append_user_audio_wav appends a user message with input_audio"
     CHECK(std::string(cJSON_GetObjectItem(ia, "data")->valuestring) == "AAAA");
     CHECK(std::string(cJSON_GetObjectItem(ia, "format")->valuestring) == "wav");
     cJSON_Delete(arr);
+}
+
+TEST_CASE("openai append_user_audio_wav_if_present skips empty follow-up audio") {
+    std::string conv = init_conversation("sys");
+    std::string unchanged = append_user_audio_wav_if_present(conv, NULL, 0);
+    CHECK(unchanged == conv);
 }
 
 TEST_CASE("openai append_tool_result adds a role=tool message") {

--- a/tests/openai_codec_test.cpp
+++ b/tests/openai_codec_test.cpp
@@ -1,0 +1,103 @@
+#include "doctest.h"
+#include "openai_codec.h"
+#include "cJSON/cJSON.h"
+#include <string>
+
+using aiden::openai::build_chat_request;
+using aiden::openai::parse_chat_response;
+using aiden::openai::init_conversation;
+using aiden::openai::append_user_audio_wav;
+using aiden::openai::append_assistant_message;
+using aiden::openai::append_tool_result;
+using aiden::openai::ChatResult;
+
+TEST_CASE("openai build_chat_request wraps conversation with model and tools") {
+    std::string conv = init_conversation("sys");
+    std::string req = build_chat_request(conv, "gpt-4o-audio-preview");
+
+    cJSON* obj = cJSON_Parse(req.c_str());
+    REQUIRE(obj != nullptr);
+    cJSON* model = cJSON_GetObjectItem(obj, "model");
+    REQUIRE(model != nullptr);
+    REQUIRE(model->type == cJSON_String);
+    CHECK(std::string(model->valuestring) == "gpt-4o-audio-preview");
+    CHECK(cJSON_GetObjectItem(obj, "messages")->type == cJSON_Array);
+    CHECK(cJSON_GetObjectItem(obj, "tools")->type == cJSON_Array);
+    cJSON_Delete(obj);
+}
+
+TEST_CASE("openai parse_chat_response extracts plain text content") {
+    std::string resp = R"({"choices":[{"message":{"role":"assistant","content":"hi there"}}]})";
+    ChatResult r = parse_chat_response(resp);
+    REQUIRE(r.ok);
+    CHECK(r.content == "hi there");
+    CHECK(r.tool_calls.empty());
+    CHECK_FALSE(r.assistant_message_json.empty());
+}
+
+TEST_CASE("openai parse_chat_response extracts tool_calls") {
+    std::string resp = R"({
+      "choices":[{"message":{
+        "role":"assistant",
+        "content":null,
+        "tool_calls":[
+          {"id":"call_1","function":{"name":"touch_click","arguments":"{\"x\":100,\"y\":200}"}},
+          {"id":"call_2","function":{"name":"keyboard_text","arguments":"{\"text\":\"hi\"}"}}
+        ]
+      }}]
+    })";
+    ChatResult r = parse_chat_response(resp);
+    REQUIRE(r.ok);
+    CHECK(r.content.empty());
+    REQUIRE(r.tool_calls.size() == 2);
+    CHECK(r.tool_calls[0].id == "call_1");
+    CHECK(r.tool_calls[0].name == "touch_click");
+    CHECK(r.tool_calls[0].arguments == R"({"x":100,"y":200})");
+    CHECK(r.tool_calls[1].id == "call_2");
+    CHECK(r.tool_calls[1].name == "keyboard_text");
+}
+
+TEST_CASE("openai append_user_audio_wav appends a user message with input_audio") {
+    std::string conv = init_conversation("sys");
+    std::string appended = append_user_audio_wav(conv, "AAAA");
+
+    cJSON* arr = cJSON_Parse(appended.c_str());
+    REQUIRE(arr->type == cJSON_Array);
+    REQUIRE(cJSON_GetArraySize(arr) == 2);
+
+    cJSON* user = cJSON_GetArrayItem(arr, 1);
+    CHECK(std::string(cJSON_GetObjectItem(user, "role")->valuestring) == "user");
+    cJSON* content = cJSON_GetObjectItem(user, "content");
+    REQUIRE(content->type == cJSON_Array);
+    cJSON* first = cJSON_GetArrayItem(content, 0);
+    CHECK(std::string(cJSON_GetObjectItem(first, "type")->valuestring) == "input_audio");
+    cJSON* ia = cJSON_GetObjectItem(first, "input_audio");
+    CHECK(std::string(cJSON_GetObjectItem(ia, "data")->valuestring) == "AAAA");
+    CHECK(std::string(cJSON_GetObjectItem(ia, "format")->valuestring) == "wav");
+    cJSON_Delete(arr);
+}
+
+TEST_CASE("openai append_tool_result adds a role=tool message") {
+    std::string conv = init_conversation("sys");
+    conv = append_tool_result(conv, "call_abc", "ok");
+
+    cJSON* arr = cJSON_Parse(conv.c_str());
+    cJSON* tool = cJSON_GetArrayItem(arr, 1);
+    CHECK(std::string(cJSON_GetObjectItem(tool, "role")->valuestring) == "tool");
+    CHECK(std::string(cJSON_GetObjectItem(tool, "tool_call_id")->valuestring) == "call_abc");
+    CHECK(std::string(cJSON_GetObjectItem(tool, "content")->valuestring) == "ok");
+    cJSON_Delete(arr);
+}
+
+TEST_CASE("openai append_assistant_message appends verbatim message JSON") {
+    std::string conv = init_conversation("sys");
+    std::string assistant = R"({"role":"assistant","content":"hello"})";
+    conv = append_assistant_message(conv, assistant);
+
+    cJSON* arr = cJSON_Parse(conv.c_str());
+    REQUIRE(cJSON_GetArraySize(arr) == 2);
+    cJSON* msg = cJSON_GetArrayItem(arr, 1);
+    CHECK(std::string(cJSON_GetObjectItem(msg, "role")->valuestring) == "assistant");
+    CHECK(std::string(cJSON_GetObjectItem(msg, "content")->valuestring) == "hello");
+    cJSON_Delete(arr);
+}

--- a/tests/openrouter_codec_test.cpp
+++ b/tests/openrouter_codec_test.cpp
@@ -9,6 +9,7 @@ using aiden::openrouter::build_tool_definitions_json;
 using aiden::openrouter::parse_chat_response;
 using aiden::openrouter::init_conversation;
 using aiden::openrouter::append_user_audio_wav;
+using aiden::openrouter::append_user_audio_wav_if_present;
 using aiden::openrouter::append_assistant_message;
 using aiden::openrouter::append_tool_result;
 using aiden::openrouter::build_chat_request;
@@ -142,6 +143,12 @@ TEST_CASE("append_user_audio_wav appends a user message with input_audio") {
     CHECK(std::string(cJSON_GetObjectItem(ia, "data")->valuestring) == "AAAA");
     CHECK(std::string(cJSON_GetObjectItem(ia, "format")->valuestring) == "wav");
     cJSON_Delete(arr);
+}
+
+TEST_CASE("append_user_audio_wav_if_present skips empty follow-up audio") {
+    std::string conv = init_conversation("sys");
+    std::string unchanged = append_user_audio_wav_if_present(conv, NULL, 0);
+    CHECK(unchanged == conv);
 }
 
 TEST_CASE("append_tool_result adds a role=tool message") {

--- a/tests/provider_factory_test.cpp
+++ b/tests/provider_factory_test.cpp
@@ -11,10 +11,14 @@ using aiden::check_llm_config;
 using aiden::check_tts_config;
 using aiden::check_provider_config;
 
-TEST_CASE("check_llm_provider accepts openrouter") {
-    ProviderCheckResult r = check_llm_provider("openrouter");
-    CHECK(r.ok);
-    CHECK(r.normalized == "openrouter");
+TEST_CASE("check_llm_provider accepts openrouter and openai") {
+    ProviderCheckResult openrouter = check_llm_provider("openrouter");
+    CHECK(openrouter.ok);
+    CHECK(openrouter.normalized == "openrouter");
+
+    ProviderCheckResult openai = check_llm_provider("openai");
+    CHECK(openai.ok);
+    CHECK(openai.normalized == "openai");
 }
 
 TEST_CASE("check_tts_provider accepts minimax") {
@@ -37,6 +41,24 @@ TEST_CASE("check_llm_config validates openrouter independently") {
     CHECK(missing_model.error == "model provider openrouter requires model");
 
     std::snprintf(cfg.model, sizeof(cfg.model), "%s", "openai/gpt-4o-audio-preview");
+    ProviderCheckResult ok = check_llm_config(cfg);
+    CHECK(ok.ok);
+}
+
+TEST_CASE("check_llm_config validates openai independently") {
+    aiden::ModelConfig cfg;
+    std::snprintf(cfg.provider, sizeof(cfg.provider), "%s", "openai");
+
+    ProviderCheckResult missing_key = check_llm_config(cfg);
+    CHECK_FALSE(missing_key.ok);
+    CHECK(missing_key.error == "model provider openai requires api_key");
+
+    std::snprintf(cfg.api_key, sizeof(cfg.api_key), "%s", "sk-openai");
+    ProviderCheckResult missing_model = check_llm_config(cfg);
+    CHECK_FALSE(missing_model.ok);
+    CHECK(missing_model.error == "model provider openai requires model");
+
+    std::snprintf(cfg.model, sizeof(cfg.model), "%s", "gpt-4o-audio-preview");
     ProviderCheckResult ok = check_llm_config(cfg);
     CHECK(ok.ok);
 }
@@ -169,6 +191,19 @@ TEST_CASE("check_provider_config accepts complete provider config") {
     std::snprintf(cfg.model.provider, sizeof(cfg.model.provider), "%s", "openrouter");
     std::snprintf(cfg.model.api_key, sizeof(cfg.model.api_key), "%s", "sk-key");
     std::snprintf(cfg.model.model, sizeof(cfg.model.model), "%s", "openai/gpt-4o-audio-preview");
+    std::snprintf(cfg.tts.provider, sizeof(cfg.tts.provider), "%s", "minimax");
+    std::snprintf(cfg.tts.api_key, sizeof(cfg.tts.api_key), "%s", "mm-key");
+    std::snprintf(cfg.tts.voice_id, sizeof(cfg.tts.voice_id), "%s", "voice-a");
+
+    ProviderCheckResult r = check_provider_config(cfg);
+    CHECK(r.ok);
+}
+
+TEST_CASE("check_provider_config accepts openai model provider") {
+    aiden::AgentConfig cfg;
+    std::snprintf(cfg.model.provider, sizeof(cfg.model.provider), "%s", "openai");
+    std::snprintf(cfg.model.api_key, sizeof(cfg.model.api_key), "%s", "sk-openai");
+    std::snprintf(cfg.model.model, sizeof(cfg.model.model), "%s", "gpt-4o-audio-preview");
     std::snprintf(cfg.tts.provider, sizeof(cfg.tts.provider), "%s", "minimax");
     std::snprintf(cfg.tts.api_key, sizeof(cfg.tts.api_key), "%s", "mm-key");
     std::snprintf(cfg.tts.voice_id, sizeof(cfg.tts.voice_id), "%s", "voice-a");


### PR DESCRIPTION
## Summary
- add an OpenAI-backed `LlmClient` and codec for chat completions with audio input and tool calls
- extend provider validation and runtime factory wiring for `model.provider = openai`
- add host-native tests for the OpenAI codec and provider config coverage

## Test plan
- [x] `make test`
- [x] `sh build.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)