### PR TITLE
Add OpenRouter STT provider

### DIFF
--- a/docs/04-agent/audio-features.md
+++ b/docs/04-agent/audio-features.md
@@ -26,7 +26,7 @@ Go Agent 支持设备侧语音交互，主要由 `internal/agent/audio_client.go
 | --- | --- | --- |
 | Audio client | `audio_client.go` | 连接 `audio_service`，启动录音/播放 session，读写 PCM chunk |
 | VAD | `vad.go` | 基于能量阈值的语音活动检测 |
-| STT | `stt.go` | OpenAI Whisper 实现；Tencent ASR 字段已预留 |
+| STT | `stt.go` | OpenAI Whisper / OpenRouter 实现；Tencent ASR 字段已预留 |
 | TTS | `tts.go` | Minimax TTS，使用 `ffmpeg` 转 PCM 后播放 |
 | Dialog manager | `audio_dialog.go` | 编排录音、VAD、STT/LLM/TTS 流程 |
 
@@ -82,6 +82,11 @@ bit_width = 16
 provider = "openai-whisper"
 api_key = "sk-..."
 model = "whisper-1"
+
+# OpenRouter alternative:
+# provider = "openrouter"
+# api_key = "OPENROUTER_API_KEY"
+# model = "qwen/qwen3-asr-flash-2026-02-10"
 
 [tts]
 provider = "minimax"

--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -64,9 +64,9 @@ model = "bytedance-seed/seed-2.0-lite"
 token_env = "OPENROUTER_API_KEY"
 
 [stt]
-provider = "openai-whisper"
-api_key = "sk-..."
-model = "whisper-1"
+provider = "openrouter"
+api_key = "OPENROUTER_API_KEY"
+model = "qwen/qwen3-asr-flash-2026-02-10"
 
 [tts]
 provider = "minimax"
@@ -147,6 +147,7 @@ frame_socket = "/run/frame_service/frame_service.sock"
 STT：
 
 - `provider = "openai-whisper"`：当前可用；
+- `provider = "openrouter"`：当前可用，默认 endpoint 为 `https://openrouter.ai/api/v1/audio/transcriptions`，请求体使用 base64 WAV；
 - `provider = "tencent"`：字段已声明，Tencent ASR 仍属于待完善项。
 
 TTS：

--- a/overlay/userdata/agent/agent.toml
+++ b/overlay/userdata/agent/agent.toml
@@ -52,10 +52,16 @@ bit_width = 16
 # Speech-to-Text (STT) configuration
 # Required when input_mode = "stt"
 [stt]
-provider = "openai-whisper"  # "openai-whisper" or "tencent"
+provider = "openai-whisper"  # "openai-whisper", "openrouter", or "tencent"
 api_key = "OPENAI_API_KEY"
 model = "whisper-1"
 # base_url = "https://api.openai.com/v1"  # Optional: custom endpoint
