### PR TITLE
Add spoken tool action descriptions

### DIFF
--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"log"
+	"strings"
 )
 
 type TurnInput = AudioInputResult
@@ -183,6 +184,11 @@ func (d *AudioDialog) RunAgentTurn(ctx context.Context, input TurnInput, runtime
 	result, err := runtime.Run(ctx, RunRequest{
 		Input:       input.InputText,
 		Attachments: input.Attachments,
+		EventHandler: func(event RunEvent) {
+			if event.Type == "tool_call" {
+				d.SpeakToolDescription(ctx, event.Description)
+			}
+		},
 	})
 	if err != nil {
 		return RunResult{}, fmt.Errorf("LLM request failed: %w", err)
@@ -190,6 +196,16 @@ func (d *AudioDialog) RunAgentTurn(ctx context.Context, input TurnInput, runtime
 
 	log.Printf("[llm] Response received\n")
 	return result, nil
+}
+
+func (d *AudioDialog) SpeakToolDescription(ctx context.Context, description string) {
+	description = strings.TrimSpace(description)
+	if description == "" {
+		return
+	}
+	if err := d.Speak(ctx, description, nil); err != nil {
+		log.Printf("[error] Tool description TTS failed: %v", err)
+	}
 }
 
 func (d *AudioDialog) Speak(ctx context.Context, text string, interrupt <-chan struct{}) error {
@@ -236,6 +252,11 @@ func (d *AudioDialog) ProcessTextInput(ctx context.Context, text string, runtime
 
 	result, err := runtime.Run(ctx, RunRequest{
 		Input: text,
+		EventHandler: func(event RunEvent) {
+			if event.Type == "tool_call" {
+				d.SpeakToolDescription(ctx, event.Description)
+			}
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("LLM request failed: %w", err)

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 )
 
 type TurnInput = AudioInputResult
+
+const toolDescriptionSpeechTimeout = 5 * time.Second
 
 // AudioDialog manages the audio conversation loop
 type AudioDialog struct {
@@ -203,7 +206,12 @@ func (d *AudioDialog) SpeakToolDescription(ctx context.Context, description stri
 	if description == "" {
 		return
 	}
-	if err := d.Speak(ctx, description, nil); err != nil {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	speakCtx, cancel := context.WithTimeout(ctx, toolDescriptionSpeechTimeout)
+	defer cancel()
+	if err := d.Speak(speakCtx, description, nil); err != nil {
 		log.Printf("[error] Tool description TTS failed: %v", err)
 	}
 }

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -135,6 +135,66 @@ func TestProcessUtteranceAudioModeSendsWAVAttachmentToRuntime(t *testing.T) {
 	}
 }
 
+func TestAudioDialogSpeaksToolDescriptionBeforeFinalAnswer(t *testing.T) {
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			{
+				Choices: []*llms.ContentChoice{{
+					ToolCalls: []llms.ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						FunctionCall: &llms.FunctionCall{
+							Name:      "audio_volume",
+							Arguments: `{"__arg1":"{}","description":"我先检查当前音量。"}`,
+						},
+					}},
+				}},
+			},
+			{
+				Choices: []*llms.ContentChoice{{
+					Content: "当前音量是 42。",
+				}},
+			},
+		},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:       ModelConfig{Provider: "fake"},
+			Instruction: "Use tools when external state is requested.",
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"audio_volume": &stubTool{
+				name:        "audio_volume",
+				description: "Get the current audio playback volume.",
+				output:      `{"volume":42}`,
+			},
+		}},
+		NewSkillIndex(),
+	)
+	tts := &fakeTTSClient{}
+	dialog := &AudioDialog{
+		config: Config{
+			Model:     ModelConfig{Provider: "fake"},
+			Audio:     AudioConfig{SampleRate: 16000},
+			InputMode: "audio",
+		},
+		audioClient: NewAudioServiceClient("/tmp/audio.sock"),
+		ttsClient:   tts,
+	}
+
+	if err := dialog.ProcessUtterance(context.Background(), []int16{100, -100, 200, -200}, runtime); err != nil {
+		t.Fatalf("ProcessUtterance() error = %v", err)
+	}
+	if len(tts.texts) != 2 {
+		t.Fatalf("expected tool description and final answer TTS, got %#v", tts.texts)
+	}
+	if tts.texts[0] != "我先检查当前音量。" || tts.texts[1] != "当前音量是 42。" {
+		t.Fatalf("unexpected TTS order: %#v", tts.texts)
+	}
+}
+
 type fakeTTSClient struct {
 	texts []string
 	audio *AudioServiceClient

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -193,15 +193,21 @@ func TestAudioDialogSpeaksToolDescriptionBeforeFinalAnswer(t *testing.T) {
 	if tts.texts[0] != "我先检查当前音量。" || tts.texts[1] != "当前音量是 42。" {
 		t.Fatalf("unexpected TTS order: %#v", tts.texts)
 	}
+	if len(tts.deadlineSet) != 2 || !tts.deadlineSet[0] || tts.deadlineSet[1] {
+		t.Fatalf("unexpected TTS deadline use: %#v", tts.deadlineSet)
+	}
 }
 
 type fakeTTSClient struct {
-	texts []string
-	audio *AudioServiceClient
+	texts       []string
+	audio       *AudioServiceClient
+	deadlineSet []bool
 }
 
 func (c *fakeTTSClient) TextToSpeechStream(ctx context.Context, text string, audio *AudioServiceClient) error {
+	_, hasDeadline := ctx.Deadline()
 	c.texts = append(c.texts, text)
 	c.audio = audio
+	c.deadlineSet = append(c.deadlineSet, hasDeadline)
 	return nil
 }

--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -28,7 +28,13 @@ type visualObservationTool interface {
 	ReturnsVisualObservation() bool
 }
 
-const toolDescriptionLogMarker = "\nTool description: "
+const toolActionLogVersion = 1
+
+type toolActionLog struct {
+	Version         int    `json:"aiden_action_log_version"`
+	Message         string `json:"message"`
+	ToolDescription string `json:"tool_description,omitempty"`
+}
 
 type toolInvocation struct {
 	Input       string
@@ -139,6 +145,7 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 			functionName := toolCall.FunctionCall.Name
 			toolInputStr := toolCall.FunctionCall.Arguments
 			invocation := extractToolInvocation(toolInputStr)
+			invocation.Description = toolDescriptionOrFallback(functionName, invocation.Description)
 
 			contentMsg := "\n"
 			if choice.Content != "" {
@@ -159,6 +166,7 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 		functionName := choice.FuncCall.Name
 		toolInputStr := choice.FuncCall.Arguments
 		invocation := extractToolInvocation(toolInputStr)
+		invocation.Description = toolDescriptionOrFallback(functionName, invocation.Description)
 
 		contentMsg := "\n"
 		if choice.Content != "" {
@@ -236,8 +244,11 @@ func (a *FunctionAgent) constructFunctionScratchPad(steps []schema.AgentStep) []
 				ID:   steps[j].Action.ToolID,
 				Type: "function",
 				FunctionCall: &llms.FunctionCall{
-					Name:      steps[j].Action.Tool,
-					Arguments: encodeToolArguments(steps[j].Action.ToolInput, toolDescriptionFromAction(steps[j].Action)),
+					Name: steps[j].Action.Tool,
+					Arguments: encodeToolArguments(
+						steps[j].Action.ToolInput,
+						toolDescriptionOrFallback(steps[j].Action.Tool, toolDescriptionFromAction(steps[j].Action)),
+					),
 				},
 			})
 		}
@@ -415,19 +426,39 @@ func encodeToolArguments(input string, descriptions ...string) string {
 }
 
 func formatToolActionLog(name, arguments, description, contentMsg string) string {
-	log := fmt.Sprintf("Invoking: %s with %s %s", name, arguments, contentMsg)
-	if description == "" {
-		return log
+	message := fmt.Sprintf("Invoking: %s with %s %s", name, arguments, contentMsg)
+	metadata := toolActionLog{
+		Version:         toolActionLogVersion,
+		Message:         message,
+		ToolDescription: toolDescriptionOrFallback(name, description),
 	}
-	return log + toolDescriptionLogMarker + description
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return message
+	}
+	return string(encoded)
 }
 
 func toolDescriptionFromAction(action schema.AgentAction) string {
-	idx := strings.LastIndex(action.Log, toolDescriptionLogMarker)
-	if idx < 0 {
+	var metadata toolActionLog
+	if err := json.Unmarshal([]byte(action.Log), &metadata); err != nil {
 		return ""
 	}
-	return strings.TrimSpace(action.Log[idx+len(toolDescriptionLogMarker):])
+	if metadata.Version != toolActionLogVersion {
+		return ""
+	}
+	return strings.TrimSpace(metadata.ToolDescription)
+}
+
+func toolDescriptionOrFallback(toolName, description string) string {
+	if description = strings.TrimSpace(description); description != "" {
+		return description
+	}
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		return "I will use a tool."
+	}
+	return fmt.Sprintf("I will use the %s tool.", toolName)
 }
 
 func extractFinalAnswer(content string) string {

--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -28,6 +28,13 @@ type visualObservationTool interface {
 	ReturnsVisualObservation() bool
 }
 
+const toolDescriptionLogMarker = "\nTool description: "
+
+type toolInvocation struct {
+	Input       string
+	Description string
+}
+
 func NewFunctionAgent(
 	llm llms.Model,
 	tools []langtools.Tool,
@@ -131,7 +138,7 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 			}
 			functionName := toolCall.FunctionCall.Name
 			toolInputStr := toolCall.FunctionCall.Arguments
-			toolInput := extractToolInput(toolInputStr)
+			invocation := extractToolInvocation(toolInputStr)
 
 			contentMsg := "\n"
 			if choice.Content != "" {
@@ -140,8 +147,8 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 
 			actions = append(actions, schema.AgentAction{
 				Tool:      functionName,
-				ToolInput: toolInput,
-				Log:       fmt.Sprintf("Invoking: %s with %s %s", functionName, toolInputStr, contentMsg),
+				ToolInput: invocation.Input,
+				Log:       formatToolActionLog(functionName, toolInputStr, invocation.Description, contentMsg),
 				ToolID:    toolCall.ID,
 			})
 		}
@@ -151,7 +158,7 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 	if choice.FuncCall != nil {
 		functionName := choice.FuncCall.Name
 		toolInputStr := choice.FuncCall.Arguments
-		toolInput := extractToolInput(toolInputStr)
+		invocation := extractToolInvocation(toolInputStr)
 
 		contentMsg := "\n"
 		if choice.Content != "" {
@@ -160,8 +167,8 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 
 		return []schema.AgentAction{{
 			Tool:      functionName,
-			ToolInput: toolInput,
-			Log:       fmt.Sprintf("Invoking: %s with %s %s", functionName, toolInputStr, contentMsg),
+			ToolInput: invocation.Input,
+			Log:       formatToolActionLog(functionName, toolInputStr, invocation.Description, contentMsg),
 		}}, nil, nil
 	}
 
@@ -185,11 +192,17 @@ func (a *FunctionAgent) toolsAsLLM() []llms.Tool {
 					"type": "object",
 					"properties": map[string]any{
 						"__arg1": map[string]string{
-							"title": "__arg1",
-							"type":  "string",
+							"title":       "__arg1",
+							"type":        "string",
+							"description": "The plain string input for the selected tool.",
+						},
+						"description": map[string]string{
+							"title":       "description",
+							"type":        "string",
+							"description": "A short first-person sentence in the user's language that says what you are about to do with this tool. This will be spoken aloud before the tool runs.",
 						},
 					},
-					"required": []string{"__arg1"},
+					"required": []string{"__arg1", "description"},
 				},
 			},
 		})
@@ -224,7 +237,7 @@ func (a *FunctionAgent) constructFunctionScratchPad(steps []schema.AgentStep) []
 				Type: "function",
 				FunctionCall: &llms.FunctionCall{
 					Name:      steps[j].Action.Tool,
-					Arguments: encodeToolArguments(steps[j].Action.ToolInput),
+					Arguments: encodeToolArguments(steps[j].Action.ToolInput, toolDescriptionFromAction(steps[j].Action)),
 				},
 			})
 		}
