### PR TITLE
Fix web UI audio recording via device service

### DIFF
--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -20,14 +20,38 @@ import (
 
 // Server provides HTTP API for agent interactions
 type Server struct {
-	runtime     *Runtime
-	addr        string
-	logger      *Logger
-	mu          sync.Mutex
-	history     []Message
-	sttClient   STTClient
-	ttsClient   TTSClient
-	audioClient *AudioServiceClient
+	runtime      *Runtime
+	addr         string
+	logger       *Logger
+	mu           sync.Mutex
+	history      []Message
+	sttClient    STTClient
+	ttsClient    TTSClient
+	audioClient  *AudioServiceClient
+	recordMu     sync.Mutex
+	webRecording *webAudioRecording
+}
+
+type webAudioRecording struct {
+	sessionID  uint64
+	sampleRate int
+	done       chan struct{}
+
+	mu         sync.Mutex
+	samples    []int16
+	hasPending bool
+	pending    byte
+	stopping   bool
+	err        error
+}
+
+type AudioRecordStartResponse struct {
+	Status     string `json:"status"`
+	SampleRate int    `json:"sample_rate"`
+}
+
+type AudioRecordStopResponse struct {
+	Attachment MessageAttachment `json:"attachment"`
 }
 
 type MessageAttachment struct {
@@ -97,6 +121,8 @@ func NewServer(runtime *Runtime, addr string) *Server {
 
 	// Initialize TTS client if configured
 	cfg := runtime.config
+	s.audioClient = NewAudioServiceClient(cfg.Audio.SocketOrDefault())
+
 	sttClient, err := NewSTTClientFromConfig(cfg)
 	if err != nil {
 		if s.logger != nil {
@@ -113,7 +139,6 @@ func NewServer(runtime *Runtime, addr string) *Server {
 		}
 	} else if ttsClient != nil {
 		s.ttsClient = ttsClient
-		s.audioClient = NewAudioServiceClient(cfg.Audio.SocketOrDefault())
 		if s.logger != nil {
 			s.logger.Info("TTS enabled: provider=%s voice=%s", cfg.TTS.Provider, cfg.TTS.VoiceID)
 		}
@@ -133,6 +158,8 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/api/tools", s.handleTools)
 	mux.HandleFunc("/api/tools/", s.handleTools)
 	mux.HandleFunc("/api/tool-skills", s.handleToolSkills)
+	mux.HandleFunc("/api/audio/record/start", s.handleAudioRecordStart)
+	mux.HandleFunc("/api/audio/record/stop", s.handleAudioRecordStop)
 
 	// Static web UI
 	mux.HandleFunc("/", s.handleIndex)
@@ -292,6 +319,177 @@ func (s *Server) handleClear(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleAudioRecordStart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.audioClient == nil {
+		http.Error(w, "audio service client is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	s.recordMu.Lock()
+	defer s.recordMu.Unlock()
+
+	if s.webRecording != nil {
+		http.Error(w, "audio recording is already active", http.StatusConflict)
+		return
+	}
+
+	sampleRate := s.runtime.config.Audio.SampleRateOrDefault()
+	result, err := s.audioClient.StartRecording(AudioFormat{
+		SampleRate: uint32(sampleRate),
+		Channels:   1,
+		BitWidth:   16,
+	})
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("Web audio recording start failed: %v", err)
+		}
+		http.Error(w, "start device audio recording: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	recording := &webAudioRecording{
+		sessionID:  result.SessionID,
+		sampleRate: sampleRate,
+		done:       make(chan struct{}),
+		samples:    make([]int16, 0, sampleRate),
+	}
+	s.webRecording = recording
+	go s.readWebAudioRecording(recording)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(AudioRecordStartResponse{
+		Status:     "recording",
+		SampleRate: sampleRate,
+	})
+}
+
+func (s *Server) handleAudioRecordStop(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.audioClient == nil {
+		http.Error(w, "audio service client is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	s.recordMu.Lock()
+	recording := s.webRecording
+	if recording == nil {
+		s.recordMu.Unlock()
+		http.Error(w, "audio recording is not active", http.StatusBadRequest)
+		return
+	}
+	recording.setStopping()
+	s.recordMu.Unlock()
+
+	stopErr := s.audioClient.StopRecording(recording.sessionID)
+
+	select {
+	case <-recording.done:
+	case <-time.After(7 * time.Second):
+		if stopErr == nil {
+			stopErr = fmt.Errorf("timed out waiting for audio recording to drain")
+		}
+	}
+
+	s.recordMu.Lock()
+	if s.webRecording == recording {
+		s.webRecording = nil
+	}
+	s.recordMu.Unlock()
+
+	if stopErr != nil {
+		if s.logger != nil {
+			s.logger.Error("Web audio recording stop failed: %v", stopErr)
+		}
+		http.Error(w, "stop device audio recording: "+stopErr.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := recording.readError(); err != nil {
+		if s.logger != nil {
+			s.logger.Error("Web audio recording read failed: %v", err)
+		}
+		http.Error(w, "read device audio recording: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	samples := recording.snapshotSamples()
+	wavData := pcm16MonoToWAV(samples, recording.sampleRate)
+	attachment := MessageAttachment{
+		Kind:     AttachmentKindAudio,
+		Name:     "recording.wav",
+		MIMEType: "audio/wav",
+		Data:     base64.StdEncoding.EncodeToString(wavData),
+		Size:     len(wavData),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(AudioRecordStopResponse{Attachment: attachment})
+}
+
+func (s *Server) readWebAudioRecording(recording *webAudioRecording) {
+	defer close(recording.done)
+
+	for {
+		chunk, err := s.audioClient.ReadRecordChunk(recording.sessionID, 1000)
+		if err != nil {
+			if !recording.isStopping() {
+				recording.setError(err)
+			}
+			return
+		}
+		if len(chunk.PCM) > 0 {
+			recording.appendPCM(chunk.PCM)
+		}
+		if chunk.EndOfStream {
+			return
+		}
+	}
+}
+
+func (r *webAudioRecording) appendPCM(pcm []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	AppendPCM16Samples(pcm, &r.samples, &r.hasPending, &r.pending)
+}
+
+func (r *webAudioRecording) setStopping() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stopping = true
+}
+
+func (r *webAudioRecording) isStopping() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stopping
+}
+
+func (r *webAudioRecording) setError(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.err = err
+}
+
+func (r *webAudioRecording) readError() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.err
+}
+
+func (r *webAudioRecording) snapshotSamples() []int16 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	samples := make([]int16, len(r.samples))
+	copy(samples, r.samples)
+	return samples
 }
 
 func (s *Server) handleTools(w http.ResponseWriter, r *http.Request) {
@@ -2096,9 +2294,27 @@ const webUI = `<!DOCTYPE html>
 
         async function startRecording() {
             if (recorderState.isRecording) return;
+
+            const startedOnServer = await startServerRecording();
+            if (startedOnServer) {
+                recorderState = {
+                    isRecording: true,
+                    mode: 'server',
+                    stream: null,
+                    context: null,
+                    source: null,
+                    processor: null,
+                    sink: null,
+                    chunks: [],
+                    sampleRate: targetAudioSampleRate
+                };
+                updateRecordButton();
+                return;
+            }
+
             const AudioContextClass = window.AudioContext || window.webkitAudioContext;
             if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia || !AudioContextClass) {
-                throw new Error('This browser does not support audio recording.');
+                throw new Error('Device audio recording is unavailable and this browser cannot record audio from the page.');
             }
 
             const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
@@ -2121,6 +2337,7 @@ const webUI = `<!DOCTYPE html>
 
             recorderState = {
                 isRecording: true,
+                mode: 'browser',
                 stream: stream,
                 context: context,
                 source: source,
@@ -2135,6 +2352,21 @@ const webUI = `<!DOCTYPE html>
 
         async function stopRecording() {
             if (!recorderState.isRecording) return;
+
+            if (recorderState.mode === 'server') {
+                recorderState.isRecording = false;
+                const attachment = await stopServerRecording();
+                await teardownRecorder();
+                upsertAudioAttachment({
+                    id: nextAttachmentId++,
+                    kind: attachment.kind || 'audio',
+                    name: attachment.name || 'recording.wav',
+                    mime_type: attachment.mime_type || 'audio/wav',
+                    data: attachment.data || '',
+                    size: attachment.size || 0
+                });
+                return;
+            }
 
             recorderState.isRecording = false;
             const chunks = recorderState.chunks.slice();
@@ -2153,6 +2385,29 @@ const webUI = `<!DOCTYPE html>
                 size: wavBlob.size,
                 preview_url: URL.createObjectURL(wavBlob)
             });
+        }
+
+        async function startServerRecording() {
+            const res = await fetch('/api/audio/record/start', { method: 'POST' });
+            if (res.status === 404) {
+                return false;
+            }
+            if (!res.ok) {
+                throw new Error(await res.text() || 'Device audio recording failed to start.');
+            }
+            return true;
+        }
+
+        async function stopServerRecording() {
+            const res = await fetch('/api/audio/record/stop', { method: 'POST' });
+            if (!res.ok) {
+                throw new Error(await res.text() || 'Device audio recording failed to stop.');
+            }
+            const data = await res.json();
+            if (!data.attachment || !data.attachment.data) {
+                throw new Error('Device audio recording returned no audio data.');
+            }
+            return data.attachment;
         }
 
         function upsertAudioAttachment(attachment) {
@@ -2191,6 +2446,7 @@ const webUI = `<!DOCTYPE html>
         function createRecorderState() {
             return {
                 isRecording: false,
+                mode: '',
                 stream: null,
                 context: null,
                 source: null,

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -4,9 +4,14 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/tmc/langchaingo/llms"
@@ -197,6 +202,81 @@ func TestServerHandleChatWithAudioAttachmentUsesSTT(t *testing.T) {
 	}
 	if len(resp.History[0].Attachments) != 1 || resp.History[0].Attachments[0].Transcript != "你好，帮我总结一下" {
 		t.Fatalf("expected transcript on audio attachment, got %#v", resp.History[0].Attachments)
+	}
+}
+
+func TestServerDeviceAudioRecordingEndpointsReturnWAVAttachment(t *testing.T) {
+	stopCh := make(chan struct{})
+	var stopOnce sync.Once
+	var readCount int32
+
+	socketPath := startFakeAudioServiceSocket(t, func(req audioRequest) (audioResponse, []byte) {
+		switch req.Op {
+		case "start_recording":
+			if req.SampleRate != 16000 || req.Channels != 1 || req.BitWidth != 16 {
+				t.Errorf("unexpected recording format: %#v", req)
+			}
+			return audioResponse{Status: "OK", SessionID: stringUint64(42)}, nil
+		case "read_record_chunk":
+			count := atomic.AddInt32(&readCount, 1)
+			if count == 1 {
+				return audioResponse{Status: "OK"}, []byte{1, 0, 2, 0}
+			}
+			<-stopCh
+			return audioResponse{Status: "OK", EndOfStream: true}, nil
+		case "stop_recording":
+			stopOnce.Do(func() { close(stopCh) })
+			return audioResponse{Status: "OK"}, nil
+		default:
+			return audioResponse{Status: "INTERNAL_ERROR"}, nil
+		}
+	})
+
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model: ModelConfig{Provider: "fake"},
+			Audio: AudioConfig{
+				Socket:     socketPath,
+				SampleRate: 16000,
+			},
+		},
+		&testModelResolver{model: &scriptedModel{}},
+		NewMemoryManager(),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+	server := NewServer(runtime, ":0")
+
+	startReq := httptest.NewRequest(http.MethodPost, "/api/audio/record/start", nil)
+	startRec := httptest.NewRecorder()
+	server.handleAudioRecordStart(startRec, startReq)
+	if startRec.Code != http.StatusOK {
+		t.Fatalf("unexpected start status: %d body=%s", startRec.Code, startRec.Body.String())
+	}
+
+	stopReq := httptest.NewRequest(http.MethodPost, "/api/audio/record/stop", nil)
+	stopRec := httptest.NewRecorder()
+	server.handleAudioRecordStop(stopRec, stopReq)
+	if stopRec.Code != http.StatusOK {
+		t.Fatalf("unexpected stop status: %d body=%s", stopRec.Code, stopRec.Body.String())
+	}
+
+	var resp AudioRecordStopResponse
+	if err := json.NewDecoder(stopRec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode stop response: %v", err)
+	}
+	if resp.Attachment.Kind != AttachmentKindAudio || resp.Attachment.MIMEType != "audio/wav" {
+		t.Fatalf("unexpected attachment metadata: %#v", resp.Attachment)
+	}
+	wavData, err := base64.StdEncoding.DecodeString(resp.Attachment.Data)
+	if err != nil {
+		t.Fatalf("decode wav payload: %v", err)
+	}
+	if !bytes.HasPrefix(wavData, []byte("RIFF")) || !bytes.Contains(wavData[:44], []byte("WAVE")) {
+		t.Fatalf("expected wav payload, got %q", string(wavData[:12]))
+	}
+	if len(wavData) != 48 {
+		t.Fatalf("expected 2 PCM16 samples in WAV, got %d bytes", len(wavData))
 	}
 }
 
@@ -407,4 +487,62 @@ func TestWebUIRedactsScreenshotBase64Payloads(t *testing.T) {
 	if strings.Contains(webUI, "toolName !== 'screenshot'") {
 		t.Fatalf("webUI still limits screenshot parsing to only the screenshot tool")
 	}
+}
+
+func startFakeAudioServiceSocket(t *testing.T, handler func(audioRequest) (audioResponse, []byte)) string {
+	t.Helper()
+
+	socketDir, err := os.MkdirTemp("/tmp", "aiden-audio-test-*")
+	if err != nil {
+		t.Fatalf("create fake audio socket dir: %v", err)
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(socketDir)
+	})
+
+	socketPath := filepath.Join(socketDir, "audio.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen on fake audio socket: %v", err)
+	}
+	t.Cleanup(func() {
+		listener.Close()
+	})
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+
+				msg, err := readUdsMessage(conn)
+				if err != nil {
+					t.Errorf("fake audio read request: %v", err)
+					return
+				}
+
+				var req audioRequest
+				if err := json.Unmarshal([]byte(msg.HeaderJSON), &req); err != nil {
+					t.Errorf("fake audio decode request: %v", err)
+					return
+				}
+
+				resp, payload := handler(req)
+				respHeader, err := json.Marshal(resp)
+				if err != nil {
+					t.Errorf("fake audio encode response: %v", err)
+					return
+				}
+				if err := writeUdsMessage(conn, udsMessage{HeaderJSON: string(respHeader), Payload: payload}); err != nil {
+					t.Errorf("fake audio write response: %v", err)
+					return
+				}
+			}()
+		}
+	}()
+
+	return socketPath
 }


### PR DESCRIPTION
## Summary
- add server endpoints for starting/stopping device audio recording from the web UI
- return recorded device audio as a WAV attachment for chat submission
- add coverage with a fake audio service socket

## Tests
- go test ./internal/agent
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added server-side audio recording accessible through the web interface
  * Automatically falls back to browser-based recording if server recording is unavailable
  * Recorded audio files are processed and returned in WAV format

* **Tests**
  * Added comprehensive test coverage for audio recording endpoints and functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->