### PR TITLE
fix(tts): prevent duplicate audio playback in MiniMax streaming

### DIFF
--- a/src/minimax_tts.cpp
+++ b/src/minimax_tts.cpp
@@ -86,6 +86,10 @@ bool MinimaxTTS::text_to_speech_stream(const char* text, aiden::AudioPlayer& pla
     cJSON_AddNumberToObject(audio_setting, "channel", 1);
     cJSON_AddItemToObject(request, "audio_setting", audio_setting);
 
+    cJSON* stream_options = cJSON_CreateObject();
+    cJSON_AddBoolToObject(stream_options, "exclude_aggregated_audio", true);
+    cJSON_AddItemToObject(request, "stream_options", stream_options);
+
     cJSON_AddBoolToObject(request, "subtitle_enable", false);
 
     char* request_str = cJSON_PrintUnformatted(request);


### PR DESCRIPTION
## Summary
- Add `exclude_aggregated_audio: true` parameter to `stream_options` in MiniMax TTS API request
- Prevents the final chunk from containing aggregated audio data, which was causing duplicate playback during streaming
- Based on MiniMax API documentation: when `exclude_aggregated_audio` is false (default), the last chunk includes complete audio, leading to duplicate playback if all chunks are played sequentially

## Test plan
- [x] Build the project successfully
- [x] Test MiniMax TTS streaming with the new parameter
- [x] Verify no duplicate audio playback occurs
- [x] Confirm audio quality and completeness remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)