### PR TITLE
fix: report invalid shell actions

### DIFF
--- a/src/agent/internal/agent/tools_shell.go
+++ b/src/agent/internal/agent/tools_shell.go
@@ -585,15 +585,7 @@ func shellIntArg(arguments map[string]interface{}, key string, defaultValue int)
 
 func shellHasAction(arguments map[string]interface{}) bool {
 	action, ok := arguments["action"].(string)
-	if !ok {
-		return false
-	}
-	switch strings.TrimSpace(action) {
-	case "start", "poll", "write", "submit", "send_keys", "resize", "stop":
-		return true
-	default:
-		return false
-	}
+	return ok && strings.TrimSpace(action) != ""
 }
 
 func shellStringSliceArg(arguments map[string]interface{}, key string) []string {

--- a/src/agent/internal/agent/tools_shell_test.go
+++ b/src/agent/internal/agent/tools_shell_test.go
@@ -259,10 +259,8 @@ func TestShellToolUnknownAction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Call returned error: %v", err)
 	}
-	// Unknown actions don't pass shellHasAction, so they fall through to the
-	// foreground path which then complains about a missing command.
-	if !strings.Contains(out, "Missing required parameter: command") {
-		t.Fatalf("expected missing-command error, got %q", out)
+	if out != "error: invalid action: bogus" {
+		t.Fatalf("expected invalid-action error, got %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Route any non-empty shell `action` field through background action dispatch
- Return `error: invalid action: <action>` for unsupported shell actions instead of falling through to missing-command
- Update the shell unknown-action regression test

## Test Plan
- [x] `go test ./internal/agent/tools_shell.go ./internal/agent/tools_shell_session.go ./internal/agent/tools_shell_kill_unix.go ./internal/agent/tools_shell_test.go -run TestShellToolUnknownAction -count=1`
- [x] `go test ./internal/agent/tools_shell.go ./internal/agent/tools_shell_session.go ./internal/agent/tools_shell_kill_unix.go ./internal/agent/tools_shell_test.go -run 'TestShell' -count=1`\n- [ ] `go test ./internal/agent -run 'TestShell' -count=1` currently blocked by unrelated build error: `internal/agent/tools_hid_test.go:353:17: undefined: unix.Pipe2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for shell tool actions; invalid actions now return explicit error messages instead of generic missing parameter errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->