### PR TITLE
feat(agent): apply proxy config to shell commands

### DIFF
--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -32,7 +32,7 @@ max_tokens = 1000
 http_proxy = ""
 https_proxy = ""
 all_proxy = ""
-no_proxy = "localhost,127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+no_proxy = ""
 
 [audio]
 socket = "/run/audio_service/audio_service.sock"
@@ -139,14 +139,14 @@ frame_socket = "/run/frame_service/frame_service.sock"
 
 ## `[proxy]`
 
-可选。用于 Agent 发起的外部 HTTP 请求（OpenAI-compatible / OpenRouter / Ollama 模型请求、OpenAI Whisper STT、Minimax TTS），并会注入到 Agent `shell` 工具启动的子进程环境中。`http_proxy` / `https_proxy` / `all_proxy` 留空时使用进程环境变量中的代理设置。
+可选。用于 Agent 发起的外部 HTTP 请求（OpenAI-compatible / OpenRouter / Ollama 模型请求、OpenAI Whisper STT、Minimax TTS），并会注入到 Agent `shell` 工具启动的子进程环境中。所有字段留空时使用进程环境变量中的代理设置。
 
 | 字段 | 说明 |
 | --- | --- |
 | `http_proxy` | HTTP 请求代理，例如 `http://127.0.0.1:7890` |
 | `https_proxy` | HTTPS 请求代理，通常也填写 HTTP 代理地址，例如 `http://127.0.0.1:7890` |
 | `all_proxy` | HTTP/HTTPS 未分别配置时使用的通用代理，支持 `http://`、`https://`、`socks5://` |
-| `no_proxy` | 逗号/空格分隔的直连规则；支持主机名、域名后缀、`host:port`、CIDR 和 `*`；默认 `localhost,127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` |
+| `no_proxy` | 逗号/空格分隔的直连规则；支持主机名、域名后缀、`host:port`、CIDR 和 `*`；当显式配置了 `http_proxy` / `https_proxy` / `all_proxy` 且本字段留空时，默认 `localhost,127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` |
 
 ## `[audio]`
 

--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -32,7 +32,7 @@ max_tokens = 1000
 http_proxy = ""
 https_proxy = ""
 all_proxy = ""
-no_proxy = ""
+no_proxy = "localhost,127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
 
 [audio]
 socket = "/run/audio_service/audio_service.sock"
@@ -139,14 +139,14 @@ frame_socket = "/run/frame_service/frame_service.sock"
 
 ## `[proxy]`
 
-可选。用于 Agent 发起的外部 HTTP 请求（OpenAI-compatible / OpenRouter / Ollama 模型请求、OpenAI Whisper STT、Minimax TTS）。留空时使用进程环境变量中的 `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`。
+可选。用于 Agent 发起的外部 HTTP 请求（OpenAI-compatible / OpenRouter / Ollama 模型请求、OpenAI Whisper STT、Minimax TTS），并会注入到 Agent `shell` 工具启动的子进程环境中。`http_proxy` / `https_proxy` / `all_proxy` 留空时使用进程环境变量中的代理设置。
 
 | 字段 | 说明 |
 | --- | --- |
 | `http_proxy` | HTTP 请求代理，例如 `http://127.0.0.1:7890` |
 | `https_proxy` | HTTPS 请求代理，通常也填写 HTTP 代理地址，例如 `http://127.0.0.1:7890` |
 | `all_proxy` | HTTP/HTTPS 未分别配置时使用的通用代理，支持 `http://`、`https://`、`socks5://` |
-| `no_proxy` | 逗号/空格分隔的直连规则；支持主机名、域名后缀、`host:port`、CIDR 和 `*` |
+| `no_proxy` | 逗号/空格分隔的直连规则；支持主机名、域名后缀、`host:port`、CIDR 和 `*`；默认 `localhost,127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` |
 
 ## `[audio]`
 

--- a/overlay/userdata/agent/agent.toml
+++ b/overlay/userdata/agent/agent.toml
@@ -42,13 +42,13 @@ api_key = "OPENROUTER_API_KEY"
 temperature = 0.2
 max_tokens = 1000
 
-# Optional request proxy configuration for outbound Agent HTTP requests.
-# Leave all fields blank to use the process environment (HTTP_PROXY / HTTPS_PROXY / NO_PROXY).
+# Optional request proxy configuration for outbound Agent HTTP requests and shell tool commands.
+# Leave http_proxy / https_proxy / all_proxy blank to use the process environment.
 [proxy]
 http_proxy = ""
 https_proxy = ""
 all_proxy = ""
-no_proxy = ""
+no_proxy = "localhost,127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
 
 # Optional future field parsed by config but not currently used by the runtime.
 # [model_text]

--- a/overlay/userdata/agent/agent.toml
+++ b/overlay/userdata/agent/agent.toml
@@ -43,12 +43,12 @@ temperature = 0.2
 max_tokens = 1000
 
 # Optional request proxy configuration for outbound Agent HTTP requests and shell tool commands.
-# Leave http_proxy / https_proxy / all_proxy blank to use the process environment.
+# Leave all fields blank to use the process environment.
 [proxy]
 http_proxy = ""
 https_proxy = ""
 all_proxy = ""
