### PR TITLE
feat(agent): acknowledge wakeup before listening

### DIFF
--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -16,7 +16,10 @@ import (
 	"aiden-agent/internal/agent"
 )
 
-const wakeupListenTimeout = 10 * time.Second
+const (
+	wakeupListenTimeout = 10 * time.Second
+	wakeupAckText       = "我在"
+)
 
 func main() {
 	var (
@@ -234,6 +237,7 @@ func runWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Ru
 			return
 		case <-events:
 			log.Println("\n[wakeup] GPIO 33 triggered, opening voice session...")
+			speakWakeupAck(dialog)
 			if exit := runVoiceSession(cfg, dialog, runtime, sigChan, events); exit {
 				dialog.StopRecording()
 				log.Println("\n[exit] Stopped.")
@@ -293,6 +297,7 @@ func runLegacyWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *ag
 		}
 
 		// Start recording
+		speakWakeupAck(dialog)
 		log.Println("[listen] Recording audio...")
 		if err := dialog.StartRecording(); err != nil {
 			log.Printf("[error] Failed to start recording: %v\n", err)
@@ -318,6 +323,15 @@ func runLegacyWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *ag
 		wakeupMutex.Unlock()
 
 		log.Println("[ready] Waiting for next wakeup event...")
+	}
+}
+
+func speakWakeupAck(dialog audioDialogRunner) {
+	if dialog == nil {
+		return
+	}
+	if err := dialog.Speak(context.Background(), wakeupAckText, nil); err != nil {
+		log.Printf("[wakeup] acknowledgement failed: %v\n", err)
 	}
 }
 
@@ -354,6 +368,9 @@ func runVoiceSession(cfg agent.Config, dialog audioDialogRunner, runtime *agent.
 		firstTurn = false
 		if interrupted {
 			log.Println("[session] turn interrupted, listening for follow-up")
+			if maxTurns <= 0 || turns < maxTurns {
+				speakWakeupAck(dialog)
+			}
 		}
 	}
 }

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -26,12 +26,14 @@ type fakeAudioDialog struct {
 	spoken             []string
 	repeatEmpty        bool
 	readDelay          time.Duration
+	ops                []string
 	starts             int
 	stops              int
 	resets             int
 }
 
 func (d *fakeAudioDialog) StartRecording() error {
+	d.ops = append(d.ops, "start")
 	d.starts++
 	if len(d.chunkBatches) > 0 {
 		d.chunks = d.chunkBatches[0]
@@ -41,6 +43,7 @@ func (d *fakeAudioDialog) StartRecording() error {
 }
 
 func (d *fakeAudioDialog) StopRecording() error {
+	d.ops = append(d.ops, "stop")
 	d.stops++
 	return nil
 }
@@ -103,6 +106,7 @@ func (d *fakeAudioDialog) RunAgentTurn(ctx context.Context, input agent.TurnInpu
 }
 
 func (d *fakeAudioDialog) Speak(ctx context.Context, text string, interrupt <-chan struct{}) error {
+	d.ops = append(d.ops, "speak:"+text)
 	d.spoken = append(d.spoken, text)
 	if d.speak != nil {
 		return d.speak(ctx)
@@ -113,6 +117,7 @@ func (d *fakeAudioDialog) Speak(ctx context.Context, text string, interrupt <-ch
 func (d *fakeAudioDialog) FlushVAD() []int16 { return nil }
 
 func (d *fakeAudioDialog) ResetVAD() {
+	d.ops = append(d.ops, "reset")
 	d.resets++
 	if d.vad != nil {
 		d.vad.Reset()
@@ -253,6 +258,43 @@ func TestRunWakeupModeProcessesTriggeredAudioAndStopsOnSignal(t *testing.T) {
 	}
 	if len(dialog.frames) != 1 || dialog.frames[0][0] != 300 || dialog.frames[0][1] != 400 {
 		t.Fatalf("unexpected VAD frames: %#v", dialog.frames)
+	}
+}
+
+func TestRunWakeupModeLegacyAcknowledgesWakeupBeforeRecording(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	dialog := &fakeAudioDialog{
+		frameSamples: 2,
+		chunks: []*agent.AudioChunkResult{
+			{PCM: pcm16BytesFromSamples(300, 400)},
+		},
+		utterance: []int16{300, 400},
+		onUtterance: func() {
+			sigChan <- syscall.SIGTERM
+		},
+	}
+	watcher := &fakeWakeupWatcher{}
+
+	done := make(chan struct{})
+	go func() {
+		runWakeupMode(agent.Config{}, dialog, nil, sigChan, func(pin int, callback func()) (wakeupWatcher, error) {
+			watcher.callback = callback
+			return watcher, nil
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runWakeupMode did not stop after signal")
+	}
+
+	if len(dialog.ops) < 3 {
+		t.Fatalf("dialog ops = %#v, want acknowledgement before recording", dialog.ops)
+	}
+	if dialog.ops[0] != "speak:"+wakeupAckText || dialog.ops[1] != "start" || dialog.ops[2] != "reset" {
+		t.Fatalf("dialog ops = %#v, want speak acknowledgement before start/reset", dialog.ops)
 	}
 }
 
@@ -466,7 +508,7 @@ func TestRunWakeupModeVoiceSessionProcessesFollowupWithoutSecondWakeup(t *testin
 			{300, 400},
 		},
 		speak: func(ctx context.Context) error {
-			if len(dialog.spoken) == 2 {
+			if len(dialog.spoken) == 3 {
 				sigChan <- syscall.SIGTERM
 			}
 			return nil
@@ -494,8 +536,57 @@ func TestRunWakeupModeVoiceSessionProcessesFollowupWithoutSecondWakeup(t *testin
 	if len(dialog.utterances) != 2 {
 		t.Fatalf("utterances = %d, want 2", len(dialog.utterances))
 	}
-	if len(dialog.spoken) != 2 {
-		t.Fatalf("spoken replies = %d, want 2", len(dialog.spoken))
+	if len(dialog.spoken) != 3 {
+		t.Fatalf("spoken replies = %d, want wakeup acknowledgement plus 2 replies", len(dialog.spoken))
+	}
+	if dialog.spoken[0] != wakeupAckText {
+		t.Fatalf("first spoken text = %q, want wakeup acknowledgement", dialog.spoken[0])
+	}
+}
+
+func TestRunWakeupModeVoiceSessionAcknowledgesWakeupBeforeRecording(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	watcher := &fakeWakeupWatcher{}
+	var dialog *fakeAudioDialog
+	dialog = &fakeAudioDialog{
+		frameSamples: 2,
+		chunkBatches: [][]*agent.AudioChunkResult{
+			{{PCM: pcm16BytesFromSamples(100, 200)}},
+		},
+		utterancesToReturn: [][]int16{
+			{100, 200},
+		},
+		speak: func(ctx context.Context) error {
+			if len(dialog.spoken) == 2 {
+				go func() {
+					time.Sleep(10 * time.Millisecond)
+					sigChan <- syscall.SIGTERM
+				}()
+			}
+			return nil
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		runWakeupMode(agent.Config{InputMode: "stt", VoiceMaxTurns: 1}, dialog, nil, sigChan, func(pin int, callback func()) (wakeupWatcher, error) {
+			watcher.callback = callback
+			return watcher, nil
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runWakeupMode did not stop after signal")
+	}
+
+	if len(dialog.ops) < 3 {
+		t.Fatalf("dialog ops = %#v, want acknowledgement before recording", dialog.ops)
+	}
+	if dialog.ops[0] != "speak:"+wakeupAckText || dialog.ops[1] != "start" || dialog.ops[2] != "reset" {
+		t.Fatalf("dialog ops = %#v, want speak acknowledgement before start/reset", dialog.ops)
 	}
 }
 
@@ -605,12 +696,13 @@ func TestRunVoiceSessionWakeupInterruptsThinking(t *testing.T) {
 	default:
 		t.Fatal("thinking context was not canceled")
 	}
-	if len(dialog.spoken) != 0 {
-		t.Fatalf("spoken replies = %d, want 0 after thinking interrupt", len(dialog.spoken))
+	if len(dialog.spoken) != 1 || dialog.spoken[0] != wakeupAckText {
+		t.Fatalf("spoken texts = %#v, want wakeup acknowledgement after thinking interrupt", dialog.spoken)
 	}
 	if dialog.starts < 2 {
 		t.Fatalf("dialog starts = %d, want follow-up listening after interrupt", dialog.starts)
 	}
+	assertWakeupAckBeforeSecondRecording(t, dialog.ops)
 }
 
 func TestRunVoiceSessionWakeupInterruptsSpeaking(t *testing.T) {
@@ -618,6 +710,7 @@ func TestRunVoiceSessionWakeupInterruptsSpeaking(t *testing.T) {
 	events := make(chan voiceEvent, 2)
 	speakStarted := make(chan struct{})
 	ctxCanceled := make(chan struct{})
+	speakCalls := 0
 	dialog := &fakeAudioDialog{
 		frameSamples: 2,
 		chunkBatches: [][]*agent.AudioChunkResult{
@@ -630,6 +723,10 @@ func TestRunVoiceSessionWakeupInterruptsSpeaking(t *testing.T) {
 		repeatEmpty: true,
 		readDelay:   time.Millisecond,
 		speak: func(ctx context.Context) error {
+			speakCalls++
+			if speakCalls > 1 {
+				return nil
+			}
 			close(speakStarted)
 			<-ctx.Done()
 			close(ctxCanceled)
@@ -651,11 +748,36 @@ func TestRunVoiceSessionWakeupInterruptsSpeaking(t *testing.T) {
 	default:
 		t.Fatal("speaking context was not canceled")
 	}
-	if len(dialog.spoken) != 1 {
-		t.Fatalf("spoken replies = %d, want 1 before speaking interrupt", len(dialog.spoken))
+	if len(dialog.spoken) != 2 {
+		t.Fatalf("spoken texts = %d, want reply plus wakeup acknowledgement", len(dialog.spoken))
+	}
+	if dialog.spoken[1] != wakeupAckText {
+		t.Fatalf("second spoken text = %q, want wakeup acknowledgement", dialog.spoken[1])
 	}
 	if dialog.starts < 2 {
 		t.Fatalf("dialog starts = %d, want follow-up listening after interrupt", dialog.starts)
+	}
+	assertWakeupAckBeforeSecondRecording(t, dialog.ops)
+}
+
+func assertWakeupAckBeforeSecondRecording(t *testing.T, ops []string) {
+	t.Helper()
+	ackIdx := -1
+	secondStartIdx := -1
+	startsSeen := 0
+	for i, op := range ops {
+		if op == "speak:"+wakeupAckText && ackIdx == -1 {
+			ackIdx = i
+		}
+		if op == "start" {
+			startsSeen++
+			if startsSeen == 2 {
+				secondStartIdx = i
+			}
+		}
+	}
+	if ackIdx == -1 || secondStartIdx == -1 || ackIdx > secondStartIdx {
+		t.Fatalf("dialog ops = %#v, want wakeup acknowledgement before second recording", ops)
 	}
 }
 


### PR DESCRIPTION
## Summary
- play a fixed wakeup acknowledgement ("我在") before starting microphone recording
- cover legacy wakeup, voice session wakeup, and wakeup-interrupt follow-up paths
- add tests asserting the acknowledgement happens before recording starts

## Tests
- go test ./cmd/daemon
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio acknowledgement when the device wakes up via GPIO events, providing immediate audio feedback to users during wake activation.
  * Acknowledgement is intelligently suppressed after the final turn in sessions with defined turn limits to avoid redundant audio output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->