### PR TITLE
chore: document Docker cross-platform build

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,30 @@ cmake --build build
 For the Luckfox cross-compilation environment, use:
 
 ```bash
-sh ./build.sh
+./build.sh
 ```
+
+On macOS Apple Silicon with Colima and Docker CLI, run the Luckfox Docker image as `linux/amd64`:
+
+```bash
+# Install Docker CLI, buildx, and Colima if needed.
+brew install docker docker-buildx colima
+
+# Start an x86_64 Colima VM so linux/amd64 containers run reliably.
+colima start --arch x86_64
+
+# Install amd64 binfmt support inside the Docker VM.
+docker run --privileged --rm tonistiigi/binfmt --install amd64
+
+# Verify that buildx is available and Docker can see the builder.
+docker buildx version
+docker buildx ls
+
+# Cross-compile inside the pinned Luckfox amd64 image.
+./build.sh
+```
+
+`build.sh` runs `luckfoxtech/luckfox_pico:1.0` with `--platform linux/amd64` and maps your host UID/GID so generated build files remain owned by your user.
 
 All build artifacts are placed in `build/`:
 - `build/lib/` - Static libraries

--- a/README.md
+++ b/README.md
@@ -46,17 +46,14 @@ For the Luckfox cross-compilation environment, use:
 ./build.sh
 ```
 
-On macOS Apple Silicon with Colima and Docker CLI, run the Luckfox Docker image as `linux/amd64`:
+On macOS Apple Silicon with Colima and Docker CLI, keep the Colima VM on the native `aarch64` architecture and enable Rosetta for `linux/amd64` containers:
 
 ```bash
 # Install Docker CLI, buildx, and Colima if needed.
 brew install docker docker-buildx colima
 
-# Start an x86_64 Colima VM so linux/amd64 containers run reliably.
-colima start --arch x86_64
-
-# Install amd64 binfmt support inside the Docker VM.
-docker run --privileged --rm tonistiigi/binfmt --install amd64
+# Start a native Apple Silicon VM with Rosetta-based amd64 emulation.
+colima start --vm-type vz --vz-rosetta
 
 # Verify that buildx is available and Docker can see the builder.
 docker buildx version
@@ -66,7 +63,7 @@ docker buildx ls
 ./build.sh
 ```
 
-`build.sh` runs `luckfoxtech/luckfox_pico:1.0` with `--platform linux/amd64` and maps your host UID/GID so generated build files remain owned by your user.
+`build.sh` runs `luckfoxtech/luckfox_pico:1.0` with `--platform linux/amd64` and maps your host UID/GID so generated build files remain owned by your user. Avoid starting Colima with `--arch x86_64` for this workflow; use the native `aarch64` VM plus `--platform linux/amd64` for the container instead.
 
 All build artifacts are placed in `build/`:
 - `build/lib/` - Static libraries

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,11 @@
-docker run -u $(id -u):$(id -g) --rm -v $(pwd):/home -w /home luckfoxtech/luckfox_pico:1.0 /bin/bash -c "./_build.sh"
+#!/usr/bin/env bash
+set -e
 
+docker run \
+  --platform linux/amd64 \
+  -u "$(id -u):$(id -g)" \
+  --rm \
+  -v "$(pwd):/home" \
+  -w /home \
+  luckfoxtech/luckfox_pico:1.0 \
+  /bin/bash -c "./_build.sh"


### PR DESCRIPTION
## Summary
- Update build.sh to run the Luckfox Docker image with an explicit linux/amd64 platform
- Preserve UID/GID mapping and quote the project bind mount safely
- Document Apple Silicon Colima/Docker CLI setup for cross-platform builds

## Test Plan
- bash -n build.sh
- git diff --check -- README.md build.sh
- docker buildx version
- docker run --platform linux/amd64 --rm luckfoxtech/luckfox_pico:1.0 uname -m
- ./build.sh
- file build/bin/agent_main build/bin/hello build/lib/libaiden.a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified and clarified build instructions for better usability
  * Added detailed setup guide for macOS Apple Silicon environments

* **Improvements**
  * Enhanced build script to explicitly specify target platform architecture, ensuring consistent behavior across different system configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->