@@ -368,23 +381,53 @@ func attachmentAwarePrompt(text string, attachments []InputAttachment, descripti
 	return text + "\n\nAttached content:\n- " + strings.Join(descriptions, "\n- ")
 }
 
-func extractToolInput(raw string) string {
+func extractToolInvocation(raw string) toolInvocation {
 	var toolInputMap map[string]any
 	if err := json.Unmarshal([]byte(raw), &toolInputMap); err != nil {
-		return raw
+		return toolInvocation{Input: raw}
 	}
+	invocation := toolInvocation{Input: raw}
 	if arg1, ok := toolInputMap["__arg1"].(string); ok {
-		return arg1
+		invocation.Input = arg1
 	}
-	return raw
+	if description, ok := toolInputMap["description"].(string); ok {
+		invocation.Description = strings.TrimSpace(description)
+	}
+	return invocation
 }
 
-func encodeToolArguments(input string) string {
-	encoded, err := json.Marshal(map[string]string{"__arg1": input})
+func extractToolInput(raw string) string {
+	return extractToolInvocation(raw).Input
+}
+
+func encodeToolArguments(input string, descriptions ...string) string {
+	args := map[string]string{"__arg1": input}
+	if len(descriptions) > 0 {
+		if description := strings.TrimSpace(descriptions[0]); description != "" {
+			args["description"] = description
+		}
+	}
+	encoded, err := json.Marshal(args)
 	if err != nil {
 		return input
 	}
 	return string(encoded)
+}
+
+func formatToolActionLog(name, arguments, description, contentMsg string) string {
+	log := fmt.Sprintf("Invoking: %s with %s %s", name, arguments, contentMsg)
+	if description == "" {
+		return log
+	}
+	return log + toolDescriptionLogMarker + description
+}
+
+func toolDescriptionFromAction(action schema.AgentAction) string {
+	idx := strings.LastIndex(action.Log, toolDescriptionLogMarker)
+	if idx < 0 {
+		return ""
+	}
+	return strings.TrimSpace(action.Log[idx+len(toolDescriptionLogMarker):])
 }
 
 func extractFinalAnswer(content string) string {

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/schema"
 	langtools "github.com/tmc/langchaingo/tools"
 )
 
@@ -69,6 +70,84 @@ func TestFunctionAgentParseOutputExtractsToolDescription(t *testing.T) {
 	}
 	if got := toolDescriptionFromAction(actions[0]); got != "我会发送一段测试文本。" {
 		t.Fatalf("tool description = %q", got)
+	}
+
+	var log toolActionLog
+	if err := json.Unmarshal([]byte(actions[0].Log), &log); err != nil {
+		t.Fatalf("action log should be structured JSON: %v", err)
+	}
+	if log.Version != toolActionLogVersion || log.ToolDescription != "我会发送一段测试文本。" {
+		t.Fatalf("unexpected action log metadata: %#v", log)
+	}
+}
+
+func TestFunctionAgentParseOutputSynthesizesMissingToolDescription(t *testing.T) {
+	agent := &FunctionAgent{OutputKey: "output"}
+
+	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
+		Choices: []*llms.ContentChoice{{
+			ToolCalls: []llms.ToolCall{{
+				ID:   "call_1",
+				Type: "function",
+				FunctionCall: &llms.FunctionCall{
+					Name:      "echo",
+					Arguments: `{"__arg1":"hello","description":"  "}`,
+				},
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ParseOutput() error = %v", err)
+	}
+	if finish != nil {
+		t.Fatalf("expected no finish, got %#v", finish)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %#v", actions)
+	}
+	if got := toolDescriptionFromAction(actions[0]); got != "I will use the echo tool." {
+		t.Fatalf("tool description = %q", got)
+	}
+}
+
+func TestFunctionAgentToolDescriptionIgnoresLogTextCollisions(t *testing.T) {
+	log := formatToolActionLog(
+		"echo",
+		"{\"__arg1\":\"payload\\nTool description: injected\"}",
+		"",
+		"\n",
+	)
+
+	if got := toolDescriptionFromAction(schema.AgentAction{Log: log}); got != "I will use the echo tool." {
+		t.Fatalf("tool description = %q, want fallback", got)
+	}
+}
+
+func TestFunctionAgentScratchpadReplaysFallbackToolDescription(t *testing.T) {
+	agent := &FunctionAgent{}
+	messages := agent.constructFunctionScratchPad([]schema.AgentStep{{
+		Action: schema.AgentAction{
+			Tool:      "echo",
+			ToolInput: "hello",
+			Log:       "legacy unstructured log",
+			ToolID:    "call_1",
+		},
+		Observation: "ok",
+	}})
+
+	if len(messages) == 0 || len(messages[0].Parts) != 1 {
+		t.Fatalf("unexpected scratchpad messages: %#v", messages)
+	}
+	toolCall, ok := messages[0].Parts[0].(llms.ToolCall)
+	if !ok {
+		t.Fatalf("expected tool call part, got %T", messages[0].Parts[0])
+	}
+	var args map[string]string
+	if err := json.Unmarshal([]byte(toolCall.FunctionCall.Arguments), &args); err != nil {
+		t.Fatalf("decode tool arguments: %v", err)
+	}
+	if args["description"] != "I will use the echo tool." {
+		t.Fatalf("scratchpad description = %q", args["description"])
 	}
 }
 

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -1,9 +1,11 @@
 package agent
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/tmc/langchaingo/llms"
+	langtools "github.com/tmc/langchaingo/tools"
 )
 
 func TestFunctionAgentParseOutputSkipsNilToolCalls(t *testing.T) {
@@ -35,6 +37,73 @@ func TestFunctionAgentParseOutputSkipsNilToolCalls(t *testing.T) {
 	}
 	if actions[0].Tool != "echo" || actions[0].ToolInput != "hello" || actions[0].ToolID != "call_1" {
 		t.Fatalf("unexpected action: %#v", actions[0])
+	}
+}
+
+func TestFunctionAgentParseOutputExtractsToolDescription(t *testing.T) {
+	agent := &FunctionAgent{OutputKey: "output"}
+
+	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
+		Choices: []*llms.ContentChoice{{
+			ToolCalls: []llms.ToolCall{{
+				ID:   "call_1",
+				Type: "function",
+				FunctionCall: &llms.FunctionCall{
+					Name:      "echo",
+					Arguments: `{"__arg1":"hello","description":"我会发送一段测试文本。"}`,
+				},
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ParseOutput() error = %v", err)
+	}
+	if finish != nil {
+		t.Fatalf("expected no finish, got %#v", finish)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %#v", actions)
+	}
+	if actions[0].ToolInput != "hello" {
+		t.Fatalf("ToolInput = %q, want stripped tool input", actions[0].ToolInput)
+	}
+	if got := toolDescriptionFromAction(actions[0]); got != "我会发送一段测试文本。" {
+		t.Fatalf("tool description = %q", got)
+	}
+}
+
+func TestFunctionAgentToolsAsLLMRequiresDescriptionParameter(t *testing.T) {
+	agent := &FunctionAgent{
+		Tools: []langtools.Tool{&stubTool{
+			name:        "echo",
+			description: "Echo text.",
+			output:      "ok",
+		}},
+	}
+
+	tools := agent.toolsAsLLM()
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %#v", tools)
+	}
+
+	params, ok := tools[0].Function.Parameters.(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected parameters type: %T", tools[0].Function.Parameters)
+	}
+	props, ok := params["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected properties: %#v", params["properties"])
+	}
+	if _, ok := props["description"]; !ok {
+		encoded, _ := json.Marshal(params)
+		t.Fatalf("missing description property in %s", encoded)
+	}
+	required, ok := params["required"].([]string)
+	if !ok {
+		t.Fatalf("unexpected required type: %T", params["required"])
+	}
+	if len(required) != 2 || required[0] != "__arg1" || required[1] != "description" {
+		t.Fatalf("required = %#v, want __arg1 and description", required)
 	}
 }
 

--- a/src/agent/internal/agent/prompt.go
+++ b/src/agent/internal/agent/prompt.go
@@ -25,6 +25,7 @@ func buildPrompt(agentName string, cfg AgentConfig, skills ResolvedSkills, avail
 		"",
 		"For any request that reads or changes external device or service state, you must use the relevant tool.",
 		"Never claim a state change succeeded until you have a tool Observation confirming it.",
+		"When calling a tool, include a concise description of what you are about to do; it will be spoken aloud to the user before the tool runs.",
 		"",
 		"Use the following format:",
 		"Question: the user's current request",
@@ -72,6 +73,7 @@ func buildFunctionAgentSystemMessage(cfg AgentConfig, skills ResolvedSkills, ava
 		"",
 		"For any request that reads or changes external device or service state, you must use the relevant tool.",
 		"Never claim a state change succeeded until you have a tool result confirming it.",
+		"When calling a tool, fill the description argument with a concise sentence in the user's language explaining what you are about to do; it will be spoken aloud before the tool runs.",
 		"If no tool is needed, answer directly.",
 	}
 	return strings.Join(parts, "\n")

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -64,12 +64,13 @@ type RunMetrics struct {
 }
 
 type RunEvent struct {
-	Type      string    `json:"type"`
-	ToolName  string    `json:"tool_name,omitempty"`
-	ToolInput string    `json:"tool_input,omitempty"`
-	Content   string    `json:"content,omitempty"`
-	Timestamp time.Time `json:"timestamp"`
-	IsError   bool      `json:"is_error,omitempty"`
+	Type        string    `json:"type"`
+	ToolName    string    `json:"tool_name,omitempty"`
+	ToolInput   string    `json:"tool_input,omitempty"`
+	Description string    `json:"description,omitempty"`
+	Content     string    `json:"content,omitempty"`
+	Timestamp   time.Time `json:"timestamp"`
+	IsError     bool      `json:"is_error,omitempty"`
 }
 
 type usageTrackingModel struct {
@@ -494,17 +495,25 @@ func (h *runtimeCallbackHandler) HandleToolError(ctx context.Context, err error)
 }
 
 func (h *runtimeCallbackHandler) HandleAgentAction(ctx context.Context, action schema.AgentAction) {
+	description := toolDescriptionFromAction(action)
 	if h.logger != nil {
-		h.logger.Info("Tool call: name=%s input=%s",
-			action.Tool, truncateForLog(action.ToolInput, 240))
+		if description != "" {
+			h.logger.Info("Tool call: name=%s input=%s description=%s",
+				action.Tool, truncateForLog(action.ToolInput, 240), truncateForLog(description, 240))
+		} else {
+			h.logger.Info("Tool call: name=%s input=%s",
+				action.Tool, truncateForLog(action.ToolInput, 240))
+		}
 	}
 	if h.eventHandler != nil {
 		h.pushPendingAction(action)
 		h.eventHandler(RunEvent{
-			Type:      "tool_call",
-			ToolName:  action.Tool,
-			ToolInput: action.ToolInput,
-			Timestamp: time.Now(),
+			Type:        "tool_call",
+			ToolName:    action.Tool,
+			ToolInput:   action.ToolInput,
+			Description: description,
+			Content:     description,
+			Timestamp:   time.Now(),
 		})
 	}
 }

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -78,6 +78,7 @@ type scriptedModel struct {
 	callCount    int
 	sawStreaming []bool
 	messages     [][]llms.MessageContent
+	tools        [][]llms.Tool
 }
 
 func (m *scriptedModel) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
@@ -87,6 +88,7 @@ func (m *scriptedModel) GenerateContent(ctx context.Context, messages []llms.Mes
 	}
 	m.sawStreaming = append(m.sawStreaming, callOptions.StreamingFunc != nil)
 	m.messages = append(m.messages, messages)
+	m.tools = append(m.tools, callOptions.Tools)
 
 	if callOptions.StreamingFunc != nil && m.callCount < len(m.responses) {
 		content := m.responses[m.callCount].Choices[0].Content
@@ -236,6 +238,74 @@ func TestRuntimeRunFakeProviderUsesFunctionAgentToolCalls(t *testing.T) {
 	}
 	if len(tool.inputs) != 1 || tool.inputs[0] != "{}" {
 		t.Fatalf("unexpected tool inputs: %#v", tool.inputs)
+	}
+}
+
+func TestRuntimeRunEmitsToolDescriptionEventAndStripsToolInput(t *testing.T) {
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			{
+				Choices: []*llms.ContentChoice{{
+					ToolCalls: []llms.ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						FunctionCall: &llms.FunctionCall{
+							Name:      "audio_volume",
+							Arguments: `{"__arg1":"{}","description":"我先读取当前音量。"}`,
+						},
+					}},
+				}},
+			},
+			{
+				Choices: []*llms.ContentChoice{{
+					Content: "The current audio volume is 42.",
+				}},
+			},
+		},
+	}
+	tool := &stubTool{
+		name:        "audio_volume",
+		description: "Get the current audio playback volume.",
+		output:      `{"volume":42}`,
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:       ModelConfig{Provider: "fake"},
+			Instruction: "Use tools when external state is requested.",
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"audio_volume": tool,
+		}},
+		NewSkillIndex(),
+	)
+
+	var events []RunEvent
+	result, err := runtime.Run(context.Background(), RunRequest{
+		Input: "当前音量是多少？",
+		EventHandler: func(event RunEvent) {
+			events = append(events, event)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if result.Output != "The current audio volume is 42." {
+		t.Fatalf("unexpected output: %q", result.Output)
+	}
+	if len(tool.inputs) != 1 || tool.inputs[0] != "{}" {
+		t.Fatalf("unexpected tool inputs: %#v", tool.inputs)
+	}
+	if len(events) < 1 || events[0].Type != "tool_call" {
+		t.Fatalf("expected first event to be tool_call, got %#v", events)
+	}
+	if events[0].Description != "我先读取当前音量。" || events[0].Content != events[0].Description {
+		t.Fatalf("unexpected tool description event: %#v", events[0])
+	}
+	if events[0].ToolInput != "{}" {
+		t.Fatalf("tool_call event input = %q, want stripped input", events[0].ToolInput)
 	}
 }
 

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -70,6 +70,7 @@ type Message struct {
 	Content     string              `json:"content"`
 	ToolName    string              `json:"tool_name,omitempty"`
 	ToolInput   string              `json:"tool_input,omitempty"`
+	Description string              `json:"description,omitempty"`
 	Attachments []MessageAttachment `json:"attachments,omitempty"`
 	Timestamp   time.Time           `json:"timestamp"`
 	IsError     bool                `json:"is_error,omitempty"`
@@ -244,13 +245,17 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		Skills:      req.Skills,
 		EventHandler: func(event RunEvent) {
 			s.appendHistory(Message{
-				Type:      event.Type,
-				Content:   event.Content,
-				ToolName:  event.ToolName,
-				ToolInput: event.ToolInput,
-				Timestamp: event.Timestamp,
-				IsError:   event.IsError,
+				Type:        event.Type,
+				Content:     event.Content,
+				ToolName:    event.ToolName,
+				ToolInput:   event.ToolInput,
+				Description: event.Description,
+				Timestamp:   event.Timestamp,
+				IsError:     event.IsError,
 			})
+			if event.Type == "tool_call" {
+				s.speakToolDescription(r.Context(), event.Description)
+			}
 		},
 	})
 
@@ -290,6 +295,21 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		Response: result.Output,
 		History:  historySnapshot,
 	})
