### PR TITLE
Reduce frame service screenshot latency

### DIFF
--- a/docs/03-services/frame-service.md
+++ b/docs/03-services/frame-service.md
@@ -18,7 +18,7 @@
 | Socket（开发直接运行） | `/tmp/frame_service.sock` | `frame_service_main.cpp` 默认值 |
 | Socket（固件服务） | `/run/frame_service/frame_service.sock` | init 配置默认值 |
 | Ring size | `3` | `kDefaultFrameServiceRingSize` |
-| FPS | `1.0` | 降低 CPU、内存带宽和发热 |
+| FPS | `3.0` | 降低 CPU、内存带宽和发热，同时保持截图帧龄更低 |
 | Screenshot max edge | `960` | Go screenshot 工具默认压缩策略相关 |
 
 ## 启动

--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -18,7 +18,7 @@ TOML 是当前支持的配置格式；JSON 配置已废弃。
 
 ```toml
 instruction = "You are a helpful assistant. Use tools when they help."
-max_iterations = 6
+max_iterations = -1
 input_mode = "text"
 
 [model]
@@ -93,7 +93,7 @@ frame_socket = "/run/frame_service/frame_service.sock"
 | --- | --- | --- |
 | `instruction` | - | Agent system instruction |
 | `additional_prompt` | - | 额外 prompt 字段；当前解析但未完全接入 prompt 构造 |
-| `max_iterations` | `6` | 单次运行最大工具调用循环次数 |
+| `max_iterations` | `-1` | 单次运行最大工具调用循环次数；`-1` 表示不限制 |
 | `input_mode` | `text` / `stt` / `audio` | 输入模式 |
 | `trigger_mode` | `manual` / `wakeup` | 语音模式触发方式 |
 | `energy_threshold` | `500` | VAD 能量阈值 |

--- a/overlay/etc/aiden_frame_service.conf
+++ b/overlay/etc/aiden_frame_service.conf
@@ -4,6 +4,7 @@
 FRAME_SERVICE_BIN=/oem/usr/bin/frame_service
 
 SOCKET_PATH=/run/frame_service/frame_service.sock
+FRAME_SERVICE_FPS=3
 LOG_PATH=/var/log/frame_service/frame_service.log
 PID_FILE=/run/frame_service/frame_service.pid
 WATCHDOG_PID_FILE=/run/frame_service/frame_service_watchdog.pid

--- a/overlay/etc/init.d/S52frame_service
+++ b/overlay/etc/init.d/S52frame_service
@@ -7,6 +7,7 @@ CONFIG_FILE=/etc/aiden_frame_service.conf
 
 FRAME_SERVICE_BIN=/oem/usr/bin/frame_service
 SOCKET_PATH=/run/frame_service/frame_service.sock
+FRAME_SERVICE_FPS=3
 LOG_PATH=/var/log/frame_service/frame_service.log
 PID_FILE=/run/frame_service/frame_service.pid
 WATCHDOG_PID_FILE=/run/frame_service/frame_service_watchdog.pid
@@ -87,8 +88,8 @@ start() {
                 continue
             fi
 
-            echo "[frame_service] starting $FRAME_SERVICE_BIN --socket $SOCKET_PATH" >> "$LOG_PATH"
-            "$FRAME_SERVICE_BIN" --socket "$SOCKET_PATH" >> "$LOG_PATH" 2>&1 &
+            echo "[frame_service] starting $FRAME_SERVICE_BIN --socket $SOCKET_PATH --fps $FRAME_SERVICE_FPS" >> "$LOG_PATH"
+            "$FRAME_SERVICE_BIN" --socket "$SOCKET_PATH" --fps "$FRAME_SERVICE_FPS" >> "$LOG_PATH" 2>&1 &
             child="$!"
             echo "$child" > "$PID_FILE"
             wait "$child"

--- a/overlay/userdata/agent/agent.toml
+++ b/overlay/userdata/agent/agent.toml
@@ -23,7 +23,7 @@ min_speech_ms = 300       # Minimum speech duration to accept (ms)
 # Primary LLM model configuration
 [model]
 provider = "openrouter"
-model = "bytedance-seed/seed-2.0-lite"
+model = "google/gemini-3.5-flash"
 api_key = "OPENROUTER_API_KEY"
 temperature = 0.2
 max_tokens = 1000

--- a/overlay/userdata/agent/agent.toml
+++ b/overlay/userdata/agent/agent.toml
@@ -1,7 +1,7 @@
 # Agent instruction and behavior
 instruction = "You are a helpful assistant. Use tools when they help accomplish the task."
 additional_prompt = ""
-max_iterations = 6
+max_iterations = -1
 
 # Input mode:
 # - text: run HTTP server with Web UI

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -19,6 +20,13 @@ import (
 	"github.com/tmc/langchaingo/schema"
 	langtools "github.com/tmc/langchaingo/tools"
 )
+
+func effectiveMaxIterations(configured int) int {
+	if configured <= 0 {
+		return math.MaxInt
+	}
+	return configured
+}
 
 type Runtime struct {
 	config       Config
@@ -152,10 +160,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 
 	availableTools := r.resolveTools(resolvedSkills)
 
-	maxIterations := r.config.MaxIterations
-	if maxIterations <= 0 {
-		maxIterations = 6
-	}
+	maxIterations := effectiveMaxIterations(r.config.MaxIterations)
 
 	callOptions := r.models.CallOptions()
 	var streamCallbackHandler *runtimeCallbackHandler

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,18 @@ import (
 	fakellm "github.com/tmc/langchaingo/llms/fake"
 	langtools "github.com/tmc/langchaingo/tools"
 )
+
+func TestEffectiveMaxIterationsDefaultsAndUnlimited(t *testing.T) {
+	if got := effectiveMaxIterations(-1); got != math.MaxInt {
+		t.Fatalf("effectiveMaxIterations(-1) = %d, want math.MaxInt", got)
+	}
+	if got := effectiveMaxIterations(0); got != math.MaxInt {
+		t.Fatalf("effectiveMaxIterations(0) = %d, want math.MaxInt", got)
+	}
+	if got := effectiveMaxIterations(10); got != 10 {
+		t.Fatalf("effectiveMaxIterations(10) = %d, want 10", got)
+	}
+}
 
 type testModelResolver struct {
 	model llms.Model

--- a/src/agent_toml.h
+++ b/src/agent_toml.h
@@ -70,7 +70,7 @@ struct AgentToml {
     int energy_threshold = 0;
     int silence_ms = 0;
     int min_speech_ms = 0;
-    int max_iterations = 0;
+    int max_iterations = -1;
 };
 
 bool load_agent_toml(const char* path, AgentToml& config, std::string* error = nullptr);

--- a/src/aiden_sdk.cpp
+++ b/src/aiden_sdk.cpp
@@ -1352,6 +1352,45 @@ bool CameraCapture::capture_frame_timeout(VideoFrame& frame, std::vector<uint8_t
     return false;
 }
 
+bool CameraCapture::discard_frame_timeout(int timeout_ms) {
+    if (!impl_->initialized || impl_->running) {
+        return false;
+    }
+
+    CameraConfig retry_config = impl_->config;
+    const int max_attempts = retry_config.capture_retries + 1;
+
+    for (int attempt = 0; attempt < max_attempts; ++attempt) {
+        if (!impl_->initialized) {
+            if (!init(retry_config)) {
+                fprintf(stderr, "Camera init failed while discarding frame (attempt %d/%d): %s\n",
+                        attempt + 1, max_attempts, strerror(errno));
+                continue;
+            }
+        }
+
+        VideoFrame frame{};
+        if (!impl_->acquire_frame(&frame, timeout_ms)) {
+            fprintf(stderr, "Failed to discard frame (attempt %d/%d): %s\n",
+                    attempt + 1, max_attempts, strerror(errno));
+        } else {
+            release_frame();
+            return true;
+        }
+
+        if (impl_->frame_held) {
+            release_frame();
+        }
+        if (attempt + 1 >= max_attempts) {
+            break;
+        }
+
+        stop();
+    }
+
+    return false;
+}
+
 bool CameraCapture::capture_once(const CameraConfig& config,
                                  VideoFrame& frame,
                                  std::vector<uint8_t>& buffer) {

--- a/src/aiden_sdk.h
+++ b/src/aiden_sdk.h
@@ -176,6 +176,9 @@ public:
     // Get a single frame with timeout and copy it into a caller-owned buffer.
     bool capture_frame_timeout(VideoFrame& frame, std::vector<uint8_t>& buffer, int timeout_ms);
 
+    // Dequeue and release a single frame without copying it.
+    bool discard_frame_timeout(int timeout_ms);
+
     // One-shot still capture helper: init, capture, and stop internally.
     bool capture_once(const CameraConfig& config,
                       VideoFrame& frame,

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -451,7 +451,7 @@ void apply_default_agent_config(aiden::AgentToml& cfg) {
     cfg.energy_threshold = 500;
     cfg.silence_ms = 1000;
     cfg.min_speech_ms = 300;
-    cfg.max_iterations = 6;
+    cfg.max_iterations = -1;
 
     cfg.model.provider = "openrouter";
     cfg.model.model = "bytedance-seed/seed-2.0-lite";

--- a/src/frame_camera_capture_source.cpp
+++ b/src/frame_camera_capture_source.cpp
@@ -63,6 +63,10 @@ bool FrameCameraCaptureSource::capture(CapturedFrame* frame) {
     return true;
 }
 
+bool FrameCameraCaptureSource::discard() {
+    return camera_.discard_frame_timeout(500);
+}
+
 void FrameCameraCaptureSource::close() {
     camera_.stop();
 }

--- a/src/frame_camera_capture_source.h
+++ b/src/frame_camera_capture_source.h
@@ -12,6 +12,7 @@ public:
 
     bool open() override;
     bool capture(CapturedFrame* frame) override;
+    bool discard() override;
     void close() override;
 
 private:

--- a/src/frame_capture_manager.cpp
+++ b/src/frame_capture_manager.cpp
@@ -72,33 +72,39 @@ void FrameCaptureManager::run() {
         }
         server_->set_state("RUNNING");
         backoff_ms = options_.recovery_initial_backoff_ms > 0 ? options_.recovery_initial_backoff_ms : 1;
-        bool have_next_capture_time = false;
-        std::chrono::steady_clock::time_point next_capture_time;
+        bool have_next_publish_time = false;
+        std::chrono::steady_clock::time_point next_publish_time;
 
         while (running_) {
-            if (options_.capture_interval_ms > 0 && have_next_capture_time) {
-                std::unique_lock<std::mutex> lock(mutex_);
-                stop_cv_.wait_until(lock, next_capture_time, [&]() {
-                    return !running_ || restart_requested_.load();
-                });
-            }
-            if (!running_) {
-                break;
-            }
             if (restart_requested_.exchange(false)) {
                 recover(&backoff_ms, "restart requested", false);
                 break;
             }
+
+            if (options_.capture_interval_ms > 0 && have_next_publish_time) {
+                // Keep dequeuing frames between publish ticks so V4L2 driver
+                // buffers do not accumulate seconds-old completed frames.
+                const auto now = std::chrono::steady_clock::now();
+                if (now < next_publish_time) {
+                    if (!source_->discard()) {
+                        recover(&backoff_ms, "capture failed", true);
+                        break;
+                    }
+                    continue;
+                }
+            }
+
             CapturedFrame frame;
             if (!source_->capture(&frame)) {
                 recover(&backoff_ms, "capture failed", true);
                 break;
             }
             server_->append_frame(frame.metadata, frame.data.data(), frame.data.size(), nullptr);
+
             if (options_.capture_interval_ms > 0) {
-                next_capture_time = std::chrono::steady_clock::now() +
+                next_publish_time = std::chrono::steady_clock::now() +
                     std::chrono::milliseconds(options_.capture_interval_ms);
-                have_next_capture_time = true;
+                have_next_publish_time = true;
             }
         }
     }

--- a/src/frame_capture_manager.h
+++ b/src/frame_capture_manager.h
@@ -19,6 +19,13 @@ public:
     virtual ~FrameCaptureSource() {}
     virtual bool open() = 0;
     virtual bool capture(CapturedFrame* frame) = 0;
+    // Drain one frame without publishing it. Implementations can override this
+    // to avoid copying payload bytes for frames that are only used to keep the
+    // underlying capture queue fresh.
+    virtual bool discard() {
+        CapturedFrame frame;
+        return capture(&frame);
+    }
     virtual void close() = 0;
 };
 

--- a/src/frame_service_defaults.h
+++ b/src/frame_service_defaults.h
@@ -6,7 +6,7 @@
 namespace aiden {
 
 static const size_t kDefaultFrameServiceRingSize = 3;
-static const double kDefaultFrameServiceFps = 1.0;
+static const double kDefaultFrameServiceFps = 3.0;
 static const uint32_t kDefaultScreenshotMaxEdge = 960;
 
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(AIDEN_TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/src/frame_ipc.cpp
     ${CMAKE_SOURCE_DIR}/src/frame_capture_manager.cpp
     ${CMAKE_SOURCE_DIR}/src/frame_processing.cpp
+    ${CMAKE_SOURCE_DIR}/tests/frame_jpeg_encoder_stub.cpp
     ${CMAKE_SOURCE_DIR}/src/frame_service_client.cpp
     ${CMAKE_SOURCE_DIR}/src/frame_service_server.cpp
     ${CMAKE_SOURCE_DIR}/src/audio_service_protocol.cpp

--- a/tests/agent_toml_test.cpp
+++ b/tests/agent_toml_test.cpp
@@ -133,6 +133,7 @@ TEST_CASE("agent_toml ignores unknown sections and keys") {
     REQUIRE(aiden::load_agent_toml(path.c_str(), cfg, &err));
     REQUIRE(err.empty());
     CHECK(cfg.input_mode == "text");
+    CHECK(cfg.max_iterations == -1);
     CHECK(cfg.model.provider == "openai");
     CHECK(cfg.model.model == "gpt-4o-mini");
 

--- a/tests/frame_capture_manager_test.cpp
+++ b/tests/frame_capture_manager_test.cpp
@@ -53,6 +53,7 @@ public:
     bool repeat_last = false;
     int open_count = 0;
     int close_count = 0;
+    int capture_delay_ms = 0;
 
     bool open() override {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -65,6 +66,9 @@ public:
     }
 
     bool capture(CapturedFrame* frame) override {
+        if (capture_delay_ms > 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(capture_delay_ms));
+        }
         std::lock_guard<std::mutex> lock(mutex_);
         if (fail_after >= 0 && captures_ == fail_after) {
             fail_after = -1;
@@ -243,13 +247,14 @@ TEST_CASE("FrameCaptureManager publishes failure and copy latency health metrics
     server.stop();
 }
 
-TEST_CASE("FrameCaptureManager limits capture cadence when configured") {
+TEST_CASE("FrameCaptureManager drains captures while limiting publish cadence") {
     TempSocketPath socket_path;
-    FrameServiceServer server(socket_path.path.c_str(), 4);
+    FrameServiceServer server(socket_path.path.c_str(), 8);
     REQUIRE(server.start() == FrameServiceStatus::OK);
 
     FakeCaptureSource source;
     source.repeat_last = true;
+    source.capture_delay_ms = 10;
     source.frames.push_back(CapturedFrame{metadata(50), std::vector<uint8_t>{1, 2}});
     FrameCaptureManagerOptions options;
     options.recovery_initial_backoff_ms = 1;
@@ -260,7 +265,13 @@ TEST_CASE("FrameCaptureManager limits capture cadence when configured") {
 
     std::this_thread::sleep_for(std::chrono::milliseconds(260));
     manager.stop();
-    CHECK(source.capture_count() >= 2);
-    CHECK(source.capture_count() <= 4);
+
+    FrameServiceClient client(socket_path.path.c_str());
+    HealthResult health;
+    REQUIRE(client.health(&health) == FrameServiceStatus::OK);
+    CHECK(source.capture_count() >= 10);
+    CHECK(health.latest_seq >= 2);
+    CHECK(health.latest_seq <= 4);
+    CHECK(health.ring_buffer_used == health.latest_seq);
     server.stop();
 }

--- a/tests/frame_jpeg_encoder_stub.cpp
+++ b/tests/frame_jpeg_encoder_stub.cpp
@@ -1,0 +1,16 @@
+#include "frame_jpeg_encoder.h"
+
+namespace aiden {
+
+bool encode_frame_to_jpeg_hw(const uint8_t*, uint32_t, uint32_t, int,
+                             std::vector<uint8_t>*, uint32_t*, uint32_t*) {
+    return false;
+}
+
+bool encode_yuv_to_jpeg_hw(const std::vector<uint8_t>&, uint32_t, uint32_t,
+                           const std::string&, int, std::vector<uint8_t>*,
+                           uint32_t*, uint32_t*) {
+    return false;
+}
+
+}  // namespace aiden

--- a/tests/frame_service_defaults_test.cpp
+++ b/tests/frame_service_defaults_test.cpp
@@ -3,6 +3,6 @@
 
 TEST_CASE("frame_service defaults keep memory footprint modest") {
     CHECK(aiden::kDefaultFrameServiceRingSize == 3);
-    CHECK(aiden::kDefaultFrameServiceFps == 1.0);
+    CHECK(aiden::kDefaultFrameServiceFps == 3.0);
     CHECK(aiden::kDefaultScreenshotMaxEdge == 960);
 }


### PR DESCRIPTION
## Summary
- drain V4L2 capture buffers continuously while publishing frames at configured FPS
- raise frame_service default/init FPS to 3
- make agent max_iterations default to -1 and treat non-positive values as effectively unlimited

## Tests
- cd src/agent && go test ./internal/agent
- ./build-host/bin/aiden_tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent now supports unlimited run iterations (previously limited to 6).
  * Updated default AI model to Google Gemini 3.5 Flash.

* **Performance**
  * Increased default frame capture rate to 3 FPS for improved responsiveness with lower CPU impact.
  * Optimized frame capture timing and queue management for better efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->