+
+# For OpenRouter STT:
+# provider = "openrouter"
+# api_key = "OPENROUTER_API_KEY"
+# model = "qwen/qwen3-asr-flash-2026-02-10"
+# base_url = "https://openrouter.ai/api/v1"  # Optional: custom endpoint
 
 # For Tencent ASR (alternative to OpenAI Whisper):
 # provider = "tencent"

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -53,7 +53,7 @@ type TTSConfig struct {
 }
 
 type STTConfig struct {
-	Provider        string `toml:"provider"` // "openai", "tencent"
+	Provider        string `toml:"provider"` // "openai", "openai-whisper", "openrouter", "tencent"
 	APIKey          string `toml:"api_key,omitempty"`
 	Model           string `toml:"model,omitempty"`
 	BaseURL         string `toml:"base_url,omitempty"`

--- a/src/agent/internal/agent/input_processing.go
+++ b/src/agent/internal/agent/input_processing.go
@@ -32,6 +32,8 @@ func NewSTTClientFromConfig(cfg Config) (STTClient, error) {
 	switch provider {
 	case "openai", "openai-whisper":
 		return NewOpenAIWhisperSTT(cfg.STT.APIKey, cfg.STT.Model, cfg.STT.BaseURL, newProxyHTTPClient(cfg.Proxy)), nil
+	case "openrouter":
+		return NewOpenRouterSTT(cfg.STT.APIKey, cfg.STT.Model, cfg.STT.BaseURL, newProxyHTTPClient(cfg.Proxy)), nil
 	case "tencent":
 		return NewTencentASRSTT(cfg.STT.SecretID, cfg.STT.SecretKey, cfg.STT.Region, cfg.STT.EngineModelType), nil
 	default:

--- a/src/agent/internal/agent/stt.go
+++ b/src/agent/internal/agent/stt.go
@@ -2,12 +2,16 @@ package agent
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
+	"strings"
 )
+
+const openRouterSTTModel = "qwen/qwen3-asr-flash-2026-02-10"
 
 // STTClient is the interface for speech-to-text providers
 type STTClient interface {
@@ -88,6 +92,82 @@ func (s *OpenAIWhisperSTT) TranscribeWAV(wavData []byte) (string, error) {
 	}
 
 	// Parse response
+	var result struct {
+		Text string `json:"text"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+
+	return result.Text, nil
+}
+
+// OpenRouterSTT implements STT using OpenRouter's audio transcription API.
+type OpenRouterSTT struct {
+	apiKey     string
+	model      string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewOpenRouterSTT creates a new OpenRouter STT client.
+func NewOpenRouterSTT(apiKey, model, baseURL string, httpClients ...*http.Client) *OpenRouterSTT {
+	if baseURL == "" {
+		baseURL = "https://openrouter.ai/api/v1"
+	}
+	if model == "" {
+		model = openRouterSTTModel
+	}
+	httpClient := http.DefaultClient
+	if len(httpClients) > 0 && httpClients[0] != nil {
+		httpClient = httpClients[0]
+	}
+	return &OpenRouterSTT{
+		apiKey:     apiKey,
+		model:      model,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: httpClient,
+	}
+}
+
+// TranscribeWAV transcribes a WAV file to text through OpenRouter.
+func (s *OpenRouterSTT) TranscribeWAV(wavData []byte) (string, error) {
+	reqBody := struct {
+		Model      string `json:"model"`
+		InputAudio struct {
+			Data   string `json:"data"`
+			Format string `json:"format"`
+		} `json:"input_audio"`
+	}{
+		Model: s.model,
+	}
+	reqBody.InputAudio.Data = base64.StdEncoding.EncodeToString(wavData)
+	reqBody.InputAudio.Format = "wav"
+
+	reqData, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/audio/transcriptions", s.baseURL)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(reqData))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
+	}
+
 	var result struct {
 		Text string `json:"text"`
 	}

--- a/src/agent/internal/agent/stt_test.go
+++ b/src/agent/internal/agent/stt_test.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewSTTClientFromConfigOpenRouter(t *testing.T) {
+	client, err := NewSTTClientFromConfig(Config{
+		STT: STTConfig{
+			Provider: " openrouter ",
+			APIKey:   "sk-or",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewSTTClientFromConfig() error = %v", err)
+	}
+
+	stt, ok := client.(*OpenRouterSTT)
+	if !ok {
+		t.Fatalf("client type = %T, want *OpenRouterSTT", client)
+	}
+	if stt.model != openRouterSTTModel {
+		t.Fatalf("model = %q, want %q", stt.model, openRouterSTTModel)
+	}
+}
+
+func TestOpenRouterSTTTranscribeWAVSendsJSONAudioPayload(t *testing.T) {
+	wavData := []byte("RIFF wav data")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/audio/transcriptions" {
+			t.Fatalf("path = %s, want /audio/transcriptions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-or" {
+			t.Fatalf("Authorization = %q, want bearer token", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", got)
+		}
+
+		var body struct {
+			Model      string `json:"model"`
+			InputAudio struct {
+				Data   string `json:"data"`
+				Format string `json:"format"`
+			} `json:"input_audio"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if body.Model != "custom/asr" {
+			t.Fatalf("model = %q, want custom/asr", body.Model)
+		}
+		if body.InputAudio.Data != base64.StdEncoding.EncodeToString(wavData) {
+			t.Fatalf("input_audio.data = %q, want base64 wav data", body.InputAudio.Data)
+		}
+		if body.InputAudio.Format != "wav" {
+			t.Fatalf("input_audio.format = %q, want wav", body.InputAudio.Format)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"text":"hello world"}`))
+	}))
+	defer server.Close()
+
+	client := NewOpenRouterSTT("sk-or", "custom/asr", server.URL+"/", server.Client())
+	text, err := client.TranscribeWAV(wavData)
+	if err != nil {
+		t.Fatalf("TranscribeWAV() error = %v", err)
+	}
+	if text != "hello world" {
+		t.Fatalf("text = %q, want hello world", text)
+	}
+}
+
+func TestOpenRouterSTTTranscribeWAVReturnsAPIErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"bad token"}`)
+	}))
+	defer server.Close()
+
+	client := NewOpenRouterSTT("bad-token", "custom/asr", server.URL, server.Client())
+	_, err := client.TranscribeWAV([]byte("wav"))
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	if !strings.Contains(err.Error(), "API error 401") || !strings.Contains(err.Error(), "bad token") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/src/agent/internal/agent/stt_test.go
+++ b/src/agent/internal/agent/stt_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -32,19 +33,29 @@ func TestNewSTTClientFromConfigOpenRouter(t *testing.T) {
 
 func TestOpenRouterSTTTranscribeWAVSendsJSONAudioPayload(t *testing.T) {
 	wavData := []byte("RIFF wav data")
+	errCh := make(chan error, 1)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fail := func(format string, args ...any) {
+			errCh <- fmt.Errorf(format, args...)
+			http.Error(w, "bad request", http.StatusBadRequest)
+		}
+
 		if r.Method != http.MethodPost {
-			t.Fatalf("method = %s, want POST", r.Method)
+			fail("method = %s, want POST", r.Method)
+			return
 		}
 		if r.URL.Path != "/audio/transcriptions" {
-			t.Fatalf("path = %s, want /audio/transcriptions", r.URL.Path)
+			fail("path = %s, want /audio/transcriptions", r.URL.Path)
+			return
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer sk-or" {
-			t.Fatalf("Authorization = %q, want bearer token", got)
+			fail("Authorization = %q, want bearer token", got)
+			return
 		}
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
-			t.Fatalf("Content-Type = %q, want application/json", got)
+			fail("Content-Type = %q, want application/json", got)
+			return
 		}
 
 		var body struct {
@@ -55,18 +66,23 @@ func TestOpenRouterSTTTranscribeWAVSendsJSONAudioPayload(t *testing.T) {
 			} `json:"input_audio"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode request body: %v", err)
+			fail("decode request body: %v", err)
+			return
 		}
 		if body.Model != "custom/asr" {
-			t.Fatalf("model = %q, want custom/asr", body.Model)
+			fail("model = %q, want custom/asr", body.Model)
+			return
 		}
 		if body.InputAudio.Data != base64.StdEncoding.EncodeToString(wavData) {
-			t.Fatalf("input_audio.data = %q, want base64 wav data", body.InputAudio.Data)
+			fail("input_audio.data = %q, want base64 wav data", body.InputAudio.Data)
+			return
 		}
 		if body.InputAudio.Format != "wav" {
-			t.Fatalf("input_audio.format = %q, want wav", body.InputAudio.Format)
+			fail("input_audio.format = %q, want wav", body.InputAudio.Format)
+			return
 		}
 
+		errCh <- nil
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"text":"hello world"}`))
 	}))
