### PR TITLE
test(provider): cover asr_mode-dependent STT validation behavior

### DIFF
--- a/tests/provider_factory_test.cpp
+++ b/tests/provider_factory_test.cpp
@@ -211,3 +211,33 @@ TEST_CASE("check_provider_config accepts openai model provider") {
     ProviderCheckResult r = check_provider_config(cfg);
     CHECK(r.ok);
 }
+
+TEST_CASE("check_provider_config skips stt validation in direct_audio mode") {
+    aiden::AgentConfig cfg;
+    std::snprintf(cfg.model.provider, sizeof(cfg.model.provider), "%s", "openrouter");
+    std::snprintf(cfg.model.api_key, sizeof(cfg.model.api_key), "%s", "sk-key");
+    std::snprintf(cfg.model.model, sizeof(cfg.model.model), "%s", "openai/gpt-4o-audio-preview");
+    std::snprintf(cfg.tts.provider, sizeof(cfg.tts.provider), "%s", "minimax");
+    std::snprintf(cfg.tts.api_key, sizeof(cfg.tts.api_key), "%s", "mm-key");
+    std::snprintf(cfg.tts.voice_id, sizeof(cfg.tts.voice_id), "%s", "voice-a");
+    std::snprintf(cfg.asr_mode, sizeof(cfg.asr_mode), "%s", "direct_audio");
+
+    ProviderCheckResult r = check_provider_config(cfg);
+    CHECK(r.ok);
+}
+
+TEST_CASE("check_provider_config requires stt config in stt_then_text mode") {
+    aiden::AgentConfig cfg;
+    std::snprintf(cfg.model.provider, sizeof(cfg.model.provider), "%s", "openrouter");
+    std::snprintf(cfg.model.api_key, sizeof(cfg.model.api_key), "%s", "sk-key");
+    std::snprintf(cfg.model.model, sizeof(cfg.model.model), "%s", "openai/gpt-4o-audio-preview");
+    std::snprintf(cfg.tts.provider, sizeof(cfg.tts.provider), "%s", "minimax");
+    std::snprintf(cfg.tts.api_key, sizeof(cfg.tts.api_key), "%s", "mm-key");
+    std::snprintf(cfg.tts.voice_id, sizeof(cfg.tts.voice_id), "%s", "voice-a");
+    std::snprintf(cfg.asr_mode, sizeof(cfg.asr_mode), "%s", "stt_then_text");
+    std::snprintf(cfg.stt.provider, sizeof(cfg.stt.provider), "%s", "tencent_asr");
+
+    ProviderCheckResult r = check_provider_config(cfg);
+    CHECK_FALSE(r.ok);
+    CHECK(r.error == "stt provider tencent_asr requires secret_id");
+}

--- a/tests/provider_factory_test.cpp
+++ b/tests/provider_factory_test.cpp
@@ -220,6 +220,9 @@ TEST_CASE("check_provider_config skips stt validation in direct_audio mode") {
     std::snprintf(cfg.tts.provider, sizeof(cfg.tts.provider), "%s", "minimax");
     std::snprintf(cfg.tts.api_key, sizeof(cfg.tts.api_key), "%s", "mm-key");
     std::snprintf(cfg.tts.voice_id, sizeof(cfg.tts.voice_id), "%s", "voice-a");
+    // Intentionally incomplete STT config: should be ignored in direct_audio mode.
+    std::snprintf(cfg.stt.provider, sizeof(cfg.stt.provider), "%s", "tencent_asr");
+    std::snprintf(cfg.stt.secret_id, sizeof(cfg.stt.secret_id), "%s", "id-only");
     std::snprintf(cfg.asr_mode, sizeof(cfg.asr_mode), "%s", "direct_audio");
 
     ProviderCheckResult r = check_provider_config(cfg);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test cases verifying configuration validation for different audio modes: in "direct_audio" incomplete speech-to-text (STT) settings are tolerated, while in "stt_then_text" complete STT credentials are required and missing credentials produce a validation error.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/16)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->