### PR TITLE
feat(memory): derive compression context_window from active model (AID-7)

### DIFF
--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -27,6 +27,12 @@ type MemoryHandle struct {
 // summary of the events being archived into a chunk.
 type SummarizeFn func(ctx context.Context, events []SessionEvent) string
 
+// ContextWindowFn returns the current model's context window in tokens. The
+// memory manager calls it on every compression decision so model swaps take
+// effect at runtime without restart. Implementations should return 0 when the
+// window is unknown; callers fall back to the yaml-configured default.
+type ContextWindowFn func() int
+
 type MemoryManager struct {
 	mu               sync.Mutex
 	handles          map[string]*MemoryHandle
@@ -36,6 +42,7 @@ type MemoryManager struct {
 	lastPromptTokens int
 	summarizeFn      SummarizeFn
 	profileFn        ProfileFn
+	contextWindowFn  ContextWindowFn
 	logger           *Logger
 }
 
@@ -74,6 +81,14 @@ func WithProfileFn(fn ProfileFn) MemoryManagerOption {
 
 func WithMemoryLogger(logger *Logger) MemoryManagerOption {
 	return func(m *MemoryManager) { m.logger = logger }
+}
+
+// WithContextWindowFn lets the runtime supply the active model's context
+// window dynamically. When the callback returns a positive value it overrides
+// the yaml-configured ContextWindow for compression decisions. A zero return
+// means "unknown, use the yaml default". The yaml value remains the fallback.
+func WithContextWindowFn(fn ContextWindowFn) MemoryManagerOption {
+	return func(m *MemoryManager) { m.contextWindowFn = fn }
 }
 
 func NewMemoryManager(storageDir string, opts ...MemoryManagerOption) *MemoryManager {
@@ -377,9 +392,10 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 	}
 
 	promptTokens := m.LastPromptTokens()
+	contextWindow := m.effectiveContextWindow()
 	if m.logger != nil {
 		m.logger.Info("[memory] compression triggered: events=%d, prompt_tokens=%d, context_window=%d, threshold=%d%%",
-			len(events), promptTokens, m.extraction.ContextWindow, m.extraction.CompressAtPercent)
+			len(events), promptTokens, contextWindow, m.extraction.CompressAtPercent)
 	}
 
 	hotWindow := m.extraction.HotWindowEvents
@@ -449,8 +465,9 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 
 func (m *MemoryManager) shouldCompress(eventCount int) bool {
 	lastPromptTokens := m.LastPromptTokens()
-	if lastPromptTokens > 0 && m.extraction.ContextWindow > 0 {
-		ratio := float64(lastPromptTokens) / float64(m.extraction.ContextWindow)
+	contextWindow := m.effectiveContextWindow()
+	if lastPromptTokens > 0 && contextWindow > 0 {
+		ratio := float64(lastPromptTokens) / float64(contextWindow)
 		threshold := float64(m.extraction.CompressAtPercent) / 100.0
 		if ratio >= threshold {
 			return true
@@ -461,6 +478,19 @@ func (m *MemoryManager) shouldCompress(eventCount int) bool {
 		hotWindow = defaultMemoryHotWindowEvents
 	}
 	return eventCount > hotWindow
+}
+
+// effectiveContextWindow returns the context window in tokens that should be
+// used for compression decisions. It prefers the resolver-supplied callback
+// (so model swaps take effect at runtime); a zero from the callback means
+// "unknown" and falls back to the yaml-configured default.
+func (m *MemoryManager) effectiveContextWindow() int {
+	if m.contextWindowFn != nil {
+		if w := m.contextWindowFn(); w > 0 {
+			return w
+		}
+	}
+	return m.extraction.ContextWindow
 }
 
 func summarizeSessionEvents(events []SessionEvent) string {

--- a/src/agent/internal/agent/memory_config.go
+++ b/src/agent/internal/agent/memory_config.go
@@ -8,11 +8,16 @@ import (
 )
 
 type MemoryExtractionConfig struct {
-	TagCandidates     []string `yaml:"tag_candidates"`
-	EntitySuffixes    []string `yaml:"entity_suffixes"`
-	HotWindowEvents   int      `yaml:"hot_window_events"`
-	ContextWindow     int      `yaml:"context_window"`
-	CompressAtPercent int      `yaml:"compress_at_percent"`
+	TagCandidates   []string `yaml:"tag_candidates"`
+	EntitySuffixes  []string `yaml:"entity_suffixes"`
+	HotWindowEvents int      `yaml:"hot_window_events"`
+	// ContextWindow is the fallback context window in tokens used by the
+	// memory manager's compression trigger when the active model is unknown
+	// to the model_specs registry. The runtime normally derives the window
+	// from ModelResolver.Spec(); this value only kicks in for unrecognised
+	// models so behaviour stays sane instead of disabling compression.
+	ContextWindow     int `yaml:"context_window"`
+	CompressAtPercent int `yaml:"compress_at_percent"`
 }
 
 func DefaultMemoryExtractionConfig() MemoryExtractionConfig {

--- a/src/agent/internal/agent/memory_context_window_test.go
+++ b/src/agent/internal/agent/memory_context_window_test.go
@@ -1,0 +1,182 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// shouldCompress is the only place where the "current model context window"
+// matters at runtime. These tests pin its behaviour at three representative
+// model tiers (8k / 32k / 128k) so a future refactor that breaks the
+// dependency on the resolver-supplied window will fail visibly.
+
+func TestShouldCompressUsesResolverContextWindow8k(t *testing.T) {
+	cfg := DefaultMemoryExtractionConfig()
+	cfg.ContextWindow = 32_000 // yaml fallback should be ignored
+	cfg.CompressAtPercent = 50
+	cfg.HotWindowEvents = 100 // event count must not be the trigger here
+
+	mgr := NewMemoryManager("",
+		WithExtractionConfig(cfg),
+		WithContextWindowFn(func() int { return 8_000 }),
+	)
+
+	// 50% of 8k = 4000 tokens. 3999 must NOT trigger; 4000 must.
+	mgr.SetLastPromptTokens(3999)
+	if mgr.shouldCompress(5) {
+		t.Fatalf("8k window: 3999 tokens (49.99%%) should not trigger compression")
+	}
+	mgr.SetLastPromptTokens(4000)
+	if !mgr.shouldCompress(5) {
+		t.Fatalf("8k window: 4000 tokens (50%%) should trigger compression")
+	}
+	// Sanity: 32k yaml fallback is NOT being read — 5000 / 32000 = 15.6%
+	// would otherwise stay below threshold; instead 5000 / 8000 = 62.5%
+	// which must trigger.
+	mgr.SetLastPromptTokens(5000)
+	if !mgr.shouldCompress(5) {
+		t.Fatalf("8k window: 5000 tokens (62.5%% of 8k) should trigger; resolver value being ignored?")
+	}
+}
+
+func TestShouldCompressUsesResolverContextWindow32k(t *testing.T) {
+	cfg := DefaultMemoryExtractionConfig()
+	cfg.ContextWindow = 8_000 // yaml fallback should be ignored
+	cfg.CompressAtPercent = 50
+	cfg.HotWindowEvents = 100
+
+	mgr := NewMemoryManager("",
+		WithExtractionConfig(cfg),
+		WithContextWindowFn(func() int { return 32_000 }),
+	)
+
+	// 50% of 32k = 16000 tokens.
+	mgr.SetLastPromptTokens(15_999)
+	if mgr.shouldCompress(5) {
+		t.Fatalf("32k window: 15999 tokens (49.99%%) should not trigger compression")
+	}
+	mgr.SetLastPromptTokens(16_000)
+	if !mgr.shouldCompress(5) {
+		t.Fatalf("32k window: 16000 tokens (50%%) should trigger compression")
+	}
+}
+
+func TestShouldCompressUsesResolverContextWindow128k(t *testing.T) {
+	cfg := DefaultMemoryExtractionConfig()
+	cfg.ContextWindow = 32_000 // yaml fallback should be ignored
+	cfg.CompressAtPercent = 50
+	cfg.HotWindowEvents = 100
+
+	mgr := NewMemoryManager("",
+		WithExtractionConfig(cfg),
+		WithContextWindowFn(func() int { return 128_000 }),
+	)
+
+	// 50% of 128k = 64000 tokens. With the old hardcoded 32k, 20000 tokens
+	// (62.5% of 32k) would have triggered prematurely; against the real
+	// 128k window it must NOT.
+	mgr.SetLastPromptTokens(20_000)
+	if mgr.shouldCompress(5) {
+		t.Fatalf("128k window: 20000 tokens (15.6%%) should not trigger; old 32k hardcode would have")
+	}
+	mgr.SetLastPromptTokens(63_999)
+	if mgr.shouldCompress(5) {
+		t.Fatalf("128k window: 63999 tokens (49.99%%) should not trigger compression")
+	}
+	mgr.SetLastPromptTokens(64_000)
+	if !mgr.shouldCompress(5) {
+		t.Fatalf("128k window: 64000 tokens (50%%) should trigger compression")
+	}
+}
+
+func TestShouldCompressFallsBackToYAMLWhenResolverUnknown(t *testing.T) {
+	cfg := DefaultMemoryExtractionConfig()
+	cfg.ContextWindow = 32_000
+	cfg.CompressAtPercent = 50
+	cfg.HotWindowEvents = 100
+
+	mgr := NewMemoryManager("",
+		WithExtractionConfig(cfg),
+		// Resolver returns 0 → unknown model → fall back to yaml's 32k.
+		WithContextWindowFn(func() int { return 0 }),
+	)
+
+	mgr.SetLastPromptTokens(15_999)
+	if mgr.shouldCompress(5) {
+		t.Fatalf("yaml fallback (32k): 15999 tokens should not trigger")
+	}
+	mgr.SetLastPromptTokens(16_000)
+	if !mgr.shouldCompress(5) {
+		t.Fatalf("yaml fallback (32k): 16000 tokens should trigger; fallback path broken")
+	}
+}
+
+func TestShouldCompressFallsBackWhenNoResolverFnSet(t *testing.T) {
+	cfg := DefaultMemoryExtractionConfig()
+	cfg.ContextWindow = 10_000
+	cfg.CompressAtPercent = 50
+	cfg.HotWindowEvents = 100
+
+	mgr := NewMemoryManager("", WithExtractionConfig(cfg))
+
+	mgr.SetLastPromptTokens(4_999)
+	if mgr.shouldCompress(5) {
+		t.Fatalf("no resolver fn: 4999/10000 should not trigger")
+	}
+	mgr.SetLastPromptTokens(5_000)
+	if !mgr.shouldCompress(5) {
+		t.Fatalf("no resolver fn: 5000/10000 (50%%) should trigger")
+	}
+}
+
+func TestMaintainFilesystemMemoryUsesResolverContextWindow(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+
+	cfg := DefaultMemoryExtractionConfig()
+	cfg.ContextWindow = 1_000 // yaml fallback would have triggered at 600 tokens
+	cfg.CompressAtPercent = 50
+	cfg.HotWindowEvents = 100
+
+	mgr := NewMemoryManager(storageDir,
+		WithExtractionConfig(cfg),
+		WithContextWindowFn(func() int { return 100_000 }),
+	)
+
+	sessionDir := filepath.Join(storageDir, "session")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session: %v", err)
+	}
+	session := NewSessionMemoryStore(sessionDir)
+	now := time.Now().UTC()
+	for i := 0; i < 5; i++ {
+		if _, err := session.AppendEvent(ctx, SessionEvent{
+			EventID: fmt.Sprintf("evt_%d", i),
+			Ts:      now.Format(time.RFC3339Nano),
+			Type:    "user_input",
+			Role:    "user",
+			Content: "message",
+		}); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+
+	// 600 tokens / 100k window = 0.6% — far below the 50% threshold.
+	// Compression must NOT happen, even though the same prompt-tokens value
+	// (600 / 1000 = 60%) would have tripped the old hardcoded path.
+	mgr.SetLastPromptTokens(600)
+	if err := mgr.maintainFilesystemMemory(ctx); err != nil {
+		t.Fatalf("maintainFilesystemMemory: %v", err)
+	}
+	chunks, err := session.RecallChunks(ctx, ChunkRecallQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("RecallChunks: %v", err)
+	}
+	if len(chunks) != 0 {
+		t.Fatalf("expected no compression with 100k resolver window; got %d chunks (resolver value being ignored?)", len(chunks))
+	}
+}

--- a/src/agent/internal/agent/model_specs.go
+++ b/src/agent/internal/agent/model_specs.go
@@ -1,0 +1,56 @@
+package agent
+
+import "strings"
+
+// ModelSpec describes static capabilities of a chat completion model that the
+// runtime needs at decision time (e.g. when to compress session history).
+//
+// ContextWindow is the model's total context window in tokens (input + output).
+// MaxOutput is the per-request output cap the model advertises; 0 means unknown.
+type ModelSpec struct {
+	ContextWindow int
+	MaxOutput     int
+}
+
+// modelSpecRegistry covers the chat models referenced from this repo (overlay
+// agent.toml, configuration docs, common OpenRouter routes used in dev/staging)
+// plus a couple of common siblings. Numbers reflect public model cards; when in
+// doubt prefer the smaller advertised window so we err on the side of
+// triggering compression earlier instead of overflowing the prompt.
+var modelSpecRegistry = map[string]ModelSpec{
+	"google/gemini-3.5-flash":      {ContextWindow: 1_000_000, MaxOutput: 8_192},
+	"google/gemini-3.5-pro":        {ContextWindow: 1_000_000, MaxOutput: 8_192},
+	"anthropic/claude-3.5-sonnet":  {ContextWindow: 200_000, MaxOutput: 8_192},
+	"anthropic/claude-3.7-sonnet":  {ContextWindow: 200_000, MaxOutput: 8_192},
+	"bytedance-seed/seed-2.0-lite": {ContextWindow: 128_000, MaxOutput: 8_192},
+	"openai/gpt-4o":                {ContextWindow: 128_000, MaxOutput: 16_384},
+	"openai/gpt-4o-mini":           {ContextWindow: 128_000, MaxOutput: 16_384},
+}
+
+// LookupModelSpec returns the spec for the given (provider, model). It tries
+// the full canonical id first (e.g. "google/gemini-3.5-flash") and then falls
+// back to the bare model name without a provider prefix so configurations that
+// drop the prefix still resolve. The boolean is false when the model is
+// unknown; callers must then fall back to a configured default.
+func LookupModelSpec(provider, model string) (ModelSpec, bool) {
+	key := strings.ToLower(strings.TrimSpace(model))
+	if key == "" {
+		return ModelSpec{}, false
+	}
+	if spec, ok := modelSpecRegistry[key]; ok {
+		return spec, true
+	}
+	if i := strings.LastIndex(key, "/"); i >= 0 && i+1 < len(key) {
+		if spec, ok := modelSpecRegistry[key[i+1:]]; ok {
+			return spec, true
+		}
+	}
+	// Provider-prefixed retry for entries registered without a provider.
+	if provider != "" {
+		full := strings.ToLower(strings.TrimSpace(provider)) + "/" + key
+		if spec, ok := modelSpecRegistry[full]; ok {
+			return spec, true
+		}
+	}
+	return ModelSpec{}, false
+}

--- a/src/agent/internal/agent/model_specs_test.go
+++ b/src/agent/internal/agent/model_specs_test.go
@@ -1,0 +1,63 @@
+package agent
+
+import "testing"
+
+func TestLookupModelSpecKnownModels(t *testing.T) {
+	tests := []struct {
+		name          string
+		provider      string
+		model         string
+		wantContext   int
+		wantMaxOutput int
+	}{
+		{"openrouter gemini flash", "openrouter", "google/gemini-3.5-flash", 1_000_000, 8_192},
+		{"claude sonnet 3.5", "openrouter", "anthropic/claude-3.5-sonnet", 200_000, 8_192},
+		{"bytedance seed lite", "openrouter", "bytedance-seed/seed-2.0-lite", 128_000, 8_192},
+		{"gpt-4o", "openai", "openai/gpt-4o", 128_000, 16_384},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, ok := LookupModelSpec(tt.provider, tt.model)
+			if !ok {
+				t.Fatalf("LookupModelSpec(%q, %q): expected ok, got !ok", tt.provider, tt.model)
+			}
+			if spec.ContextWindow != tt.wantContext {
+				t.Errorf("ContextWindow = %d, want %d", spec.ContextWindow, tt.wantContext)
+			}
+			if spec.MaxOutput != tt.wantMaxOutput {
+				t.Errorf("MaxOutput = %d, want %d", spec.MaxOutput, tt.wantMaxOutput)
+			}
+		})
+	}
+}
+
+func TestLookupModelSpecCaseInsensitive(t *testing.T) {
+	spec, ok := LookupModelSpec("OpenRouter", "GOOGLE/Gemini-3.5-Flash")
+	if !ok {
+		t.Fatalf("expected case-insensitive lookup to succeed")
+	}
+	if spec.ContextWindow != 1_000_000 {
+		t.Errorf("ContextWindow = %d, want 1_000_000", spec.ContextWindow)
+	}
+}
+
+func TestLookupModelSpecUnknownModelReturnsNotOK(t *testing.T) {
+	if spec, ok := LookupModelSpec("openrouter", "vendor/unknown-model-9001"); ok {
+		t.Fatalf("expected !ok for unknown model, got spec=%+v", spec)
+	}
+	if spec, ok := LookupModelSpec("openai", ""); ok {
+		t.Fatalf("expected !ok for empty model, got spec=%+v", spec)
+	}
+}
+
+func TestModelManagerSpecUsesConfig(t *testing.T) {
+	mgr := NewModelManager(ModelConfig{Provider: "openrouter", Model: "google/gemini-3.5-flash"}, ProxyConfig{})
+	if got := mgr.Spec().ContextWindow; got != 1_000_000 {
+		t.Errorf("ModelManager.Spec().ContextWindow = %d, want 1_000_000", got)
+	}
+
+	unknown := NewModelManager(ModelConfig{Provider: "fake", Model: "vendor/no-such-model"}, ProxyConfig{})
+	if got := unknown.Spec().ContextWindow; got != 0 {
+		t.Errorf("unknown model: ContextWindow = %d, want 0 (caller falls back to yaml default)", got)
+	}
+}

--- a/src/agent/internal/agent/models.go
+++ b/src/agent/internal/agent/models.go
@@ -22,6 +22,10 @@ import (
 type ModelResolver interface {
 	Get() (llms.Model, error)
 	CallOptions() []chains.ChainCallOption
+	// Spec returns static capabilities (context window, max output) for the
+	// configured model. Implementations return a zero-value ModelSpec for
+	// unknown models; callers must fall back to a configured default.
+	Spec() ModelSpec
 }
 
 type ModelManager struct {
@@ -56,6 +60,11 @@ func (m *ModelManager) CallOptions() []chains.ChainCallOption {
 		options = append(options, chains.WithMaxTokens(m.config.MaxTokens))
 	}
 	return options
+}
+
+func (m *ModelManager) Spec() ModelSpec {
+	spec, _ := LookupModelSpec(m.config.Provider, m.config.Model)
+	return spec
 }
 
 func (m *ModelManager) build(cfg ModelConfig) (llms.Model, error) {

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -122,8 +122,9 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 	modelManager := NewModelManager(cfg.Model, cfg.Proxy)
 	summarizeFn := buildLLMSummarizeFn(modelManager)
 	profileFn := buildLLMProfileFn(modelManager)
+	contextWindowFn := func() int { return modelManager.Spec().ContextWindow }
 	toolSet.RegisterMemoryTools(memoryDir, profileFn)
-	rt := NewRuntimeWithDeps(cfg, modelManager, NewMemoryManager(memoryDir, WithExtractionConfig(extractionCfg), WithSummarizeFn(summarizeFn), WithProfileFn(profileFn), WithMemoryLogger(logger)), toolSet, skillIndex)
+	rt := NewRuntimeWithDeps(cfg, modelManager, NewMemoryManager(memoryDir, WithExtractionConfig(extractionCfg), WithSummarizeFn(summarizeFn), WithProfileFn(profileFn), WithContextWindowFn(contextWindowFn), WithMemoryLogger(logger)), toolSet, skillIndex)
 	rt.logger = logger
 	return rt, nil
 }

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -31,6 +31,7 @@ func TestEffectiveMaxIterationsDefaultsAndUnlimited(t *testing.T) {
 type testModelResolver struct {
 	model llms.Model
 	calls int
+	spec  ModelSpec
 }
 
 func (r *testModelResolver) Get() (llms.Model, error) {
@@ -40,6 +41,10 @@ func (r *testModelResolver) Get() (llms.Model, error) {
 
 func (r *testModelResolver) CallOptions() []chains.ChainCallOption {
 	return nil
+}
+
+func (r *testModelResolver) Spec() ModelSpec {
+	return r.spec
 }
 
 func TestRuntimeRun(t *testing.T) {


### PR DESCRIPTION
## Summary

The memory manager's compression trigger reads `context_window=32000`
from `extraction.yaml`, so the same threshold fires regardless of the
model in use — too aggressive on a 128k model, an overflow risk on an
8k one. This change makes it follow the active model.

## Changes

- New `model_specs.go`: `ModelSpec{ContextWindow, MaxOutput}` registry +
  `LookupModelSpec(provider, model)`. Covers the chat models we ship
  configs for: `google/gemini-3.5-flash`/`-pro`,
  `anthropic/claude-3.5/3.7-sonnet`, `bytedance-seed/seed-2.0-lite`,
  `openai/gpt-4o`/`-mini`. Easy to extend.
- `ModelResolver` gains `Spec() ModelSpec`. `ModelManager.Spec()` looks
  up its config; unknown models return zero-value (caller falls back).
- `MemoryManager` gains `WithContextWindowFn`. `shouldCompress` and the
  compression-triggered log line both read through a new
  `effectiveContextWindow()` helper: callback-supplied value wins when
  positive, otherwise yaml `ContextWindow` is the fallback default. The
  yaml field's doc comment now spells that out.
- `runtime.go` wires `WithContextWindowFn(func() int { return modelManager.Spec().ContextWindow })`
  so model swaps take effect at runtime without restart.

## Tests

- `model_specs_test.go`: known-model lookups (8k/32k/128k tier) +
  case-insensitive + unknown-model + empty-model fallback +
  `ModelManager.Spec()` end-to-end.
- `memory_context_window_test.go`: `shouldCompress` tipping points at
  8k / 32k / 128k (each verifies just-below and just-at the 50%
  threshold), unknown-model yaml fallback, no-resolver-fn fallback, and
  an end-to-end `maintainFilesystemMemory` check that proves the
  resolver value (not the yaml) drives the decision.
- Full `go test ./...` and `go vet ./...` pass.

## Acceptance criteria (from AID-7)

- [x] Compression trigger reads `modelSpec.ContextWindow`
- [x] Unknown model falls back without panic / without blocking flow
- [x] Unit tests cover 8k / 32k / 128k tipping points
- [x] yaml `context_window` re-documented as fallback default

Tracking: [AID-7](https://github.com/AidenAI-IO/aiden-hardware-demo) — issue `15a66f11-816e-44b4-ae5e-7f732479ab72`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Memory management now dynamically resolves the active model's context window to improve compression behavior based on the specific model in use.

* **Improvements**
  * Enhanced model capability detection and fallback handling for context window configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->