@@ -74,6 +90,9 @@ func TestOpenRouterSTTTranscribeWAVSendsJSONAudioPayload(t *testing.T) {
 
 	client := NewOpenRouterSTT("sk-or", "custom/asr", server.URL+"/", server.Client())
 	text, err := client.TranscribeWAV(wavData)
+	if handlerErr := <-errCh; handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
 	if err != nil {
 		t.Fatalf("TranscribeWAV() error = %v", err)
 	}

--- a/src/agent/internal/agent/stt_test.go
+++ b/src/agent/internal/agent/stt_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewSTTClientFromConfigOpenRouter(t *testing.T) {
@@ -90,8 +91,13 @@ func TestOpenRouterSTTTranscribeWAVSendsJSONAudioPayload(t *testing.T) {
 
 	client := NewOpenRouterSTT("sk-or", "custom/asr", server.URL+"/", server.Client())
 	text, err := client.TranscribeWAV(wavData)
-	if handlerErr := <-errCh; handlerErr != nil {
-		t.Fatal(handlerErr)
+	select {
+	case handlerErr := <-errCh:
+		if handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for OpenRouter STT test handler")
 	}
 	if err != nil {
 		t.Fatalf("TranscribeWAV() error = %v", err)


### PR DESCRIPTION
## Summary
- add an OpenRouter STT client that posts base64 WAV audio to `/audio/transcriptions`
- wire `stt.provider = "openrouter"` into agent STT provider selection
- document OpenRouter STT config and add focused request/response tests

## Tests
- go test ./internal/agent
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter as a supported speech-to-text (STT) provider for transcriptions.

* **Documentation**
  * Updated docs and config samples to include OpenRouter settings, default endpoint guidance, base64 WAV usage, and noted Tencent ASR fields are reserved.
  * Broadened documented STT provider options in config examples.

* **Tests**
  * Added tests covering OpenRouter STT behavior and API error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->