### PR TITLE
fix(text-mode): ignore empty lines and enable IUTF8 for CJK backspace

### DIFF
--- a/src/agent_main.cpp
+++ b/src/agent_main.cpp
@@ -294,7 +294,15 @@ int main(int argc, char* argv[]) {
                         config.min_speech_ms, mode == MODE_MANUAL);
 
     if (mode == MODE_TEXT) {
-        printf("\n[ready] Type a command and press Enter (empty line or Ctrl+C to quit)\n");
+        // Enable IUTF8 so the TTY driver erases multi-byte UTF-8 chars (e.g. CJK)
+        // as a single unit on backspace, instead of byte-by-byte.
+        struct termios tio;
+        if (tcgetattr(STDIN_FILENO, &tio) == 0) {
+            tio.c_iflag |= IUTF8;
+            tcsetattr(STDIN_FILENO, TCSANOW, &tio);
+        }
+
+        printf("\n[ready] Type a command and press Enter (Ctrl+D or Ctrl+C to quit)\n");
         while (!quit) {
             printf("\n> ");
             fflush(stdout);
@@ -302,10 +310,7 @@ int main(int argc, char* argv[]) {
             std::string line;
             if (!std::getline(std::cin, line)) break;
 
-            if (line.empty()) {
-                printf("[text] Empty input, exiting.\n");
-                break;
-            }
+            if (line.empty()) continue;
 
             process_text_input(line, *llm, *tts, player, config);
         }


### PR DESCRIPTION
## Problem

In `--mode=text`, two issues made the REPL feel broken:

1. **Empty line exits the program.** Pressing Enter on a blank prompt prints `[text] Empty input, exiting.` and terminates `agent_main`. Easy to trigger by accident (e.g. while editing input on the serial console).
2. **First Chinese character cannot be deleted.** When the user types CJK text and tries to backspace through it, the last (leftmost) character appears undeletable. Root cause: the device TTY runs in canonical mode without the `IUTF8` termios flag, so the kernel erases UTF-8 sequences byte-by-byte. The displayed column counter desyncs from the line buffer and the kernel stops emitting `\b \b` once it thinks it would overwrite the prompt — leaving orphan bytes on screen.

## Fix

- Empty line → `continue` instead of `break`. Quitting now requires EOF (Ctrl-D) or a signal (Ctrl-C). Banner updated to reflect this.
- Set `IUTF8` on stdin via `tcsetattr` when entering text mode, so backspace erases full UTF-8 characters.

## Test

Verified on Pico Zero (RV1106) over serial:

```
RESULT: saw ready banner OK
RESULT: saw 1st prompt OK
RESULT: empty line ignored, 2nd prompt shown PASS
RESULT: 2nd empty line also ignored PASS
```

Ctrl-C still terminates cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 backspace handling in text input mode
  * Updated interactive prompt to display keyboard shortcuts (Ctrl+D/Ctrl+C) for quitting
  * Empty input lines are now skipped instead of terminating the session

<!-- end of auto-generated comment: release notes by coderabbit.ai -->