### PR TITLE
Tune swipe gestures and retry transient model errors

### DIFF
--- a/src/agent/internal/agent/logger.go
+++ b/src/agent/internal/agent/logger.go
@@ -34,6 +34,8 @@ func NewLogger(configDir string) (*Logger, error) {
 	// Write to both file and stderr
 	multiWriter := io.MultiWriter(f, os.Stderr)
 	logger := log.New(multiWriter, "", log.LstdFlags)
+	log.SetOutput(multiWriter)
+	log.SetFlags(log.LstdFlags)
 
 	return &Logger{
 		file:   f,
@@ -42,6 +44,8 @@ func NewLogger(configDir string) (*Logger, error) {
 }
 
 func (l *Logger) Close() error {
+	log.SetOutput(os.Stderr)
+	log.SetFlags(log.LstdFlags)
 	if l.file != nil {
 		return l.file.Close()
 	}

--- a/src/agent/internal/agent/models.go
+++ b/src/agent/internal/agent/models.go
@@ -126,9 +126,12 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		resp, err = t.wrapped.RoundTrip(req)
 		if err != nil {
 			if attempt == maxAttempts-1 || !shouldRetryTransportError(req.Context(), err) {
+				if attempt > 0 {
+					log.Printf("[WARN] [http-retry] giving up after attempt %d/%d: %v", attempt+1, maxAttempts, err)
+				}
 				return resp, err
 			}
-			log.Printf("[http-retry] transport error on attempt %d/%d: %v", attempt+1, maxAttempts, err)
+			log.Printf("[WARN] [http-retry] transport error on attempt %d/%d: %v", attempt+1, maxAttempts, err)
 			if waitErr := t.waitBeforeRetry(req.Context(), attempt+1, maxAttempts); waitErr != nil {
 				return resp, waitErr
 			}
@@ -142,7 +145,7 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// Read error body for logging, then close
 		errBody, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		log.Printf("[http-retry] got retryable status %d on attempt %d/%d: %s", resp.StatusCode, attempt+1, maxAttempts, string(errBody))
+		log.Printf("[WARN] [http-retry] got retryable status %d on attempt %d/%d: %s", resp.StatusCode, attempt+1, maxAttempts, string(errBody))
 
 		// On last attempt, return a reconstructed response
 		if attempt == maxAttempts-1 {
@@ -159,7 +162,7 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func (t *retryTransport) waitBeforeRetry(ctx context.Context, retryNumber, maxAttempts int) error {
 	delay := time.Duration(retryNumber) * t.retryDelayBase
-	log.Printf("[http-retry] retrying attempt %d/%d after %v", retryNumber+1, maxAttempts, delay)
+	log.Printf("[INFO] [http-retry] retrying attempt %d/%d after %v", retryNumber+1, maxAttempts, delay)
 	if delay <= 0 {
 		return nil
 	}
@@ -202,7 +205,7 @@ func newRetryHTTPClient(proxy ProxyConfig) *http.Client {
 	return &http.Client{
 		Transport: &retryTransport{
 			wrapped:        newProxyTransport(proxy),
-			maxRetries:     2,
+			maxRetries:     5,
 			retryDelayBase: 2 * time.Second,
 		},
 	}

--- a/src/agent/internal/agent/models.go
+++ b/src/agent/internal/agent/models.go
@@ -2,9 +2,12 @@ package agent
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -96,10 +99,11 @@ func resolveToken(cfg ModelConfig) string {
 	return ""
 }
 
-// retryTransport retries on 5xx errors with exponential backoff
+// retryTransport retries transient HTTP and transport failures with backoff.
 type retryTransport struct {
-	wrapped    http.RoundTripper
-	maxRetries int
+	wrapped        http.RoundTripper
+	maxRetries     int
+	retryDelayBase time.Duration
 }
 
 func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -112,44 +116,94 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	var resp *http.Response
 	var err error
+	maxAttempts := t.maxRetries + 1
 
-	for attempt := 0; attempt <= t.maxRetries; attempt++ {
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if attempt > 0 {
-			delay := time.Duration(attempt) * 2 * time.Second
-			log.Printf("[http-retry] attempt %d/%d, waiting %v", attempt+1, t.maxRetries+1, delay)
-			time.Sleep(delay)
 			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 		}
 
 		resp, err = t.wrapped.RoundTrip(req)
 		if err != nil {
+			if attempt == maxAttempts-1 || !shouldRetryTransportError(req.Context(), err) {
+				return resp, err
+			}
+			log.Printf("[http-retry] transport error on attempt %d/%d: %v", attempt+1, maxAttempts, err)
+			if waitErr := t.waitBeforeRetry(req.Context(), attempt+1, maxAttempts); waitErr != nil {
+				return resp, waitErr
+			}
 			continue
 		}
 
-		if resp.StatusCode < 500 {
+		if !shouldRetryHTTPStatus(resp.StatusCode) {
 			return resp, nil
 		}
 
 		// Read error body for logging, then close
 		errBody, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		log.Printf("[http-retry] got %d: %s", resp.StatusCode, string(errBody))
+		log.Printf("[http-retry] got retryable status %d on attempt %d/%d: %s", resp.StatusCode, attempt+1, maxAttempts, string(errBody))
 
 		// On last attempt, return a reconstructed response
-		if attempt == t.maxRetries {
+		if attempt == maxAttempts-1 {
 			resp.Body = io.NopCloser(bytes.NewReader(errBody))
 			return resp, nil
+		}
+		if waitErr := t.waitBeforeRetry(req.Context(), attempt+1, maxAttempts); waitErr != nil {
+			return nil, waitErr
 		}
 	}
 
 	return resp, err
 }
 
+func (t *retryTransport) waitBeforeRetry(ctx context.Context, retryNumber, maxAttempts int) error {
+	delay := time.Duration(retryNumber) * t.retryDelayBase
+	log.Printf("[http-retry] retrying attempt %d/%d after %v", retryNumber+1, maxAttempts, delay)
+	if delay <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func shouldRetryTransportError(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	return true
+}
+
+func shouldRetryHTTPStatus(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode >= 500
+}
+
 func newRetryHTTPClient(proxy ProxyConfig) *http.Client {
 	return &http.Client{
 		Transport: &retryTransport{
-			wrapped:    newProxyTransport(proxy),
-			maxRetries: 2,
+			wrapped:        newProxyTransport(proxy),
+			maxRetries:     2,
+			retryDelayBase: 2 * time.Second,
 		},
 	}
 }

--- a/src/agent/internal/agent/models_test.go
+++ b/src/agent/internal/agent/models_test.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestRetryTransportRetriesEOFAndReplaysBody(t *testing.T) {
+	attempts := 0
+	var bodies []string
+	transport := &retryTransport{
+		maxRetries:     2,
+		retryDelayBase: 0,
+		wrapped: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll body: %v", err)
+			}
+			bodies = append(bodies, string(body))
+			if attempts == 1 {
+				return nil, io.EOF
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://openrouter.ai/api/v1/chat/completions", bytes.NewBufferString(`{"model":"test"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if len(bodies) != 2 || bodies[0] != `{"model":"test"}` || bodies[1] != `{"model":"test"}` {
+		t.Fatalf("request bodies were not replayed: %#v", bodies)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestRetryTransportDoesNotRetryCanceledContext(t *testing.T) {
+	attempts := 0
+	transport := &retryTransport{
+		maxRetries:     2,
+		retryDelayBase: 0,
+		wrapped: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return nil, context.Canceled
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://openrouter.ai/api/v1/chat/completions", bytes.NewBufferString(`{"model":"test"}`))
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+	_, err = transport.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected context canceled error")
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestRetryTransportRetriesTooManyRequests(t *testing.T) {
+	attempts := 0
+	transport := &retryTransport{
+		maxRetries:     2,
+		retryDelayBase: 0,
+		wrapped: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts == 1 {
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Body:       io.NopCloser(strings.NewReader(`rate limited`)),
+					Request:    req,
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://openrouter.ai/api/v1/chat/completions", bytes.NewBufferString(`{"model":"test"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -155,5 +156,55 @@ func TestOpenAICompatibleModelIncludesUsageInGenerationInfo(t *testing.T) {
 	got := resp.Choices[0].GenerationInfo
 	if got["prompt_tokens"] != 11 || got["completion_tokens"] != 7 || got["total_tokens"] != 18 {
 		t.Fatalf("unexpected generation info: %#v", got)
+	}
+}
+
+func TestModelManagerOpenRouterRetriesEOFInModelCall(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if _, err := io.ReadAll(r.Body); err != nil {
+			t.Fatalf("ReadAll body: %v", err)
+		}
+		if attempts == 1 {
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("response writer does not support hijacking")
+			}
+			conn, _, err := hijacker.Hijack()
+			if err != nil {
+				t.Fatalf("Hijack: %v", err)
+			}
+			conn.Close()
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok after retry"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	manager := NewModelManager(ModelConfig{
+		Provider: "openrouter",
+		Model:    "test-model",
+		APIKey:   "token",
+		BaseURL:  server.URL,
+	}, ProxyConfig{})
+	model, err := manager.Get()
+	if err != nil {
+		t.Fatalf("Get model: %v", err)
+	}
+
+	resp, err := model.GenerateContent(context.Background(), []llms.MessageContent{{
+		Role:  llms.ChatMessageTypeHuman,
+		Parts: []llms.ContentPart{llms.TextPart("hello")},
+	}})
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if resp.Choices[0].Content != "ok after retry" {
+		t.Fatalf("unexpected response: %#v", resp.Choices[0].Content)
 	}
 }

--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -27,7 +27,16 @@ const (
 	// recognises the touchdown frame before the touch begins moving. The
 	// edge-back recogniser in particular rejects swipes that move on the same
 	// frame as the press.
-	defaultSwipeHoldBeforeMs = 40
+	defaultSwipeHoldBeforeMs = 80
+
+	// defaultSwipeHoldAfterMs keeps the touch down briefly at the destination
+	// before releasing. Releasing immediately after the final move leaves a
+	// high terminal velocity, which mobile UIs often interpret as inertial
+	// scrolling instead of a precise drag-like swipe.
+	defaultSwipeHoldAfterMs = 300
+
+	defaultSwipeDurationMs = 700
+	defaultSwipeSteps      = 24
 
 	// defaultCursorSettleMs is the dwell between positioning the HID absolute
 	// cursor and pressing a button at that position. iOS HID cursor mode
@@ -450,12 +459,12 @@ func (t *TouchGestureTool) Name() string { return "touch_gesture" }
 
 func (t *TouchGestureTool) Description() string {
 	return `Perform a touch-like gesture using the absolute mouse HID device. ` +
-		`Input JSON examples: {"type":"tap","point":{"x":0.5,"y":0.5}}, {"type":"swipe","start":{"x":0.01,"y":0.5},"end":{"x":0.6,"y":0.5},"duration_ms":260,"steps":12}. ` +
+		`Input JSON examples: {"type":"tap","point":{"x":0.5,"y":0.5}}, {"type":"swipe","start":{"x":0.01,"y":0.5},"end":{"x":0.6,"y":0.5},"duration_ms":700,"steps":24}. ` +
 		`Supported types: "tap", "double_tap", "long_press", "drag", "swipe". ` +
 		`coord_space defaults to "normalized" (x/y in [0,1]) and also supports "pixel" and "absolute". ` +
 		`Every gesture first positions the cursor at the target and waits for iOS HID-cursor smoothing to settle before pressing, so clicks register on the intended element instead of as drags from the previous cursor position. ` +
 		`Tap and double_tap accept an optional "hold_ms" (dwell between press and release, default 60ms). ` +
-		`Swipe applies a default "hold_before_ms" of 40ms after the press so iOS recognises the touchdown frame (important for the left-edge back gesture: swipe from x near 0 toward the right). Drag keeps the previous 0 default to avoid unintended long-press behaviour during slow content drag.`
+		`Swipe defaults to a slower 700ms / 24-step motion, applies "hold_before_ms" of 80ms after the press, and holds at the destination for "hold_after_ms" 300ms before release to reduce inertial scrolling. Drag keeps the previous 250ms / 12-step motion with 0ms hold defaults to avoid unintended long-press behaviour during slow content drag.`
 }
 
 func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error) {
@@ -468,6 +477,7 @@ func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error)
 		Button       string        `json:"button"`
 		DurationMs   *int          `json:"duration_ms"`
 		HoldBeforeMs *int          `json:"hold_before_ms"`
+		HoldAfterMs  *int          `json:"hold_after_ms"`
 		HoldMs       *int          `json:"hold_ms"`
 		PauseMs      *int          `json:"pause_ms"`
 		Steps        *int          `json:"steps"`
@@ -533,9 +543,15 @@ func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error)
 		if err != nil {
 			return fmt.Sprintf("error: %v", err), nil
 		}
-		defaultHold := 0
+		defaultDuration := 250
+		defaultSteps := 12
+		defaultHoldBefore := 0
+		defaultHoldAfter := 0
 		if gestureType == "swipe" {
-			defaultHold = defaultSwipeHoldBeforeMs
+			defaultDuration = defaultSwipeDurationMs
+			defaultSteps = defaultSwipeSteps
+			defaultHoldBefore = defaultSwipeHoldBeforeMs
+			defaultHoldAfter = defaultSwipeHoldAfterMs
 		}
 		if err := dragPointer(
 			t.dev,
@@ -543,9 +559,10 @@ func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error)
 			start,
 			end,
 			button,
-			intOrDefault(args.DurationMs, 250),
-			intOrDefault(args.HoldBeforeMs, defaultHold),
-			positiveIntOrDefault(args.Steps, 12),
+			intOrDefault(args.DurationMs, defaultDuration),
+			intOrDefault(args.HoldBeforeMs, defaultHoldBefore),
+			intOrDefault(args.HoldAfterMs, defaultHoldAfter),
+			positiveIntOrDefault(args.Steps, defaultSteps),
 		); err != nil {
 			return fmt.Sprintf("error: %v", err), nil
 		}
@@ -762,7 +779,7 @@ func scrollPointer(dev *HIDDevice, state *pointerState, delta int) error {
 	return writeAbsMouseReport(dev, state, x, y, 0, int8(delta))
 }
 
-func dragPointer(dev *HIDDevice, state *pointerState, start, end resolvedPointerPoint, button uint8, durationMs, holdBeforeMs, steps int) (dragErr error) {
+func dragPointer(dev *HIDDevice, state *pointerState, start, end resolvedPointerPoint, button uint8, durationMs, holdBeforeMs, holdAfterMs, steps int) (dragErr error) {
 	if steps < 1 {
 		steps = 1
 	}
@@ -771,6 +788,9 @@ func dragPointer(dev *HIDDevice, state *pointerState, start, end resolvedPointer
 	}
 	if holdBeforeMs < 0 {
 		holdBeforeMs = 0
+	}
+	if holdAfterMs < 0 {
+		holdAfterMs = 0
 	}
 
 	if err := settlePointer(dev, state, start.x, start.y); err != nil {
@@ -805,6 +825,7 @@ func dragPointer(dev *HIDDevice, state *pointerState, start, end resolvedPointer
 		}
 	}
 
+	sleepMs(holdAfterMs)
 	return nil
 }
 

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -409,6 +409,35 @@ func TestTouchGestureSwipeAppliesDefaultHoldBeforeMs(t *testing.T) {
 	}
 }
 
+func TestTouchGestureSwipeDefaultsUseSlowerMotionAndDelayedRelease(t *testing.T) {
+	dev, w := newTimedHIDDevice()
+	tool := &TouchGestureTool{dev: dev, screen: &screenState{}, state: &pointerState{}}
+
+	out, err := tool.Call(context.Background(), `{"type":"swipe","start":{"x":0.1,"y":0.5},"end":{"x":0.9,"y":0.5}}`)
+	if err != nil {
+		t.Fatalf("Call error: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("output = %q, want ok", out)
+	}
+
+	// Writes: pre-move, press, 24 default move steps, release.
+	times := w.writeTimes()
+	if len(times) != defaultSwipeSteps+3 {
+		t.Fatalf("len(times) = %d, want %d", len(times), defaultSwipeSteps+3)
+	}
+	moveStart := 2
+	lastMove := len(times) - 2
+	moveDuration := times[lastMove].Sub(times[moveStart])
+	if moveDuration < 550*time.Millisecond {
+		t.Fatalf("swipe move duration = %v, want >= 550ms", moveDuration)
+	}
+	releaseDelay := times[len(times)-1].Sub(times[lastMove])
+	if releaseDelay < 270*time.Millisecond {
+		t.Fatalf("swipe final-move-to-release gap = %v, want >= 270ms", releaseDelay)
+	}
+}
+
 func TestTouchGestureDragKeepsZeroHoldBeforeMs(t *testing.T) {
 	dev, w := newTimedHIDDevice()
 	tool := &TouchGestureTool{dev: dev, screen: &screenState{}, state: &pointerState{}}
@@ -422,7 +451,8 @@ func TestTouchGestureDragKeepsZeroHoldBeforeMs(t *testing.T) {
 	}
 
 	// Writes: pre-move, press, move1, move2, release. Drag must not inherit
-	// the swipe hold_before_ms default, so the press → first move gap is ~0.
+	// the swipe hold defaults, so the press-to-first-move and final-move-to-
+	// release gaps are both ~0.
 	times := w.writeTimes()
 	if len(times) < 4 {
 		t.Fatalf("len(times) = %d, want >= 4", len(times))
@@ -430,6 +460,10 @@ func TestTouchGestureDragKeepsZeroHoldBeforeMs(t *testing.T) {
 	gap := times[2].Sub(times[1])
 	if gap > 20*time.Millisecond {
 		t.Fatalf("drag press-to-first-move gap = %v, want < 20ms (drag must not inherit swipe hold)", gap)
+	}
+	releaseGap := times[len(times)-1].Sub(times[len(times)-2])
+	if releaseGap > 20*time.Millisecond {
+		t.Fatalf("drag final-move-to-release gap = %v, want < 20ms (drag must not inherit swipe release hold)", releaseGap)
 	}
 }
 
@@ -445,7 +479,7 @@ func TestDragPointerReleasesOnMoveError(t *testing.T) {
 
 	start := resolvedPointerPoint{x: 100, y: 100}
 	end := resolvedPointerPoint{x: 200, y: 200}
-	err := dragPointer(dev, &pointerState{}, start, end, 0x01, 0, 0, 3)
+	err := dragPointer(dev, &pointerState{}, start, end, 0x01, 0, 0, 0, 3)
 	if err == nil {
 		t.Fatal("expected error from dragPointer")
 	}


### PR DESCRIPTION
## Summary
- slow default touch swipe gestures and delay release to reduce inertial scrolling
- add configurable hold_after_ms for drag/swipe execution while keeping drag defaults unchanged
- make OpenAI-compatible model retries explicitly handle EOF/transport errors and 429 responses

## Tests
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced HTTP retry behavior with context-aware retries, configurable retry limits/delays, and safer response/body handling
  * Adjusted package logging to align created logger output and restore defaults on close
  * Updated swipe gesture timing for smoother motion and delayed release

* **New Features**
  * Optional hold-after duration for touch swipe gestures

* **Tests**
  * Added tests covering HTTP retry scenarios and touch gesture timing/behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->