### PR TITLE
Cover agent audio wakeup path

### DIFF
--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -84,14 +84,36 @@ func runAudioMode(cfg agent.Config, runtime *agent.Runtime) {
 	if triggerMode == "manual" {
 		runManualMode(cfg, dialog, runtime, sigChan)
 	} else if triggerMode == "wakeup" {
-		runWakeupMode(cfg, dialog, runtime, sigChan)
+		runWakeupMode(cfg, dialog, runtime, sigChan, newGPIOWatcher)
 	} else {
 		log.Printf("[error] Unsupported trigger mode: %s\n", triggerMode)
 		os.Exit(1)
 	}
 }
 
-func runManualMode(cfg agent.Config, dialog *agent.AudioDialog, runtime *agent.Runtime, sigChan chan os.Signal) {
+type audioDialogRunner interface {
+	StartRecording() error
+	StopRecording() error
+	ReadRecordChunk(timeoutMs uint32) (*agent.AudioChunkResult, error)
+	ProcessVADFrame(samples []int16) []int16
+	ProcessUtterance(ctx context.Context, utterance []int16, runtime *agent.Runtime) error
+	FlushVAD() []int16
+	ResetVAD()
+	VADFrameSamples() int
+}
+
+type wakeupWatcher interface {
+	Start() error
+	Stop()
+}
+
+type wakeupWatcherFactory func(pin int, callback func()) (wakeupWatcher, error)
+
+func newGPIOWatcher(pin int, callback func()) (wakeupWatcher, error) {
+	return agent.NewGPIOWatcher(pin, callback)
+}
+
+func runManualMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Runtime, sigChan chan os.Signal) {
 	log.Println("\n[ready] Press Enter to start recording, press Enter again to stop")
 
 	scanner := bufio.NewScanner(os.Stdin)
@@ -155,7 +177,7 @@ func runManualMode(cfg agent.Config, dialog *agent.AudioDialog, runtime *agent.R
 	log.Println("\n[exit] Stopped.")
 }
 
-func runWakeupMode(cfg agent.Config, dialog *agent.AudioDialog, runtime *agent.Runtime, sigChan chan os.Signal) {
+func runWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Runtime, sigChan chan os.Signal, newWatcher wakeupWatcherFactory) {
 	log.Println("\n[ready] Starting GPIO wakeup listener on GPIO 33...")
 
 	ctx := context.Background()
@@ -163,7 +185,7 @@ func runWakeupMode(cfg agent.Config, dialog *agent.AudioDialog, runtime *agent.R
 	var wakeupMutex sync.Mutex
 
 	// Create GPIO watcher
-	watcher, err := agent.NewGPIOWatcher(33, func() {
+	watcher, err := newWatcher(33, func() {
 		wakeupMutex.Lock()
 		defer wakeupMutex.Unlock()
 		if !wakeupTriggered {
@@ -216,63 +238,10 @@ func runWakeupMode(cfg agent.Config, dialog *agent.AudioDialog, runtime *agent.R
 		}
 
 		dialog.ResetVAD()
-		vadPending := make([]int16, 0, 480*10)
-		var hasPendingByte bool
-		var pendingByte byte
-
-		// Process audio until VAD detects end of speech
-		utteranceDetected := false
-		for !utteranceDetected {
-			select {
-			case <-sigChan:
-				dialog.StopRecording()
-				log.Println("\n[exit] Stopped.")
-				return
-			default:
-			}
-
-			// Read audio chunk
-			chunk, err := dialog.ReadRecordChunk(200)
-			if err != nil {
-				log.Printf("[listen] read_record_chunk error: %v\n", err)
-				break
-			}
-
-			if chunk == nil {
-				continue
-			}
-
-			if chunk.EndOfStream {
-				log.Println("[listen] record session closed by service")
-				break
-			}
-
-			if len(chunk.PCM) == 0 {
-				continue
-			}
-
-			// Convert PCM bytes to int16 samples
-			agent.AppendPCM16Samples(chunk.PCM, &vadPending, &hasPendingByte, &pendingByte)
-
-			// Feed VAD in 30ms frames (480 samples at 16kHz)
-			const frameSamples = 480
-			consumed := 0
-			for consumed+frameSamples <= len(vadPending) {
-				utterance := dialog.ProcessVADFrame(vadPending[consumed : consumed+frameSamples])
-				consumed += frameSamples
-				if utterance != nil {
-					log.Println("[utterance] VAD detected end of speech")
-					if err := dialog.ProcessUtterance(ctx, utterance, runtime); err != nil {
-						log.Printf("[error] %v\n", err)
-					}
-					utteranceDetected = true
-					break
-				}
-			}
-
-			if consumed > 0 {
-				vadPending = vadPending[consumed:]
-			}
+		if exit := processAudioUntilUtterance(dialog, runtime, ctx, sigChan); exit {
+			dialog.StopRecording()
+			log.Println("\n[exit] Stopped.")
+			return
 		}
 
 		// Stop recording
@@ -287,8 +256,76 @@ func runWakeupMode(cfg agent.Config, dialog *agent.AudioDialog, runtime *agent.R
 	}
 }
 
-func processAudioLoop(dialog *agent.AudioDialog, runtime *agent.Runtime, recording *bool, ctx context.Context) {
-	vadPending := make([]int16, 0, 480*10)
+func processAudioUntilUtterance(dialog audioDialogRunner, runtime *agent.Runtime, ctx context.Context, sigChan chan os.Signal) bool {
+	frameSamples := dialog.VADFrameSamples()
+	if frameSamples <= 0 {
+		log.Printf("[listen] invalid VAD frame size: %d\n", frameSamples)
+		return false
+	}
+
+	vadPending := make([]int16, 0, frameSamples*10)
+	var hasPendingByte bool
+	var pendingByte byte
+
+	for {
+		// Read audio chunk
+		select {
+		case <-sigChan:
+			return true
+		default:
+		}
+
+		chunk, err := dialog.ReadRecordChunk(200)
+		if err != nil {
+			log.Printf("[listen] read_record_chunk error: %v\n", err)
+			return false
+		}
+
+		if chunk == nil {
+			continue
+		}
+
+		if chunk.EndOfStream {
+			log.Println("[listen] record session closed by service")
+			return false
+		}
+
+		if len(chunk.PCM) == 0 {
+			continue
+		}
+
+		// Convert PCM bytes to int16 samples
+		agent.AppendPCM16Samples(chunk.PCM, &vadPending, &hasPendingByte, &pendingByte)
+
+		// Feed VAD in 30ms frames.
+		consumed := 0
+		for consumed+frameSamples <= len(vadPending) {
+			utterance := dialog.ProcessVADFrame(vadPending[consumed : consumed+frameSamples])
+			consumed += frameSamples
+			if utterance != nil {
+				log.Println("[utterance] VAD detected end of speech")
+				if err := dialog.ProcessUtterance(ctx, utterance, runtime); err != nil {
+					log.Printf("[error] %v\n", err)
+				}
+				return false
+			}
+		}
+
+		if consumed > 0 {
+			vadPending = vadPending[consumed:]
+		}
+	}
+}
+
+func processAudioLoop(dialog audioDialogRunner, runtime *agent.Runtime, recording *bool, ctx context.Context) {
+	frameSamples := dialog.VADFrameSamples()
+	if frameSamples <= 0 {
+		log.Printf("[listen] invalid VAD frame size: %d\n", frameSamples)
+		*recording = false
+		return
+	}
+
+	vadPending := make([]int16, 0, frameSamples*10)
 	var hasPendingByte bool
 	var pendingByte byte
 
@@ -318,8 +355,7 @@ func processAudioLoop(dialog *agent.AudioDialog, runtime *agent.Runtime, recordi
 		// Convert PCM bytes to int16 samples
 		agent.AppendPCM16Samples(chunk.PCM, &vadPending, &hasPendingByte, &pendingByte)
 
-		// Feed VAD in 30ms frames (480 samples at 16kHz)
-		const frameSamples = 480
+		// Feed VAD in 30ms frames.
 		consumed := 0
 		for consumed+frameSamples <= len(vadPending) {
 			utterance := dialog.ProcessVADFrame(vadPending[consumed : consumed+frameSamples])

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"aiden-agent/internal/agent"
+)
+
+type fakeAudioDialog struct {
+	chunks       []*agent.AudioChunkResult
+	frameSamples int
+	frames       [][]int16
+	utterance    []int16
+	onUtterance  func()
+	starts       int
+	stops        int
+	resets       int
+}
+
+func (d *fakeAudioDialog) StartRecording() error {
+	d.starts++
+	return nil
+}
+
+func (d *fakeAudioDialog) StopRecording() error {
+	d.stops++
+	return nil
+}
+
+func (d *fakeAudioDialog) ReadRecordChunk(timeoutMs uint32) (*agent.AudioChunkResult, error) {
+	if len(d.chunks) == 0 {
+		return &agent.AudioChunkResult{EndOfStream: true}, nil
+	}
+	chunk := d.chunks[0]
+	d.chunks = d.chunks[1:]
+	return chunk, nil
+}
+
+func (d *fakeAudioDialog) ProcessVADFrame(samples []int16) []int16 {
+	copied := append([]int16(nil), samples...)
+	d.frames = append(d.frames, copied)
+	if d.utterance != nil {
+		utterance := d.utterance
+		d.utterance = nil
+		return utterance
+	}
+	return nil
+}
+
+func (d *fakeAudioDialog) ProcessUtterance(ctx context.Context, utterance []int16, runtime *agent.Runtime) error {
+	if d.onUtterance != nil {
+		d.onUtterance()
+	}
+	return nil
+}
+
+func (d *fakeAudioDialog) FlushVAD() []int16 { return nil }
+
+func (d *fakeAudioDialog) ResetVAD() { d.resets++ }
+
+func (d *fakeAudioDialog) VADFrameSamples() int { return d.frameSamples }
+
+type fakeWakeupWatcher struct {
+	callback func()
+	started  bool
+	stopped  bool
+}
+
+func (w *fakeWakeupWatcher) Start() error {
+	w.started = true
+	w.callback()
+	return nil
+}
+
+func (w *fakeWakeupWatcher) Stop() {
+	w.stopped = true
+}
+
+func TestProcessAudioUntilUtteranceUsesConfiguredFrameSizeAndCarriesOddPCMByte(t *testing.T) {
+	dialog := &fakeAudioDialog{
+		frameSamples: 2,
+		chunks: []*agent.AudioChunkResult{
+			{PCM: pcm16Bytes(100)[:1]},
+			{PCM: pcm16BytesFromSamples(100, 200)[1:]},
+		},
+		utterance: []int16{100, 200},
+	}
+
+	if exit := processAudioUntilUtterance(dialog, nil, context.Background(), make(chan os.Signal, 1)); exit {
+		t.Fatal("processAudioUntilUtterance() returned exit=true")
+	}
+	if len(dialog.frames) != 1 {
+		t.Fatalf("expected one VAD frame, got %d", len(dialog.frames))
+	}
+	if got := dialog.frames[0]; len(got) != 2 || got[0] != 100 || got[1] != 200 {
+		t.Fatalf("unexpected VAD frame: %#v", got)
+	}
+}
+
+func TestRunWakeupModeProcessesTriggeredAudioAndStopsOnSignal(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	dialog := &fakeAudioDialog{
+		frameSamples: 2,
+		chunks: []*agent.AudioChunkResult{
+			{PCM: pcm16BytesFromSamples(300, 400)},
+		},
+		utterance: []int16{300, 400},
+		onUtterance: func() {
+			sigChan <- syscall.SIGTERM
+		},
+	}
+	watcher := &fakeWakeupWatcher{}
+	var watcherPin int
+
+	done := make(chan struct{})
+	go func() {
+		runWakeupMode(agent.Config{}, dialog, nil, sigChan, func(pin int, callback func()) (wakeupWatcher, error) {
+			watcherPin = pin
+			watcher.callback = callback
+			return watcher, nil
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runWakeupMode did not stop after signal")
+	}
+
+	if !watcher.started || !watcher.stopped {
+		t.Fatalf("watcher lifecycle started=%v stopped=%v", watcher.started, watcher.stopped)
+	}
+	if watcherPin != 33 {
+		t.Fatalf("watcher pin = %d, want 33", watcherPin)
+	}
+	if dialog.starts != 1 || dialog.stops == 0 || dialog.resets != 1 {
+		t.Fatalf("dialog lifecycle starts=%d stops=%d resets=%d", dialog.starts, dialog.stops, dialog.resets)
+	}
+	if len(dialog.frames) != 1 || dialog.frames[0][0] != 300 || dialog.frames[0][1] != 400 {
+		t.Fatalf("unexpected VAD frames: %#v", dialog.frames)
+	}
+}
+
+func pcm16Bytes(sample int16) []byte {
+	return pcm16BytesFromSamples(sample)
+}
+
+func pcm16BytesFromSamples(samples ...int16) []byte {
+	out := make([]byte, len(samples)*2)
+	for i, sample := range samples {
+		binary.LittleEndian.PutUint16(out[i*2:], uint16(sample))
+	}
+	return out
+}

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -131,6 +131,11 @@ func (d *AudioDialog) ResetVAD() {
 	d.vad.Reset()
 }
 
+// VADFrameSamples returns the number of samples to feed into each VAD frame.
+func (d *AudioDialog) VADFrameSamples() int {
+	return d.vad.FrameSamples()
+}
+
 // ProcessUtterance processes a detected utterance
 func (d *AudioDialog) ProcessUtterance(ctx context.Context, utterance []int16, runtime *Runtime) error {
 	duration := float64(len(utterance)) / float64(d.config.Audio.SampleRateOrDefault())

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -1,6 +1,13 @@
 package agent
 
-import "testing"
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+	langtools "github.com/tmc/langchaingo/tools"
+)
 
 func TestAudioDialogReadRecordChunkRequiresActiveRecording(t *testing.T) {
 	dialog := &AudioDialog{}
@@ -12,4 +19,109 @@ func TestAudioDialogReadRecordChunkRequiresActiveRecording(t *testing.T) {
 	if chunk != nil {
 		t.Fatalf("expected nil chunk, got %#v", chunk)
 	}
+}
+
+func TestNewAudioDialogAudioWakeupUsesDirectAudioPath(t *testing.T) {
+	dialog, err := NewAudioDialog(Config{
+		Model:       ModelConfig{Provider: "fake"},
+		TTS:         TTSConfig{Provider: "minimax"},
+		Audio:       AudioConfig{Socket: "/tmp/audio.sock", SampleRate: 32000},
+		InputMode:   "audio",
+		TriggerMode: "wakeup",
+	})
+	if err != nil {
+		t.Fatalf("NewAudioDialog() error = %v", err)
+	}
+
+	if dialog.sttClient != nil {
+		t.Fatal("audio input mode should not create an STT client")
+	}
+	if dialog.audioClient.socketPath != "/tmp/audio.sock" {
+		t.Fatalf("audio socket = %q, want /tmp/audio.sock", dialog.audioClient.socketPath)
+	}
+	if dialog.vad.alwaysBuffer {
+		t.Fatal("wakeup trigger mode should use normal VAD buffering")
+	}
+	if got := dialog.VADFrameSamples(); got != 960 {
+		t.Fatalf("VADFrameSamples() = %d, want 960 for 32kHz", got)
+	}
+}
+
+func TestProcessUtteranceAudioModeSendsWAVAttachmentToRuntime(t *testing.T) {
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			{
+				Choices: []*llms.ContentChoice{{
+					Content: "heard it",
+				}},
+			},
+		},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:       ModelConfig{Provider: "fake"},
+			Instruction: "Use attached audio.",
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(),
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+
+	tts := &fakeTTSClient{}
+	audioClient := NewAudioServiceClient("/tmp/audio.sock")
+	dialog := &AudioDialog{
+		config: Config{
+			Model:     ModelConfig{Provider: "fake"},
+			Audio:     AudioConfig{SampleRate: 16000},
+			InputMode: "audio",
+		},
+		audioClient: audioClient,
+		ttsClient:   tts,
+	}
+
+	if err := dialog.ProcessUtterance(context.Background(), []int16{100, -100, 200, -200}, runtime); err != nil {
+		t.Fatalf("ProcessUtterance() error = %v", err)
+	}
+	if len(model.messages) != 1 {
+		t.Fatalf("expected one model call, got %d", len(model.messages))
+	}
+
+	userMessage := model.messages[0][len(model.messages[0])-1]
+	var text string
+	var audio []byte
+	for _, part := range userMessage.Parts {
+		switch p := part.(type) {
+		case llms.TextContent:
+			text = p.Text
+		case llms.BinaryContent:
+			if p.MIMEType == "audio/wav" {
+				audio = p.Data
+			}
+		}
+	}
+
+	if !strings.Contains(text, "recording.wav") {
+		t.Fatalf("expected audio attachment name in prompt text, got %q", text)
+	}
+	if len(audio) < 48 || string(audio[:4]) != "RIFF" || string(audio[8:12]) != "WAVE" {
+		t.Fatalf("expected WAV binary attachment, got %d bytes", len(audio))
+	}
+	if len(tts.texts) != 1 || tts.texts[0] != "heard it" {
+		t.Fatalf("unexpected TTS texts: %#v", tts.texts)
+	}
+	if tts.audio != audioClient {
+		t.Fatal("expected TTS to receive the dialog audio client")
+	}
+}
+
+type fakeTTSClient struct {
+	texts []string
+	audio *AudioServiceClient
+}
+
+func (c *fakeTTSClient) TextToSpeechStream(text string, audio *AudioServiceClient) error {
+	c.texts = append(c.texts, text)
+	c.audio = audio
+	return nil
 }

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -23,24 +23,24 @@ func (s SearchConfig) ProviderOrDefault() string {
 }
 
 type Config struct {
-	Model            ModelConfig `toml:"model"`
-	ModelText        ModelConfig `toml:"model_text,omitempty"` // Override for STT-then-text mode
-	TTS              TTSConfig   `toml:"tts,omitempty"`
-	STT              STTConfig   `toml:"stt,omitempty"`
+	Model            ModelConfig  `toml:"model"`
+	ModelText        ModelConfig  `toml:"model_text,omitempty"` // Override for STT-then-text mode
+	TTS              TTSConfig    `toml:"tts,omitempty"`
+	STT              STTConfig    `toml:"stt,omitempty"`
 	HID              HIDConfig    `toml:"hid"`
 	Audio            AudioConfig  `toml:"audio,omitempty"`
 	Proxy            ProxyConfig  `toml:"proxy,omitempty"`
 	Search           SearchConfig `toml:"search,omitempty"`
 	Instruction      string       `toml:"instruction"`
-	AdditionalPrompt string      `toml:"additional_prompt,omitempty"`
-	InputMode        string      `toml:"input_mode,omitempty"`   // "text", "audio", "stt"
-	TriggerMode      string      `toml:"trigger_mode,omitempty"` // "manual", "wakeup"
-	EnergyThreshold  int         `toml:"energy_threshold,omitempty"`
-	SilenceMs        int         `toml:"silence_ms,omitempty"`
-	MinSpeechMs      int         `toml:"min_speech_ms,omitempty"`
-	MaxIterations    int         `toml:"max_iterations,omitempty"`
-	SkillsDirs       []string    `toml:"skills_dirs"`
-	ConfigDir        string      `toml:"-"`
+	AdditionalPrompt string       `toml:"additional_prompt,omitempty"`
+	InputMode        string       `toml:"input_mode,omitempty"`   // "text", "audio", "stt"
+	TriggerMode      string       `toml:"trigger_mode,omitempty"` // "manual", "wakeup"
+	EnergyThreshold  int          `toml:"energy_threshold,omitempty"`
+	SilenceMs        int          `toml:"silence_ms,omitempty"`
+	MinSpeechMs      int          `toml:"min_speech_ms,omitempty"`
+	MaxIterations    int          `toml:"max_iterations,omitempty"`
+	SkillsDirs       []string     `toml:"skills_dirs"`
+	ConfigDir        string       `toml:"-"`
 }
 
 type TTSConfig struct {
@@ -246,22 +246,41 @@ func (c Config) Validate() error {
 	}
 
 	// Validate input_mode
-	if c.InputMode != "" {
-		mode := strings.ToLower(c.InputMode)
+	if strings.TrimSpace(c.InputMode) != "" {
+		mode := strings.ToLower(strings.TrimSpace(c.InputMode))
 		if mode != "text" && mode != "audio" && mode != "stt" {
 			return fmt.Errorf("invalid input_mode: %s (expected text, audio, or stt)", c.InputMode)
 		}
 
 		// Validate STT config if in stt mode
 		if mode == "stt" {
-			if c.STT.Provider == "" {
+			if strings.TrimSpace(c.STT.Provider) == "" {
 				return errors.New("stt.provider is required when input_mode=stt")
 			}
 		}
 
 		// Validate TTS config if not in text mode
-		if mode != "text" && c.TTS.Provider == "" {
+		if mode != "text" && strings.TrimSpace(c.TTS.Provider) == "" {
 			return errors.New("tts.provider is required when input_mode is audio or stt")
+		}
+
+		if mode != "text" {
+			if c.Audio.SampleRate != 0 && c.Audio.SampleRate < 8000 {
+				return fmt.Errorf("audio.sample_rate must be at least 8000 when set, got %d", c.Audio.SampleRate)
+			}
+			if c.Audio.Channels != 0 && c.Audio.Channels != 1 {
+				return fmt.Errorf("audio.channels must be 1 when input_mode is audio or stt, got %d", c.Audio.Channels)
+			}
+			if c.Audio.BitWidth != 0 && c.Audio.BitWidth != 16 {
+				return fmt.Errorf("audio.bit_width must be 16 when input_mode is audio or stt, got %d", c.Audio.BitWidth)
+			}
+		}
+	}
+
+	if strings.TrimSpace(c.TriggerMode) != "" {
+		triggerMode := strings.ToLower(strings.TrimSpace(c.TriggerMode))
+		if triggerMode != "manual" && triggerMode != "wakeup" {
+			return fmt.Errorf("invalid trigger_mode: %s (expected manual or wakeup)", c.TriggerMode)
 		}
 	}
 
@@ -270,16 +289,18 @@ func (c Config) Validate() error {
 
 // InputModeOrDefault returns the input mode or "text" as default
 func (c Config) InputModeOrDefault() string {
-	if c.InputMode == "" {
+	mode := strings.TrimSpace(c.InputMode)
+	if mode == "" {
 		return "text"
 	}
-	return strings.ToLower(c.InputMode)
+	return strings.ToLower(mode)
 }
 
 // TriggerModeOrDefault returns the trigger mode or "manual" as default
 func (c Config) TriggerModeOrDefault() string {
-	if c.TriggerMode == "" {
+	mode := strings.TrimSpace(c.TriggerMode)
+	if mode == "" {
 		return "manual"
 	}
-	return strings.ToLower(c.TriggerMode)
+	return strings.ToLower(mode)
 }

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -282,6 +282,13 @@ func (c Config) Validate() error {
 		if triggerMode != "manual" && triggerMode != "wakeup" {
 			return fmt.Errorf("invalid trigger_mode: %s (expected manual or wakeup)", c.TriggerMode)
 		}
+		effectiveInputMode := strings.ToLower(strings.TrimSpace(c.InputMode))
+		if effectiveInputMode == "" {
+			effectiveInputMode = "text"
+		}
+		if triggerMode == "wakeup" && effectiveInputMode != "audio" && effectiveInputMode != "stt" {
+			return fmt.Errorf("incompatible trigger_mode %q with input_mode %q: wakeup requires input_mode audio or stt", c.TriggerMode, c.InputMode)
+		}
 	}
 
 	return nil

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -1,0 +1,103 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfigValidateAcceptsAudioWakeup(t *testing.T) {
+	cfg := Config{
+		Model:       ModelConfig{Provider: "fake"},
+		TTS:         TTSConfig{Provider: "minimax"},
+		InputMode:   " audio ",
+		TriggerMode: " wakeup ",
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if got := cfg.InputModeOrDefault(); got != "audio" {
+		t.Fatalf("InputModeOrDefault() = %q, want audio", got)
+	}
+	if got := cfg.TriggerModeOrDefault(); got != "wakeup" {
+		t.Fatalf("TriggerModeOrDefault() = %q, want wakeup", got)
+	}
+}
+
+func TestConfigValidateRejectsInvalidTriggerMode(t *testing.T) {
+	cfg := Config{
+		Model:       ModelConfig{Provider: "fake"},
+		TTS:         TTSConfig{Provider: "minimax"},
+		InputMode:   "audio",
+		TriggerMode: "gpio",
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected invalid trigger_mode error")
+	}
+	if !strings.Contains(err.Error(), "invalid trigger_mode") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConfigValidateRequiresTTSForAudioWakeup(t *testing.T) {
+	cfg := Config{
+		Model:       ModelConfig{Provider: "fake"},
+		TTS:         TTSConfig{Provider: "   "},
+		InputMode:   "audio",
+		TriggerMode: "wakeup",
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected missing TTS provider error")
+	}
+	if !strings.Contains(err.Error(), "tts.provider is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConfigValidateRejectsUnsupportedAudioFormatForVoiceInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		audio   AudioConfig
+		wantErr string
+	}{
+		{
+			name:    "stereo",
+			audio:   AudioConfig{Channels: 2},
+			wantErr: "audio.channels must be 1",
+		},
+		{
+			name:    "eight bit",
+			audio:   AudioConfig{BitWidth: 8},
+			wantErr: "audio.bit_width must be 16",
+		},
+		{
+			name:    "too low sample rate",
+			audio:   AudioConfig{SampleRate: 1},
+			wantErr: "audio.sample_rate must be at least 8000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				Model:       ModelConfig{Provider: "fake"},
+				TTS:         TTSConfig{Provider: "minimax"},
+				Audio:       tt.audio,
+				InputMode:   "audio",
+				TriggerMode: "wakeup",
+			}
+
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatal("expected audio format validation error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -41,6 +41,34 @@ func TestConfigValidateRejectsInvalidTriggerMode(t *testing.T) {
 	}
 }
 
+func TestConfigValidateRejectsWakeupForTextInput(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputMode string
+	}{
+		{name: "default text", inputMode: ""},
+		{name: "explicit text", inputMode: " text "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				Model:       ModelConfig{Provider: "fake"},
+				InputMode:   tt.inputMode,
+				TriggerMode: " wakeup ",
+			}
+
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatal("expected incompatible trigger_mode/input_mode error")
+			}
+			if !strings.Contains(err.Error(), "incompatible trigger_mode") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestConfigValidateRequiresTTSForAudioWakeup(t *testing.T) {
 	cfg := Config{
 		Model:       ModelConfig{Provider: "fake"},

--- a/src/agent/internal/agent/vad.go
+++ b/src/agent/internal/agent/vad.go
@@ -34,6 +34,11 @@ func NewAudioVAD(sampleRate, energyThreshold, silenceMs, minSpeechMs int, always
 	}
 }
 
+// FrameSamples returns the number of samples expected in each VAD frame.
+func (v *AudioVAD) FrameSamples() int {
+	return v.frameSamples
+}
+
 // computeEnergy calculates the average energy of audio samples
 func computeEnergy(samples []int16) int {
 	if len(samples) == 0 {


### PR DESCRIPTION
## Summary
- validate audio + wakeup config early, including trigger mode and supported voice audio format
- make wakeup audio processing injectable and use VAD-derived frame sizes instead of hard-coded 16 kHz frames
- add tests for wakeup trigger flow, PCM framing, direct audio attachment, runtime handoff, and TTS playback handoff

## Tests
- go test ./...
- go test -race ./cmd/daemon ./internal/agent -run 'Test(ProcessAudioUntilUtteranceUsesConfiguredFrameSizeAndCarriesOddPCMByte|RunWakeupModeProcessesTriggeredAudioAndStopsOnSignal|ConfigValidateAcceptsAudioWakeup|ConfigValidateRejectsInvalidTriggerMode|ConfigValidateRequiresTTSForAudioWakeup|ConfigValidateRejectsUnsupportedAudioFormatForVoiceInput|NewAudioDialogAudioWakeupUsesDirectAudioPath|ProcessUtteranceAudioModeSendsWAVAttachmentToRuntime)$'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved wakeup audio flow and unified audio dialog handling for more reliable voice-triggered interactions.

* **Improvements**
  * Audio VAD now respects configured frame sizes for accurate utterance detection.
  * Stronger audio/config validation: trimmed/normalized modes, required providers, min sample rate 8000 Hz, mono, 16-bit.

* **Tests**
  * Added unit tests covering VAD framing, wakeup audio processing, and config validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->