### PR TITLE
Fix MiniMax TTS playback on device

### DIFF
--- a/src/agent_main.cpp
+++ b/src/agent_main.cpp
@@ -109,9 +109,9 @@ static void process_utterance(const std::vector<int16_t>& utterance,
                 printf("[reply] %s\n", response.c_str());
 
                 printf("[tts] Requesting speech synthesis for: \"%s\"\n", response.c_str());
-                printf("[tts] Starting streaming playback...\n");
+                printf("[tts] Starting playback...\n");
                 if (tts.text_to_speech_stream(response.c_str(), player)) {
-                    printf("[tts] Streaming playback complete\n");
+                    printf("[tts] Playback complete\n");
                 } else {
                     fprintf(stderr, "[error] TTS streaming failed\n");
                 }

--- a/src/minimax_codec.cpp
+++ b/src/minimax_codec.cpp
@@ -122,7 +122,7 @@ std::vector<StreamChunk> StreamParser::feed(const char* data, size_t len) {
                     } else {
                         StreamChunk chunk;
                         chunk.audio = std::move(mp3_chunk);
-                        chunk.reset_decoder = true;
+                        chunk.reset_decoder = false;
                         out.push_back(chunk);
                         previous_audio_ = chunk.audio;
                     }

--- a/src/minimax_codec.cpp
+++ b/src/minimax_codec.cpp
@@ -1,5 +1,6 @@
 #include "minimax_codec.h"
 #include "cJSON/cJSON.h"
+#include <algorithm>
 #include <string.h>
 
 namespace aiden {
@@ -77,14 +78,41 @@ std::vector<std::vector<uint8_t>> StreamParser::feed(const char* data, size_t le
         pos = 0;
 
         cJSON* json = cJSON_Parse(json_str.c_str());
-        if (!json) continue;
+        if (!json) {
+            fprintf(stderr, "[minimax] Failed to parse JSON: %s\n", json_str.c_str());
+            continue;
+        }
+
+        // Check for error response
+        cJSON* base_resp = cJSON_GetObjectItem(json, "base_resp");
+        if (base_resp) {
+            cJSON* status_code = cJSON_GetObjectItem(base_resp, "status_code");
+            cJSON* status_msg = cJSON_GetObjectItem(base_resp, "status_msg");
+            if (status_code && status_code->valueint != 0) {
+                fprintf(stderr, "[minimax] API error: code=%d, msg=%s\n",
+                        status_code->valueint,
+                        status_msg ? status_msg->valuestring : "unknown");
+                cJSON_Delete(json);
+                continue;
+            }
+        }
 
         cJSON* data_obj = cJSON_GetObjectItem(json, "data");
         if (data_obj) {
             cJSON* audio = cJSON_GetObjectItem(data_obj, "audio");
             if (audio && audio->type == cJSON_String) {
                 std::vector<uint8_t> mp3_chunk = hex_decode(audio->valuestring);
-                if (!mp3_chunk.empty()) out.push_back(mp3_chunk);
+                if (!mp3_chunk.empty()) {
+                    if (mp3_chunk.size() >= previous_audio_.size() &&
+                        std::equal(previous_audio_.begin(), previous_audio_.end(), mp3_chunk.begin())) {
+                        if (mp3_chunk.size() > previous_audio_.size()) {
+                            out.emplace_back(mp3_chunk.begin() + previous_audio_.size(), mp3_chunk.end());
+                        }
+                    } else {
+                        out.push_back(mp3_chunk);
+                    }
+                    previous_audio_ = std::move(mp3_chunk);
+                }
             }
         }
 
@@ -96,6 +124,7 @@ std::vector<std::vector<uint8_t>> StreamParser::feed(const char* data, size_t le
 
 void StreamParser::reset() {
     buffer_.clear();
+    previous_audio_.clear();
 }
 
 }

--- a/src/minimax_codec.cpp
+++ b/src/minimax_codec.cpp
@@ -103,15 +103,10 @@ std::vector<std::vector<uint8_t>> StreamParser::feed(const char* data, size_t le
             if (audio && audio->type == cJSON_String) {
                 std::vector<uint8_t> mp3_chunk = hex_decode(audio->valuestring);
                 if (!mp3_chunk.empty()) {
-                    if (mp3_chunk.size() >= previous_audio_.size() &&
-                        std::equal(previous_audio_.begin(), previous_audio_.end(), mp3_chunk.begin())) {
-                        if (mp3_chunk.size() > previous_audio_.size()) {
-                            out.emplace_back(mp3_chunk.begin() + previous_audio_.size(), mp3_chunk.end());
-                        }
-                    } else {
+                    if (mp3_chunk != previous_audio_) {
                         out.push_back(mp3_chunk);
+                        previous_audio_ = mp3_chunk;
                     }
-                    previous_audio_ = std::move(mp3_chunk);
                 }
             }
         }

--- a/src/minimax_codec.cpp
+++ b/src/minimax_codec.cpp
@@ -23,8 +23,8 @@ std::vector<uint8_t> hex_decode(const char* hex) {
     return result;
 }
 
-std::vector<std::vector<uint8_t>> StreamParser::feed(const char* data, size_t len) {
-    std::vector<std::vector<uint8_t>> out;
+std::vector<StreamChunk> StreamParser::feed(const char* data, size_t len) {
+    std::vector<StreamChunk> out;
     buffer_.append(data, len);
 
     size_t pos = 0;
@@ -103,9 +103,28 @@ std::vector<std::vector<uint8_t>> StreamParser::feed(const char* data, size_t le
             if (audio && audio->type == cJSON_String) {
                 std::vector<uint8_t> mp3_chunk = hex_decode(audio->valuestring);
                 if (!mp3_chunk.empty()) {
-                    if (mp3_chunk != previous_audio_) {
-                        out.push_back(mp3_chunk);
-                        previous_audio_ = mp3_chunk;
+                    if (previous_audio_.empty()) {
+                        StreamChunk chunk;
+                        chunk.audio = std::move(mp3_chunk);
+                        chunk.reset_decoder = false;
+                        out.push_back(chunk);
+                        previous_audio_ = chunk.audio;
+                    } else if (mp3_chunk == previous_audio_) {
+                    } else if (mp3_chunk.size() > previous_audio_.size() &&
+                               std::equal(previous_audio_.begin(), previous_audio_.end(), mp3_chunk.begin())) {
+                        StreamChunk chunk;
+                        chunk.audio = std::vector<uint8_t>(mp3_chunk.begin() + previous_audio_.size(), mp3_chunk.end());
+                        chunk.reset_decoder = false;
+                        out.push_back(chunk);
+                        previous_audio_ = std::move(mp3_chunk);
+                    } else if (mp3_chunk.size() < previous_audio_.size() &&
+                               std::equal(mp3_chunk.begin(), mp3_chunk.end(), previous_audio_.begin())) {
+                    } else {
+                        StreamChunk chunk;
+                        chunk.audio = std::move(mp3_chunk);
+                        chunk.reset_decoder = true;
+                        out.push_back(chunk);
+                        previous_audio_ = chunk.audio;
                     }
                 }
             }

--- a/src/minimax_codec.h
+++ b/src/minimax_codec.h
@@ -9,9 +9,14 @@ namespace minimax {
 
 std::vector<uint8_t> hex_decode(const char* hex);
 
+struct StreamChunk {
+    std::vector<uint8_t> audio;
+    bool reset_decoder = false;
+};
+
 class StreamParser {
 public:
-    std::vector<std::vector<uint8_t>> feed(const char* data, size_t len);
+    std::vector<StreamChunk> feed(const char* data, size_t len);
     void reset();
 
 private:

--- a/src/minimax_codec.h
+++ b/src/minimax_codec.h
@@ -16,6 +16,7 @@ public:
 
 private:
     std::string buffer_;
+    std::vector<uint8_t> previous_audio_;
 };
 
 }

--- a/src/minimax_tts.cpp
+++ b/src/minimax_tts.cpp
@@ -13,135 +13,26 @@
 
 namespace aiden {
 
-struct StreamDecoder {
+struct StreamContext {
     int ffmpeg_stdin;
     int ffmpeg_stdout;
     pid_t ffmpeg_pid;
     aiden::AudioPlayer* player;
     pthread_t reader_thread;
-    bool reader_running;
 };
 
 static void* pcm_reader_thread(void* arg) {
-    StreamDecoder* decoder = (StreamDecoder*)arg;
+    StreamContext* ctx = (StreamContext*)arg;
+
     uint8_t pcm_buf[4096];
-    while (decoder->reader_running) {
-        ssize_t n = read(decoder->ffmpeg_stdout, pcm_buf, sizeof(pcm_buf));
+    while (true) {
+        ssize_t n = read(ctx->ffmpeg_stdout, pcm_buf, sizeof(pcm_buf));
         if (n <= 0) break;
-        decoder->player->play(pcm_buf, n);
+
+        ctx->player->play(pcm_buf, n);
     }
+
     return NULL;
-}
-
-static bool start_decoder(StreamDecoder& decoder, aiden::AudioPlayer* player) {
-    int stdin_pipe[2], stdout_pipe[2];
-    if (pipe(stdin_pipe) < 0 || pipe(stdout_pipe) < 0) {
-        fprintf(stderr, "[error] Failed to create decoder pipes\n");
-        return false;
-    }
-
-    pid_t pid = fork();
-    if (pid < 0) {
-        fprintf(stderr, "[error] Failed to fork ffmpeg\n");
-        close(stdin_pipe[0]);
-        close(stdin_pipe[1]);
-        close(stdout_pipe[0]);
-        close(stdout_pipe[1]);
-        return false;
-    }
-
-    if (pid == 0) {
-        close(stdin_pipe[1]);
-        close(stdout_pipe[0]);
-        dup2(stdin_pipe[0], STDIN_FILENO);
-        dup2(stdout_pipe[1], STDOUT_FILENO);
-        close(stdin_pipe[0]);
-        close(stdout_pipe[1]);
-
-        execlp("ffmpeg", "ffmpeg",
-               "-loglevel", "error",
-               "-i", "pipe:0",
-               "-f", "s16le",
-               "-ar", "16000",
-               "-ac", "1",
-               "pipe:1",
-               NULL);
-        _exit(1);
-    }
-
-    close(stdin_pipe[0]);
-    close(stdout_pipe[1]);
-
-    decoder.ffmpeg_stdin = stdin_pipe[1];
-    decoder.ffmpeg_stdout = stdout_pipe[0];
-    decoder.ffmpeg_pid = pid;
-    decoder.player = player;
-    decoder.reader_running = true;
-
-    pthread_create(&decoder.reader_thread, NULL, pcm_reader_thread, &decoder);
-    return true;
-}
-
-static void stop_decoder(StreamDecoder& decoder) {
-    close(decoder.ffmpeg_stdin);
-    decoder.reader_running = false;
-    pthread_join(decoder.reader_thread, NULL);
-    close(decoder.ffmpeg_stdout);
-    int status;
-    waitpid(decoder.ffmpeg_pid, &status, 0);
-}
-
-struct StreamContext {
-    aiden::AudioPlayer* player;
-    minimax::StreamParser parser;
-    StreamDecoder decoder;
-    bool decoder_started;
-};
-
-static void stream_chunk_callback(const char* data, size_t len, void* user_data) {
-    StreamContext* ctx = (StreamContext*)user_data;
-    std::vector<minimax::StreamChunk> chunks = ctx->parser.feed(data, len);
-
-    for (size_t i = 0; i < chunks.size(); i++) {
-        const minimax::StreamChunk& chunk = chunks[i];
-
-        if (chunk.reset_decoder) {
-            fprintf(stderr, "[minimax] Reset decoder due to unrelated snapshot\n");
-            if (ctx->decoder_started) {
-                stop_decoder(ctx->decoder);
-            }
-            ctx->decoder_started = start_decoder(ctx->decoder, ctx->player);
-            if (!ctx->decoder_started) {
-                fprintf(stderr, "[error] Failed to restart decoder\n");
-                continue;
-            }
-        }
-
-        if (!ctx->decoder_started) {
-            ctx->decoder_started = start_decoder(ctx->decoder, ctx->player);
-            if (!ctx->decoder_started) {
-                fprintf(stderr, "[error] Failed to start decoder\n");
-                continue;
-            }
-        }
-
-        if (!chunk.audio.empty()) {
-            size_t offset = 0;
-            while (offset < chunk.audio.size()) {
-                ssize_t n = write(ctx->decoder.ffmpeg_stdin,
-                                  chunk.audio.data() + offset,
-                                  chunk.audio.size() - offset);
-                if (n > 0) {
-                    offset += (size_t)n;
-                    continue;
-                }
-                if (n < 0 && errno == EINTR)
-                    continue;
-                fprintf(stderr, "[error] Failed to write mp3 delta to decoder: %s\n", strerror(errno));
-                break;
-            }
-        }
-    }
 }
 
 MinimaxTTS::MinimaxTTS(const char* api_key, const char* voice_id,
@@ -176,29 +67,121 @@ bool MinimaxTTS::text_to_speech_stream(const char* text, aiden::AudioPlayer& pla
     fprintf(stderr, "[minimax] Request: %s\n", request_str);
     cJSON_Delete(request);
 
-    StreamContext ctx;
-    ctx.player = &player;
-    ctx.decoder_started = false;
-
+    std::string response;
     HttpClient http;
-    bool success = http.post_stream(
+    bool success = http.post_json(
         "https://api.minimaxi.com/v1/t2a_v2",
         api_key_.c_str(),
         request_str,
-        stream_chunk_callback,
-        &ctx);
+        response);
     free(request_str);
 
-    if (ctx.decoder_started) {
-        stop_decoder(ctx.decoder);
-    }
-
-    if (!success) {
-        fprintf(stderr, "[error] MiniMax TTS stream failed\n");
+    if (!success || response.empty()) {
+        fprintf(stderr, "[error] MiniMax TTS request failed or returned empty response\n");
         return false;
     }
 
-    fprintf(stderr, "[minimax] TTS stream complete\n");
+    cJSON* json = cJSON_Parse(response.c_str());
+    if (!json) {
+        fprintf(stderr, "[error] MiniMax TTS returned invalid JSON\n");
+        return false;
+    }
+
+    cJSON* base_resp = cJSON_GetObjectItem(json, "base_resp");
+    if (base_resp) {
+        cJSON* status_code = cJSON_GetObjectItem(base_resp, "status_code");
+        cJSON* status_msg = cJSON_GetObjectItem(base_resp, "status_msg");
+        if (status_code && status_code->valueint != 0) {
+            fprintf(stderr, "[error] MiniMax TTS API error: code=%d, msg=%s\n",
+                    status_code->valueint,
+                    status_msg ? status_msg->valuestring : "unknown");
+            cJSON_Delete(json);
+            return false;
+        }
+    }
+
+    cJSON* data_obj = cJSON_GetObjectItem(json, "data");
+    cJSON* audio = data_obj ? cJSON_GetObjectItem(data_obj, "audio") : NULL;
+    if (!audio || audio->type != cJSON_String || !audio->valuestring || audio->valuestring[0] == '\0') {
+        fprintf(stderr, "[error] MiniMax TTS response missing audio payload\n");
+        cJSON_Delete(json);
+        return false;
+    }
+
+    std::vector<uint8_t> mp3 = minimax::hex_decode(audio->valuestring);
+    cJSON_Delete(json);
+
+    if (mp3.empty()) {
+        fprintf(stderr, "[error] MiniMax TTS audio payload decoded empty\n");
+        return false;
+    }
+
+    int stdin_pipe[2], stdout_pipe[2];
+    if (pipe(stdin_pipe) < 0 || pipe(stdout_pipe) < 0) {
+        fprintf(stderr, "[error] Failed to create pipes\n");
+        return false;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        fprintf(stderr, "[error] Failed to fork\n");
+        return false;
+    }
+
+    if (pid == 0) {
+        close(stdin_pipe[1]);
+        close(stdout_pipe[0]);
+        dup2(stdin_pipe[0], STDIN_FILENO);
+        dup2(stdout_pipe[1], STDOUT_FILENO);
+        close(stdin_pipe[0]);
+        close(stdout_pipe[1]);
+
+        execlp("ffmpeg", "ffmpeg",
+               "-i", "pipe:0",
+               "-f", "s16le",
+               "-ar", "16000",
+               "-ac", "1",
+               "pipe:1",
+               NULL);
+        _exit(1);
+    }
+
+    close(stdin_pipe[0]);
+    close(stdout_pipe[1]);
+
+    StreamContext ctx;
+    ctx.ffmpeg_stdin = stdin_pipe[1];
+    ctx.ffmpeg_stdout = stdout_pipe[0];
+    ctx.ffmpeg_pid = pid;
+    ctx.player = &player;
+
+    pthread_create(&ctx.reader_thread, NULL, pcm_reader_thread, &ctx);
+
+    size_t offset = 0;
+    while (offset < mp3.size()) {
+        ssize_t n = write(ctx.ffmpeg_stdin, mp3.data() + offset, mp3.size() - offset);
+        if (n > 0) {
+            offset += (size_t)n;
+            continue;
+        }
+        if (n < 0 && errno == EINTR)
+            continue;
+        fprintf(stderr, "[error] Failed to write mp3 to ffmpeg: %s\n", strerror(errno));
+        close(ctx.ffmpeg_stdin);
+        close(ctx.ffmpeg_stdout);
+        pthread_join(ctx.reader_thread, NULL);
+        waitpid(ctx.ffmpeg_pid, NULL, 0);
+        return false;
+    }
+
+    close(ctx.ffmpeg_stdin);
+
+    int status;
+    waitpid(ctx.ffmpeg_pid, &status, 0);
+    pthread_join(ctx.reader_thread, NULL);
+    close(ctx.ffmpeg_stdout);
+
+    fprintf(stderr, "[minimax] TTS complete\n");
     return true;
 }
 

--- a/src/minimax_tts.cpp
+++ b/src/minimax_tts.cpp
@@ -7,21 +7,36 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <pthread.h>
 #include <sys/wait.h>
 #include <vector>
 
 namespace aiden {
 
-struct StreamContext {
+struct StreamDecoder {
+    int ffmpeg_stdin;
+    int ffmpeg_stdout;
+    pid_t ffmpeg_pid;
     aiden::AudioPlayer* player;
-    minimax::StreamParser parser;
-    std::vector<uint8_t> previous_pcm;
+    pthread_t reader_thread;
+    bool reader_running;
 };
 
-static bool decode_mp3_to_pcm(const std::vector<uint8_t>& mp3, std::vector<uint8_t>& pcm) {
+static void* pcm_reader_thread(void* arg) {
+    StreamDecoder* decoder = (StreamDecoder*)arg;
+    uint8_t pcm_buf[4096];
+    while (decoder->reader_running) {
+        ssize_t n = read(decoder->ffmpeg_stdout, pcm_buf, sizeof(pcm_buf));
+        if (n <= 0) break;
+        decoder->player->play(pcm_buf, n);
+    }
+    return NULL;
+}
+
+static bool start_decoder(StreamDecoder& decoder, aiden::AudioPlayer* player) {
     int stdin_pipe[2], stdout_pipe[2];
     if (pipe(stdin_pipe) < 0 || pipe(stdout_pipe) < 0) {
-        fprintf(stderr, "[error] Failed to create decode pipes\n");
+        fprintf(stderr, "[error] Failed to create decoder pipes\n");
         return false;
     }
 
@@ -57,65 +72,75 @@ static bool decode_mp3_to_pcm(const std::vector<uint8_t>& mp3, std::vector<uint8
     close(stdin_pipe[0]);
     close(stdout_pipe[1]);
 
-    size_t offset = 0;
-    while (offset < mp3.size()) {
-        ssize_t n = write(stdin_pipe[1], mp3.data() + offset, mp3.size() - offset);
-        if (n > 0) {
-            offset += (size_t)n;
-            continue;
-        }
-        if (n < 0 && errno == EINTR)
-            continue;
-        fprintf(stderr, "[error] Failed to write mp3 to ffmpeg: %s\n", strerror(errno));
-        close(stdin_pipe[1]);
-        close(stdout_pipe[0]);
-        waitpid(pid, NULL, 0);
-        return false;
-    }
-    close(stdin_pipe[1]);
+    decoder.ffmpeg_stdin = stdin_pipe[1];
+    decoder.ffmpeg_stdout = stdout_pipe[0];
+    decoder.ffmpeg_pid = pid;
+    decoder.player = player;
+    decoder.reader_running = true;
 
-    pcm.clear();
-    uint8_t buf[4096];
-    while (true) {
-        ssize_t n = read(stdout_pipe[0], buf, sizeof(buf));
-        if (n > 0) {
-            pcm.insert(pcm.end(), buf, buf + n);
-            continue;
-        }
-        if (n < 0 && errno == EINTR)
-            continue;
-        break;
-    }
-    close(stdout_pipe[0]);
-
-    int status = 0;
-    waitpid(pid, &status, 0);
-    return WIFEXITED(status) && WEXITSTATUS(status) == 0 && !pcm.empty();
+    pthread_create(&decoder.reader_thread, NULL, pcm_reader_thread, &decoder);
+    return true;
 }
+
+static void stop_decoder(StreamDecoder& decoder) {
+    close(decoder.ffmpeg_stdin);
+    decoder.reader_running = false;
+    pthread_join(decoder.reader_thread, NULL);
+    close(decoder.ffmpeg_stdout);
+    int status;
+    waitpid(decoder.ffmpeg_pid, &status, 0);
+}
+
+struct StreamContext {
+    aiden::AudioPlayer* player;
+    minimax::StreamParser parser;
+    StreamDecoder decoder;
+    bool decoder_started;
+};
 
 static void stream_chunk_callback(const char* data, size_t len, void* user_data) {
     StreamContext* ctx = (StreamContext*)user_data;
-    std::vector<std::vector<uint8_t>> snapshots = ctx->parser.feed(data, len);
+    std::vector<minimax::StreamChunk> chunks = ctx->parser.feed(data, len);
 
-    for (size_t i = 0; i < snapshots.size(); i++) {
-        std::vector<uint8_t> pcm;
-        if (!decode_mp3_to_pcm(snapshots[i], pcm)) {
-            fprintf(stderr, "[error] Failed to decode streamed MiniMax audio snapshot\n");
-            continue;
+    for (size_t i = 0; i < chunks.size(); i++) {
+        const minimax::StreamChunk& chunk = chunks[i];
+
+        if (chunk.reset_decoder) {
+            fprintf(stderr, "[minimax] Reset decoder due to unrelated snapshot\n");
+            if (ctx->decoder_started) {
+                stop_decoder(ctx->decoder);
+            }
+            ctx->decoder_started = start_decoder(ctx->decoder, ctx->player);
+            if (!ctx->decoder_started) {
+                fprintf(stderr, "[error] Failed to restart decoder\n");
+                continue;
+            }
         }
 
-        size_t prefix = 0;
-        while (prefix < ctx->previous_pcm.size() &&
-               prefix < pcm.size() &&
-               ctx->previous_pcm[prefix] == pcm[prefix]) {
-            prefix++;
+        if (!ctx->decoder_started) {
+            ctx->decoder_started = start_decoder(ctx->decoder, ctx->player);
+            if (!ctx->decoder_started) {
+                fprintf(stderr, "[error] Failed to start decoder\n");
+                continue;
+            }
         }
 
-        if (prefix < pcm.size()) {
-            ctx->player->play(pcm.data() + prefix, (uint32_t)(pcm.size() - prefix));
+        if (!chunk.audio.empty()) {
+            size_t offset = 0;
+            while (offset < chunk.audio.size()) {
+                ssize_t n = write(ctx->decoder.ffmpeg_stdin,
+                                  chunk.audio.data() + offset,
+                                  chunk.audio.size() - offset);
+                if (n > 0) {
+                    offset += (size_t)n;
+                    continue;
+                }
+                if (n < 0 && errno == EINTR)
+                    continue;
+                fprintf(stderr, "[error] Failed to write mp3 delta to decoder: %s\n", strerror(errno));
+                break;
+            }
         }
-
-        ctx->previous_pcm = std::move(pcm);
     }
 }
 
@@ -153,6 +178,7 @@ bool MinimaxTTS::text_to_speech_stream(const char* text, aiden::AudioPlayer& pla
 
     StreamContext ctx;
     ctx.player = &player;
+    ctx.decoder_started = false;
 
     HttpClient http;
     bool success = http.post_stream(
@@ -162,6 +188,10 @@ bool MinimaxTTS::text_to_speech_stream(const char* text, aiden::AudioPlayer& pla
         stream_chunk_callback,
         &ctx);
     free(request_str);
+
+    if (ctx.decoder_started) {
+        stop_decoder(ctx.decoder);
+    }
 
     if (!success) {
         fprintf(stderr, "[error] MiniMax TTS stream failed\n");

--- a/src/minimax_tts.cpp
+++ b/src/minimax_tts.cpp
@@ -153,7 +153,7 @@ bool MinimaxTTS::text_to_speech_stream(const char* text, aiden::AudioPlayer& pla
     cJSON* request = cJSON_CreateObject();
     cJSON_AddStringToObject(request, "model", "speech-2.8-hd");
     cJSON_AddStringToObject(request, "text", text);
-    cJSON_AddBoolToObject(request, "stream", true);
+    cJSON_AddBoolToObject(request, "stream", false);
 
     cJSON* voice_setting = cJSON_CreateObject();
     cJSON_AddStringToObject(voice_setting, "voice_id", voice_id_.c_str());

--- a/src/minimax_tts.cpp
+++ b/src/minimax_tts.cpp
@@ -19,15 +19,13 @@ struct StreamContext {
     pid_t ffmpeg_pid;
     aiden::AudioPlayer* player;
     pthread_t reader_thread;
-    bool reader_running;
-    minimax::StreamParser parser;
 };
 
 static void* pcm_reader_thread(void* arg) {
     StreamContext* ctx = (StreamContext*)arg;
 
     uint8_t pcm_buf[4096];
-    while (ctx->reader_running) {
+    while (true) {
         ssize_t n = read(ctx->ffmpeg_stdout, pcm_buf, sizeof(pcm_buf));
         if (n <= 0) break;
 
@@ -35,29 +33,6 @@ static void* pcm_reader_thread(void* arg) {
     }
 
     return NULL;
-}
-
-static void stream_chunk_callback(const char* data, size_t len, void* user_data) {
-    StreamContext* ctx = (StreamContext*)user_data;
-    std::vector<std::vector<uint8_t>> chunks = ctx->parser.feed(data, len);
-    for (size_t i = 0; i < chunks.size(); i++) {
-        const std::vector<uint8_t>& mp3_chunk = chunks[i];
-        if (!mp3_chunk.empty()) {
-            size_t offset = 0;
-            while (offset < mp3_chunk.size()) {
-                ssize_t n = write(ctx->ffmpeg_stdin,
-                                  mp3_chunk.data() + offset,
-                                  mp3_chunk.size() - offset);
-                if (n > 0) {
-                    offset += (size_t)n;
-                    continue;
-                }
-                if (n < 0 && errno == EINTR)
-                    continue;
-                return;
-            }
-        }
-    }
 }
 
 MinimaxTTS::MinimaxTTS(const char* api_key, const char* voice_id,
@@ -69,7 +44,7 @@ bool MinimaxTTS::text_to_speech_stream(const char* text, aiden::AudioPlayer& pla
     cJSON* request = cJSON_CreateObject();
     cJSON_AddStringToObject(request, "model", "speech-2.8-hd");
     cJSON_AddStringToObject(request, "text", text);
-    cJSON_AddBoolToObject(request, "stream", true);
+    cJSON_AddBoolToObject(request, "stream", false);
 
     cJSON* voice_setting = cJSON_CreateObject();
     cJSON_AddStringToObject(voice_setting, "voice_id", voice_id_.c_str());
@@ -92,17 +67,64 @@ bool MinimaxTTS::text_to_speech_stream(const char* text, aiden::AudioPlayer& pla
     fprintf(stderr, "[minimax] Request: %s\n", request_str);
     cJSON_Delete(request);
 
+    std::string response;
+    HttpClient http;
+    bool success = http.post_json(
+        "https://api.minimaxi.com/v1/t2a_v2",
+        api_key_.c_str(),
+        request_str,
+        response);
+    free(request_str);
+
+    if (!success || response.empty()) {
+        fprintf(stderr, "[error] MiniMax TTS request failed or returned empty response\n");
+        return false;
+    }
+
+    cJSON* json = cJSON_Parse(response.c_str());
+    if (!json) {
+        fprintf(stderr, "[error] MiniMax TTS returned invalid JSON\n");
+        return false;
+    }
+
+    cJSON* base_resp = cJSON_GetObjectItem(json, "base_resp");
+    if (base_resp) {
+        cJSON* status_code = cJSON_GetObjectItem(base_resp, "status_code");
+        cJSON* status_msg = cJSON_GetObjectItem(base_resp, "status_msg");
+        if (status_code && status_code->valueint != 0) {
+            fprintf(stderr, "[error] MiniMax TTS API error: code=%d, msg=%s\n",
+                    status_code->valueint,
+                    status_msg ? status_msg->valuestring : "unknown");
+            cJSON_Delete(json);
+            return false;
+        }
+    }
+
+    cJSON* data_obj = cJSON_GetObjectItem(json, "data");
+    cJSON* audio = data_obj ? cJSON_GetObjectItem(data_obj, "audio") : NULL;
+    if (!audio || audio->type != cJSON_String || !audio->valuestring || audio->valuestring[0] == '\0') {
+        fprintf(stderr, "[error] MiniMax TTS response missing audio payload\n");
+        cJSON_Delete(json);
+        return false;
+    }
+
+    std::vector<uint8_t> mp3 = minimax::hex_decode(audio->valuestring);
+    cJSON_Delete(json);
+
+    if (mp3.empty()) {
+        fprintf(stderr, "[error] MiniMax TTS audio payload decoded empty\n");
+        return false;
+    }
+
     int stdin_pipe[2], stdout_pipe[2];
     if (pipe(stdin_pipe) < 0 || pipe(stdout_pipe) < 0) {
         fprintf(stderr, "[error] Failed to create pipes\n");
-        free(request_str);
         return false;
     }
 
     pid_t pid = fork();
     if (pid < 0) {
         fprintf(stderr, "[error] Failed to fork\n");
-        free(request_str);
         return false;
     }
 
@@ -132,34 +154,34 @@ bool MinimaxTTS::text_to_speech_stream(const char* text, aiden::AudioPlayer& pla
     ctx.ffmpeg_stdout = stdout_pipe[0];
     ctx.ffmpeg_pid = pid;
     ctx.player = &player;
-    ctx.reader_running = true;
 
     pthread_create(&ctx.reader_thread, NULL, pcm_reader_thread, &ctx);
 
-    HttpClient http;
-    bool success = http.post_stream(
-        "https://api.minimaxi.com/v1/t2a_v2",
-        api_key_.c_str(),
-        request_str,
-        stream_chunk_callback,
-        &ctx);
-    free(request_str);
-
-    close(ctx.ffmpeg_stdin);
-
-    ctx.reader_running = false;
-    pthread_join(ctx.reader_thread, NULL);
-
-    close(ctx.ffmpeg_stdout);
-    int status;
-    waitpid(ctx.ffmpeg_pid, &status, 0);
-
-    if (!success) {
-        fprintf(stderr, "[error] MiniMax TTS stream failed\n");
+    size_t offset = 0;
+    while (offset < mp3.size()) {
+        ssize_t n = write(ctx.ffmpeg_stdin, mp3.data() + offset, mp3.size() - offset);
+        if (n > 0) {
+            offset += (size_t)n;
+            continue;
+        }
+        if (n < 0 && errno == EINTR)
+            continue;
+        fprintf(stderr, "[error] Failed to write mp3 to ffmpeg: %s\n", strerror(errno));
+        close(ctx.ffmpeg_stdin);
+        close(ctx.ffmpeg_stdout);
+        pthread_join(ctx.reader_thread, NULL);
+        waitpid(ctx.ffmpeg_pid, NULL, 0);
         return false;
     }
 
-    fprintf(stderr, "[minimax] TTS stream complete\n");
+    close(ctx.ffmpeg_stdin);
+
+    int status;
+    waitpid(ctx.ffmpeg_pid, &status, 0);
+    pthread_join(ctx.reader_thread, NULL);
+    close(ctx.ffmpeg_stdout);
+
+    fprintf(stderr, "[minimax] TTS complete\n");
     return true;
 }
 

--- a/src/minimax_tts.cpp
+++ b/src/minimax_tts.cpp
@@ -7,32 +7,116 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <pthread.h>
 #include <sys/wait.h>
 #include <vector>
 
 namespace aiden {
 
 struct StreamContext {
-    int ffmpeg_stdin;
-    int ffmpeg_stdout;
-    pid_t ffmpeg_pid;
     aiden::AudioPlayer* player;
-    pthread_t reader_thread;
+    minimax::StreamParser parser;
+    std::vector<uint8_t> previous_pcm;
 };
 
-static void* pcm_reader_thread(void* arg) {
-    StreamContext* ctx = (StreamContext*)arg;
-
-    uint8_t pcm_buf[4096];
-    while (true) {
-        ssize_t n = read(ctx->ffmpeg_stdout, pcm_buf, sizeof(pcm_buf));
-        if (n <= 0) break;
-
-        ctx->player->play(pcm_buf, n);
+static bool decode_mp3_to_pcm(const std::vector<uint8_t>& mp3, std::vector<uint8_t>& pcm) {
+    int stdin_pipe[2], stdout_pipe[2];
+    if (pipe(stdin_pipe) < 0 || pipe(stdout_pipe) < 0) {
+        fprintf(stderr, "[error] Failed to create decode pipes\n");
+        return false;
     }
 
-    return NULL;
+    pid_t pid = fork();
+    if (pid < 0) {
+        fprintf(stderr, "[error] Failed to fork ffmpeg\n");
+        close(stdin_pipe[0]);
+        close(stdin_pipe[1]);
+        close(stdout_pipe[0]);
+        close(stdout_pipe[1]);
+        return false;
+    }
+
+    if (pid == 0) {
+        close(stdin_pipe[1]);
+        close(stdout_pipe[0]);
+        dup2(stdin_pipe[0], STDIN_FILENO);
+        dup2(stdout_pipe[1], STDOUT_FILENO);
+        close(stdin_pipe[0]);
+        close(stdout_pipe[1]);
+
+        execlp("ffmpeg", "ffmpeg",
+               "-loglevel", "error",
+               "-i", "pipe:0",
+               "-f", "s16le",
+               "-ar", "16000",
+               "-ac", "1",
+               "pipe:1",
+               NULL);
+        _exit(1);
+    }
+
+    close(stdin_pipe[0]);
+    close(stdout_pipe[1]);
+
+    size_t offset = 0;
+    while (offset < mp3.size()) {
+        ssize_t n = write(stdin_pipe[1], mp3.data() + offset, mp3.size() - offset);
+        if (n > 0) {
+            offset += (size_t)n;
+            continue;
+        }
+        if (n < 0 && errno == EINTR)
+            continue;
+        fprintf(stderr, "[error] Failed to write mp3 to ffmpeg: %s\n", strerror(errno));
+        close(stdin_pipe[1]);
+        close(stdout_pipe[0]);
+        waitpid(pid, NULL, 0);
+        return false;
+    }
+    close(stdin_pipe[1]);
+
+    pcm.clear();
+    uint8_t buf[4096];
+    while (true) {
+        ssize_t n = read(stdout_pipe[0], buf, sizeof(buf));
+        if (n > 0) {
+            pcm.insert(pcm.end(), buf, buf + n);
+            continue;
+        }
+        if (n < 0 && errno == EINTR)
+            continue;
+        break;
+    }
+    close(stdout_pipe[0]);
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+    return WIFEXITED(status) && WEXITSTATUS(status) == 0 && !pcm.empty();
+}
+
+static void stream_chunk_callback(const char* data, size_t len, void* user_data) {
+    StreamContext* ctx = (StreamContext*)user_data;
+    std::vector<std::vector<uint8_t>> snapshots = ctx->parser.feed(data, len);
+
+    for (size_t i = 0; i < snapshots.size(); i++) {
+        std::vector<uint8_t> pcm;
+        if (!decode_mp3_to_pcm(snapshots[i], pcm)) {
+            fprintf(stderr, "[error] Failed to decode streamed MiniMax audio snapshot\n");
+            continue;
+        }
+
+        size_t prefix = 0;
+        while (prefix < ctx->previous_pcm.size() &&
+               prefix < pcm.size() &&
+               ctx->previous_pcm[prefix] == pcm[prefix]) {
+            prefix++;
+        }
+
+        if (prefix < pcm.size()) {
+            ctx->player->play(pcm.data() + prefix, (uint32_t)(pcm.size() - prefix));
+        }
+
+        ctx->previous_pcm = std::move(pcm);
+    }
 }
 
 MinimaxTTS::MinimaxTTS(const char* api_key, const char* voice_id,
@@ -44,7 +128,7 @@ bool MinimaxTTS::text_to_speech_stream(const char* text, aiden::AudioPlayer& pla
     cJSON* request = cJSON_CreateObject();
     cJSON_AddStringToObject(request, "model", "speech-2.8-hd");
     cJSON_AddStringToObject(request, "text", text);
-    cJSON_AddBoolToObject(request, "stream", false);
+    cJSON_AddBoolToObject(request, "stream", true);
 
     cJSON* voice_setting = cJSON_CreateObject();
     cJSON_AddStringToObject(voice_setting, "voice_id", voice_id_.c_str());
@@ -67,121 +151,24 @@ bool MinimaxTTS::text_to_speech_stream(const char* text, aiden::AudioPlayer& pla
     fprintf(stderr, "[minimax] Request: %s\n", request_str);
     cJSON_Delete(request);
 
-    std::string response;
+    StreamContext ctx;
+    ctx.player = &player;
+
     HttpClient http;
-    bool success = http.post_json(
+    bool success = http.post_stream(
         "https://api.minimaxi.com/v1/t2a_v2",
         api_key_.c_str(),
         request_str,
-        response);
+        stream_chunk_callback,
+        &ctx);
     free(request_str);
 
-    if (!success || response.empty()) {
-        fprintf(stderr, "[error] MiniMax TTS request failed or returned empty response\n");
+    if (!success) {
+        fprintf(stderr, "[error] MiniMax TTS stream failed\n");
         return false;
     }
 
-    cJSON* json = cJSON_Parse(response.c_str());
-    if (!json) {
-        fprintf(stderr, "[error] MiniMax TTS returned invalid JSON\n");
-        return false;
-    }
-
-    cJSON* base_resp = cJSON_GetObjectItem(json, "base_resp");
-    if (base_resp) {
-        cJSON* status_code = cJSON_GetObjectItem(base_resp, "status_code");
-        cJSON* status_msg = cJSON_GetObjectItem(base_resp, "status_msg");
-        if (status_code && status_code->valueint != 0) {
-            fprintf(stderr, "[error] MiniMax TTS API error: code=%d, msg=%s\n",
-                    status_code->valueint,
-                    status_msg ? status_msg->valuestring : "unknown");
-            cJSON_Delete(json);
-            return false;
-        }
-    }
-
-    cJSON* data_obj = cJSON_GetObjectItem(json, "data");
-    cJSON* audio = data_obj ? cJSON_GetObjectItem(data_obj, "audio") : NULL;
-    if (!audio || audio->type != cJSON_String || !audio->valuestring || audio->valuestring[0] == '\0') {
-        fprintf(stderr, "[error] MiniMax TTS response missing audio payload\n");
-        cJSON_Delete(json);
-        return false;
-    }
-
-    std::vector<uint8_t> mp3 = minimax::hex_decode(audio->valuestring);
-    cJSON_Delete(json);
-
-    if (mp3.empty()) {
-        fprintf(stderr, "[error] MiniMax TTS audio payload decoded empty\n");
-        return false;
-    }
-
-    int stdin_pipe[2], stdout_pipe[2];
-    if (pipe(stdin_pipe) < 0 || pipe(stdout_pipe) < 0) {
-        fprintf(stderr, "[error] Failed to create pipes\n");
-        return false;
-    }
-
-    pid_t pid = fork();
-    if (pid < 0) {
-        fprintf(stderr, "[error] Failed to fork\n");
-        return false;
-    }
-
-    if (pid == 0) {
-        close(stdin_pipe[1]);
-        close(stdout_pipe[0]);
-        dup2(stdin_pipe[0], STDIN_FILENO);
-        dup2(stdout_pipe[1], STDOUT_FILENO);
-        close(stdin_pipe[0]);
-        close(stdout_pipe[1]);
-
-        execlp("ffmpeg", "ffmpeg",
-               "-i", "pipe:0",
-               "-f", "s16le",
-               "-ar", "16000",
-               "-ac", "1",
-               "pipe:1",
-               NULL);
-        _exit(1);
-    }
-
-    close(stdin_pipe[0]);
-    close(stdout_pipe[1]);
-
-    StreamContext ctx;
-    ctx.ffmpeg_stdin = stdin_pipe[1];
-    ctx.ffmpeg_stdout = stdout_pipe[0];
-    ctx.ffmpeg_pid = pid;
-    ctx.player = &player;
-
-    pthread_create(&ctx.reader_thread, NULL, pcm_reader_thread, &ctx);
-
-    size_t offset = 0;
-    while (offset < mp3.size()) {
-        ssize_t n = write(ctx.ffmpeg_stdin, mp3.data() + offset, mp3.size() - offset);
-        if (n > 0) {
-            offset += (size_t)n;
-            continue;
-        }
-        if (n < 0 && errno == EINTR)
-            continue;
-        fprintf(stderr, "[error] Failed to write mp3 to ffmpeg: %s\n", strerror(errno));
-        close(ctx.ffmpeg_stdin);
-        close(ctx.ffmpeg_stdout);
-        pthread_join(ctx.reader_thread, NULL);
-        waitpid(ctx.ffmpeg_pid, NULL, 0);
-        return false;
-    }
-
-    close(ctx.ffmpeg_stdin);
-
-    int status;
-    waitpid(ctx.ffmpeg_pid, &status, 0);
-    pthread_join(ctx.reader_thread, NULL);
-    close(ctx.ffmpeg_stdout);
-
-    fprintf(stderr, "[minimax] TTS complete\n");
+    fprintf(stderr, "[minimax] TTS stream complete\n");
     return true;
 }
 

--- a/tests/minimax_codec_test.cpp
+++ b/tests/minimax_codec_test.cpp
@@ -85,16 +85,29 @@ TEST_CASE("stream parser emits multiple audio payloads from one input") {
     CHECK(chunks[2][0] == 'C');
 }
 
-TEST_CASE("stream parser reset clears partial buffered state") {
+TEST_CASE("stream parser emits only new suffix when audio payload is cumulative") {
     StreamParser parser;
-    const char* part = "{\"data\":{\"audio\":\"41";
-    auto first = parser.feed(part, std::strlen(part));
-    CHECK(first.empty());
+    const char* first = R"({"data":{"audio":"4142"}})";
+    const char* second = R"({"data":{"audio":"41424344"}})";
 
-    parser.reset();
+    auto first_chunks = parser.feed(first, std::strlen(first));
+    REQUIRE(first_chunks.size() == 1);
+    CHECK(std::string(first_chunks[0].begin(), first_chunks[0].end()) == "AB");
 
-    const char* whole = "{\"data\":{\"audio\":\"42\"}}";
-    auto second = parser.feed(whole, std::strlen(whole));
-    REQUIRE(second.size() == 1);
-    CHECK(second[0][0] == 'B');
+    auto second_chunks = parser.feed(second, std::strlen(second));
+    REQUIRE(second_chunks.size() == 1);
+    CHECK(std::string(second_chunks[0].begin(), second_chunks[0].end()) == "CD");
 }
+
+TEST_CASE("stream parser ignores identical repeated audio payloads") {
+    StreamParser parser;
+    const char* json = R"({"data":{"audio":"4142"}})";
+
+    auto first_chunks = parser.feed(json, std::strlen(json));
+    REQUIRE(first_chunks.size() == 1);
+    CHECK(std::string(first_chunks[0].begin(), first_chunks[0].end()) == "AB");
+
+    auto second_chunks = parser.feed(json, std::strlen(json));
+    CHECK(second_chunks.empty());
+}
+

--- a/tests/minimax_codec_test.cpp
+++ b/tests/minimax_codec_test.cpp
@@ -32,7 +32,8 @@ TEST_CASE("stream parser emits decoded audio from a single complete object") {
     const char* json = R"({"data":{"audio":"48656c6c6f"}})";
     auto chunks = parser.feed(json, std::strlen(json));
     REQUIRE(chunks.size() == 1);
-    CHECK(std::string(chunks[0].begin(), chunks[0].end()) == "Hello");
+    CHECK_FALSE(chunks[0].reset_decoder);
+    CHECK(std::string(chunks[0].audio.begin(), chunks[0].audio.end()) == "Hello");
 }
 
 TEST_CASE("stream parser waits for object completion across chunk boundaries") {
@@ -44,7 +45,8 @@ TEST_CASE("stream parser waits for object completion across chunk boundaries") {
 
     auto second = parser.feed(part2, std::strlen(part2));
     REQUIRE(second.size() == 1);
-    CHECK(std::string(second[0].begin(), second[0].end()) == "Hello");
+    CHECK_FALSE(second[0].reset_decoder);
+    CHECK(std::string(second[0].audio.begin(), second[0].audio.end()) == "Hello");
 }
 
 TEST_CASE("stream parser handles escaped quotes inside unrelated strings") {
@@ -52,8 +54,9 @@ TEST_CASE("stream parser handles escaped quotes inside unrelated strings") {
     const char* json = "{\"trace\":\"brace \\\"}\\\" inside\",\"data\":{\"audio\":\"41\"}}";
     auto chunks = parser.feed(json, std::strlen(json));
     REQUIRE(chunks.size() == 1);
-    CHECK(chunks[0].size() == 1);
-    CHECK(chunks[0][0] == 'A');
+    CHECK_FALSE(chunks[0].reset_decoder);
+    CHECK(chunks[0].audio.size() == 1);
+    CHECK(chunks[0].audio[0] == 'A');
 }
 
 TEST_CASE("stream parser skips objects without audio") {
@@ -68,8 +71,9 @@ TEST_CASE("stream parser skips invalid JSON objects and continues") {
     std::string stream = "{bad json}{\"data\":{\"audio\":\"41\"}}";
     auto chunks = parser.feed(stream.c_str(), stream.size());
     REQUIRE(chunks.size() == 1);
-    CHECK(chunks[0].size() == 1);
-    CHECK(chunks[0][0] == 'A');
+    CHECK_FALSE(chunks[0].reset_decoder);
+    CHECK(chunks[0].audio.size() == 1);
+    CHECK(chunks[0].audio[0] == 'A');
 }
 
 TEST_CASE("stream parser emits multiple audio payloads from one input") {
@@ -80,23 +84,28 @@ TEST_CASE("stream parser emits multiple audio payloads from one input") {
         "{\"data\":{\"audio\":\"43\"}}";
     auto chunks = parser.feed(stream.c_str(), stream.size());
     REQUIRE(chunks.size() == 3);
-    CHECK(chunks[0][0] == 'A');
-    CHECK(chunks[1][0] == 'B');
-    CHECK(chunks[2][0] == 'C');
+    CHECK_FALSE(chunks[0].reset_decoder);
+    CHECK(chunks[0].audio[0] == 'A');
+    CHECK(chunks[1].reset_decoder);
+    CHECK(chunks[1].audio[0] == 'B');
+    CHECK(chunks[2].reset_decoder);
+    CHECK(chunks[2].audio[0] == 'C');
 }
 
-TEST_CASE("stream parser emits full updated audio when payload is cumulative") {
+TEST_CASE("stream parser emits only delta when payload is cumulative") {
     StreamParser parser;
     const char* first = R"({"data":{"audio":"4142"}})";
     const char* second = R"({"data":{"audio":"41424344"}})";
 
     auto first_chunks = parser.feed(first, std::strlen(first));
     REQUIRE(first_chunks.size() == 1);
-    CHECK(std::string(first_chunks[0].begin(), first_chunks[0].end()) == "AB");
+    CHECK_FALSE(first_chunks[0].reset_decoder);
+    CHECK(std::string(first_chunks[0].audio.begin(), first_chunks[0].audio.end()) == "AB");
 
     auto second_chunks = parser.feed(second, std::strlen(second));
     REQUIRE(second_chunks.size() == 1);
-    CHECK(std::string(second_chunks[0].begin(), second_chunks[0].end()) == "ABCD");
+    CHECK_FALSE(second_chunks[0].reset_decoder);
+    CHECK(std::string(second_chunks[0].audio.begin(), second_chunks[0].audio.end()) == "CD");
 }
 
 TEST_CASE("stream parser ignores identical repeated audio payloads") {
@@ -105,9 +114,38 @@ TEST_CASE("stream parser ignores identical repeated audio payloads") {
 
     auto first_chunks = parser.feed(json, std::strlen(json));
     REQUIRE(first_chunks.size() == 1);
-    CHECK(std::string(first_chunks[0].begin(), first_chunks[0].end()) == "AB");
+    CHECK_FALSE(first_chunks[0].reset_decoder);
+    CHECK(std::string(first_chunks[0].audio.begin(), first_chunks[0].audio.end()) == "AB");
 
     auto second_chunks = parser.feed(json, std::strlen(json));
     CHECK(second_chunks.empty());
+}
+
+TEST_CASE("stream parser ignores regressive snapshots") {
+    StreamParser parser;
+    const char* first = R"({"data":{"audio":"41424344"}})";
+    const char* second = R"({"data":{"audio":"4142"}})";
+
+    auto first_chunks = parser.feed(first, std::strlen(first));
+    REQUIRE(first_chunks.size() == 1);
+    CHECK(std::string(first_chunks[0].audio.begin(), first_chunks[0].audio.end()) == "ABCD");
+
+    auto second_chunks = parser.feed(second, std::strlen(second));
+    CHECK(second_chunks.empty());
+}
+
+TEST_CASE("stream parser signals reset for unrelated snapshots") {
+    StreamParser parser;
+    const char* first = R"({"data":{"audio":"4142"}})";
+    const char* second = R"({"data":{"audio":"4344"}})";
+
+    auto first_chunks = parser.feed(first, std::strlen(first));
+    REQUIRE(first_chunks.size() == 1);
+    CHECK(std::string(first_chunks[0].audio.begin(), first_chunks[0].audio.end()) == "AB");
+
+    auto second_chunks = parser.feed(second, std::strlen(second));
+    REQUIRE(second_chunks.size() == 1);
+    CHECK(second_chunks[0].reset_decoder);
+    CHECK(std::string(second_chunks[0].audio.begin(), second_chunks[0].audio.end()) == "CD");
 }
 

--- a/tests/minimax_codec_test.cpp
+++ b/tests/minimax_codec_test.cpp
@@ -86,9 +86,9 @@ TEST_CASE("stream parser emits multiple audio payloads from one input") {
     REQUIRE(chunks.size() == 3);
     CHECK_FALSE(chunks[0].reset_decoder);
     CHECK(chunks[0].audio[0] == 'A');
-    CHECK(chunks[1].reset_decoder);
+    CHECK_FALSE(chunks[1].reset_decoder);
     CHECK(chunks[1].audio[0] == 'B');
-    CHECK(chunks[2].reset_decoder);
+    CHECK_FALSE(chunks[2].reset_decoder);
     CHECK(chunks[2].audio[0] == 'C');
 }
 
@@ -134,7 +134,7 @@ TEST_CASE("stream parser ignores regressive snapshots") {
     CHECK(second_chunks.empty());
 }
 
-TEST_CASE("stream parser signals reset for unrelated snapshots") {
+TEST_CASE("stream parser emits unrelated snapshots without reset") {
     StreamParser parser;
     const char* first = R"({"data":{"audio":"4142"}})";
     const char* second = R"({"data":{"audio":"4344"}})";
@@ -145,7 +145,7 @@ TEST_CASE("stream parser signals reset for unrelated snapshots") {
 
     auto second_chunks = parser.feed(second, std::strlen(second));
     REQUIRE(second_chunks.size() == 1);
-    CHECK(second_chunks[0].reset_decoder);
+    CHECK_FALSE(second_chunks[0].reset_decoder);
     CHECK(std::string(second_chunks[0].audio.begin(), second_chunks[0].audio.end()) == "CD");
 }
 

--- a/tests/minimax_codec_test.cpp
+++ b/tests/minimax_codec_test.cpp
@@ -85,7 +85,7 @@ TEST_CASE("stream parser emits multiple audio payloads from one input") {
     CHECK(chunks[2][0] == 'C');
 }
 
-TEST_CASE("stream parser emits only new suffix when audio payload is cumulative") {
+TEST_CASE("stream parser emits full updated audio when payload is cumulative") {
     StreamParser parser;
     const char* first = R"({"data":{"audio":"4142"}})";
     const char* second = R"({"data":{"audio":"41424344"}})";
@@ -96,7 +96,7 @@ TEST_CASE("stream parser emits only new suffix when audio payload is cumulative"
 
     auto second_chunks = parser.feed(second, std::strlen(second));
     REQUIRE(second_chunks.size() == 1);
-    CHECK(std::string(second_chunks[0].begin(), second_chunks[0].end()) == "CD");
+    CHECK(std::string(second_chunks[0].begin(), second_chunks[0].end()) == "ABCD");
 }
 
 TEST_CASE("stream parser ignores identical repeated audio payloads") {


### PR DESCRIPTION
## Summary
- fix MiniMax TTS playback by using non-streaming API (`stream: false`)
- decode complete MP3 response with ffmpeg and play via persistent reader thread
- avoid streaming API issues with cumulative snapshots and MP3 delta extraction

## Test plan
- [x] User verified on target device that TTS playback works without duplication
- [x] `/Users/apple/IdeaProjects/aiden-hardware-demo/build-host/tests/aiden_tests --test-case="*stream parser*"`

## Notes
Initial attempts to preserve streaming with MP3 delta extraction caused audio loss on device. Non-streaming approach successfully delivers audio without duplication or loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)