### PR TITLE
feat(agent): add text input mode with --mode parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,22 @@ Copy `build/bin/` executables into board, setup Wi-Fi for hid server demo.
 ### 使用
 
 ```bash
-# GPIO触发模式（生产环境）
+# GPIO 唤醒模式（默认，生产环境）
 sudo ./build/bin/agent_main
+sudo ./build/bin/agent_main --mode=wakeup
 
-# 手动触发模式（调试用）
-sudo ./build/bin/agent_main --manual
+# 手动触发模式（Enter 开始/停止录音，调试用）
+sudo ./build/bin/agent_main --mode=manual
 # 第一次按 Enter: 开始录音
-# 第二次按 Enter: 立即停止录音并发送已录音频（绕过VAD等待）
+# 第二次按 Enter: 立即停止录音并发送已录音频（绕过 VAD 等待）
+
+# 文字输入模式（从 stdin 读一行作为指令，无需录音）
+sudo ./build/bin/agent_main --mode=text
+# 在 `> ` 提示符后输入文字，按 Enter 提交
+# 空行或 Ctrl+C 退出
 
 # 指定配置文件
-sudo ./build/bin/agent_main --manual /etc/agent.conf
+sudo ./build/bin/agent_main --mode=manual /etc/agent.conf
 ```
 
 ### 配置文件 (`agent.conf`)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ sudo ./build/bin/agent_main --mode=manual
 sudo ./build/bin/agent_main --mode=text
 # 在 `> ` 提示符后输入文字，按 Enter 提交
 # 空行或 Ctrl+C 退出
+# 注意：文字模式需使用非音频模型（如 gpt-4o 或 gpt-4o-mini），
+#      不兼容 gpt-4o-audio-preview
 
 # 指定配置文件
 sudo ./build/bin/agent_main --mode=manual /etc/agent.conf

--- a/src/agent_main.cpp
+++ b/src/agent_main.cpp
@@ -18,6 +18,12 @@
 #include <vector>
 #include <string>
 
+enum TriggerMode {
+    MODE_WAKEUP,
+    MODE_MANUAL,
+    MODE_TEXT
+};
+
 static volatile bool quit = false;
 static volatile bool wakeup_triggered = false;
 
@@ -80,30 +86,13 @@ static std::string execute_tool(const char* hid_binary, const char* tool_name,
     return result.empty() ? "ok" : result;
 }
 
