### PR TITLE
fix(tts): play MiniMax stream to completion instead of cutting off tail

### DIFF
--- a/src/minimax_tts.cpp
+++ b/src/minimax_tts.cpp
@@ -19,7 +19,6 @@ struct StreamContext {
     pid_t ffmpeg_pid;
     aiden::AudioPlayer* player;
     pthread_t reader_thread;
-    bool reader_running;
     minimax::StreamParser parser;
 };
 
@@ -27,11 +26,15 @@ static void* pcm_reader_thread(void* arg) {
     StreamContext* ctx = (StreamContext*)arg;
 
     uint8_t pcm_buf[4096];
-    while (ctx->reader_running) {
+    for (;;) {
         ssize_t n = read(ctx->ffmpeg_stdout, pcm_buf, sizeof(pcm_buf));
-        if (n <= 0) break;
-
-        ctx->player->play(pcm_buf, n);
+        if (n > 0) {
+            ctx->player->play(pcm_buf, (uint32_t)n);
+            continue;
+        }
+        if (n < 0 && errno == EINTR)
+            continue;
+        break;
     }
 
     return NULL;
@@ -136,7 +139,6 @@ bool MinimaxTTS::text_to_speech_stream(const char* text, aiden::AudioPlayer& pla
     ctx.ffmpeg_stdout = stdout_pipe[0];
     ctx.ffmpeg_pid = pid;
     ctx.player = &player;
-    ctx.reader_running = true;
 
     pthread_create(&ctx.reader_thread, NULL, pcm_reader_thread, &ctx);
 
@@ -151,7 +153,6 @@ bool MinimaxTTS::text_to_speech_stream(const char* text, aiden::AudioPlayer& pla
 
     close(ctx.ffmpeg_stdin);
 
-    ctx.reader_running = false;
     pthread_join(ctx.reader_thread, NULL);
 
     close(ctx.ffmpeg_stdout);


### PR DESCRIPTION
## Summary
- Fix MiniMax streaming TTS playing only the first few seconds then cutting off.
- Reader thread previously exited when the HTTP stream ended, but ffmpeg still had seconds of PCM queued (HTTP/decode run faster than realtime playback). Closing `ffmpeg_stdout` then broke ffmpeg's write with SIGPIPE and truncated the output.
- Drop the `reader_running` flag; let the reader loop until ffmpeg closes its stdout (EOF). Closing `ffmpeg_stdin` lets ffmpeg drain the remaining MP3 and exit cleanly.

## Root cause
From the reported log:
- `[http] Stream complete, 304970 bytes received` (full MP3 received)
- `size=     112kB time=00:00:03.58` (ffmpeg only wrote ~3.58s of PCM)
- `av_interleaved_write_frame(): Broken pipe` (ffmpeg killed mid-write)

The main thread was setting `reader_running = false` immediately after `post_stream` returned, so the reader exited on its next loop check while ffmpeg was still producing PCM. The subsequent `close(ffmpeg_stdout)` in the main thread caused SIGPIPE in ffmpeg.

## Test plan
- [x] Host-native unit tests pass: `cmake -S . -B build-test -DAIDEN_TESTS=ON && cmake --build build-test && ./build-test/tests/aiden_tests` — 99 test cases, 504 assertions, all passing.
- [x] Full Docker cross-compile build succeeds (`./build.sh`).
- [x] On-device: replay the same prompt (`你好呀，说个笑话`) and confirm the full sentence plays without truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal audio streaming architecture for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->