+}
+
+func (s *Server) speakToolDescription(ctx context.Context, description string) {
+	description = strings.TrimSpace(description)
+	if description == "" || s.ttsClient == nil || s.audioClient == nil {
+		return
+	}
+	if s.logger != nil {
+		s.logger.Info("Tool description TTS playback: %q", description)
+	}
+	if err := s.ttsClient.TextToSpeechStream(ctx, description, s.audioClient); err != nil {
+		if s.logger != nil {
+			s.logger.Error("Tool description TTS playback failed: %v", err)
+		}
+	}
 }
 
 // handleHistory returns the conversation history

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -254,7 +254,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 				IsError:     event.IsError,
 			})
 			if event.Type == "tool_call" {
-				s.speakToolDescription(r.Context(), event.Description)
+				go s.speakToolDescription(r.Context(), event.Description)
 			}
 		},
 	})
@@ -302,10 +302,15 @@ func (s *Server) speakToolDescription(ctx context.Context, description string) {
 	if description == "" || s.ttsClient == nil || s.audioClient == nil {
 		return
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ttsCtx, cancel := context.WithTimeout(ctx, toolDescriptionSpeechTimeout)
+	defer cancel()
 	if s.logger != nil {
 		s.logger.Info("Tool description TTS playback: %q", description)
 	}
-	if err := s.ttsClient.TextToSpeechStream(ctx, description, s.audioClient); err != nil {
+	if err := s.ttsClient.TextToSpeechStream(ttsCtx, description, s.audioClient); err != nil {
 		if s.logger != nil {
 			s.logger.Error("Tool description TTS playback failed: %v", err)
 		}

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -40,7 +40,7 @@ func TestServerHandleChatReturnsToolHistory(t *testing.T) {
 						Type: "function",
 						FunctionCall: &llms.FunctionCall{
 							Name:      "audio_volume",
-							Arguments: `{"__arg1":"{}"}`,
+							Arguments: `{"__arg1":"{}","description":"我先读取当前音量。"}`,
 						},
 					}},
 				}},
@@ -100,11 +100,31 @@ func TestServerHandleChatReturnsToolHistory(t *testing.T) {
 	if resp.History[1].Type != "tool_call" || resp.History[1].ToolName != "audio_volume" || resp.History[1].ToolInput != "{}" {
 		t.Fatalf("unexpected tool_call message: %#v", resp.History[1])
 	}
+	if resp.History[1].Description != "我先读取当前音量。" || resp.History[1].Content != "我先读取当前音量。" {
+		t.Fatalf("unexpected tool_call description: %#v", resp.History[1])
+	}
 	if resp.History[2].Type != "tool_result" || resp.History[2].ToolName != "audio_volume" || resp.History[2].Content != `{"volume":42}` {
 		t.Fatalf("unexpected tool_result message: %#v", resp.History[2])
 	}
 	if resp.History[3].Type != "assistant" || resp.History[3].Content != "The current audio volume is 42." {
 		t.Fatalf("unexpected assistant message: %#v", resp.History[3])
+	}
+}
+
+func TestServerSpeakToolDescriptionUsesTTS(t *testing.T) {
+	tts := &fakeTTSClient{}
+	server := &Server{
+		ttsClient:   tts,
+		audioClient: NewAudioServiceClient("/tmp/audio.sock"),
+	}
+
+	server.speakToolDescription(context.Background(), " 我先读取当前音量。 ")
+
+	if len(tts.texts) != 1 || tts.texts[0] != "我先读取当前音量。" {
+		t.Fatalf("unexpected TTS texts: %#v", tts.texts)
+	}
+	if tts.audio != server.audioClient {
+		t.Fatal("expected server audio client to be used for tool description TTS")
 	}
 }
 

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/tmc/langchaingo/llms"
 	fakellm "github.com/tmc/langchaingo/llms/fake"
@@ -123,9 +124,101 @@ func TestServerSpeakToolDescriptionUsesTTS(t *testing.T) {
 	if len(tts.texts) != 1 || tts.texts[0] != "我先读取当前音量。" {
 		t.Fatalf("unexpected TTS texts: %#v", tts.texts)
 	}
+	if len(tts.deadlineSet) != 1 || !tts.deadlineSet[0] {
+		t.Fatalf("tool description TTS should use a deadline, got %#v", tts.deadlineSet)
+	}
 	if tts.audio != server.audioClient {
 		t.Fatal("expected server audio client to be used for tool description TTS")
 	}
+}
+
+func TestServerHandleChatDoesNotWaitForToolDescriptionTTS(t *testing.T) {
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			{
+				Choices: []*llms.ContentChoice{{
+					ToolCalls: []llms.ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						FunctionCall: &llms.FunctionCall{
+							Name:      "audio_volume",
+							Arguments: `{"__arg1":"{}","description":"我先读取当前音量。"}`,
+						},
+					}},
+				}},
+			},
+			{
+				Choices: []*llms.ContentChoice{{
+					Content: "The current audio volume is 42.",
+				}},
+			},
+		},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:       ModelConfig{Provider: "fake"},
+			Instruction: "Use tools when external state is requested.",
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"audio_volume": &stubTool{
+				name:        "audio_volume",
+				description: "Get the current audio playback volume.",
+				output:      `{"volume":42}`,
+			},
+		}},
+		NewSkillIndex(),
+	)
+	server := NewServer(runtime, ":0")
+	tts := &blockingUntilContextTTS{started: make(chan struct{}), blockText: "我先读取当前音量。"}
+	server.ttsClient = tts
+	server.audioClient = NewAudioServiceClient("/tmp/audio.sock")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"当前音量是多少？"}`)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		server.handleChat(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		cancel()
+		<-done
+		t.Fatal("handleChat waited for tool description TTS")
+	}
+	select {
+	case <-tts.started:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("tool description TTS was not started")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+type blockingUntilContextTTS struct {
+	started   chan struct{}
+	blockText string
+	once      sync.Once
+}
+
+func (t *blockingUntilContextTTS) TextToSpeechStream(ctx context.Context, text string, audio *AudioServiceClient) error {
+	if text != t.blockText {
+		return nil
+	}
+	t.once.Do(func() {
+		close(t.started)
+	})
+	<-ctx.Done()
+	return ctx.Err()
 }
 
 func TestServerHistoryEndpointIncludesToolMessages(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a required tool-call description parameter so the model states what it is about to do
- strip the description from actual tool inputs while surfacing it on tool_call events
- play tool descriptions through existing TTS paths in audio dialog and web chat

## Tests
- go test ./internal/agent
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent speaks a concise description aloud before executing tools (non-blocking playback).
  * Tool-call events and chat history now include the spoken description; raw tool inputs are omitted from initial event content.
  * Prompts/system messages now ask LLMs to provide a concise spoken description in the user’s language.

* **Tests**
  * Added tests validating TTS playback, non-blocking behavior, and tool-description handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->