-static void process_utterance(const std::vector<int16_t>& utterance,
-                              aiden::LlmClient& llm,
-                              aiden::TtsClient& tts,
-                              aiden::AudioPlayer& player,
-                              const aiden::AgentConfig& config) {
-    float duration = utterance.size() / 16000.0f;
-    printf("[utterance] %.1fs of speech\n", duration);
-
-    std::vector<uint8_t> wav = aiden::pcm16_mono_16khz_to_wav(utterance);
-    printf("[debug] WAV size: %zu bytes\n", wav.size());
-
+static void run_after_first_turn(aiden::LlmClient& llm,
+                                 aiden::TtsClient& tts,
+                                 aiden::AudioPlayer& player,
+                                 const aiden::AgentConfig& config,
+                                 std::string response,
+                                 std::vector<aiden::ToolCall> tool_calls) {
     while (true) {
-        std::string response;
-        std::vector<aiden::ToolCall> tool_calls;
-
-        printf("[llm] Sending request to provider '%s' (model=%s)...\n",
-               config.model.provider, config.model.model);
-        if (!llm.chat(wav.data(), wav.size(), response, tool_calls)) {
-            fprintf(stderr, "[error] LLM request failed\n");
-            break;
-        }
-
-        printf("[llm] Response received\n");
-
         if (tool_calls.empty()) {
             if (!response.empty()) {
                 printf("[reply] %s\n", response.c_str());
@@ -118,7 +107,7 @@ static void process_utterance(const std::vector<int16_t>& utterance,
             } else {
                 printf("[llm] Empty response from LLM\n");
             }
-            break;
+            return;
         }
 
         printf("[tools] Executing %zu tool call(s)...\n", tool_calls.size());
@@ -132,19 +121,95 @@ static void process_utterance(const std::vector<int16_t>& utterance,
             llm.add_tool_result(tc.id.c_str(), result.c_str());
         }
 
-        wav.clear();
+        response.clear();
+        tool_calls.clear();
+
+        printf("[llm] Sending tool results to provider '%s' (model=%s)...\n",
+               config.model.provider, config.model.model);
+        if (!llm.chat(NULL, 0, response, tool_calls)) {
+            fprintf(stderr, "[error] LLM request failed\n");
+            return;
+        }
+        printf("[llm] Response received\n");
     }
+}
+
+static void process_utterance(const std::vector<int16_t>& utterance,
+                              aiden::LlmClient& llm,
+                              aiden::TtsClient& tts,
+                              aiden::AudioPlayer& player,
+                              const aiden::AgentConfig& config) {
+    float duration = utterance.size() / 16000.0f;
+    printf("[utterance] %.1fs of speech\n", duration);
+
+    std::vector<uint8_t> wav = aiden::pcm16_mono_16khz_to_wav(utterance);
+    printf("[debug] WAV size: %zu bytes\n", wav.size());
+
+    std::string response;
+    std::vector<aiden::ToolCall> tool_calls;
+
+    printf("[llm] Sending request to provider '%s' (model=%s)...\n",
+           config.model.provider, config.model.model);
+    if (!llm.chat(wav.data(), wav.size(), response, tool_calls)) {
+        fprintf(stderr, "[error] LLM request failed\n");
+        return;
+    }
+    printf("[llm] Response received\n");
+
+    run_after_first_turn(llm, tts, player, config, response, tool_calls);
+}
+
+static void process_text_input(const std::string& text,
+                               aiden::LlmClient& llm,
+                               aiden::TtsClient& tts,
+                               aiden::AudioPlayer& player,
+                               const aiden::AgentConfig& config) {
+    printf("[text] %s\n", text.c_str());
+
+    std::string response;
+    std::vector<aiden::ToolCall> tool_calls;
+
+    printf("[llm] Sending request to provider '%s' (model=%s)...\n",
+           config.model.provider, config.model.model);
+    if (!llm.chat_text(text.c_str(), response, tool_calls)) {
+        fprintf(stderr, "[error] LLM request failed\n");
+        return;
+    }
+    printf("[llm] Response received\n");
+
+    run_after_first_turn(llm, tts, player, config, response, tool_calls);
+}
+
+static bool parse_mode_value(const char* v, TriggerMode& mode) {
+    if (strcmp(v, "wakeup") == 0) { mode = MODE_WAKEUP; return true; }
+    if (strcmp(v, "manual") == 0) { mode = MODE_MANUAL; return true; }
+    if (strcmp(v, "text") == 0)   { mode = MODE_TEXT;   return true; }
+    return false;
 }
 
 int main(int argc, char* argv[]) {
     signal(SIGINT, signal_handler);
 
-    bool manual_mode = false;
+    TriggerMode mode = MODE_WAKEUP;
     const char* config_path = "agent.conf";
 
     for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "--manual") == 0) {
-            manual_mode = true;
+        if (strncmp(argv[i], "--mode=", 7) == 0) {
+            const char* v = argv[i] + 7;
+            if (!parse_mode_value(v, mode)) {
+                fprintf(stderr, "[error] Unknown mode: %s (expected wakeup|manual|text)\n", v);
+                return 1;
+            }
+        } else if (strcmp(argv[i], "--mode") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "[error] --mode requires a value (wakeup|manual|text)\n");
+                return 1;
+            }
+            const char* v = argv[++i];
+            if (!parse_mode_value(v, mode)) {
+                fprintf(stderr, "[error] Unknown mode: %s (expected wakeup|manual|text)\n", v);
+                return 1;
+            }
         } else {
             config_path = argv[i];
         }
