### PR TITLE
feat(memory): split removePersisted into ClearSession and ClearAll

### DIFF
--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -170,7 +170,7 @@ func (m *MemoryManager) Snapshot(ctx context.Context, agentName string) ([]Messa
 	return result, nil
 }
 
-func (m *MemoryManager) Clear(ctx context.Context, agentName string) error {
+func (m *MemoryManager) ClearSession(ctx context.Context, agentName string) error {
 	m.mu.Lock()
 	handle, ok := m.handles[agentName]
 	if ok {
@@ -181,10 +181,21 @@ func (m *MemoryManager) Clear(ctx context.Context, agentName string) error {
 	}
 	m.mu.Unlock()
 
-	if !ok {
-		return m.removePersisted(agentName)
+	return m.removeSessionPersisted(agentName)
+}
+
+func (m *MemoryManager) ClearAll(ctx context.Context, agentName string) error {
+	m.mu.Lock()
+	handle, ok := m.handles[agentName]
+	if ok {
+		if err := handle.Memory.Clear(ctx); err != nil {
+			m.mu.Unlock()
+			return err
+		}
 	}
-	return m.removePersisted(agentName)
+	m.mu.Unlock()
+
+	return m.removeAllPersisted(agentName)
 }
 
 func (m *MemoryManager) Save(ctx context.Context, agentName string) error {
@@ -333,7 +344,21 @@ func (m *MemoryManager) persistSnapshot(agentName string, records []MessageRecor
 	return nil
 }
 
-func (m *MemoryManager) removePersisted(agentName string) error {
+func (m *MemoryManager) removeSessionPersisted(agentName string) error {
+	if m.storageDir == "" {
+		return nil
+	}
+	if err := os.Remove(m.memoryPath(agentName)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove persisted memory for %q: %w", agentName, err)
+	}
+	if err := os.RemoveAll(filepath.Join(m.storageDir, "session")); err != nil {
+		return fmt.Errorf("remove session memory for %q: %w", agentName, err)
+	}
+	m.eventCount[agentName] = 0
+	return nil
+}
+
+func (m *MemoryManager) removeAllPersisted(agentName string) error {
 	if m.storageDir == "" {
 		return nil
 	}

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -278,7 +278,7 @@ func TestMemoryManagerTokenTrackingConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
-func TestMemoryManagerClearRemovesFilesystemMemoryArtifacts(t *testing.T) {
+func TestMemoryManagerClearAllRemovesFilesystemMemoryArtifacts(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()
 	manager := NewMemoryManager(storageDir)
@@ -302,8 +302,8 @@ func TestMemoryManagerClearRemovesFilesystemMemoryArtifacts(t *testing.T) {
 		t.Fatalf("expected session chunk index before clear: %v", err)
 	}
 
-	if err := manager.Clear(ctx, "default"); err != nil {
-		t.Fatalf("Clear() error = %v", err)
+	if err := manager.ClearAll(ctx, "default"); err != nil {
+		t.Fatalf("ClearAll() error = %v", err)
 	}
 	for _, path := range []string{
 		filepath.Join(storageDir, "session"),
@@ -313,6 +313,67 @@ func TestMemoryManagerClearRemovesFilesystemMemoryArtifacts(t *testing.T) {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("expected %s to be removed, stat err = %v", path, err)
 		}
+	}
+}
+
+func TestMemoryManagerClearSessionPreservesLongTermMemory(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	manager := NewMemoryManager(storageDir)
+	handle, err := manager.Get("default", MemoryConfig{Type: "window", WindowSize: 10})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	// Create long_term and lifecycle directories with content
+	longTermDir := filepath.Join(storageDir, "long_term")
+	lifecycleDir := filepath.Join(storageDir, "lifecycle")
+	if err := os.MkdirAll(longTermDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll long_term: %v", err)
+	}
+	if err := os.MkdirAll(lifecycleDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll lifecycle: %v", err)
+	}
+	profilePath := filepath.Join(longTermDir, "profile.md")
+	if err := os.WriteFile(profilePath, []byte("# User Profile\nPrefers concise answers."), 0o644); err != nil {
+		t.Fatalf("WriteFile profile.md: %v", err)
+	}
+	tombstonePath := filepath.Join(lifecycleDir, "tombstones.jsonl")
+	if err := os.WriteFile(tombstonePath, []byte(`{"id":"mem-1","reason":"outdated"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile tombstones.jsonl: %v", err)
+	}
+
+	// Create session data via Save
+	messages := []llms.ChatMessage{
+		llms.HumanChatMessage{Content: "hello"},
+	}
+	for i := 0; i < 22; i++ {
+		messages = append(messages, llms.HumanChatMessage{Content: "filler"})
+	}
+	if err := handle.History.SetMessages(ctx, messages); err != nil {
+		t.Fatalf("SetMessages() error = %v", err)
+	}
+	if err := manager.Save(ctx, "default"); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	sessionDir := filepath.Join(storageDir, "session")
+	if _, err := os.Stat(sessionDir); err != nil {
+		t.Fatalf("expected session dir to exist before clear: %v", err)
+	}
+
+	// ClearSession should remove session but preserve long_term and lifecycle
+	if err := manager.ClearSession(ctx, "default"); err != nil {
+		t.Fatalf("ClearSession() error = %v", err)
+	}
+
+	if _, err := os.Stat(sessionDir); !os.IsNotExist(err) {
+		t.Fatalf("expected session dir to be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(profilePath); err != nil {
+		t.Fatalf("expected long_term/profile.md to be preserved: %v", err)
+	}
+	if _, err := os.Stat(tombstonePath); err != nil {
+		t.Fatalf("expected lifecycle/tombstones.jsonl to be preserved: %v", err)
 	}
 }
 

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -260,7 +260,11 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 }
 
 func (r *Runtime) ClearMemory(ctx context.Context) error {
-	return r.memories.Clear(ctx, "default")
+	return r.memories.ClearSession(ctx, "default")
+}
+
+func (r *Runtime) ClearAllMemory(ctx context.Context) error {
+	return r.memories.ClearAll(ctx, "default")
 }
 
 func (r *Runtime) resolveTools(skills ResolvedSkills) []langtools.Tool {

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -157,6 +157,7 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/api/chat", s.handleChat)
 	mux.HandleFunc("/api/history", s.handleHistory)
 	mux.HandleFunc("/api/clear", s.handleClear)
+	mux.HandleFunc("/api/clear-all", s.handleClearAll)
 	mux.HandleFunc("/api/tools", s.handleTools)
 	mux.HandleFunc("/api/tools/", s.handleTools)
 	mux.HandleFunc("/api/tool-skills", s.handleToolSkills)
@@ -323,6 +324,31 @@ func (s *Server) handleClear(w http.ResponseWriter, r *http.Request) {
 			s.logger.Error("Clear memory failed: %v", err)
 		}
 		http.Error(w, fmt.Sprintf("Clear memory failed: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleClearAll(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.Lock()
+	s.history = make([]Message, 0)
+	s.mu.Unlock()
+
+	if s.logger != nil {
+		s.logger.Info("All memory cleared")
+	}
+	if err := s.runtime.ClearAllMemory(r.Context()); err != nil {
+		if s.logger != nil {
+			s.logger.Error("Clear all memory failed: %v", err)
+		}
+		http.Error(w, fmt.Sprintf("Clear all memory failed: %v", err), http.StatusInternalServerError)
 		return
 	}
 
@@ -1701,6 +1727,7 @@ const webUI = `<!DOCTYPE html>
                 <h1>Aiden Agent</h1>
                 <div class="topbar-actions">
                     <button type="button" class="new-chat-btn" onclick="clearHistory()">New chat</button>
+                    <button type="button" class="new-chat-btn" onclick="resetAllMemory()" style="background:#c0392b;">Reset all memory</button>
                 </div>
             </header>
 
@@ -2166,6 +2193,18 @@ const webUI = `<!DOCTYPE html>
                 renderHistory([]);
             } catch (err) {
                 console.error('Failed to clear history:', err);
+            }
+        }
+
+        async function resetAllMemory() {
+            if (!confirm('This will permanently delete ALL memory including long-term memories and user profile. Continue?')) return;
+
+            try {
+                await fetch('/api/clear-all', { method: 'POST' });
+                clearDraftAttachments();
+                renderHistory([]);
+            } catch (err) {
+                console.error('Failed to reset all memory:', err);
             }
         }
 


### PR DESCRIPTION
## Summary

Splits the destructive `removePersisted` into two separate APIs:

- **`ClearSession()`** — only removes `session/` directory (events.jsonl, chunks/, summary.md) and the in-memory conversation buffer. Preserves `long_term/`, `lifecycle/`, and `profile.md`.
- **`ClearAll()`** — retains the original destructive semantics, removing all memory directories.

## Changes

- `memory.go`: Replaced `Clear()` with `ClearSession()` and `ClearAll()`; split `removePersisted` into `removeSessionPersisted` and `removeAllPersisted`
- `runtime.go`: `ClearMemory()` now calls `ClearSession`; added `ClearAllMemory()` for full reset
- `server.go`: Added `/api/clear-all` endpoint; existing `/api/clear` now only clears session; added "Reset all memory" button to UI
- `memory_test.go`: Added `TestMemoryManagerClearSessionPreservesLongTermMemory` and renamed existing test to `TestMemoryManagerClearAllRemovesFilesystemMemoryArtifacts`

## Testing

All existing tests pass. New test verifies that `ClearSession` preserves `long_term/profile.md` and `lifecycle/tombstones.jsonl` while removing `session/`.

Closes AID-11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Reset all memory" button to the user interface. Clears all stored memory and conversation history with a confirmation prompt to prevent accidental activation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->