### PR TITLE
feat(agent): add build version command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,19 @@ target_link_libraries(audio_stream PRIVATE aiden)
 add_library(cjson STATIC src/cJSON/cJSON.c)
 target_include_directories(cjson PUBLIC ${CMAKE_SOURCE_DIR}/src)
 
+set(AIDEN_AGENT_VERSION_HEADER "${CMAKE_BINARY_DIR}/generated/agent_version_build.h")
+add_custom_target(agent_version_header
+    COMMAND ${CMAKE_COMMAND}
+            "-DOUTPUT_FILE=${AIDEN_AGENT_VERSION_HEADER}"
+            "-DSOURCE_DIR=${CMAKE_SOURCE_DIR}"
+            -P "${CMAKE_SOURCE_DIR}/cmake/generate_agent_version.cmake"
+    BYPRODUCTS ${AIDEN_AGENT_VERSION_HEADER}
+    VERBATIM
+)
+
 add_executable(agent_main
     src/agent_main.cpp
+    src/agent_version.cpp
     src/config.cpp
     src/http_client.cpp
     src/openrouter_client.cpp
@@ -130,4 +141,6 @@ add_executable(agent_main
     src/provider_factory_runtime.cpp
     src/vad.cpp
 )
+target_include_directories(agent_main PRIVATE ${CMAKE_BINARY_DIR}/generated)
+add_dependencies(agent_main agent_version_header)
 target_link_libraries(agent_main PRIVATE aiden cjson pthread)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ sudo ./build/bin/agent_main --mode=text
 
 # Specify a config file
 sudo ./build/bin/agent_main --mode=manual /etc/agent.conf
+
+# Print build version (git tag if built from a tag, otherwise commit hash)
+./build/bin/agent_main version
+./build/bin/agent_main --version
+./build/bin/agent_main -v
 ```
 
 ### Config file (`agent.conf`)

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ sudo ./build/bin/agent_main --mode=text
 # Specify a config file
 sudo ./build/bin/agent_main --mode=manual /etc/agent.conf
 
-# Print build version (git tag if built from a tag, otherwise commit hash)
+# Print build version and commit time (git tag if built from a tag, otherwise commit hash)
 ./build/bin/agent_main version
 ./build/bin/agent_main --version
 ./build/bin/agent_main -v

--- a/cmake/generate_agent_version.cmake
+++ b/cmake/generate_agent_version.cmake
@@ -7,9 +7,23 @@ if(NOT DEFINED SOURCE_DIR OR SOURCE_DIR STREQUAL "")
 endif()
 
 set(_version "unknown")
+set(_commit_time "unknown")
 find_package(Git QUIET)
 
 if(GIT_FOUND)
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" show -s --format=%cI HEAD
+        WORKING_DIRECTORY "${SOURCE_DIR}"
+        RESULT_VARIABLE _commit_time_result
+        OUTPUT_VARIABLE _git_commit_time
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(_commit_time_result EQUAL 0 AND NOT _git_commit_time STREQUAL "")
+        set(_commit_time "${_git_commit_time}")
+    endif()
+
     execute_process(
         COMMAND "${GIT_EXECUTABLE}" describe --tags --exact-match HEAD
         WORKING_DIRECTORY "${SOURCE_DIR}"
@@ -41,10 +55,14 @@ set(_escaped_version "${_version}")
 string(REPLACE "\\" "\\\\" _escaped_version "${_escaped_version}")
 string(REPLACE "\"" "\\\"" _escaped_version "${_escaped_version}")
 
+set(_escaped_commit_time "${_commit_time}")
+string(REPLACE "\\" "\\\\" _escaped_commit_time "${_escaped_commit_time}")
+string(REPLACE "\"" "\\\"" _escaped_commit_time "${_escaped_commit_time}")
+
 get_filename_component(_output_dir "${OUTPUT_FILE}" DIRECTORY)
 file(MAKE_DIRECTORY "${_output_dir}")
 
-set(_contents "#pragma once\n#define AIDEN_AGENT_VERSION \"${_escaped_version}\"\n")
+set(_contents "#pragma once\n#define AIDEN_AGENT_VERSION \"${_escaped_version}\"\n#define AIDEN_AGENT_COMMIT_TIME \"${_escaped_commit_time}\"\n")
 if(EXISTS "${OUTPUT_FILE}")
     file(READ "${OUTPUT_FILE}" _existing_contents)
 else()

--- a/cmake/generate_agent_version.cmake
+++ b/cmake/generate_agent_version.cmake
@@ -1,0 +1,56 @@
+if(NOT DEFINED OUTPUT_FILE OR OUTPUT_FILE STREQUAL "")
+    message(FATAL_ERROR "OUTPUT_FILE is required")
+endif()
+
+if(NOT DEFINED SOURCE_DIR OR SOURCE_DIR STREQUAL "")
+    message(FATAL_ERROR "SOURCE_DIR is required")
+endif()
+
+set(_version "unknown")
+find_package(Git QUIET)
+
+if(GIT_FOUND)
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" describe --tags --exact-match HEAD
+        WORKING_DIRECTORY "${SOURCE_DIR}"
+        RESULT_VARIABLE _tag_result
+        OUTPUT_VARIABLE _tag
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(_tag_result EQUAL 0 AND NOT _tag STREQUAL "")
+        set(_version "${_tag}")
+    else()
+        execute_process(
+            COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD
+            WORKING_DIRECTORY "${SOURCE_DIR}"
+            RESULT_VARIABLE _hash_result
+            OUTPUT_VARIABLE _hash
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+        if(_hash_result EQUAL 0 AND NOT _hash STREQUAL "")
+            set(_version "${_hash}")
+        endif()
+    endif()
+endif()
+
+set(_escaped_version "${_version}")
+string(REPLACE "\\" "\\\\" _escaped_version "${_escaped_version}")
+string(REPLACE "\"" "\\\"" _escaped_version "${_escaped_version}")
+
+get_filename_component(_output_dir "${OUTPUT_FILE}" DIRECTORY)
+file(MAKE_DIRECTORY "${_output_dir}")
+
+set(_contents "#pragma once\n#define AIDEN_AGENT_VERSION \"${_escaped_version}\"\n")
+if(EXISTS "${OUTPUT_FILE}")
+    file(READ "${OUTPUT_FILE}" _existing_contents)
+else()
+    set(_existing_contents "")
+endif()
+
+if(NOT _existing_contents STREQUAL _contents)
+    file(WRITE "${OUTPUT_FILE}" "${_contents}")
+endif()

--- a/src/agent_main.cpp
+++ b/src/agent_main.cpp
@@ -324,7 +324,8 @@ static bool parse_mode_value(const char* v, TriggerMode& mode) {
 
 int main(int argc, char* argv[]) {
     if (aiden::is_agent_version_command(argc, argv)) {
-        printf("%s\n", aiden::agent_version());
+        printf("version: %s\n", aiden::agent_version());
+        printf("commit_time: %s\n", aiden::agent_commit_time());
         return 0;
     }
 

--- a/src/agent_main.cpp
+++ b/src/agent_main.cpp
@@ -1,4 +1,5 @@
 #include "aiden_sdk.h"
+#include "agent_version.h"
 #include "config.h"
 #include "http_client.h"
 #include "provider_factory.h"
@@ -322,6 +323,11 @@ static bool parse_mode_value(const char* v, TriggerMode& mode) {
 }
 
 int main(int argc, char* argv[]) {
+    if (aiden::is_agent_version_command(argc, argv)) {
+        printf("%s\n", aiden::agent_version());
+        return 0;
+    }
+
     signal(SIGINT, signal_handler);
 
     TriggerMode mode = MODE_WAKEUP;
@@ -355,6 +361,7 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "[error] Failed to load config from %s: %s\n",
                 config_path, config_error.c_str());
         fprintf(stderr, "Usage: %s [--mode=wakeup|manual|text] [config_file]\n", argv[0]);
+        fprintf(stderr, "       %s version|--version|-v\n", argv[0]);
         fprintf(stderr, "  --mode=wakeup: Use GPIO 33 wakeup trigger (default)\n");
         fprintf(stderr, "  --mode=manual: Press Enter to start/stop audio recording\n");
         fprintf(stderr, "  --mode=text:   Type commands directly via stdin\n");

--- a/src/agent_version.cpp
+++ b/src/agent_version.cpp
@@ -9,6 +9,10 @@ const char* agent_version() {
     return AIDEN_AGENT_VERSION;
 }
 
+const char* agent_commit_time() {
+    return AIDEN_AGENT_COMMIT_TIME;
+}
+
 bool is_agent_version_command(int argc, char* const argv[]) {
     if (argc != 2 || !argv || !argv[1]) return false;
     return strcmp(argv[1], "version") == 0 ||

--- a/src/agent_version.cpp
+++ b/src/agent_version.cpp
@@ -1,0 +1,19 @@
+#include "agent_version.h"
+
+#include <agent_version_build.h>
+#include <string.h>
+
+namespace aiden {
+
+const char* agent_version() {
+    return AIDEN_AGENT_VERSION;
+}
+
+bool is_agent_version_command(int argc, char* const argv[]) {
+    if (argc != 2 || !argv || !argv[1]) return false;
+    return strcmp(argv[1], "version") == 0 ||
+           strcmp(argv[1], "--version") == 0 ||
+           strcmp(argv[1], "-v") == 0;
+}
+
+}

--- a/src/agent_version.h
+++ b/src/agent_version.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace aiden {
+
+const char* agent_version();
+bool is_agent_version_command(int argc, char* const argv[]);
+
+}

--- a/src/agent_version.h
+++ b/src/agent_version.h
@@ -3,6 +3,7 @@
 namespace aiden {
 
 const char* agent_version();
+const char* agent_commit_time();
 bool is_agent_version_command(int argc, char* const argv[]);
 
 }

--- a/src/agent_version_build.h
+++ b/src/agent_version_build.h
@@ -3,3 +3,7 @@
 #ifndef AIDEN_AGENT_VERSION
 #define AIDEN_AGENT_VERSION "unknown"
 #endif
+
+#ifndef AIDEN_AGENT_COMMIT_TIME
+#define AIDEN_AGENT_COMMIT_TIME "unknown"
+#endif

--- a/src/agent_version_build.h
+++ b/src/agent_version_build.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifndef AIDEN_AGENT_VERSION
+#define AIDEN_AGENT_VERSION "unknown"
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(AIDEN_TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/src/openai_codec.cpp
     ${CMAKE_SOURCE_DIR}/src/minimax_codec.cpp
     ${CMAKE_SOURCE_DIR}/src/tool_dispatch.cpp
+    ${CMAKE_SOURCE_DIR}/src/agent_version.cpp
     ${CMAKE_SOURCE_DIR}/src/wav_codec.cpp
     ${CMAKE_SOURCE_DIR}/src/provider_factory.cpp
     ${CMAKE_SOURCE_DIR}/src/llm_api_url.cpp
@@ -69,6 +70,7 @@ add_executable(aiden_tests
     openai_codec_test.cpp
     minimax_codec_test.cpp
     tool_dispatch_test.cpp
+    agent_version_test.cpp
     wav_codec_test.cpp
     provider_factory_test.cpp
     llm_api_url_test.cpp

--- a/tests/agent_version_test.cpp
+++ b/tests/agent_version_test.cpp
@@ -1,0 +1,44 @@
+#include "doctest.h"
+#include "agent_version.h"
+#include <string>
+
+TEST_CASE("agent version defaults to unknown without build injection") {
+    CHECK(std::string(aiden::agent_version()) == "unknown");
+}
+
+TEST_CASE("agent version command accepts version subcommand") {
+    char arg0[] = "agent_main";
+    char arg1[] = "version";
+    char* argv[] = {arg0, arg1};
+
+    CHECK(aiden::is_agent_version_command(2, argv));
+}
+
+TEST_CASE("agent version command accepts --version flag") {
+    char arg0[] = "agent_main";
+    char arg1[] = "--version";
+    char* argv[] = {arg0, arg1};
+
+    CHECK(aiden::is_agent_version_command(2, argv));
+}
+
+TEST_CASE("agent version command accepts -v flag") {
+    char arg0[] = "agent_main";
+    char arg1[] = "-v";
+    char* argv[] = {arg0, arg1};
+
+    CHECK(aiden::is_agent_version_command(2, argv));
+}
+
+TEST_CASE("agent version command requires only the version argument") {
+    char arg0[] = "agent_main";
+    char arg1[] = "version";
+    char arg2[] = "agent.conf";
+    char* no_args[] = {arg0};
+    char* extra_arg[] = {arg0, arg1, arg2};
+    char* other_arg[] = {arg0, arg2};
+
+    CHECK_FALSE(aiden::is_agent_version_command(1, no_args));
+    CHECK_FALSE(aiden::is_agent_version_command(3, extra_arg));
+    CHECK_FALSE(aiden::is_agent_version_command(2, other_arg));
+}

--- a/tests/agent_version_test.cpp
+++ b/tests/agent_version_test.cpp
@@ -6,6 +6,10 @@ TEST_CASE("agent version defaults to unknown without build injection") {
     CHECK(std::string(aiden::agent_version()) == "unknown");
 }
 
+TEST_CASE("agent commit time defaults to unknown without build injection") {
+    CHECK(std::string(aiden::agent_commit_time()) == "unknown");
+}
+
 TEST_CASE("agent version command accepts version subcommand") {
     char arg0[] = "agent_main";
     char arg1[] = "version";


### PR DESCRIPTION
## Summary
- Add `agent_main version`, `agent_main --version`, and `agent_main -v` to print the build version without loading config or initializing hardware.
- Generate the build version from git at CMake build time, preferring an exact tag and falling back to the short commit hash.
- Cover version command parsing with host-native tests and document usage.

## Testing
- `cmake --build /var/folders/q5/_pdzc8l57x194zft5gb6z8580000gp/T/opencode/aiden-agent-version-tests && /var/folders/q5/_pdzc8l57x194zft5gb6z8580000gp/T/opencode/aiden-agent-version-tests/bin/aiden_tests --test-case="*agent version*"`
- `git diff --check`

## Notes
- Full `ctest --test-dir /var/folders/q5/_pdzc8l57x194zft5gb6z8580000gp/T/opencode/aiden-agent-version-tests --output-on-failure` still fails in existing `config_test` cases unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version command functionality—users can now query the agent's build version using `version`, `--version`, or `-v` commands.
  * Version information is automatically sourced from Git tags or commit hashes during build; defaults to "unknown" if unavailable.
  * Updated documentation with version command usage instructions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/15)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->