### PR TITLE
fix: forward ReturnsVisualObservation through callbackTool

### DIFF
--- a/src/agent/internal/agent/callback_tool.go
+++ b/src/agent/internal/agent/callback_tool.go
@@ -38,3 +38,10 @@ func (t *callbackTool) Call(ctx context.Context, input string) (string, error) {
 	}
 	return output, nil
 }
+
+func (t *callbackTool) ReturnsVisualObservation() bool {
+	if visual, ok := t.inner.(visualObservationTool); ok {
+		return visual.ReturnsVisualObservation()
+	}
+	return false
+}

--- a/src/agent/internal/agent/callback_tool_test.go
+++ b/src/agent/internal/agent/callback_tool_test.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCallbackToolPassesThroughVisualObservation(t *testing.T) {
+	visual := &stubTool{name: "screenshot", visual: true, output: "{}"}
+	wrapped := &callbackTool{inner: visual}
+
+	v, ok := any(wrapped).(visualObservationTool)
+	if !ok {
+		t.Fatalf("callbackTool does not implement visualObservationTool")
+	}
+	if !v.ReturnsVisualObservation() {
+		t.Fatalf("expected ReturnsVisualObservation() to pass through as true")
+	}
+
+	nonVisual := &stubTool{name: "shell", visual: false, output: "{}"}
+	wrappedNonVisual := &callbackTool{inner: nonVisual}
+	if v2, ok := any(wrappedNonVisual).(visualObservationTool); !ok || v2.ReturnsVisualObservation() {
+		t.Fatalf("expected non-visual tool to remain non-visual after wrapping")
+	}
+}
+
+func TestCallbackToolCallDelegates(t *testing.T) {
+	inner := &stubTool{name: "x", output: "result"}
+	wrapped := &callbackTool{inner: inner}
+	got, err := wrapped.Call(context.Background(), "input-1")
+	if err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+	if got != "result" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+	if len(inner.inputs) != 1 || inner.inputs[0] != "input-1" {
+		t.Fatalf("inner tool not invoked with expected input: %#v", inner.inputs)
+	}
+}

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -351,6 +351,89 @@ func TestRuntimeRunScreenshotAddsBinaryImageObservation(t *testing.T) {
 	}
 }
 
+func TestRuntimeRunScreenshotImageSurvivesCallbackToolWrapping(t *testing.T) {
+	jpegBytes := []byte("fake-jpeg-binary")
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			{
+				Choices: []*llms.ContentChoice{{
+					ToolCalls: []llms.ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						FunctionCall: &llms.FunctionCall{
+							Name:      "screenshot",
+							Arguments: `{"__arg1":"{}"}`,
+						},
+					}},
+				}},
+			},
+			{
+				Choices: []*llms.ContentChoice{{
+					Content: "The screenshot shows a UI.",
+				}},
+			},
+		},
+	}
+	tool := &stubTool{
+		name:        "screenshot",
+		description: "Capture a screenshot from the connected display.",
+		visual:      true,
+		output: `{"width":800,"height":600,"format":"jpeg","size":16,"data":"` +
+			base64.StdEncoding.EncodeToString(jpegBytes) + `"}`,
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:       ModelConfig{Provider: "openrouter"},
+			Instruction: "Use tools when visual state is requested.",
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"screenshot": tool,
+		}},
+		NewSkillIndex(),
+	)
+
+	var streamBuf bytes.Buffer
+	if _, err := runtime.Run(context.Background(), RunRequest{
+		Input:        "屏幕上有什么？",
+		StreamWriter: &streamBuf,
+	}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(model.messages) != 2 {
+		t.Fatalf("expected 2 model calls, got %d", len(model.messages))
+	}
+
+	var foundToolResponse, foundImageURL bool
+	for _, msg := range model.messages[1] {
+		for _, part := range msg.Parts {
+			switch p := part.(type) {
+			case llms.ToolCallResponse:
+				if p.ToolCallID == "call_1" {
+					foundToolResponse = true
+					if p.Content == tool.output {
+						t.Fatalf("expected screenshot tool response to be summarized when wrapped by callbackTool, got raw payload")
+					}
+				}
+			case llms.ImageURLContent:
+				foundImageURL = true
+				expected := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(jpegBytes)
+				if p.URL != expected {
+					t.Fatalf("unexpected image URL: %q", p.URL)
+				}
+			}
+		}
+	}
+	if !foundToolResponse {
+		t.Fatalf("expected screenshot tool response when wrapped by callbackTool")
+	}
+	if !foundImageURL {
+		t.Fatalf("expected screenshot image URL when wrapped by callbackTool")
+	}
+}
+
 func TestRuntimeCallbackHandlerCapturesUsageMetrics(t *testing.T) {
 	metrics := &RunMetrics{}
 	handler := &runtimeCallbackHandler{metrics: metrics}


### PR DESCRIPTION
The callbackTool wrapper used by the runtime when streaming/event/log hooks are active did not forward the optional visualObservationTool interface. As a result, isVisualObservationTool returned false for the wrapped screenshot tool, and the raw JSON payload (including the base64 image data) was sent as the tool message content instead of being decoded into an image_url part. The LLM saw a base64 string instead of an image and answered off-topic.

Forward ReturnsVisualObservation through callbackTool and add a regression test that exercises the StreamWriter path to ensure the screenshot image continues to surface as an image_url part.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for visual observations in agent tools, ensuring visual tool capabilities are properly preserved during tool wrapping.

* **Tests**
  * Added unit tests for callback tool behavior and visual observation handling.
  * Added integration test verifying visual observations work correctly in runtime environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->