### PR TITLE
chore: change default edid to 1080p30

### DIFF
--- a/docs/03-services/frame-service.md
+++ b/docs/03-services/frame-service.md
@@ -17,8 +17,9 @@
 | --- | --- | --- |
 | Socket（开发直接运行） | `/tmp/frame_service.sock` | `frame_service_main.cpp` 默认值 |
 | Socket（固件服务） | `/run/frame_service/frame_service.sock` | init 配置默认值 |
+| EDID | 内置 1080p30 CTA EDID | 未传 `--edid` 时使用 |
 | Ring size | `3` | `kDefaultFrameServiceRingSize` |
-| FPS | `3.0` | 降低 CPU、内存带宽和发热，同时保持截图帧龄更低 |
+| FPS | `3.0` | 默认 1080p 输入，服务采样 FPS 保持较低以控制 CPU、内存带宽和发热 |
 | Screenshot max edge | `960` | Go screenshot 工具默认压缩策略相关 |
 
 ## 启动

--- a/tests/frame_service_defaults_test.cpp
+++ b/tests/frame_service_defaults_test.cpp
@@ -1,7 +1,14 @@
 #include "doctest.h"
+#include "camera_frame_utils.h"
 #include "frame_service_defaults.h"
 
-TEST_CASE("frame_service defaults keep memory footprint modest") {
+TEST_CASE("frame_service defaults use 1080p30 EDID with modest sampling fps") {
+    aiden::CameraConfig camera;
+    aiden_demo::set_default_camera_config(&camera);
+
+    CHECK(camera.width == 1920);
+    CHECK(camera.height == 1080);
+    CHECK(camera.edid_path == nullptr);
     CHECK(aiden::kDefaultFrameServiceRingSize == 3);
     CHECK(aiden::kDefaultFrameServiceFps == 3.0);
     CHECK(aiden::kDefaultScreenshotMaxEdge == 960);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified default EDID configuration (1080p30 CTA EDID) when not explicitly specified.
  * Updated descriptions for default frame service parameters to reflect resource optimization benefits.

* **Tests**
  * Added validation tests for default camera configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->