### PR TITLE
docs: add iOS HID configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ All build artifacts are placed in `build/`:
 
 Copy the `build/bin/` executables onto the board and [configure Wi-Fi](https://wiki.luckfox.com/Luckfox-Pico-Zero/WiFi-BT/) before running the HID server demo.
 
+## iOS Configuration
+
+To use HID control on iOS, enable AssistiveTouch on the target device first:
+
+```text
+Settings > Accessibility > Touch > AssistiveTouch
+```
+
+For a better experience, also enable **Show Onscreen Keyboard** on the
+AssistiveTouch page.
+
 ## AI Agent
 
 Pure C++ AI agent that runs directly on the Pico Zero and drives the device's


### PR DESCRIPTION
## Summary
- Document the iOS AssistiveTouch setting required for HID control.
- Recommend enabling Show Onscreen Keyboard for a better HID input experience.

## Testing
- Not run; documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added iOS Configuration section with instructions for enabling AssistiveTouch to support HID control on iOS devices, including onscreen keyboard configuration details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/19)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->