@@ -155,8 +220,10 @@ int main(int argc, char* argv[]) {
     if (!aiden::load_config(config_path, config, &config_error)) {
         fprintf(stderr, "[error] Failed to load config from %s: %s\n",
                 config_path, config_error.c_str());
-        fprintf(stderr, "Usage: %s [--manual] [config_file]\n", argv[0]);
-        fprintf(stderr, "  --manual: Use manual trigger (press Enter) instead of GPIO wakeup\n");
+        fprintf(stderr, "Usage: %s [--mode=wakeup|manual|text] [config_file]\n", argv[0]);
+        fprintf(stderr, "  --mode=wakeup: Use GPIO 33 wakeup trigger (default)\n");
+        fprintf(stderr, "  --mode=manual: Press Enter to start/stop audio recording\n");
+        fprintf(stderr, "  --mode=text:   Type commands directly via stdin\n");
         return 1;
     }
 
@@ -176,26 +243,30 @@ int main(int argc, char* argv[]) {
     }
 
     aiden::WakeupListener wakeup;
-    if (!manual_mode) {
+    if (mode == MODE_WAKEUP) {
         printf("[init] Starting wakeup listener on GPIO 33...\n");
         if (!wakeup.start(33, on_wakeup)) {
             fprintf(stderr, "[error] Failed to start wakeup listener\n");
             return 1;
         }
-    } else {
+    } else if (mode == MODE_MANUAL) {
         printf("[init] Manual trigger mode enabled\n");
+    } else {
+        printf("[init] Text input mode enabled\n");
     }
 
-    printf("[init] Initializing audio (16kHz/16bit/mono)...\n");
     aiden::AudioConfig audio_cfg;
     audio_cfg.sample_rate = 16000;
     audio_cfg.channels = 1;
     audio_cfg.bit_width = 16;
 
     aiden::AudioCapture capture;
-    if (!capture.init(audio_cfg)) {
-        fprintf(stderr, "[error] Failed to initialize audio capture\n");
-        return 1;
+    if (mode != MODE_TEXT) {
+        printf("[init] Initializing audio (16kHz/16bit/mono)...\n");
+        if (!capture.init(audio_cfg)) {
+            fprintf(stderr, "[error] Failed to initialize audio capture\n");
+            return 1;
+        }
     }
 
     aiden::AudioPlayer player;
@@ -219,16 +290,37 @@ int main(int argc, char* argv[]) {
     }
 
     aiden::AudioVAD vad(16000, config.energy_threshold, config.silence_ms,
-                        config.min_speech_ms, manual_mode);
+                        config.min_speech_ms, mode == MODE_MANUAL);
 
-    if (manual_mode)
+    if (mode == MODE_TEXT) {
+        printf("\n[ready] Type a command and press Enter (empty line or Ctrl+C to quit)\n");
+        while (!quit) {
+            printf("\n> ");
+            fflush(stdout);
+
+            char buf[4096];
+            if (!fgets(buf, sizeof(buf), stdin)) break;
+
+            size_t len = strlen(buf);
+            while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r')) {
+                buf[--len] = '\0';
+            }
+            if (len == 0) {
+                printf("[text] Empty input, exiting.\n");
+                break;
+            }
+
+            process_text_input(buf, *llm, *tts, player, config);
+        }
+    } else if (mode == MODE_MANUAL) {
         printf("\n[ready] Press Enter to start recording, press Enter again to stop\n");
-    else
+    } else {
         printf("\n[ready] Waiting for wakeup event (GPIO 33)... Ctrl+C to quit\n\n");
+    }
 
-    while (!quit) {
+    while (!quit && mode != MODE_TEXT) {
         if (!wakeup_triggered) {
-            if (manual_mode) {
+            if (mode == MODE_MANUAL) {
                 printf("\n[manual] Press Enter to start...\n");
                 int ch = getchar();
                 if (ch == EOF) break;
@@ -247,7 +339,7 @@ int main(int argc, char* argv[]) {
         bool manual_stop = false;
         while (wakeup_triggered && !quit) {
             // Check for manual stop in manual mode
-            if (manual_mode && stdin_has_data()) {
+            if (mode == MODE_MANUAL && stdin_has_data()) {
                 getchar();
                 drain_stdin();
                 printf("[manual] Stop triggered by user\n");
@@ -288,7 +380,7 @@ int main(int argc, char* argv[]) {
     }
 
     wakeup.stop();
-    capture.stop();
+    if (mode != MODE_TEXT) capture.stop();
     printf("\n[exit] Stopped.\n");
     return 0;
 }

--- a/src/agent_main.cpp
+++ b/src/agent_main.cpp
@@ -15,6 +15,7 @@
 #include <sys/select.h>
 #include <sys/wait.h>
 #include <termios.h>
+#include <iostream>
 #include <vector>
 #include <string>
 
@@ -298,19 +299,15 @@ int main(int argc, char* argv[]) {
             printf("\n> ");
             fflush(stdout);
 
-            char buf[4096];
-            if (!fgets(buf, sizeof(buf), stdin)) break;
+            std::string line;
+            if (!std::getline(std::cin, line)) break;
 
-            size_t len = strlen(buf);
-            while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r')) {
-                buf[--len] = '\0';
-            }
-            if (len == 0) {
+            if (line.empty()) {
                 printf("[text] Empty input, exiting.\n");
                 break;
             }
 
-            process_text_input(buf, *llm, *tts, player, config);
+            process_text_input(line, *llm, *tts, player, config);
         }
     } else if (mode == MODE_MANUAL) {
         printf("\n[ready] Press Enter to start recording, press Enter again to stop\n");

--- a/src/openai_client.cpp
+++ b/src/openai_client.cpp
@@ -57,6 +57,39 @@ bool OpenAIClient::chat(const uint8_t* wav_data, size_t wav_len,
     return true;
 }
 
+bool OpenAIClient::chat_text(const char* text,
+                             std::string& response, std::vector<ToolCall>& tool_calls) {
+    std::string conversation_with_user = openai::append_user_text(conversation_, text);
+    std::string request_body = openai::build_chat_request(conversation_with_user, llm_model_);
+    std::string url = build_chat_completions_url(base_url_.c_str(), "https://api.openai.com/v1");
+
+    HttpClient http;
+    std::string http_response;
+    bool success = http.post_json(
+        url.c_str(),
+        api_key_.c_str(),
+        request_body.c_str(),
+        http_response);
+    if (!success) {
+        fprintf(stderr, "[error] HTTP request failed\n");
+        fprintf(stderr, "[error] Response: %s\n", http_response.c_str());
+        return false;
+    }
+
+    openai::ChatResult result = openai::parse_chat_response(http_response);
+    if (!result.ok) {
+        fprintf(stderr, "[error] Failed to parse OpenAI response: %s\n", result.error.c_str());
+        fprintf(stderr, "[error] Raw response: %s\n", http_response.c_str());
+        return false;
+    }
+
+    response = result.content;
+    tool_calls = result.tool_calls;
+    conversation_ = openai::append_assistant_message(conversation_with_user,
+                                                     result.assistant_message_json);
+    return true;
+}
+
 void OpenAIClient::add_tool_result(const char* tool_call_id, const char* result) {
     conversation_ = openai::append_tool_result(conversation_, tool_call_id, result);
 }

--- a/src/openai_client.h
+++ b/src/openai_client.h
@@ -15,6 +15,9 @@ public:
     bool chat(const uint8_t* wav_data, size_t wav_len,
               std::string& response, std::vector<ToolCall>& tool_calls) override;
 
+    bool chat_text(const char* text,
+                   std::string& response, std::vector<ToolCall>& tool_calls) override;
+
     void add_tool_result(const char* tool_call_id, const char* result) override;
 
 private:

--- a/src/openai_codec.cpp
+++ b/src/openai_codec.cpp
@@ -244,6 +244,22 @@ std::string append_user_audio_wav_if_present(const std::string& conversation_jso
     return append_user_audio_wav(conversation_json, base64_encode(wav_data, wav_len));
 }
 
+std::string append_user_text(const std::string& conversation_json,
+                             const char* text) {
+    const char* safe = text ? text : "";
+    cJSON* messages = parse_conversation_or_empty(conversation_json);
+    cJSON* user_msg = cJSON_CreateObject();
+    cJSON_AddStringToObject(user_msg, "role", "user");
+    cJSON_AddStringToObject(user_msg, "content", safe);
+    cJSON_AddItemToArray(messages, user_msg);
+
+    char* json = cJSON_PrintUnformatted(messages);
+    std::string result = json ? json : "[]";
+    free(json);
+    cJSON_Delete(messages);
+    return result;
+}
+
 std::string append_assistant_message(const std::string& conversation_json,
                                      const std::string& assistant_message_json) {
     cJSON* messages = parse_conversation_or_empty(conversation_json);

--- a/src/openai_codec.h
+++ b/src/openai_codec.h
@@ -27,6 +27,8 @@ std::string append_user_audio_wav(const std::string& conversation_json,
 std::string append_user_audio_wav_if_present(const std::string& conversation_json,
                                              const uint8_t* wav_data,
                                              size_t wav_len);
+std::string append_user_text(const std::string& conversation_json,
+                             const char* text);
 std::string append_assistant_message(const std::string& conversation_json,
                                      const std::string& assistant_message_json);
 std::string append_tool_result(const std::string& conversation_json,

--- a/src/openrouter_client.cpp
+++ b/src/openrouter_client.cpp
@@ -57,6 +57,39 @@ bool OpenRouterClient::chat(const uint8_t* wav_data, size_t wav_len,
     return true;
 }
 
+bool OpenRouterClient::chat_text(const char* text,
+                                 std::string& response, std::vector<ToolCall>& tool_calls) {
+    std::string conversation_with_user = openrouter::append_user_text(conversation_, text);
+    std::string request_body = openrouter::build_chat_request(conversation_with_user, llm_model_);
+    std::string url = build_chat_completions_url(base_url_.c_str(), "https://openrouter.ai/api/v1");
+
+    HttpClient http;
+    std::string http_response;
+    bool success = http.post_json(
+        url.c_str(),
+        api_key_.c_str(),
+        request_body.c_str(),
+        http_response);
+    if (!success) {
+        fprintf(stderr, "[error] HTTP request failed\n");
+        fprintf(stderr, "[error] Response: %s\n", http_response.c_str());
+        return false;
+    }
+
+    openrouter::ChatResult result = openrouter::parse_chat_response(http_response);
+    if (!result.ok) {
+        fprintf(stderr, "[error] Failed to parse OpenRouter response: %s\n", result.error.c_str());
+        fprintf(stderr, "[error] Raw response: %s\n", http_response.c_str());
+        return false;
+    }
+
+    response = result.content;
+    tool_calls = result.tool_calls;
+    conversation_ = openrouter::append_assistant_message(conversation_with_user,
+                                                         result.assistant_message_json);
+    return true;
+}
+
 void OpenRouterClient::add_tool_result(const char* tool_call_id, const char* result) {
     conversation_ = openrouter::append_tool_result(conversation_, tool_call_id, result);
 }

--- a/src/openrouter_client.h
+++ b/src/openrouter_client.h
@@ -15,6 +15,9 @@ public:
     bool chat(const uint8_t* wav_data, size_t wav_len,
               std::string& response, std::vector<ToolCall>& tool_calls) override;
 
+    bool chat_text(const char* text,
+                   std::string& response, std::vector<ToolCall>& tool_calls) override;
+
     void add_tool_result(const char* tool_call_id, const char* result) override;
 
 private:

--- a/src/openrouter_codec.cpp
+++ b/src/openrouter_codec.cpp
@@ -244,6 +244,22 @@ std::string append_user_audio_wav_if_present(const std::string& conversation_jso
     return append_user_audio_wav(conversation_json, base64_encode(wav_data, wav_len));
 }
 
+std::string append_user_text(const std::string& conversation_json,
+                             const char* text) {
+    const char* safe = text ? text : "";
+    cJSON* messages = parse_conversation_or_empty(conversation_json);
+    cJSON* user_msg = cJSON_CreateObject();
+    cJSON_AddStringToObject(user_msg, "role", "user");
+    cJSON_AddStringToObject(user_msg, "content", safe);
+    cJSON_AddItemToArray(messages, user_msg);
+
+    char* json = cJSON_PrintUnformatted(messages);
+    std::string result = json ? json : "[]";
+    free(json);
+    cJSON_Delete(messages);
+    return result;
+}
+
 std::string append_assistant_message(const std::string& conversation_json,
                                      const std::string& assistant_message_json) {
     cJSON* messages = parse_conversation_or_empty(conversation_json);

--- a/src/openrouter_codec.h
+++ b/src/openrouter_codec.h
@@ -27,6 +27,8 @@ std::string append_user_audio_wav(const std::string& conversation_json,
 std::string append_user_audio_wav_if_present(const std::string& conversation_json,
                                              const uint8_t* wav_data,
                                              size_t wav_len);
+std::string append_user_text(const std::string& conversation_json,
+                             const char* text);
 std::string append_assistant_message(const std::string& conversation_json,
                                      const std::string& assistant_message_json);
 std::string append_tool_result(const std::string& conversation_json,

--- a/src/provider_interfaces.h
+++ b/src/provider_interfaces.h
@@ -18,6 +18,9 @@ public:
     virtual bool chat(const uint8_t* wav_data, size_t wav_len,
                       std::string& response,
                       std::vector<ToolCall>& tool_calls) = 0;
+    virtual bool chat_text(const char* text,
+                           std::string& response,
+                           std::vector<ToolCall>& tool_calls) = 0;
     virtual void add_tool_result(const char* tool_call_id, const char* result) = 0;
 };
 

--- a/tests/openai_codec_test.cpp
+++ b/tests/openai_codec_test.cpp
@@ -8,6 +8,7 @@ using aiden::openai::parse_chat_response;
 using aiden::openai::init_conversation;
 using aiden::openai::append_user_audio_wav;
 using aiden::openai::append_user_audio_wav_if_present;
+using aiden::openai::append_user_text;
 using aiden::openai::append_assistant_message;
 using aiden::openai::append_tool_result;
 using aiden::openai::ChatResult;
@@ -82,6 +83,39 @@ TEST_CASE("openai append_user_audio_wav_if_present skips empty follow-up audio")
     std::string conv = init_conversation("sys");
     std::string unchanged = append_user_audio_wav_if_present(conv, NULL, 0);
     CHECK(unchanged == conv);
+}
+
+TEST_CASE("openai append_user_text appends a user message with string content") {
+    std::string conv = init_conversation("sys");
+    std::string appended = append_user_text(conv, "hello world");
+
+    cJSON* arr = cJSON_Parse(appended.c_str());
+    REQUIRE(arr->type == cJSON_Array);
+    REQUIRE(cJSON_GetArraySize(arr) == 2);
+
+    cJSON* user = cJSON_GetArrayItem(arr, 1);
+    CHECK(std::string(cJSON_GetObjectItem(user, "role")->valuestring) == "user");
+    cJSON* content = cJSON_GetObjectItem(user, "content");
+    REQUIRE(content->type == cJSON_String);
+    CHECK(std::string(content->valuestring) == "hello world");
+    cJSON_Delete(arr);
+}
+
+TEST_CASE("openai append_user_text escapes quotes and survives NULL") {
+    std::string conv = init_conversation("sys");
+    std::string quoted = append_user_text(conv, "say \"hi\" now");
+    cJSON* arr = cJSON_Parse(quoted.c_str());
+    REQUIRE(arr != nullptr);
+    cJSON* user = cJSON_GetArrayItem(arr, 1);
+    CHECK(std::string(cJSON_GetObjectItem(user, "content")->valuestring) == "say \"hi\" now");
+    cJSON_Delete(arr);
+
+    std::string null_input = append_user_text(conv, NULL);
+    cJSON* arr2 = cJSON_Parse(null_input.c_str());
+    REQUIRE(arr2 != nullptr);
+    cJSON* user2 = cJSON_GetArrayItem(arr2, 1);
+    CHECK(std::string(cJSON_GetObjectItem(user2, "content")->valuestring) == "");
+    cJSON_Delete(arr2);
 }
 
 TEST_CASE("openai append_tool_result adds a role=tool message") {

--- a/tests/openrouter_codec_test.cpp
+++ b/tests/openrouter_codec_test.cpp
@@ -10,6 +10,7 @@ using aiden::openrouter::parse_chat_response;
 using aiden::openrouter::init_conversation;
 using aiden::openrouter::append_user_audio_wav;
 using aiden::openrouter::append_user_audio_wav_if_present;
+using aiden::openrouter::append_user_text;
 using aiden::openrouter::append_assistant_message;
 using aiden::openrouter::append_tool_result;
 using aiden::openrouter::build_chat_request;
@@ -149,6 +150,39 @@ TEST_CASE("append_user_audio_wav_if_present skips empty follow-up audio") {
     std::string conv = init_conversation("sys");
     std::string unchanged = append_user_audio_wav_if_present(conv, NULL, 0);
     CHECK(unchanged == conv);
+}
+
+TEST_CASE("openrouter append_user_text appends a user message with string content") {
+    std::string conv = init_conversation("sys");
+    std::string appended = append_user_text(conv, "hello world");
+
+    cJSON* arr = cJSON_Parse(appended.c_str());
+    REQUIRE(arr->type == cJSON_Array);
+    REQUIRE(cJSON_GetArraySize(arr) == 2);
+
+    cJSON* user = cJSON_GetArrayItem(arr, 1);
+    CHECK(std::string(cJSON_GetObjectItem(user, "role")->valuestring) == "user");
+    cJSON* content = cJSON_GetObjectItem(user, "content");
+    REQUIRE(content->type == cJSON_String);
+    CHECK(std::string(content->valuestring) == "hello world");
+    cJSON_Delete(arr);
+}
+
+TEST_CASE("openrouter append_user_text escapes quotes and survives NULL") {
+    std::string conv = init_conversation("sys");
+    std::string quoted = append_user_text(conv, "say \"hi\" now");
+    cJSON* arr = cJSON_Parse(quoted.c_str());
+    REQUIRE(arr != nullptr);
+    cJSON* user = cJSON_GetArrayItem(arr, 1);
+    CHECK(std::string(cJSON_GetObjectItem(user, "content")->valuestring) == "say \"hi\" now");
+    cJSON_Delete(arr);
+
+    std::string null_input = append_user_text(conv, NULL);
+    cJSON* arr2 = cJSON_Parse(null_input.c_str());
+    REQUIRE(arr2 != nullptr);
+    cJSON* user2 = cJSON_GetArrayItem(arr2, 1);
+    CHECK(std::string(cJSON_GetObjectItem(user2, "content")->valuestring) == "");
+    cJSON_Delete(arr2);
 }
 
 TEST_CASE("append_tool_result adds a role=tool message") {

--- a/tests/openrouter_codec_test.cpp
+++ b/tests/openrouter_codec_test.cpp
@@ -157,6 +157,7 @@ TEST_CASE("openrouter append_user_text appends a user message with string conten
     std::string appended = append_user_text(conv, "hello world");
 
     cJSON* arr = cJSON_Parse(appended.c_str());
+    REQUIRE(arr != nullptr);
     REQUIRE(arr->type == cJSON_Array);
     REQUIRE(cJSON_GetArraySize(arr) == 2);
 


### PR DESCRIPTION
## Summary

- 新增第三种输入模式：text 模式，通过 stdin 输入文字指令（无需录音）
- 用统一的 `--mode=wakeup|manual|text` 参数替换原有的 `--manual` flag
- 提取 `run_after_first_turn()` 消除 `process_utterance` 和 `process_text_input` 的重复代码
- 新增 `LlmClient::chat_text()` 接口和 `append_user_text()` codec 函数
- text 模式下跳过 `AudioCapture` 初始化
- 新增 4 个 codec 测试用例（总计 99 个测试全部通过）

## 注意事项

text 模式需要使用非音频模型（如 `gpt-4o` 或 `gpt-4o-mini`），不能使用 `gpt-4o-audio-preview`（该模型强制要求至少一端是音频输入/输出）。

建议配置：
- wakeup/manual 模式：使用 `gpt-4o-audio-preview`
- text 模式：使用 `gpt-4o` 或 `gpt-4o-mini`

## Test plan

- [x] Host-native 测试全部通过（99 cases / 503 assertions）
- [x] 参数解析边界测试（`--mode` 缺参数、未知模式值）
- [x] NULL 防御测试（`append_user_text(NULL)` 返回空字符串）
- [ ] 在实际硬件上测试三种模式的切换
- [ ] 验证 text 模式下 tool calling 循环正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text input mode (`--mode=text`) to accept direct text input from standard input.
  * Introduced explicit command-line modes: `--mode=wakeup` (GPIO), `--mode=manual` (Enter-triggered), and `--mode=text` (stdin).
  * Support for alternate config path specification via command-line arguments.

* **Documentation**
  * Updated README with new mode specifications and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->