-no_proxy = "localhost,127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+no_proxy = ""
 
 # Optional future field parsed by config but not currently used by the runtime.
 # [model_text]

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -98,7 +98,7 @@ func (p ProxyConfig) HasProxyURL() bool {
 }
 
 func (p ProxyConfig) WithDefaults() ProxyConfig {
-	if strings.TrimSpace(p.NoProxy) == "" {
+	if p.HasProxyURL() && strings.TrimSpace(p.NoProxy) == "" {
 		p.NoProxy = DefaultNoProxy
 	}
 	return p

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -89,6 +89,21 @@ type ProxyConfig struct {
 	NoProxy    string `toml:"no_proxy,omitempty"`
 }
 
+const DefaultNoProxy = "localhost,127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+
+func (p ProxyConfig) HasProxyURL() bool {
+	return strings.TrimSpace(p.HTTPProxy) != "" ||
+		strings.TrimSpace(p.HTTPSProxy) != "" ||
+		strings.TrimSpace(p.AllProxy) != ""
+}
+
+func (p ProxyConfig) WithDefaults() ProxyConfig {
+	if strings.TrimSpace(p.NoProxy) == "" {
+		p.NoProxy = DefaultNoProxy
+	}
+	return p
+}
+
 func (p ProxyConfig) IsZero() bool {
 	return strings.TrimSpace(p.HTTPProxy) == "" &&
 		strings.TrimSpace(p.HTTPSProxy) == "" &&
@@ -228,6 +243,8 @@ func LoadConfig(path string) (Config, error) {
 		}
 		return Config{}, fmt.Errorf("JSON format is deprecated, please use TOML format: %s", path)
 	}
+
+	cfg.Proxy = cfg.Proxy.WithDefaults()
 
 	if err := cfg.Validate(); err != nil {
 		return Config{}, err

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -49,6 +49,28 @@ https_proxy = "http://proxy.example:18443"
 	}
 }
 
+func TestLoadConfigKeepsNoProxyEmptyWithoutProxyURL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.toml")
+	if err := os.WriteFile(path, []byte(`
+[model]
+provider = "fake"
+
+[proxy]
+no_proxy = ""
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg.Proxy.NoProxy != "" {
+		t.Fatalf("Proxy.NoProxy = %q, want empty", cfg.Proxy.NoProxy)
+	}
+}
+
 func TestConfigValidateRejectsInvalidTriggerMode(t *testing.T) {
 	cfg := Config{
 		Model:       ModelConfig{Provider: "fake"},

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +24,28 @@ func TestConfigValidateAcceptsAudioWakeup(t *testing.T) {
 	}
 	if got := cfg.TriggerModeOrDefault(); got != "wakeup" {
 		t.Fatalf("TriggerModeOrDefault() = %q, want wakeup", got)
+	}
+}
+
+func TestLoadConfigDefaultsNoProxyWhenProxyConfigured(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.toml")
+	if err := os.WriteFile(path, []byte(`
+[model]
+provider = "fake"
+
+[proxy]
+https_proxy = "http://proxy.example:18443"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg.Proxy.NoProxy != DefaultNoProxy {
+		t.Fatalf("Proxy.NoProxy = %q, want %q", cfg.Proxy.NoProxy, DefaultNoProxy)
 	}
 }
 

--- a/src/agent/internal/agent/proxy.go
+++ b/src/agent/internal/agent/proxy.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 )
 
@@ -22,9 +21,6 @@ func newProxyTransport(proxy ProxyConfig) http.RoundTripper {
 func proxyFunc(proxy ProxyConfig) func(*http.Request) (*url.URL, error) {
 	proxy = proxy.WithDefaults()
 	if !proxy.HasProxyURL() {
-		if strings.TrimSpace(proxy.NoProxy) != "" {
-			return envProxyFunc(proxy.NoProxy)
-		}
 		return http.ProxyFromEnvironment
 	}
 
@@ -52,45 +48,6 @@ func proxyFunc(proxy ProxyConfig) func(*http.Request) (*url.URL, error) {
 		}
 		return parseProxyURL(proxyURL)
 	}
-}
-
-func envProxyFunc(noProxy string) func(*http.Request) (*url.URL, error) {
-	return func(req *http.Request) (*url.URL, error) {
-		if req == nil || req.URL == nil {
-			return nil, nil
-		}
-		if bypassProxy(req.URL.Hostname(), req.URL.Port(), noProxy) {
-			return nil, nil
-		}
-		proxyURL := envProxyURLForScheme(req.URL.Scheme)
-		if strings.TrimSpace(proxyURL) == "" {
-			return nil, nil
-		}
-		return parseProxyURL(proxyURL)
-	}
-}
-
-func envProxyURLForScheme(scheme string) string {
-	switch strings.ToLower(scheme) {
-	case "http":
-		if v := getenvAny("HTTP_PROXY", "http_proxy"); strings.TrimSpace(v) != "" {
-			return v
-		}
-	case "https":
-		if v := getenvAny("HTTPS_PROXY", "https_proxy"); strings.TrimSpace(v) != "" {
-			return v
-		}
-	}
-	return getenvAny("ALL_PROXY", "all_proxy")
-}
-
-func getenvAny(keys ...string) string {
-	for _, key := range keys {
-		if value := os.Getenv(key); strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
 }
 
 func validateProxyURL(raw string) error {

--- a/src/agent/internal/agent/proxy.go
+++ b/src/agent/internal/agent/proxy.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -19,7 +20,11 @@ func newProxyTransport(proxy ProxyConfig) http.RoundTripper {
 }
 
 func proxyFunc(proxy ProxyConfig) func(*http.Request) (*url.URL, error) {
-	if proxy.IsZero() {
+	proxy = proxy.WithDefaults()
+	if !proxy.HasProxyURL() {
+		if strings.TrimSpace(proxy.NoProxy) != "" {
+			return envProxyFunc(proxy.NoProxy)
+		}
 		return http.ProxyFromEnvironment
 	}
 
@@ -47,6 +52,45 @@ func proxyFunc(proxy ProxyConfig) func(*http.Request) (*url.URL, error) {
 		}
 		return parseProxyURL(proxyURL)
 	}
+}
+
+func envProxyFunc(noProxy string) func(*http.Request) (*url.URL, error) {
+	return func(req *http.Request) (*url.URL, error) {
+		if req == nil || req.URL == nil {
+			return nil, nil
+		}
+		if bypassProxy(req.URL.Hostname(), req.URL.Port(), noProxy) {
+			return nil, nil
+		}
+		proxyURL := envProxyURLForScheme(req.URL.Scheme)
+		if strings.TrimSpace(proxyURL) == "" {
+			return nil, nil
+		}
+		return parseProxyURL(proxyURL)
+	}
+}
+
+func envProxyURLForScheme(scheme string) string {
+	switch strings.ToLower(scheme) {
+	case "http":
+		if v := getenvAny("HTTP_PROXY", "http_proxy"); strings.TrimSpace(v) != "" {
+			return v
+		}
+	case "https":
+		if v := getenvAny("HTTPS_PROXY", "https_proxy"); strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return getenvAny("ALL_PROXY", "all_proxy")
+}
+
+func getenvAny(keys ...string) string {
+	for _, key := range keys {
+		if value := os.Getenv(key); strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func validateProxyURL(raw string) error {
@@ -95,6 +139,12 @@ func bypassProxy(host, port, noProxy string) bool {
 				if _, network, err := net.ParseCIDR(rule); err == nil && network.Contains(ip) {
 					return true
 				}
+			}
+			continue
+		}
+		if ruleIP := net.ParseIP(rule); ruleIP != nil {
+			if hostIP := net.ParseIP(host); hostIP != nil && hostIP.Equal(ruleIP) {
+				return true
 			}
 			continue
 		}

--- a/src/agent/internal/agent/proxy_test.go
+++ b/src/agent/internal/agent/proxy_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"net/http"
+	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -84,35 +86,11 @@ func TestProxyFuncAppliesDefaultNoProxy(t *testing.T) {
 	}
 }
 
-func TestProxyFuncUsesEnvironmentProxyWithDefaultNoProxy(t *testing.T) {
-	t.Setenv("HTTPS_PROXY", "http://env-proxy.example:18443")
-	t.Setenv("https_proxy", "")
-	t.Setenv("ALL_PROXY", "")
-	t.Setenv("all_proxy", "")
-
+func TestProxyFuncUsesEnvironmentWhenNoProxyURLConfigured(t *testing.T) {
 	fn := proxyFunc(ProxyConfig{})
-	req, err := http.NewRequest(http.MethodGet, "https://api.openai.com/v1/models", nil)
-	if err != nil {
-		t.Fatalf("NewRequest: %v", err)
-	}
-	proxyURL, err := fn(req)
-	if err != nil {
-		t.Fatalf("proxyFunc() error = %v", err)
-	}
-	if proxyURL == nil || proxyURL.String() != "http://env-proxy.example:18443" {
-		t.Fatalf("proxyFunc() = %v, want environment proxy", proxyURL)
-	}
-
-	localReq, err := http.NewRequest(http.MethodGet, "https://192.168.42.1/status", nil)
-	if err != nil {
-		t.Fatalf("NewRequest local: %v", err)
-	}
-	proxyURL, err = fn(localReq)
-	if err != nil {
-		t.Fatalf("proxyFunc(local) error = %v", err)
-	}
-	if proxyURL != nil {
-		t.Fatalf("proxyFunc(local) = %v, want default no_proxy bypass", proxyURL)
+	got := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	if got != "net/http.ProxyFromEnvironment" {
+		t.Fatalf("proxyFunc() = %s, want net/http.ProxyFromEnvironment", got)
 	}
 }
 

--- a/src/agent/internal/agent/proxy_test.go
+++ b/src/agent/internal/agent/proxy_test.go
@@ -49,6 +49,73 @@ func TestProxyFuncHonorsNoProxy(t *testing.T) {
 	}
 }
 
+func TestProxyFuncHonorsIPv6NoProxy(t *testing.T) {
+	fn := proxyFunc(ProxyConfig{
+		AllProxy: "http://127.0.0.1:7890",
+		NoProxy:  "::1",
+	})
+	req, err := http.NewRequest(http.MethodGet, "http://[::1]:8080/status", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	proxyURL, err := fn(req)
+	if err != nil {
+		t.Fatalf("proxyFunc() error = %v", err)
+	}
+	if proxyURL != nil {
+		t.Fatalf("proxyFunc() = %v, want IPv6 no_proxy bypass", proxyURL)
+	}
+}
+
+func TestProxyFuncAppliesDefaultNoProxy(t *testing.T) {
+	fn := proxyFunc(ProxyConfig{
+		AllProxy: "http://127.0.0.1:7890",
+	})
+	req, err := http.NewRequest(http.MethodGet, "http://192.168.42.1/status", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	proxyURL, err := fn(req)
+	if err != nil {
+		t.Fatalf("proxyFunc() error = %v", err)
+	}
+	if proxyURL != nil {
+		t.Fatalf("proxyFunc() = %v, want default no_proxy bypass", proxyURL)
+	}
+}
+
+func TestProxyFuncUsesEnvironmentProxyWithDefaultNoProxy(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://env-proxy.example:18443")
+	t.Setenv("https_proxy", "")
+	t.Setenv("ALL_PROXY", "")
+	t.Setenv("all_proxy", "")
+
+	fn := proxyFunc(ProxyConfig{})
+	req, err := http.NewRequest(http.MethodGet, "https://api.openai.com/v1/models", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	proxyURL, err := fn(req)
+	if err != nil {
+		t.Fatalf("proxyFunc() error = %v", err)
+	}
+	if proxyURL == nil || proxyURL.String() != "http://env-proxy.example:18443" {
+		t.Fatalf("proxyFunc() = %v, want environment proxy", proxyURL)
+	}
+
+	localReq, err := http.NewRequest(http.MethodGet, "https://192.168.42.1/status", nil)
+	if err != nil {
+		t.Fatalf("NewRequest local: %v", err)
+	}
+	proxyURL, err = fn(localReq)
+	if err != nil {
+		t.Fatalf("proxyFunc(local) error = %v", err)
+	}
+	if proxyURL != nil {
+		t.Fatalf("proxyFunc(local) = %v, want default no_proxy bypass", proxyURL)
+	}
+}
+
 func TestProxyConfigValidateRejectsRelativeURL(t *testing.T) {
 	if err := (ProxyConfig{HTTPProxy: "127.0.0.1:7890"}).Validate(); err == nil {
 		t.Fatal("expected invalid relative proxy URL")

--- a/src/agent/internal/agent/tools.go
+++ b/src/agent/internal/agent/tools.go
@@ -52,7 +52,7 @@ func NewBuiltinToolSet(hidCfg HIDConfig, audioCfg AudioConfig, searchCfg SearchC
 		"touch_gesture": newPostActionScreenshotTool(&TouchGestureTool{dev: mouseDev, screen: screen, state: pointer}, screenshot, postActionScreenshotDelay),
 		"screenshot":    screenshot,
 		"audio_volume":  NewAudioVolumeTool(audioCfg.SocketOrDefault()),
-		"shell":         &ShellTool{},
+		"shell":         &ShellTool{proxy: proxyCfg},
 		"current_time":  NewCurrentTimeTool(),
 		"weather":       NewWeatherTool(proxyCfg),
 		"web_search":    NewWebSearchTool(searchCfg, proxyCfg),

--- a/src/agent/internal/agent/tools_shell.go
+++ b/src/agent/internal/agent/tools_shell.go
@@ -24,7 +24,9 @@ const (
 	shellDefaultPTYCols        = 120
 )
 
-type ShellTool struct{}
+type ShellTool struct {
+	proxy ProxyConfig
+}
 
 func (t *ShellTool) Name() string { return "shell" }
 
@@ -53,7 +55,7 @@ func (t *ShellTool) Call(ctx context.Context, input string) (string, error) {
 	}
 
 	if shellBoolArg(arguments, "background") || shellHasAction(arguments) {
-		return shellExecuteBackground(ctx, arguments)
+		return shellExecuteBackground(ctx, arguments, t.proxy)
 	}
 
 	command, ok := arguments["command"].(string)
@@ -75,7 +77,7 @@ func (t *ShellTool) Call(ctx context.Context, input string) (string, error) {
 	execCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSecs*float64(time.Second)))
 	defer cancel()
 
-	result, runErr := shellRunForeground(execCtx, command, workdir, usePTY)
+	result, runErr := shellRunForeground(execCtx, command, workdir, usePTY, t.proxy)
 	if errors.Is(execCtx.Err(), context.DeadlineExceeded) {
 		return shellErrorString(fmt.Sprintf("Error: command timed out after %.0f seconds", timeoutSecs)), nil
 	}
@@ -85,11 +87,11 @@ func (t *ShellTool) Call(ctx context.Context, input string) (string, error) {
 	return result, nil
 }
 
-func shellExecuteBackground(ctx context.Context, arguments map[string]interface{}) (string, error) {
+func shellExecuteBackground(ctx context.Context, arguments map[string]interface{}, proxy ProxyConfig) (string, error) {
 	action := shellStringArg(arguments, "action", "start")
 	switch action {
 	case "start":
-		return shellStartBackground(ctx, arguments)
+		return shellStartBackground(ctx, arguments, proxy)
 	case "poll":
 		return shellPollBackground(arguments)
 	case "write":
@@ -107,7 +109,7 @@ func shellExecuteBackground(ctx context.Context, arguments map[string]interface{
 	}
 }
 
-func shellStartBackground(ctx context.Context, arguments map[string]interface{}) (string, error) {
+func shellStartBackground(ctx context.Context, arguments map[string]interface{}, proxy ProxyConfig) (string, error) {
 	command := shellStringArg(arguments, "command", "")
 	if command == "" {
 		return shellErrorString("Missing required parameter: command"), nil
@@ -128,7 +130,7 @@ func shellStartBackground(ctx context.Context, arguments map[string]interface{})
 		sessionCtx, cancel = context.WithCancel(context.Background())
 	}
 
-	cmd, err := shellBuildCommand(sessionCtx, command)
+	cmd, err := shellBuildCommand(sessionCtx, command, proxy)
 	if err != nil {
 		cancel()
 		return shellErrorString(err.Error()), nil
@@ -147,7 +149,7 @@ func shellStartBackground(ctx context.Context, arguments map[string]interface{})
 	}
 
 	if usePTY {
-		if err = shellStartPTYBackground(sessionCtx, session, arguments); err != nil {
+		if err = shellStartPTYBackground(sessionCtx, session, arguments, proxy); err != nil {
 			cancel()
 			return shellErrorString(err.Error()), nil
 		}
@@ -371,34 +373,34 @@ func shellStopBackground(arguments map[string]interface{}) (string, error) {
 	}), nil
 }
 
-func shellBuildCommand(ctx context.Context, command string) (*exec.Cmd, error) {
+func shellBuildCommand(ctx context.Context, command string, proxy ProxyConfig) (*exec.Cmd, error) {
 	cmd := exec.CommandContext(ctx, shellPlatformShell(), shellPlatformShellArg(), command)
-	cmd.Env = shellCommandEnv(false)
+	cmd.Env = shellCommandEnv(false, proxy)
 	shellSetProcessGroup(cmd)
 	return cmd, nil
 }
 
-func shellBuildPtyCommand(ctx context.Context, command string) (gopty.Pty, *gopty.Cmd, error) {
+func shellBuildPtyCommand(ctx context.Context, command string, proxy ProxyConfig) (gopty.Pty, *gopty.Cmd, error) {
 	ptmx, err := gopty.New()
 	if err != nil {
 		return nil, nil, err
 	}
 	cmd := ptmx.CommandContext(ctx, shellPlatformShell(), shellPlatformShellArg(), command)
-	cmd.Env = shellCommandEnv(true)
+	cmd.Env = shellCommandEnv(true, proxy)
 	shellSetProcessGroupPty(cmd)
 	return ptmx, cmd, nil
 }
 
-func shellRunForeground(ctx context.Context, command string, workdir string, usePTY bool) (string, error) {
+func shellRunForeground(ctx context.Context, command string, workdir string, usePTY bool, proxy ProxyConfig) (string, error) {
 	if !usePTY {
-		return shellRunForegroundCmd(ctx, command, workdir)
+		return shellRunForegroundCmd(ctx, command, workdir, proxy)
 	}
-	return shellRunForegroundPTY(ctx, command, workdir)
+	return shellRunForegroundPTY(ctx, command, workdir, proxy)
 }
 
-func shellRunForegroundCmd(ctx context.Context, command string, workdir string) (string, error) {
+func shellRunForegroundCmd(ctx context.Context, command string, workdir string, proxy ProxyConfig) (string, error) {
 	cmd := exec.Command(shellPlatformShell(), shellPlatformShellArg(), command)
-	cmd.Env = shellCommandEnv(false)
+	cmd.Env = shellCommandEnv(false, proxy)
 	shellSetProcessGroup(cmd)
 	if workdir != "" {
 		cmd.Dir = workdir
@@ -454,8 +456,8 @@ func shellRunForegroundCmd(ctx context.Context, command string, workdir string) 
 	}
 }
 
-func shellRunForegroundPTY(ctx context.Context, command string, workdir string) (string, error) {
-	ptmx, ptyCmd, err := shellBuildPtyCommand(ctx, command)
+func shellRunForegroundPTY(ctx context.Context, command string, workdir string, proxy ProxyConfig) (string, error) {
+	ptmx, ptyCmd, err := shellBuildPtyCommand(ctx, command, proxy)
 	if err != nil {
 		return fmt.Sprintf("Error: %s", err.Error()), err
 	}
@@ -514,8 +516,8 @@ func shellRunForegroundPTY(ctx context.Context, command string, workdir string) 
 	}
 }
 
-func shellStartPTYBackground(ctx context.Context, session *shellSession, arguments map[string]interface{}) error {
-	ptmx, ptyCmd, err := shellBuildPtyCommand(ctx, session.command)
+func shellStartPTYBackground(ctx context.Context, session *shellSession, arguments map[string]interface{}, proxy ProxyConfig) error {
+	ptmx, ptyCmd, err := shellBuildPtyCommand(ctx, session.command, proxy)
 	if err != nil {
 		return err
 	}

--- a/src/agent/internal/agent/tools_shell_session.go
+++ b/src/agent/internal/agent/tools_shell_session.go
@@ -322,8 +322,9 @@ func shellPlatformShellArg() string {
 	return "-c"
 }
 
-func shellCommandEnv(usePTY bool) []string {
+func shellCommandEnv(usePTY bool, proxy ProxyConfig) []string {
 	env := os.Environ()
+	env = shellApplyProxyEnv(env, proxy)
 	if usePTY {
 		env = shellEnsureEnv(env, "TERM", "dumb")
 		env = shellEnsureEnv(env, "NO_COLOR", "1")
@@ -334,6 +335,53 @@ func shellCommandEnv(usePTY bool) []string {
 		env = shellEnsureEnv(env, "PAGER", "cat")
 	}
 	return env
+}
+
+func shellApplyProxyEnv(env []string, proxy ProxyConfig) []string {
+	proxy = proxy.WithDefaults()
+	if !proxy.HasProxyURL() {
+		if value := strings.TrimSpace(proxy.NoProxy); value != "" {
+			env = shellEnsureEnv(env, "no_proxy", value)
+			env = shellEnsureEnv(env, "NO_PROXY", value)
+		}
+		return env
+	}
+
+	for _, key := range []string{
+		"http_proxy", "https_proxy", "all_proxy", "no_proxy",
+		"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+	} {
+		env = shellRemoveEnv(env, key)
+	}
+
+	if value := strings.TrimSpace(proxy.HTTPProxy); value != "" {
+		env = shellEnsureEnv(env, "http_proxy", value)
+		env = shellEnsureEnv(env, "HTTP_PROXY", value)
+	}
+	if value := strings.TrimSpace(proxy.HTTPSProxy); value != "" {
+		env = shellEnsureEnv(env, "https_proxy", value)
+		env = shellEnsureEnv(env, "HTTPS_PROXY", value)
+	}
+	if value := strings.TrimSpace(proxy.AllProxy); value != "" {
+		env = shellEnsureEnv(env, "all_proxy", value)
+		env = shellEnsureEnv(env, "ALL_PROXY", value)
+	}
+	if value := strings.TrimSpace(proxy.NoProxy); value != "" {
+		env = shellEnsureEnv(env, "no_proxy", value)
+		env = shellEnsureEnv(env, "NO_PROXY", value)
+	}
+	return env
+}
+
+func shellRemoveEnv(env []string, key string) []string {
+	prefix := key + "="
+	filtered := env[:0]
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, prefix) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
 }
 
 func shellEnsureEnv(env []string, key string, value string) []string {

--- a/src/agent/internal/agent/tools_shell_session.go
+++ b/src/agent/internal/agent/tools_shell_session.go
@@ -340,10 +340,6 @@ func shellCommandEnv(usePTY bool, proxy ProxyConfig) []string {
 func shellApplyProxyEnv(env []string, proxy ProxyConfig) []string {
 	proxy = proxy.WithDefaults()
 	if !proxy.HasProxyURL() {
-		if value := strings.TrimSpace(proxy.NoProxy); value != "" {
-			env = shellEnsureEnv(env, "no_proxy", value)
-			env = shellEnsureEnv(env, "NO_PROXY", value)
-		}
 		return env
 	}
 

--- a/src/agent/internal/agent/tools_shell_test.go
+++ b/src/agent/internal/agent/tools_shell_test.go
@@ -113,10 +113,11 @@ func TestShellApplyProxyEnvDefaultsNoProxy(t *testing.T) {
 	}
 }
 
-func TestShellApplyProxyEnvKeepsEnvironmentWhenOnlyNoProxyConfigured(t *testing.T) {
+func TestShellApplyProxyEnvKeepsEnvironmentWhenNoProxyURLConfigured(t *testing.T) {
 	env := shellApplyProxyEnv([]string{
 		"PATH=/bin",
 		"HTTPS_PROXY=http://inherited-proxy",
+		"NO_PROXY=internal.example",
 	}, ProxyConfig{
 		NoProxy: DefaultNoProxy,
 	})
@@ -132,8 +133,11 @@ func TestShellApplyProxyEnvKeepsEnvironmentWhenOnlyNoProxyConfigured(t *testing.
 	if got["HTTPS_PROXY"] != "http://inherited-proxy" {
 		t.Fatalf("HTTPS_PROXY = %q, want inherited proxy preserved", got["HTTPS_PROXY"])
 	}
-	if got["no_proxy"] != DefaultNoProxy || got["NO_PROXY"] != DefaultNoProxy {
-		t.Fatalf("no_proxy = %q / %q, want configured default", got["no_proxy"], got["NO_PROXY"])
+	if _, ok := got["no_proxy"]; ok {
+		t.Fatalf("no_proxy = %q, want unset", got["no_proxy"])
+	}
+	if got["NO_PROXY"] != "internal.example" {
+		t.Fatalf("NO_PROXY = %q, want inherited value", got["NO_PROXY"])
 	}
 }
 

--- a/src/agent/internal/agent/tools_shell_test.go
+++ b/src/agent/internal/agent/tools_shell_test.go
@@ -29,6 +29,114 @@ func TestShellToolForegroundEcho(t *testing.T) {
 	}
 }
 
+func TestShellToolForegroundInjectsProxyEnv(t *testing.T) {
+	skipOnWindows(t)
+	tool := &ShellTool{proxy: ProxyConfig{
+		HTTPProxy:  "http://proxy.example:18080",
+		HTTPSProxy: "http://proxy.example:18443",
+		AllProxy:   "socks5://proxy.example:18081",
+		NoProxy:    "localhost,127.0.0.1",
+	}}
+
+	out, err := tool.Call(context.Background(), `{"command":"printf '%s|%s|%s|%s|%s|%s|%s|%s' \"$http_proxy\" \"$HTTP_PROXY\" \"$https_proxy\" \"$HTTPS_PROXY\" \"$all_proxy\" \"$ALL_PROXY\" \"$no_proxy\" \"$NO_PROXY\""}`)
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	want := strings.Join([]string{
+		"http://proxy.example:18080",
+		"http://proxy.example:18080",
+		"http://proxy.example:18443",
+		"http://proxy.example:18443",
+		"socks5://proxy.example:18081",
+		"socks5://proxy.example:18081",
+		"localhost,127.0.0.1",
+		"localhost,127.0.0.1",
+	}, "|")
+	if out != want {
+		t.Fatalf("Call output = %q, want %q", out, want)
+	}
+}
+
+func TestShellApplyProxyEnvReplacesInheritedProxy(t *testing.T) {
+	env := shellApplyProxyEnv([]string{
+		"PATH=/bin",
+		"http_proxy=http://old-http",
+		"HTTP_PROXY=http://old-http",
+		"https_proxy=http://old-https",
+		"HTTPS_PROXY=http://old-https",
+		"NO_PROXY=old.local",
+	}, ProxyConfig{
+		HTTPSProxy: " http://new-https ",
+		NoProxy:    " localhost,127.0.0.1 ",
+	})
+
+	got := map[string]string{}
+	for _, entry := range env {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) == 2 {
+			got[parts[0]] = parts[1]
+		}
+	}
+
+	if got["PATH"] != "/bin" {
+		t.Fatalf("PATH = %q, want preserved /bin", got["PATH"])
+	}
+	if _, ok := got["http_proxy"]; ok {
+		t.Fatalf("http_proxy was preserved from inherited env: %q", got["http_proxy"])
+	}
+	if _, ok := got["HTTP_PROXY"]; ok {
+		t.Fatalf("HTTP_PROXY was preserved from inherited env: %q", got["HTTP_PROXY"])
+	}
+	if got["https_proxy"] != "http://new-https" || got["HTTPS_PROXY"] != "http://new-https" {
+		t.Fatalf("https proxy env not replaced: https_proxy=%q HTTPS_PROXY=%q", got["https_proxy"], got["HTTPS_PROXY"])
+	}
+	if got["no_proxy"] != "localhost,127.0.0.1" || got["NO_PROXY"] != "localhost,127.0.0.1" {
+		t.Fatalf("no_proxy env not replaced: no_proxy=%q NO_PROXY=%q", got["no_proxy"], got["NO_PROXY"])
+	}
+}
+
+func TestShellApplyProxyEnvDefaultsNoProxy(t *testing.T) {
+	env := shellApplyProxyEnv([]string{"PATH=/bin"}, ProxyConfig{
+		HTTPSProxy: "http://proxy.example:18443",
+	})
+
+	got := map[string]string{}
+	for _, entry := range env {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) == 2 {
+			got[parts[0]] = parts[1]
+		}
+	}
+
+	if got["no_proxy"] != DefaultNoProxy || got["NO_PROXY"] != DefaultNoProxy {
+		t.Fatalf("default no_proxy not injected: no_proxy=%q NO_PROXY=%q", got["no_proxy"], got["NO_PROXY"])
+	}
+}
+
+func TestShellApplyProxyEnvKeepsEnvironmentWhenOnlyNoProxyConfigured(t *testing.T) {
+	env := shellApplyProxyEnv([]string{
+		"PATH=/bin",
+		"HTTPS_PROXY=http://inherited-proxy",
+	}, ProxyConfig{
+		NoProxy: DefaultNoProxy,
+	})
+
+	got := map[string]string{}
+	for _, entry := range env {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) == 2 {
+			got[parts[0]] = parts[1]
+		}
+	}
+
+	if got["HTTPS_PROXY"] != "http://inherited-proxy" {
+		t.Fatalf("HTTPS_PROXY = %q, want inherited proxy preserved", got["HTTPS_PROXY"])
+	}
+	if got["no_proxy"] != DefaultNoProxy || got["NO_PROXY"] != DefaultNoProxy {
+		t.Fatalf("no_proxy = %q / %q, want configured default", got["no_proxy"], got["NO_PROXY"])
+	}
+}
+
 func TestShellToolForegroundWorkdir(t *testing.T) {
 	skipOnWindows(t)
 	dir := t.TempDir()

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -109,6 +109,12 @@ bool starts_with(const std::string& text, const std::string& prefix) {
     return text.compare(0, prefix.size(), prefix) == 0;
 }
 
+bool has_proxy_url(const aiden::ProxyToml& proxy) {
+    return !trim_copy(proxy.http_proxy).empty() ||
+           !trim_copy(proxy.https_proxy).empty() ||
+           !trim_copy(proxy.all_proxy).empty();
+}
+
 bool consume_prefix(const char* arg, const char* prefix, std::string* out) {
     size_t prefix_len = strlen(prefix);
     if (strncmp(arg, prefix, prefix_len) != 0) {
@@ -496,8 +502,6 @@ void apply_default_agent_config(aiden::AgentToml& cfg) {
     cfg.hid.mouse_device = "/dev/hidg1";
     cfg.hid.frame_socket = "/run/frame_service/frame_service.sock";
 
-    cfg.proxy.no_proxy = kDefaultNoProxy;
-
     cfg.search.provider = "duckduckgo";
 }
 
@@ -520,7 +524,7 @@ void load_current_agent_config(const Options& options,
             if (loaded.search.provider.empty()) {
                 loaded.search.provider = "duckduckgo";
             }
-            if (loaded.proxy.no_proxy.empty()) {
+            if (has_proxy_url(loaded.proxy) && loaded.proxy.no_proxy.empty()) {
                 loaded.proxy.no_proxy = kDefaultNoProxy;
             }
             *config = loaded;
@@ -1382,11 +1386,11 @@ std::string build_proxy_env_exports(const aiden::ProxyToml& proxy) {
     std::string https_proxy = trim_copy(proxy.https_proxy);
     std::string all_proxy = trim_copy(proxy.all_proxy);
     std::string no_proxy = trim_copy(proxy.no_proxy);
+    if (http_proxy.empty() && https_proxy.empty() && all_proxy.empty()) {
+        return "";
+    }
     if (no_proxy.empty()) {
         no_proxy = kDefaultNoProxy;
-    }
-    if (http_proxy.empty() && https_proxy.empty() && all_proxy.empty()) {
-        return "export no_proxy=" + shell_quote(no_proxy) + " && export NO_PROXY=" + shell_quote(no_proxy) + " && ";
     }
 
     std::string exports = "unset http_proxy https_proxy all_proxy no_proxy HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY && ";

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -73,6 +73,7 @@ const char* kLoopbackBindAddress = "127.0.0.1";
 const size_t kMaxHttpHeaderSize = 8 * 1024;
 const size_t kMaxHttpBodySize = 64 * 1024;
 const int kClientReadTimeoutSeconds = 5;
+const char* kDefaultNoProxy = "localhost,127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16";
 
 enum ReadStatus {
     READ_STATUS_OK,
@@ -495,6 +496,8 @@ void apply_default_agent_config(aiden::AgentToml& cfg) {
     cfg.hid.mouse_device = "/dev/hidg1";
     cfg.hid.frame_socket = "/run/frame_service/frame_service.sock";
 
+    cfg.proxy.no_proxy = kDefaultNoProxy;
+
     cfg.search.provider = "duckduckgo";
 }
 
@@ -516,6 +519,9 @@ void load_current_agent_config(const Options& options,
         if (aiden::load_agent_toml(options.agent_config_path.c_str(), loaded, &err)) {
             if (loaded.search.provider.empty()) {
                 loaded.search.provider = "duckduckgo";
+            }
+            if (loaded.proxy.no_proxy.empty()) {
+                loaded.proxy.no_proxy = kDefaultNoProxy;
             }
             *config = loaded;
         } else if (load_error) {
@@ -1362,7 +1368,47 @@ std::string build_curl_proxy_arg(const aiden::ProxyToml& proxy) {
     if (url.empty()) url = trim_copy(proxy.http_proxy);
     if (url.empty()) url = trim_copy(proxy.all_proxy);
     if (url.empty()) return "";
-    return " -x " + shell_quote(url) + " ";
+    std::string arg = " -x " + shell_quote(url) + " ";
+    std::string no_proxy = trim_copy(proxy.no_proxy);
+    if (no_proxy.empty()) {
+        no_proxy = kDefaultNoProxy;
+    }
+    arg += "--noproxy " + shell_quote(no_proxy) + " ";
+    return arg;
+}
+
+std::string build_proxy_env_exports(const aiden::ProxyToml& proxy) {
+    std::string http_proxy = trim_copy(proxy.http_proxy);
+    std::string https_proxy = trim_copy(proxy.https_proxy);
+    std::string all_proxy = trim_copy(proxy.all_proxy);
+    std::string no_proxy = trim_copy(proxy.no_proxy);
+    if (no_proxy.empty()) {
+        no_proxy = kDefaultNoProxy;
+    }
+    if (http_proxy.empty() && https_proxy.empty() && all_proxy.empty()) {
+        return "export no_proxy=" + shell_quote(no_proxy) + " && export NO_PROXY=" + shell_quote(no_proxy) + " && ";
+    }
+
+    std::string exports = "unset http_proxy https_proxy all_proxy no_proxy HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY && ";
+    auto append_export = [&exports](const char* key, const std::string& value) {
+        if (!value.empty()) {
+            exports += "export ";
+            exports += key;
+            exports += "=";
+            exports += shell_quote(value);
+            exports += " && ";
+        }
+    };
+
+    append_export("http_proxy", http_proxy);
+    append_export("HTTP_PROXY", http_proxy);
+    append_export("https_proxy", https_proxy);
+    append_export("HTTPS_PROXY", https_proxy);
+    append_export("all_proxy", all_proxy);
+    append_export("ALL_PROXY", all_proxy);
+    append_export("no_proxy", no_proxy);
+    append_export("NO_PROXY", no_proxy);
+    return exports;
 }
 
 ApiResponse handle_config_test(const Options& options, const std::string& body) {
@@ -1392,6 +1438,7 @@ ApiResponse handle_config_test(const Options& options, const std::string& body) 
     std::string config_error;
     load_current_agent_config(options, &current_config, &config_error);
     std::string curl_proxy_arg = build_curl_proxy_arg(current_config.proxy);
+    std::string curl_env_exports = build_proxy_env_exports(current_config.proxy);
 
     if (section == "proxy") {
         const char* proxy_keys[] = {"http_proxy", "https_proxy", "all_proxy", NULL};
@@ -1428,7 +1475,7 @@ ApiResponse handle_config_test(const Options& options, const std::string& body) 
             cJSON_AddStringToObject(r, "detail", "no URL to test (provider unknown and base_url empty)");
             all_passed = false;
         } else {
-            std::string cmd = "curl -sI --max-time 6 " + curl_proxy_arg + shell_quote(url) + " 2>&1 | head -1";
+            std::string cmd = curl_env_exports + "curl -sI --max-time 6 " + curl_proxy_arg + shell_quote(url) + " 2>&1 | head -1";
             CommandResult cr = run_shell_command(cmd);
             bool reachable = cr.exit_code == 0 && cr.output.find("HTTP") != std::string::npos;
             cJSON_AddBoolToObject(r, "passed", reachable ? 1 : 0);
@@ -1496,6 +1543,7 @@ ApiResponse handle_config_test(const Options& options, const std::string& body) 
                     std::string response_path = response_path_template;
 
                     std::string cmd =
+                        curl_env_exports +
                         std::string("curl -sS --max-time 12 ") +
                         curl_proxy_arg +
                         "-o " + shell_quote(response_path) + " -w '%{http_code}' " +
@@ -1868,12 +1916,16 @@ ApiResponse handle_request(const Options& options, const HttpRequest& request) {
         std::string state = "{\"status\":\"running\",\"suite\":\"" + suite_path + "\"}";
         FILE* sf = fopen("/userdata/agent/benchmark/state.json", "w");
         if (sf) { fputs(state.c_str(), sf); fclose(sf); }
+
+        aiden::AgentToml current_config;
+        std::string config_error;
+        load_current_agent_config(options, &current_config, &config_error);
+        std::string proxy_env_exports = build_proxy_env_exports(current_config.proxy);
+
         // Launch runner in background
         std::string cmd = "cd /userdata/agent/benchmark && "
             "export OPENROUTER_API_KEY=$(grep 'api_key.*sk-or' /userdata/agent/agent.toml | sed 's/.*\"\\(sk-or[^\"]*\\)\".*/\\1/') && "
-            "export http_proxy=http://192.168.31.142:7897 && "
-            "export https_proxy=http://192.168.31.142:7897 && "
-            "export no_proxy=127.0.0.1,localhost && "
+            + proxy_env_exports +
             "python3 -c 'import sys;sys.path.insert(0,\".\");from runner.main import cli;sys.exit(cli())' "
             "run --suite " + shell_quote(suite_path) + " "
             "--agent-url http://127.0.0.1:8080 "

--- a/src/config_web_html.h
+++ b/src/config_web_html.h
@@ -206,7 +206,7 @@ static const char* CONFIG_WEB_HTML =
     "            <div class=\"field wide\"><label>http_proxy</label><input id=\"proxy_http_proxy\" data-section=\"proxy\" placeholder=\"http://127.0.0.1:7890\"></div>\n"
     "            <div class=\"field wide\"><label>https_proxy</label><input id=\"proxy_https_proxy\" data-section=\"proxy\" placeholder=\"http://127.0.0.1:7890\"></div>\n"
     "            <div class=\"field wide\"><label>all_proxy</label><input id=\"proxy_all_proxy\" data-section=\"proxy\" placeholder=\"socks5://127.0.0.1:7891\"></div>\n"
-    "            <div class=\"field wide\"><label>no_proxy</label><input id=\"proxy_no_proxy\" data-section=\"proxy\" placeholder=\"localhost,127.0.0.1,192.168.0.0/16\"></div>\n"
+    "            <div class=\"field wide\"><label>no_proxy</label><input id=\"proxy_no_proxy\" data-section=\"proxy\" placeholder=\"localhost,127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16\"></div>\n"
     "          </div>\n"
     "        </div>\n"
     "        <div class=\"section-card\" id=\"section-search\">\n"


### PR DESCRIPTION
## Summary
- pass Agent proxy config into the shell tool and inject configured proxy/no_proxy env vars for foreground, background, and PTY commands
- apply default no_proxy for localhost and private network addresses only when explicit proxy URLs are configured
- preserve process environment proxy behavior when proxy config is blank, including inherited NO_PROXY/no_proxy rules
- remove the hardcoded benchmark proxy and use configured proxy env instead

## Tests
- go test ./...
- git diff --check
- cmake --build build-review --target config_web
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default proxy bypass rules for localhost and private networks (127.0.0.1, 192.168.x.x, 10.x.x.x, etc.)
  * Proxy configuration now applies to shell tool commands

* **Documentation**
  * Updated proxy configuration guide with clearer descriptions and enhanced format support (hostname, suffix, CIDR)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AidenAI-IO/aiden-hardware-demo/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->