### PR TITLE
Return screenshots after input tools

### DIFF
--- a/docs/04-agent/tools-http-api.md
+++ b/docs/04-agent/tools-http-api.md
@@ -99,11 +99,13 @@ curl -X POST http://127.0.0.1:8080/api/tools/screenshot \
 ```
 
 `screenshot` 成功输出通常包含 `width`、`height`、`format`、`size` 和 base64 JPEG `data`。
+`keyboard_tap`、`keyboard_text`、`mouse_click`、`mouse_move`、`mouse_scroll` 和 `touch_gesture` 成功执行后，会等待 500ms 再自动截屏；其 `output` 为 JSON，包含原动作结果 `action_output`，以及截图的 `width`、`height`、`format`、`size` 和 base64 JPEG `data`。
 
 ## 外部 Agent 使用建议
 
 - 优先通过 `GET /api/tools` 做能力发现；
 - 需要屏幕操作时，先 `screenshot`，再点击/输入；
+- 点击/输入等动作成功后直接检查该工具返回的 post-action screenshot，不需要再立刻调用一次 `screenshot`；
 - 鼠标和触控优先使用 `coord_space: "normalized"`；
 - 私有 IP 或 USB 网卡访问时注意代理绕过：设置 `NO_PROXY` / `no_proxy`；
 - `shell` 的长任务应按工具说明使用后台 session，并在结束时停止。

--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -266,7 +266,7 @@ func (a *FunctionAgent) observationMessagesForStep(step schema.AgentStep) (strin
 		return step.Observation, nil
 	}
 
-	var result screenshotResult
+	var result postActionScreenshotResult
 	if err := json.Unmarshal([]byte(step.Observation), &result); err != nil {
 		return step.Observation, nil
 	}
@@ -278,12 +278,24 @@ func (a *FunctionAgent) observationMessagesForStep(step schema.AgentStep) (strin
 
 	mimeType := "image/jpeg"
 	toolContent := fmt.Sprintf(
-		"screenshot captured successfully: format=%s width=%d height=%d size=%d bytes. The image is attached in the next message.",
+		"%s returned a screenshot observation: format=%s width=%d height=%d size=%d bytes. The image is attached in the next message.",
+		step.Action.Tool,
 		result.Format,
 		result.Width,
 		result.Height,
 		result.Size,
 	)
+	if strings.TrimSpace(result.ActionOutput) != "" {
+		toolContent = fmt.Sprintf(
+			"%s completed with output %q, then returned a screenshot observation after the action settled: format=%s width=%d height=%d size=%d bytes. The image is attached in the next message.",
+			step.Action.Tool,
+			result.ActionOutput,
+			result.Format,
+			result.Width,
+			result.Height,
+			result.Size,
+		)
+	}
 	if result.Format != "" && result.Format != "jpeg" {
 		mimeType = "image/" + result.Format
 	}
@@ -291,7 +303,7 @@ func (a *FunctionAgent) observationMessagesForStep(step schema.AgentStep) (strin
 	return toolContent, []llms.MessageContent{{
 		Role: llms.ChatMessageTypeHuman,
 		Parts: []llms.ContentPart{
-			llms.TextPart("This image is the screenshot returned by the screenshot tool. Use it when answering the original request."),
+			llms.TextPart(fmt.Sprintf("This image is the screenshot observation returned by the %s tool. Use it when answering the original request.", step.Action.Tool)),
 			buildImagePart(mimeType, imageBytes),
 		},
 	}}

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -447,6 +447,88 @@ func TestRuntimeRunScreenshotImageSurvivesCallbackToolWrapping(t *testing.T) {
 	}
 }
 
+func TestRuntimeRunKeyboardToolAddsPostActionImageObservation(t *testing.T) {
+	jpegBytes := []byte("keyboard-post-action-jpeg")
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			{
+				Choices: []*llms.ContentChoice{{
+					ToolCalls: []llms.ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						FunctionCall: &llms.FunctionCall{
+							Name:      "keyboard_tap",
+							Arguments: `{"keys":["enter"]}`,
+						},
+					}},
+				}},
+			},
+			{
+				Choices: []*llms.ContentChoice{{
+					Content: "The keyboard action updated the UI.",
+				}},
+			},
+		},
+	}
+	tool := &stubTool{
+		name:        "keyboard_tap",
+		description: "Press and release keyboard keys.",
+		visual:      true,
+		output: `{"action_output":"ok","width":800,"height":600,"format":"jpeg","size":25,"data":"` +
+			base64.StdEncoding.EncodeToString(jpegBytes) + `"}`,
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:       ModelConfig{Provider: "openrouter"},
+			Instruction: "Use input tools when needed.",
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"keyboard_tap": tool,
+		}},
+		NewSkillIndex(),
+	)
+
+	result, err := runtime.Run(context.Background(), RunRequest{Input: "press enter"})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Output != "The keyboard action updated the UI." {
+		t.Fatalf("unexpected output: %q", result.Output)
+	}
+
+	var foundToolResponse, foundImageURL bool
+	for _, msg := range model.messages[1] {
+		for _, part := range msg.Parts {
+			switch p := part.(type) {
+			case llms.ToolCallResponse:
+				if p.ToolCallID == "call_1" {
+					foundToolResponse = true
+					if p.Content == tool.output {
+						t.Fatalf("expected keyboard tool response to be summarized, got raw screenshot payload")
+					}
+					if !strings.Contains(p.Content, `keyboard_tap completed with output "ok"`) {
+						t.Fatalf("unexpected keyboard tool response summary: %q", p.Content)
+					}
+				}
+			case llms.ImageURLContent:
+				foundImageURL = true
+				expected := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(jpegBytes)
+				if p.URL != expected {
+					t.Fatalf("unexpected image URL: %q", p.URL)
+				}
+			}
+		}
+	}
+	if !foundToolResponse {
+		t.Fatalf("expected keyboard tool response in second model call")
+	}
+	if !foundImageURL {
+		t.Fatalf("expected keyboard post-action screenshot image URL in second model call")
+	}
+}
+
 func TestRuntimeCallbackHandlerCapturesUsageMetrics(t *testing.T) {
 	metrics := &RunMetrics{}
 	handler := &runtimeCallbackHandler{metrics: metrics}

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -2515,12 +2515,16 @@ const webUI = `<!DOCTYPE html>
                 const grid = document.createElement('div');
                 grid.className = 'tool-meta-grid';
 
-                [
+                const metaEntries = [
                     ['Format', screenshot.format || 'jpeg'],
                     ['Width', String(screenshot.width)],
                     ['Height', String(screenshot.height)],
                     ['Bytes', String(screenshot.size)]
-                ].forEach(function(entry) {
+                ];
+                if (screenshot.action_output) {
+                    metaEntries.unshift(['Action', screenshot.action_output]);
+                }
+                metaEntries.forEach(function(entry) {
                     const item = document.createElement('div');
                     item.className = 'tool-meta-item';
 
@@ -2616,10 +2620,30 @@ const webUI = `<!DOCTYPE html>
         function formatToolPayload(value) {
             if (!value) return '';
             try {
-                return JSON.stringify(JSON.parse(value), null, 2);
+                return JSON.stringify(redactToolPayloadForDisplay(JSON.parse(value)), null, 2);
             } catch (_) {
                 return value;
             }
+        }
+
+        function redactToolPayloadForDisplay(value) {
+            if (Array.isArray(value)) {
+                return value.map(redactToolPayloadForDisplay);
+            }
+            if (!value || typeof value !== 'object') {
+                return value;
+            }
+
+            const clone = {};
+            Object.keys(value).forEach(function(key) {
+                clone[key] = redactToolPayloadForDisplay(value[key]);
+            });
+            if (isScreenshotPayload(value)) {
+                const bytes = Number(value.size);
+                const byteLabel = Number.isFinite(bytes) && bytes >= 0 ? bytes + ' bytes' : 'base64 omitted';
+                clone.data = '[base64 screenshot omitted: ' + byteLabel + ']';
+            }
+            return clone;
         }
 
         function parseScreenshotPayload(msg) {
@@ -2627,14 +2651,22 @@ const webUI = `<!DOCTYPE html>
         }
 
         function parseScreenshotOutput(toolName, content) {
-            if (toolName !== 'screenshot' || !content) return null;
+            if (!content) return null;
             try {
                 const parsed = JSON.parse(content);
-                if (!parsed || typeof parsed.data !== 'string') return null;
+                if (!isScreenshotPayload(parsed)) return null;
                 return parsed;
             } catch (_) {
                 return null;
             }
+        }
+
+        function isScreenshotPayload(value) {
+            return !!value &&
+                typeof value === 'object' &&
+                typeof value.data === 'string' &&
+                value.data.length > 0 &&
+                (value.format === 'jpeg' || value.format === 'jpg' || value.format === 'png' || value.width || value.height || value.size);
         }
     </script>
 </body>

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/tmc/langchaingo/llms"
@@ -389,5 +390,21 @@ func TestRequestBaseURLPrefersForwardedHeaders(t *testing.T) {
 	got := requestBaseURL(req)
 	if got != "https://device.example:8443" {
 		t.Fatalf("requestBaseURL = %q, want %q", got, "https://device.example:8443")
+	}
+}
+
+func TestWebUIRedactsScreenshotBase64Payloads(t *testing.T) {
+	required := []string{
+		"redactToolPayloadForDisplay(JSON.parse(value))",
+		"clone.data = '[base64 screenshot omitted: ' + byteLabel + ']'",
+		"function isScreenshotPayload(value)",
+	}
+	for _, snippet := range required {
+		if !strings.Contains(webUI, snippet) {
+			t.Fatalf("webUI missing screenshot redaction snippet %q", snippet)
+		}
+	}
+	if strings.Contains(webUI, "toolName !== 'screenshot'") {
+		t.Fatalf("webUI still limits screenshot parsing to only the screenshot tool")
 	}
 }

--- a/src/agent/internal/agent/tool_http_catalog.go
+++ b/src/agent/internal/agent/tool_http_catalog.go
@@ -201,7 +201,7 @@ func buildHTTPToolSkillMarkdown(name, description string, baseURL string, descri
 	builder.WriteString("- For private device URLs, suspect proxy interference first if the TCP port is reachable but HTTP returns gateway/proxy errors.\n\n")
 	builder.WriteString("Recommended workflow:\n")
 	builder.WriteString("- Start with `GET /api/tools` if you need to confirm the tool list or example payloads.\n")
-	builder.WriteString("- Use `screenshot` before and after state-changing pointer or touch actions.\n")
+	builder.WriteString("- Use `screenshot` before input actions when you need current screen context; keyboard, mouse, and touch tools automatically wait 500ms and return a post-action screenshot on success.\n")
 	builder.WriteString("- Prefer `coord_space: \"normalized\"` for pointer and touch inputs so the same call survives display-resolution changes.\n")
 	builder.WriteString("- For `shell` background sessions, use `action:start`, then `poll`/`write`/`submit`/`send_keys`, and always finish with `stop`.\n\n")
 	builder.WriteString("Available tools in this skill:\n")
@@ -209,6 +209,8 @@ func buildHTTPToolSkillMarkdown(name, description string, baseURL string, descri
 		builder.WriteString(fmt.Sprintf("- `%s`: %s\n", descriptor.Name, descriptor.Description))
 		if descriptor.Name == "screenshot" {
 			builder.WriteString("  Successful output JSON includes `width`, `height`, `format`, `size`, and base64 JPEG `data`.\n")
+		} else if descriptor.Category == "input" {
+			builder.WriteString("  On successful execution, output JSON includes `action_output`, `width`, `height`, `format`, `size`, and base64 JPEG `data` from a screenshot captured 500ms after the action.\n")
 		}
 		if strings.TrimSpace(descriptor.ExampleInput) != "" {
 			builder.WriteString(fmt.Sprintf("  Example input: `%s`\n", descriptor.ExampleInput))
@@ -217,6 +219,7 @@ func buildHTTPToolSkillMarkdown(name, description string, baseURL string, descri
 	builder.WriteString("\nExecution rules:\n")
 	builder.WriteString("- Treat `is_error=true` or outputs that start with `error:` as failures.\n")
 	builder.WriteString("- Use `screenshot` before pixel-based pointer actions when screen dimensions may be stale.\n")
+	builder.WriteString("- For successful keyboard, mouse, and touch calls, inspect the returned post-action screenshot before deciding the next step.\n")
 	builder.WriteString("- Keep tool input minimal and deterministic; prefer the example payloads as a starting point.\n")
 	return builder.String()
 }

--- a/src/agent/internal/agent/tools.go
+++ b/src/agent/internal/agent/tools.go
@@ -21,16 +21,17 @@ func NewBuiltinToolSet(hidCfg HIDConfig, audioCfg AudioConfig, searchCfg SearchC
 	mouseDev := NewHIDDevice(hidCfg.MouseDeviceOrDefault())
 	screen := &screenState{}
 	pointer := &pointerState{}
+	screenshot := NewScreenshotTool(hidCfg.FrameSocketOrDefault(), screen)
 
 	return &ToolSet{
 		tools: map[string]langtools.Tool{
-			"keyboard_tap":  &KeyboardTapTool{dev: kbDev},
-			"keyboard_text": &KeyboardTextTool{dev: kbDev},
-			"mouse_click":   &MouseClickTool{dev: mouseDev, screen: screen, state: pointer},
-			"mouse_move":    &MouseMoveTool{dev: mouseDev, screen: screen, state: pointer},
-			"mouse_scroll":  &MouseScrollTool{dev: mouseDev, state: pointer},
-			"touch_gesture": &TouchGestureTool{dev: mouseDev, screen: screen, state: pointer},
-			"screenshot":    NewScreenshotTool(hidCfg.FrameSocketOrDefault(), screen),
+			"keyboard_tap":  newPostActionScreenshotTool(&KeyboardTapTool{dev: kbDev}, screenshot, postActionScreenshotDelay),
+			"keyboard_text": newPostActionScreenshotTool(&KeyboardTextTool{dev: kbDev}, screenshot, postActionScreenshotDelay),
+			"mouse_click":   newPostActionScreenshotTool(&MouseClickTool{dev: mouseDev, screen: screen, state: pointer}, screenshot, postActionScreenshotDelay),
+			"mouse_move":    newPostActionScreenshotTool(&MouseMoveTool{dev: mouseDev, screen: screen, state: pointer}, screenshot, postActionScreenshotDelay),
+			"mouse_scroll":  newPostActionScreenshotTool(&MouseScrollTool{dev: mouseDev, state: pointer}, screenshot, postActionScreenshotDelay),
+			"touch_gesture": newPostActionScreenshotTool(&TouchGestureTool{dev: mouseDev, screen: screen, state: pointer}, screenshot, postActionScreenshotDelay),
+			"screenshot":    screenshot,
 			"audio_volume":  NewAudioVolumeTool(audioCfg.SocketOrDefault()),
 			"shell":         &ShellTool{},
 			"web_search":    NewWebSearchTool(searchCfg, proxyCfg),

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -129,6 +130,64 @@ func TestKeyboardTextReportsUnsupportedCharacters(t *testing.T) {
 	}
 	if len(data) != 32 {
 		t.Fatalf("expected 4 keyboard reports for 2 ASCII characters, got %d bytes", len(data))
+	}
+}
+
+func TestPostActionScreenshotToolReturnsScreenshotJSON(t *testing.T) {
+	action := &stubTool{name: "keyboard_tap", output: "ok"}
+	screenshot := &stubTool{
+		name:   "screenshot",
+		output: `{"width":320,"height":240,"format":"jpeg","size":4,"data":"ZmFrZQ=="}`,
+	}
+	tool := newPostActionScreenshotTool(action, screenshot, 0)
+
+	out, err := tool.Call(context.Background(), `{"keys":["enter"]}`)
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if out == "ok" {
+		t.Fatalf("Call output = %q, want screenshot JSON", out)
+	}
+
+	var result postActionScreenshotResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("output is not valid post-action screenshot JSON: %v", err)
+	}
+	if result.ActionOutput != "ok" {
+		t.Fatalf("ActionOutput = %q, want ok", result.ActionOutput)
+	}
+	if result.Width != 320 || result.Height != 240 || result.Format != "jpeg" || result.Data != "ZmFrZQ==" {
+		t.Fatalf("unexpected screenshot result: %#v", result)
+	}
+	if len(action.inputs) != 1 || action.inputs[0] != `{"keys":["enter"]}` {
+		t.Fatalf("action inputs = %#v", action.inputs)
+	}
+	if len(screenshot.inputs) != 1 || screenshot.inputs[0] != "{}" {
+		t.Fatalf("screenshot inputs = %#v", screenshot.inputs)
+	}
+	visual, ok := tool.(visualObservationTool)
+	if !ok || !visual.ReturnsVisualObservation() {
+		t.Fatalf("post-action tool must be a visual observation tool")
+	}
+}
+
+func TestPostActionScreenshotToolSkipsScreenshotOnActionErrorOutput(t *testing.T) {
+	action := &stubTool{name: "mouse_click", output: "error: invalid input"}
+	screenshot := &stubTool{
+		name:   "screenshot",
+		output: `{"width":320,"height":240,"format":"jpeg","size":4,"data":"ZmFrZQ=="}`,
+	}
+	tool := newPostActionScreenshotTool(action, screenshot, 0)
+
+	out, err := tool.Call(context.Background(), `{}`)
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if out != "error: invalid input" {
+		t.Fatalf("Call output = %q, want original error output", out)
+	}
+	if len(screenshot.inputs) != 0 {
+		t.Fatalf("screenshot should not be called on action error, got inputs %#v", screenshot.inputs)
 	}
 }
 

--- a/src/agent/internal/agent/tools_post_action_screenshot.go
+++ b/src/agent/internal/agent/tools_post_action_screenshot.go
@@ -1,0 +1,89 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	langtools "github.com/tmc/langchaingo/tools"
+)
+
+const postActionScreenshotDelay = 500 * time.Millisecond
+
+type postActionScreenshotResult struct {
+	screenshotResult
+	ActionOutput string `json:"action_output,omitempty"`
+}
+
+type postActionScreenshotTool struct {
+	inner      langtools.Tool
+	screenshot langtools.Tool
+	delay      time.Duration
+}
+
+func newPostActionScreenshotTool(inner langtools.Tool, screenshot langtools.Tool, delay time.Duration) langtools.Tool {
+	return &postActionScreenshotTool{
+		inner:      inner,
+		screenshot: screenshot,
+		delay:      delay,
+	}
+}
+
+func (t *postActionScreenshotTool) Name() string {
+	return t.inner.Name()
+}
+
+func (t *postActionScreenshotTool) Description() string {
+	return t.inner.Description() + " On successful execution, waits 500ms and returns a post-action screenshot observation."
+}
+
+func (t *postActionScreenshotTool) ReturnsVisualObservation() bool {
+	return true
+}
+
+func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (string, error) {
+	actionOutput, err := t.inner.Call(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	if toolOutputLooksLikeError(actionOutput) {
+		return actionOutput, nil
+	}
+
+	if err := waitForPostActionScreenshot(ctx, t.delay); err != nil {
+		return "", err
+	}
+
+	screenshotOutput, err := t.screenshot.Call(ctx, "{}")
+	if err != nil {
+		return fmt.Sprintf("error: %s completed with output %q, but post-action screenshot failed: %v", t.inner.Name(), actionOutput, err), nil
+	}
+
+	var result screenshotResult
+	if err := json.Unmarshal([]byte(screenshotOutput), &result); err != nil {
+		return fmt.Sprintf("error: %s completed with output %q, but post-action screenshot was invalid: %v", t.inner.Name(), actionOutput, err), nil
+	}
+
+	out, _ := json.Marshal(postActionScreenshotResult{
+		screenshotResult: result,
+		ActionOutput:     actionOutput,
+	})
+	return string(out), nil
+}
+
+func waitForPostActionScreenshot(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
- wrap keyboard, mouse, and touch tools so successful actions wait 500ms and return a post-action screenshot payload
- pass post-action screenshots back to the LLM as visual observations
- redact screenshot base64 in the Web UI while preserving previews and metadata
- update HTTP tool guidance and tests

## Tests
- go test ./internal/agent
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input actions (keyboard taps, text input, mouse clicks, scrolling, touch gestures) now automatically return a post-action screenshot in the response, eliminating the need to manually invoke screenshot after state-changing operations.

* **Documentation**
  * Updated HTTP tool API guidance to direct external agents to rely on automatically returned post-action screenshots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->