### PR TITLE
Improve OTA progress logging

### DIFF
--- a/src/agent/cmd/ota/main.go
+++ b/src/agent/cmd/ota/main.go
@@ -135,6 +135,7 @@ func parseConfigFlags(args []string) (ota.UpdaterConfig, error) {
 	jitter := fs.Duration("jitter", 0, "daemon check jitter")
 	healthTimeout := fs.Duration("health-timeout", 0, "pending health timeout")
 	httpTimeout := fs.Duration("http-timeout", 0, "HTTP request timeout")
+	httpResponseHeaderTimeout := fs.Duration("http-response-header-timeout", 0, "HTTP response header timeout")
 	switchTries := fs.Uint("switch-tries", 0, "tries remaining when switching slots")
 	targetSlot := fs.String("target-slot", "", "test override for target slot: a or b")
 	flags, _ := partitionFlagArgs(args)
@@ -178,6 +179,9 @@ func parseConfigFlags(args []string) (ota.UpdaterConfig, error) {
 	}
 	if *httpTimeout != 0 {
 		config.HTTPTimeout = *httpTimeout
+	}
+	if *httpResponseHeaderTimeout != 0 {
+		config.HTTPResponseHeaderTimeout = *httpResponseHeaderTimeout
 	}
 	if *switchTries != 0 {
 		if *switchTries > uint(ota.MaxTries) {
@@ -244,7 +248,7 @@ func flagIsBool(name string) bool {
 
 func flagTakesValue(name string) bool {
 	switch name {
-	case "config", "state-dir", "misc", "block-dir", "repo", "channel", "api-base", "public-key", "interval", "jitter", "health-timeout", "target-slot", "http-timeout", "switch-tries":
+	case "config", "state-dir", "misc", "block-dir", "repo", "channel", "api-base", "public-key", "interval", "jitter", "health-timeout", "target-slot", "http-timeout", "http-response-header-timeout", "switch-tries":
 		return true
 	default:
 		return false

--- a/src/agent/cmd/ota/main.go
+++ b/src/agent/cmd/ota/main.go
@@ -135,7 +135,6 @@ func parseConfigFlags(args []string) (ota.UpdaterConfig, error) {
 	jitter := fs.Duration("jitter", 0, "daemon check jitter")
 	healthTimeout := fs.Duration("health-timeout", 0, "pending health timeout")
 	httpTimeout := fs.Duration("http-timeout", 0, "HTTP request timeout")
-	httpResponseHeaderTimeout := fs.Duration("http-response-header-timeout", 0, "HTTP response header timeout")
 	switchTries := fs.Uint("switch-tries", 0, "tries remaining when switching slots")
 	targetSlot := fs.String("target-slot", "", "test override for target slot: a or b")
 	flags, _ := partitionFlagArgs(args)
@@ -179,9 +178,6 @@ func parseConfigFlags(args []string) (ota.UpdaterConfig, error) {
 	}
 	if *httpTimeout != 0 {
 		config.HTTPTimeout = *httpTimeout
-	}
-	if *httpResponseHeaderTimeout != 0 {
-		config.HTTPResponseHeaderTimeout = *httpResponseHeaderTimeout
 	}
 	if *switchTries != 0 {
 		if *switchTries > uint(ota.MaxTries) {
@@ -248,7 +244,7 @@ func flagIsBool(name string) bool {
 
 func flagTakesValue(name string) bool {
 	switch name {
-	case "config", "state-dir", "misc", "block-dir", "repo", "channel", "api-base", "public-key", "interval", "jitter", "health-timeout", "target-slot", "http-timeout", "http-response-header-timeout", "switch-tries":
+	case "config", "state-dir", "misc", "block-dir", "repo", "channel", "api-base", "public-key", "interval", "jitter", "health-timeout", "target-slot", "http-timeout", "switch-tries":
 		return true
 	default:
 		return false

--- a/src/agent/internal/ota/download.go
+++ b/src/agent/internal/ota/download.go
@@ -15,6 +15,7 @@ type DownloadOptions struct {
 	BearerToken      string
 	Progress         func(DownloadProgress)
 	ProgressInterval time.Duration
+	HTTPClient       *http.Client
 }
 
 type DownloadProgress struct {
@@ -68,7 +69,11 @@ func DownloadFileWithOptions(ctx context.Context, url string, dst string, expect
 	if resumeAt > 0 {
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", resumeAt))
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client := options.HTTPClient
+	if client == nil {
+		client = defaultOTAHTTPClient
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/src/agent/internal/ota/download.go
+++ b/src/agent/internal/ota/download.go
@@ -6,13 +6,35 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 )
 
+const defaultProgressInterval = 5 * time.Second
+
+type DownloadOptions struct {
+	BearerToken      string
+	Progress         func(DownloadProgress)
+	ProgressInterval time.Duration
+}
+
+type DownloadProgress struct {
+	URL         string
+	Path        string
+	Bytes       int64
+	Total       int64
+	ResumedFrom int64
+	Complete    bool
+}
+
 func DownloadFile(ctx context.Context, url string, dst string, expectedSize int64) error {
-	return DownloadFileWithToken(ctx, url, dst, expectedSize, "")
+	return DownloadFileWithOptions(ctx, url, dst, expectedSize, DownloadOptions{})
 }
 
 func DownloadFileWithToken(ctx context.Context, url string, dst string, expectedSize int64, bearerToken string) error {
+	return DownloadFileWithOptions(ctx, url, dst, expectedSize, DownloadOptions{BearerToken: bearerToken})
+}
+
+func DownloadFileWithOptions(ctx context.Context, url string, dst string, expectedSize int64, options DownloadOptions) error {
 	part := dst + ".part"
 	resumeAt := int64(0)
 	if info, err := os.Stat(part); err == nil {
@@ -25,7 +47,11 @@ func DownloadFileWithToken(ctx context.Context, url string, dst string, expected
 			if err := os.Rename(part, dst); err != nil {
 				return err
 			}
-			return fsyncDirFor(dst)
+			if err := fsyncDirFor(dst); err != nil {
+				return err
+			}
+			reportDownloadProgress(options.Progress, url, dst, resumeAt, expectedSize, resumeAt, true)
+			return nil
 		}
 		if resumeAt > expectedSize {
 			return fmt.Errorf("download size %d exceeds expected %d", resumeAt, expectedSize)
@@ -36,8 +62,8 @@ func DownloadFileWithToken(ctx context.Context, url string, dst string, expected
 	if err != nil {
 		return err
 	}
-	if bearerToken != "" {
-		req.Header.Set("Authorization", "Bearer "+bearerToken)
+	if options.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+options.BearerToken)
 	}
 	if resumeAt > 0 {
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", resumeAt))
@@ -58,20 +84,27 @@ func DownloadFileWithToken(ctx context.Context, url string, dst string, expected
 		flags |= os.O_TRUNC
 		resumeAt = 0
 	}
+	reporter := newDownloadProgressReporter(options.Progress, url, dst, expectedSize, resumeAt, options.ProgressInterval)
 	f, err := os.OpenFile(part, flags, 0o644)
 	if err != nil {
 		return err
 	}
 	copyErr := error(nil)
 	var copied int64
+	body := &cumulativeProgressReader{
+		reader: resp.Body,
+		onRead: func(n int64) {
+			reporter.maybeReport(resumeAt + n)
+		},
+	}
 	if expectedSize >= 0 {
 		remaining := expectedSize - resumeAt
-		copied, copyErr = io.Copy(f, io.LimitReader(resp.Body, remaining+1))
+		copied, copyErr = io.Copy(f, io.LimitReader(body, remaining+1))
 		if copyErr == nil && copied > remaining {
 			copyErr = fmt.Errorf("download size exceeds expected %d", expectedSize)
 		}
 	} else {
-		copied, copyErr = io.Copy(f, resp.Body)
+		copied, copyErr = io.Copy(f, body)
 	}
 	if copyErr == nil {
 		copyErr = f.Sync()
@@ -94,5 +127,91 @@ func DownloadFileWithToken(ctx context.Context, url string, dst string, expected
 	if err := os.Rename(part, dst); err != nil {
 		return err
 	}
-	return fsyncDirFor(dst)
+	if err := fsyncDirFor(dst); err != nil {
+		return err
+	}
+	reporter.complete(info.Size())
+	return nil
+}
+
+type cumulativeProgressReader struct {
+	reader io.Reader
+	onRead func(int64)
+	read   int64
+}
+
+func (r *cumulativeProgressReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		r.read += int64(n)
+		r.onRead(r.read)
+	}
+	return n, err
+}
+
+type downloadProgressReporter struct {
+	progress    func(DownloadProgress)
+	url         string
+	path        string
+	total       int64
+	resumedFrom int64
+	interval    time.Duration
+	lastReport  time.Time
+	nextPercent int64
+}
+
+func newDownloadProgressReporter(progress func(DownloadProgress), url string, path string, total int64, resumedFrom int64, interval time.Duration) *downloadProgressReporter {
+	if interval <= 0 {
+		interval = defaultProgressInterval
+	}
+	return &downloadProgressReporter{
+		progress:    progress,
+		url:         url,
+		path:        path,
+		total:       total,
+		resumedFrom: resumedFrom,
+		interval:    interval,
+		lastReport:  time.Now(),
+		nextPercent: 10,
+	}
+}
+
+func (r *downloadProgressReporter) maybeReport(bytes int64) {
+	if r.progress == nil {
+		return
+	}
+	now := time.Now()
+	shouldReport := now.Sub(r.lastReport) >= r.interval
+	if r.total > 0 {
+		percent := bytes * 100 / r.total
+		if percent >= r.nextPercent && percent < 100 {
+			shouldReport = true
+			for r.nextPercent <= percent {
+				r.nextPercent += 10
+			}
+		}
+	}
+	if !shouldReport {
+		return
+	}
+	r.lastReport = now
+	reportDownloadProgress(r.progress, r.url, r.path, bytes, r.total, r.resumedFrom, false)
+}
+
+func (r *downloadProgressReporter) complete(bytes int64) {
+	reportDownloadProgress(r.progress, r.url, r.path, bytes, r.total, r.resumedFrom, true)
+}
+
+func reportDownloadProgress(progress func(DownloadProgress), url string, path string, bytes int64, total int64, resumedFrom int64, complete bool) {
+	if progress == nil {
+		return
+	}
+	progress(DownloadProgress{
+		URL:         url,
+		Path:        path,
+		Bytes:       bytes,
+		Total:       total,
+		ResumedFrom: resumedFrom,
+		Complete:    complete,
+	})
 }

--- a/src/agent/internal/ota/download.go
+++ b/src/agent/internal/ota/download.go
@@ -15,7 +15,6 @@ type DownloadOptions struct {
 	BearerToken      string
 	Progress         func(DownloadProgress)
 	ProgressInterval time.Duration
-	HTTPClient       *http.Client
 }
 
 type DownloadProgress struct {
@@ -69,11 +68,7 @@ func DownloadFileWithOptions(ctx context.Context, url string, dst string, expect
 	if resumeAt > 0 {
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", resumeAt))
 	}
-	client := options.HTTPClient
-	if client == nil {
-		client = defaultOTAHTTPClient
-	}
-	resp, err := client.Do(req)
+	resp, err := defaultOTAHTTPClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/src/agent/internal/ota/download_test.go
+++ b/src/agent/internal/ota/download_test.go
@@ -149,3 +149,36 @@ func TestDownloadFailsWhenResumedResponseExceedsExpectedSize(t *testing.T) {
 		t.Fatalf("part size = %d, want bounded write", info.Size())
 	}
 }
+
+func TestDownloadReportsProgressAndCompletion(t *testing.T) {
+	content := "progress body"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "13")
+		_, _ = w.Write([]byte(content))
+	}))
+	defer server.Close()
+
+	dst := filepath.Join(t.TempDir(), "image.img")
+	var reports []DownloadProgress
+	err := DownloadFileWithOptions(context.Background(), server.URL, dst, int64(len(content)), DownloadOptions{
+		Progress: func(progress DownloadProgress) {
+			reports = append(reports, progress)
+		},
+	})
+	if err != nil {
+		t.Fatalf("DownloadFileWithOptions() error = %v", err)
+	}
+	if len(reports) == 0 {
+		t.Fatalf("no progress reports")
+	}
+	last := reports[len(reports)-1]
+	if !last.Complete {
+		t.Fatalf("last progress report = %+v, want Complete", last)
+	}
+	if last.Bytes != int64(len(content)) || last.Total != int64(len(content)) {
+		t.Fatalf("last progress report = %+v, want full byte count", last)
+	}
+	if last.Path != dst || last.URL != server.URL {
+		t.Fatalf("last progress report path/url = %q/%q", last.Path, last.URL)
+	}
+}

--- a/src/agent/internal/ota/github.go
+++ b/src/agent/internal/ota/github.go
@@ -17,10 +17,6 @@ type githubAsset struct {
 }
 
 func FetchLatestReleaseAssets(ctx context.Context, baseAPIURL string, bearerToken string) (map[string]string, error) {
-	return FetchLatestReleaseAssetsWithClient(ctx, defaultOTAHTTPClient, baseAPIURL, bearerToken)
-}
-
-func FetchLatestReleaseAssetsWithClient(ctx context.Context, client *http.Client, baseAPIURL string, bearerToken string) (map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseAPIURL, nil)
 	if err != nil {
 		return nil, err
@@ -30,10 +26,7 @@ func FetchLatestReleaseAssetsWithClient(ctx context.Context, client *http.Client
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 
-	if client == nil {
-		client = defaultOTAHTTPClient
-	}
-	resp, err := client.Do(req)
+	resp, err := defaultOTAHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/src/agent/internal/ota/github.go
+++ b/src/agent/internal/ota/github.go
@@ -17,6 +17,10 @@ type githubAsset struct {
 }
 
 func FetchLatestReleaseAssets(ctx context.Context, baseAPIURL string, bearerToken string) (map[string]string, error) {
+	return FetchLatestReleaseAssetsWithClient(ctx, defaultOTAHTTPClient, baseAPIURL, bearerToken)
+}
+
+func FetchLatestReleaseAssetsWithClient(ctx context.Context, client *http.Client, baseAPIURL string, bearerToken string) (map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseAPIURL, nil)
 	if err != nil {
 		return nil, err
@@ -26,7 +30,10 @@ func FetchLatestReleaseAssets(ctx context.Context, baseAPIURL string, bearerToke
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 
-	resp, err := http.DefaultClient.Do(req)
+	if client == nil {
+		client = defaultOTAHTTPClient
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/src/agent/internal/ota/updater.go
+++ b/src/agent/internal/ota/updater.go
@@ -28,38 +28,36 @@ const (
 )
 
 type UpdaterConfig struct {
-	ConfigPath                    string                       `json:"-"`
-	StateDir                      string                       `json:"state_dir,omitempty"`
-	DownloadDir                   string                       `json:"download_dir,omitempty"`
-	MiscPath                      string                       `json:"misc_path,omitempty"`
-	BlockDir                      string                       `json:"block_dir,omitempty"`
-	Repo                          string                       `json:"repo,omitempty"`
-	Channel                       string                       `json:"channel,omitempty"`
-	APIBase                       string                       `json:"api_base,omitempty"`
-	ManifestAsset                 string                       `json:"manifest_asset,omitempty"`
-	PublicKeyPath                 string                       `json:"public_key_path,omitempty"`
-	PublicKey                     ed25519.PublicKey            `json:"-"`
-	FactoryVersion                string                       `json:"factory_version,omitempty"`
-	FactoryBuildTime              string                       `json:"factory_build_time,omitempty"`
-	FactoryPartitionHashes        map[string]map[string]string `json:"factory_partition_hashes,omitempty"`
-	PartitionSizes                map[string]int64             `json:"partition_sizes,omitempty"`
-	GitHubToken                   string                       `json:"github_token,omitempty"`
-	GitHubTokenPath               string                       `json:"github_token_path,omitempty"`
-	Interval                      time.Duration                `json:"-"`
-	Jitter                        time.Duration                `json:"-"`
-	IntervalSeconds               int                          `json:"interval_seconds,omitempty"`
-	JitterSeconds                 int                          `json:"jitter_seconds,omitempty"`
-	SwitchTries                   uint8                        `json:"switch_tries,omitempty"`
-	HealthTimeout                 time.Duration                `json:"-"`
-	HealthTimeoutSecs             int                          `json:"health_timeout_seconds,omitempty"`
-	HealthPollInterval            time.Duration                `json:"-"`
-	HTTPTimeout                   time.Duration                `json:"-"`
-	HTTPTimeoutSecs               int                          `json:"http_timeout_seconds,omitempty"`
-	HTTPResponseHeaderTimeout     time.Duration                `json:"-"`
-	HTTPResponseHeaderTimeoutSecs int                          `json:"http_response_header_timeout_seconds,omitempty"`
-	DryRun                        bool                         `json:"dry_run,omitempty"`
-	TargetSlotOverride            string                       `json:"target_slot_override,omitempty"`
-	Logger                        *log.Logger                  `json:"-"`
+	ConfigPath             string                       `json:"-"`
+	StateDir               string                       `json:"state_dir,omitempty"`
+	DownloadDir            string                       `json:"download_dir,omitempty"`
+	MiscPath               string                       `json:"misc_path,omitempty"`
+	BlockDir               string                       `json:"block_dir,omitempty"`
+	Repo                   string                       `json:"repo,omitempty"`
+	Channel                string                       `json:"channel,omitempty"`
+	APIBase                string                       `json:"api_base,omitempty"`
+	ManifestAsset          string                       `json:"manifest_asset,omitempty"`
+	PublicKeyPath          string                       `json:"public_key_path,omitempty"`
+	PublicKey              ed25519.PublicKey            `json:"-"`
+	FactoryVersion         string                       `json:"factory_version,omitempty"`
+	FactoryBuildTime       string                       `json:"factory_build_time,omitempty"`
+	FactoryPartitionHashes map[string]map[string]string `json:"factory_partition_hashes,omitempty"`
+	PartitionSizes         map[string]int64             `json:"partition_sizes,omitempty"`
+	GitHubToken            string                       `json:"github_token,omitempty"`
+	GitHubTokenPath        string                       `json:"github_token_path,omitempty"`
+	Interval               time.Duration                `json:"-"`
+	Jitter                 time.Duration                `json:"-"`
+	IntervalSeconds        int                          `json:"interval_seconds,omitempty"`
+	JitterSeconds          int                          `json:"jitter_seconds,omitempty"`
+	SwitchTries            uint8                        `json:"switch_tries,omitempty"`
+	HealthTimeout          time.Duration                `json:"-"`
+	HealthTimeoutSecs      int                          `json:"health_timeout_seconds,omitempty"`
+	HealthPollInterval     time.Duration                `json:"-"`
+	HTTPTimeout            time.Duration                `json:"-"`
+	HTTPTimeoutSecs        int                          `json:"http_timeout_seconds,omitempty"`
+	DryRun                 bool                         `json:"dry_run,omitempty"`
+	TargetSlotOverride     string                       `json:"target_slot_override,omitempty"`
+	Logger                 *log.Logger                  `json:"-"`
 }
 
 type UpdateResult struct {
@@ -74,7 +72,6 @@ type Updater struct {
 	reboot      func() error
 	writeABData func(ABData) error
 	currentSlot func() (Slot, bool, error)
-	httpClient  *http.Client
 }
 
 func LoadUpdaterConfig(path string) (UpdaterConfig, error) {
@@ -157,13 +154,6 @@ func normalizeUpdaterConfig(config UpdaterConfig) (UpdaterConfig, error) {
 			config.HTTPTimeout = DefaultHTTPRequestLimit
 		}
 	}
-	if config.HTTPResponseHeaderTimeout <= 0 {
-		if config.HTTPResponseHeaderTimeoutSecs > 0 {
-			config.HTTPResponseHeaderTimeout = time.Duration(config.HTTPResponseHeaderTimeoutSecs) * time.Second
-		} else {
-			config.HTTPResponseHeaderTimeout = DefaultHTTPResponseHeaderTimeout
-		}
-	}
 	if config.SwitchTries > MaxTries {
 		return UpdaterConfig{}, fmt.Errorf("switch_tries %d exceeds %d", config.SwitchTries, MaxTries)
 	}
@@ -179,7 +169,6 @@ func NewUpdater(config UpdaterConfig, reboot func() error) (*Updater, error) {
 		config:      config,
 		reboot:      reboot,
 		currentSlot: currentSlotFromProcCmdline,
-		httpClient:  newOTAHTTPClient(config.HTTPResponseHeaderTimeout),
 	}
 	u.writeABData = u.writeABDataFile
 	return u, nil
@@ -567,7 +556,7 @@ func (u *Updater) Status() (State, ABData, error) {
 func (u *Updater) VerifyManifestFile(path string) (Manifest, error) {
 	ctx, cancel := u.httpContext(context.Background())
 	defer cancel()
-	data, err := readLocalOrRemoteManifest(ctx, u.httpClient, path)
+	data, err := readLocalOrRemoteManifest(ctx, path)
 	if err != nil {
 		return Manifest{}, err
 	}
@@ -586,10 +575,10 @@ func (u *Updater) httpContext(parent context.Context) (context.Context, context.
 	return context.WithTimeout(parent, timeout)
 }
 
-func readLocalOrRemoteManifest(ctx context.Context, client *http.Client, path string) ([]byte, error) {
+func readLocalOrRemoteManifest(ctx context.Context, path string) ([]byte, error) {
 	parsed, err := url.Parse(path)
 	if err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") {
-		return fetchBytesWithTokenLimitWithClient(ctx, client, path, "", MaxRemoteManifestBytes)
+		return fetchBytesWithTokenLimit(ctx, path, "", MaxRemoteManifestBytes)
 	}
 	return os.ReadFile(path)
 }
@@ -713,13 +702,13 @@ func (u *Updater) partitionSizes() map[string]int64 {
 func (u *Updater) fetchLatestReleaseAssets(parent context.Context, releaseURL string, token string) (map[string]string, error) {
 	ctx, cancel := u.httpContext(parent)
 	defer cancel()
-	return FetchLatestReleaseAssetsWithClient(ctx, u.httpClient, releaseURL, token)
+	return FetchLatestReleaseAssets(ctx, releaseURL, token)
 }
 
 func (u *Updater) fetchBytesWithTokenLimit(parent context.Context, url string, token string, limit int64) ([]byte, error) {
 	ctx, cancel := u.httpContext(parent)
 	defer cancel()
-	return fetchBytesWithTokenLimitWithClient(ctx, u.httpClient, url, token, limit)
+	return fetchBytesWithTokenLimit(ctx, url, token, limit)
 }
 
 func (u *Updater) downloadFileWithToken(parent context.Context, url string, dst string, expectedSize int64, token string) error {
@@ -728,7 +717,6 @@ func (u *Updater) downloadFileWithToken(parent context.Context, url string, dst 
 	return DownloadFileWithOptions(ctx, url, dst, expectedSize, DownloadOptions{
 		BearerToken: token,
 		Progress:    u.logDownloadProgress,
-		HTTPClient:  u.httpClient,
 	})
 }
 
@@ -763,18 +751,15 @@ func (u *Updater) logf(format string, args ...any) {
 	}
 }
 
-var defaultOTAHTTPClient = newOTAHTTPClient(DefaultHTTPResponseHeaderTimeout)
+var defaultOTAHTTPClient = newOTAHTTPClient()
 
-func newOTAHTTPClient(responseHeaderTimeout time.Duration) *http.Client {
-	if responseHeaderTimeout <= 0 {
-		responseHeaderTimeout = DefaultHTTPResponseHeaderTimeout
-	}
+func newOTAHTTPClient() *http.Client {
 	transport, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
 		return &http.Client{Transport: http.DefaultTransport}
 	}
 	clone := transport.Clone()
-	clone.ResponseHeaderTimeout = responseHeaderTimeout
+	clone.ResponseHeaderTimeout = DefaultHTTPResponseHeaderTimeout
 	return &http.Client{Transport: clone}
 }
 
@@ -871,10 +856,6 @@ func fetchBytesWithToken(ctx context.Context, url string, bearerToken string) ([
 }
 
 func fetchBytesWithTokenLimit(ctx context.Context, url string, bearerToken string, limit int64) ([]byte, error) {
-	return fetchBytesWithTokenLimitWithClient(ctx, defaultOTAHTTPClient, url, bearerToken, limit)
-}
-
-func fetchBytesWithTokenLimitWithClient(ctx context.Context, client *http.Client, url string, bearerToken string, limit int64) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -882,10 +863,7 @@ func fetchBytesWithTokenLimitWithClient(ctx context.Context, client *http.Client
 	if bearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+bearerToken)
 	}
-	if client == nil {
-		client = defaultOTAHTTPClient
-	}
-	resp, err := client.Do(req)
+	resp, err := defaultOTAHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/src/agent/internal/ota/updater.go
+++ b/src/agent/internal/ota/updater.go
@@ -170,6 +170,7 @@ func NewUpdater(config UpdaterConfig, reboot func() error) (*Updater, error) {
 }
 
 func (u *Updater) CheckOnce(ctx context.Context) (UpdateResult, error) {
+	u.logf("ota check: start repo=%s channel=%s", logValue(u.config.Repo, "<direct-api>"), logValue(u.config.Channel, "stable"))
 	if err := u.ProcessPendingHealth(ctx); err != nil {
 		u.recordError("health", err)
 		return UpdateResult{}, err
@@ -209,22 +210,26 @@ func (u *Updater) CheckOnce(ctx context.Context) (UpdateResult, error) {
 			return UpdateResult{}, err
 		}
 	}
+	u.logf("ota check: active_slot=%s target_slot=%s", slotLogName(active), slotLogName(target))
 	releaseURL, err := u.releaseURL()
 	if err != nil {
 		u.recordError("release", err)
 		return UpdateResult{}, err
 	}
 	token := u.githubToken()
+	u.logf("ota release: fetching %s", releaseURL)
 	assetsByName, err := u.fetchLatestReleaseAssets(ctx, releaseURL, token)
 	if err != nil {
 		u.recordError("release", err)
 		return UpdateResult{}, err
 	}
+	u.logf("ota release: found %d assets", len(assetsByName))
 	manifestURL, err := requiredAssetURL(assetsByName, u.config.ManifestAsset)
 	if err != nil {
 		u.recordError("manifest", err)
 		return UpdateResult{}, err
 	}
+	u.logf("ota manifest: downloading %s from %s", u.config.ManifestAsset, manifestURL)
 	manifestBytes, err := u.fetchBytesWithTokenLimit(ctx, manifestURL, token, MaxRemoteManifestBytes)
 	if err != nil {
 		u.recordError("manifest", err)
@@ -240,6 +245,7 @@ func (u *Updater) CheckOnce(ctx context.Context) (UpdateResult, error) {
 		u.recordError("manifest", err)
 		return UpdateResult{}, err
 	}
+	u.logf("ota manifest: verified version=%s channel=%s build_time=%s parts=%d", manifest.Version, logValue(manifest.Channel, "<unset>"), manifest.BuildTime, len(manifest.Parts))
 	manifestChannel := releaseManifestChannel(u.config.Channel)
 	if manifest.Channel != "" && manifestChannel != "" && manifest.Channel != manifestChannel {
 		err := fmt.Errorf("manifest channel %q, want %q", manifest.Channel, manifestChannel)
@@ -251,6 +257,7 @@ func (u *Updater) CheckOnce(ctx context.Context) (UpdateResult, error) {
 		return UpdateResult{}, err
 	}
 	if isNoUpdate(state, manifest) {
+		u.logf("ota check: no update version=%s build_time=%s", manifest.Version, manifest.BuildTime)
 		return UpdateResult{NoUpdate: true, Version: manifest.Version, TargetSlot: target}, nil
 	}
 	if err := state.ValidateSelectiveUpdate(manifest, target); err != nil {
@@ -281,6 +288,7 @@ func (u *Updater) CheckOnce(ctx context.Context) (UpdateResult, error) {
 			u.recordError("download", err)
 			return UpdateResult{}, err
 		}
+		u.logf("ota download: %s start size=%s url=%s dst=%s", asset.Name, formatBytes(asset.Size), assetURL, dst)
 		if err := u.downloadFileWithToken(ctx, assetURL, dst, asset.Size, token); err != nil {
 			u.recordError("download", err)
 			return UpdateResult{}, err
@@ -289,10 +297,12 @@ func (u *Updater) CheckOnce(ctx context.Context) (UpdateResult, error) {
 			u.recordError("verify", err)
 			return UpdateResult{}, err
 		}
+		u.logf("ota verify: %s sha256 ok", asset.Name)
 		selectedAssets[part.Name] = asset
 		downloaded[part.Name] = dst
 	}
 	if u.config.DryRun {
+		u.logf("ota check: dry-run complete version=%s target_slot=%s", manifest.Version, slotLogName(target))
 		return UpdateResult{Updated: true, Version: manifest.Version, TargetSlot: target}, nil
 	}
 	state.Phase = "writing"
@@ -323,7 +333,13 @@ func (u *Updater) CheckOnce(ctx context.Context) (UpdateResult, error) {
 
 	writer := PartitionWriter{BlockDir: u.config.BlockDir, ActiveSlot: active, PartitionSizes: u.partitionSizes()}
 	for part, image := range downloaded {
-		if err := writer.WritePart(part, target, image); err != nil {
+		blockName, err := writer.ResolveBlockName(part, target)
+		if err != nil {
+			u.recordError("write", err)
+			return UpdateResult{}, err
+		}
+		u.logf("ota write: %s -> %s start image=%s", part, blockName, image)
+		if err := writer.WritePartWithProgress(part, target, image, u.logWriteProgress); err != nil {
 			u.recordError("write", err)
 			return UpdateResult{}, err
 		}
@@ -359,7 +375,9 @@ func (u *Updater) CheckOnce(ctx context.Context) (UpdateResult, error) {
 		u.recordError("misc", err)
 		return UpdateResult{}, err
 	}
+	u.logf("ota misc: switched active slot to %s tries=%d", slotLogName(target), u.config.SwitchTries)
 	if u.reboot != nil {
+		u.logf("ota reboot: requested after switching to slot %s", slotLogName(target))
 		if err := u.reboot(); err != nil {
 			u.recordError("reboot", err)
 			return UpdateResult{}, err
@@ -380,6 +398,7 @@ func (u *Updater) ProcessPendingHealth(ctx context.Context) error {
 	if err := json.Unmarshal(data, &pending); err != nil {
 		return err
 	}
+	u.logf("ota health: pending slot=%s version=%s timeout=%s", pending.TargetSlot, pending.TargetVersion, u.config.HealthTimeout)
 	pendingSlot, err := parseSlotName(pending.TargetSlot)
 	if err != nil {
 		return err
@@ -403,11 +422,14 @@ func (u *Updater) ProcessPendingHealth(ctx context.Context) error {
 	}
 	bootID := currentBootID()
 	if err := ValidateHealthMarker(u.healthPath(), pending, bootID); err == nil {
+		u.logf("ota health: marker valid, committing slot=%s", pending.TargetSlot)
 		return u.commitPendingHealth(pending)
 	}
+	u.logf("ota health: waiting for marker path=%s", u.healthPath())
 	if err := WaitForHealth(ctx, u.healthPath(), pending, bootID, u.config.HealthTimeout, u.config.HealthPollInterval, u.reboot); err != nil {
 		return err
 	}
+	u.logf("ota health: marker received, committing slot=%s", pending.TargetSlot)
 	return u.commitPendingHealth(pending)
 }
 
@@ -492,6 +514,7 @@ func (u *Updater) commitPendingHealth(pending PendingBoot) error {
 }
 
 func (u *Updater) RunDaemon(ctx context.Context) error {
+	u.logf("ota daemon: started interval=%s jitter=%s", u.config.Interval, u.config.Jitter)
 	if err := u.ProcessPendingHealth(ctx); err != nil {
 		u.logf("ota health: %v", err)
 		u.recordError("health", err)
@@ -502,6 +525,7 @@ func (u *Updater) RunDaemon(ctx context.Context) error {
 			u.recordError("check", err)
 		}
 		wait := u.config.Interval + randomJitter(u.config.Jitter)
+		u.logf("ota daemon: next check in %s", wait)
 		timer := time.NewTimer(wait)
 		select {
 		case <-ctx.Done():
@@ -685,7 +709,10 @@ func (u *Updater) fetchBytesWithTokenLimit(parent context.Context, url string, t
 func (u *Updater) downloadFileWithToken(parent context.Context, url string, dst string, expectedSize int64, token string) error {
 	ctx, cancel := u.httpContext(parent)
 	defer cancel()
-	return DownloadFileWithToken(ctx, url, dst, expectedSize, token)
+	return DownloadFileWithOptions(ctx, url, dst, expectedSize, DownloadOptions{
+		BearerToken: token,
+		Progress:    u.logDownloadProgress,
+	})
 }
 
 func (u *Updater) githubToken() string {
@@ -717,6 +744,82 @@ func (u *Updater) logf(format string, args ...any) {
 	if u.config.Logger != nil {
 		u.config.Logger.Printf(format, args...)
 	}
+}
+
+func (u *Updater) logDownloadProgress(progress DownloadProgress) {
+	if u.config.Logger == nil {
+		return
+	}
+	name := filepath.Base(progress.Path)
+	amount := formatDownloadAmount(progress.Bytes, progress.Total)
+	if progress.Complete {
+		u.logf("ota download: %s complete %s", name, amount)
+		return
+	}
+	resume := ""
+	if progress.ResumedFrom > 0 {
+		resume = fmt.Sprintf(" resumed_from=%s", formatBytes(progress.ResumedFrom))
+	}
+	percent := ""
+	if progress.Total > 0 {
+		percent = fmt.Sprintf(" (%d%%)", progress.Bytes*100/progress.Total)
+	}
+	u.logf("ota download: %s progress %s%s%s", name, amount, percent, resume)
+}
+
+func (u *Updater) logWriteProgress(progress WriteProgress) {
+	if u.config.Logger == nil {
+		return
+	}
+	amount := formatDownloadAmount(progress.Bytes, progress.Total)
+	if progress.Complete {
+		u.logf("ota write: %s -> %s complete %s", progress.Part, progress.BlockName, amount)
+		return
+	}
+	percent := ""
+	if progress.Total > 0 {
+		percent = fmt.Sprintf(" (%d%%)", progress.Bytes*100/progress.Total)
+	}
+	u.logf("ota write: %s -> %s progress %s%s", progress.Part, progress.BlockName, amount, percent)
+}
+
+func formatDownloadAmount(bytes int64, total int64) string {
+	if total >= 0 {
+		return fmt.Sprintf("%s/%s", formatBytes(bytes), formatBytes(total))
+	}
+	return formatBytes(bytes)
+}
+
+func formatBytes(bytes int64) string {
+	if bytes < 0 {
+		return "unknown"
+	}
+	if bytes < 1024 {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	value := float64(bytes)
+	for _, unit := range []string{"KiB", "MiB", "GiB"} {
+		value /= 1024
+		if value < 1024 || unit == "GiB" {
+			return fmt.Sprintf("%.1f %s", value, unit)
+		}
+	}
+	return fmt.Sprintf("%.1f GiB", value)
+}
+
+func slotLogName(slot Slot) string {
+	name, err := slotName(slot)
+	if err != nil {
+		return fmt.Sprint(slot)
+	}
+	return name
+}
+
+func logValue(value string, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
 }
 
 func requiredAssetURL(assets map[string]string, name string) (string, error) {

--- a/src/agent/internal/ota/updater.go
+++ b/src/agent/internal/ota/updater.go
@@ -19,44 +19,47 @@ import (
 )
 
 const (
-	DefaultOTAConfigPath    = "/userdata/ota/config.json"
-	DefaultOTAStateDir      = "/userdata/ota"
-	DefaultGitHubAPIBase    = "https://api.github.com"
-	MaxRemoteManifestBytes  = 1 << 20
-	DefaultHTTPRequestLimit = 30 * time.Minute
+	DefaultOTAConfigPath             = "/userdata/ota/config.json"
+	DefaultOTAStateDir               = "/userdata/ota"
+	DefaultGitHubAPIBase             = "https://api.github.com"
+	MaxRemoteManifestBytes           = 1 << 20
+	DefaultHTTPRequestLimit          = 30 * time.Minute
+	DefaultHTTPResponseHeaderTimeout = 30 * time.Second
 )
 
 type UpdaterConfig struct {
-	ConfigPath             string                       `json:"-"`
-	StateDir               string                       `json:"state_dir,omitempty"`
-	DownloadDir            string                       `json:"download_dir,omitempty"`
-	MiscPath               string                       `json:"misc_path,omitempty"`
-	BlockDir               string                       `json:"block_dir,omitempty"`
-	Repo                   string                       `json:"repo,omitempty"`
-	Channel                string                       `json:"channel,omitempty"`
-	APIBase                string                       `json:"api_base,omitempty"`
-	ManifestAsset          string                       `json:"manifest_asset,omitempty"`
-	PublicKeyPath          string                       `json:"public_key_path,omitempty"`
-	PublicKey              ed25519.PublicKey            `json:"-"`
-	FactoryVersion         string                       `json:"factory_version,omitempty"`
-	FactoryBuildTime       string                       `json:"factory_build_time,omitempty"`
-	FactoryPartitionHashes map[string]map[string]string `json:"factory_partition_hashes,omitempty"`
-	PartitionSizes         map[string]int64             `json:"partition_sizes,omitempty"`
-	GitHubToken            string                       `json:"github_token,omitempty"`
-	GitHubTokenPath        string                       `json:"github_token_path,omitempty"`
-	Interval               time.Duration                `json:"-"`
-	Jitter                 time.Duration                `json:"-"`
-	IntervalSeconds        int                          `json:"interval_seconds,omitempty"`
-	JitterSeconds          int                          `json:"jitter_seconds,omitempty"`
-	SwitchTries            uint8                        `json:"switch_tries,omitempty"`
-	HealthTimeout          time.Duration                `json:"-"`
-	HealthTimeoutSecs      int                          `json:"health_timeout_seconds,omitempty"`
-	HealthPollInterval     time.Duration                `json:"-"`
-	HTTPTimeout            time.Duration                `json:"-"`
-	HTTPTimeoutSecs        int                          `json:"http_timeout_seconds,omitempty"`
-	DryRun                 bool                         `json:"dry_run,omitempty"`
-	TargetSlotOverride     string                       `json:"target_slot_override,omitempty"`
-	Logger                 *log.Logger                  `json:"-"`
+	ConfigPath                    string                       `json:"-"`
+	StateDir                      string                       `json:"state_dir,omitempty"`
+	DownloadDir                   string                       `json:"download_dir,omitempty"`
+	MiscPath                      string                       `json:"misc_path,omitempty"`
+	BlockDir                      string                       `json:"block_dir,omitempty"`
+	Repo                          string                       `json:"repo,omitempty"`
+	Channel                       string                       `json:"channel,omitempty"`
+	APIBase                       string                       `json:"api_base,omitempty"`
+	ManifestAsset                 string                       `json:"manifest_asset,omitempty"`
+	PublicKeyPath                 string                       `json:"public_key_path,omitempty"`
+	PublicKey                     ed25519.PublicKey            `json:"-"`
+	FactoryVersion                string                       `json:"factory_version,omitempty"`
+	FactoryBuildTime              string                       `json:"factory_build_time,omitempty"`
+	FactoryPartitionHashes        map[string]map[string]string `json:"factory_partition_hashes,omitempty"`
+	PartitionSizes                map[string]int64             `json:"partition_sizes,omitempty"`
+	GitHubToken                   string                       `json:"github_token,omitempty"`
+	GitHubTokenPath               string                       `json:"github_token_path,omitempty"`
+	Interval                      time.Duration                `json:"-"`
+	Jitter                        time.Duration                `json:"-"`
+	IntervalSeconds               int                          `json:"interval_seconds,omitempty"`
+	JitterSeconds                 int                          `json:"jitter_seconds,omitempty"`
+	SwitchTries                   uint8                        `json:"switch_tries,omitempty"`
+	HealthTimeout                 time.Duration                `json:"-"`
+	HealthTimeoutSecs             int                          `json:"health_timeout_seconds,omitempty"`
+	HealthPollInterval            time.Duration                `json:"-"`
+	HTTPTimeout                   time.Duration                `json:"-"`
+	HTTPTimeoutSecs               int                          `json:"http_timeout_seconds,omitempty"`
+	HTTPResponseHeaderTimeout     time.Duration                `json:"-"`
+	HTTPResponseHeaderTimeoutSecs int                          `json:"http_response_header_timeout_seconds,omitempty"`
+	DryRun                        bool                         `json:"dry_run,omitempty"`
+	TargetSlotOverride            string                       `json:"target_slot_override,omitempty"`
+	Logger                        *log.Logger                  `json:"-"`
 }
 
 type UpdateResult struct {
@@ -71,6 +74,7 @@ type Updater struct {
 	reboot      func() error
 	writeABData func(ABData) error
 	currentSlot func() (Slot, bool, error)
+	httpClient  *http.Client
 }
 
 func LoadUpdaterConfig(path string) (UpdaterConfig, error) {
@@ -153,6 +157,13 @@ func normalizeUpdaterConfig(config UpdaterConfig) (UpdaterConfig, error) {
 			config.HTTPTimeout = DefaultHTTPRequestLimit
 		}
 	}
+	if config.HTTPResponseHeaderTimeout <= 0 {
+		if config.HTTPResponseHeaderTimeoutSecs > 0 {
+			config.HTTPResponseHeaderTimeout = time.Duration(config.HTTPResponseHeaderTimeoutSecs) * time.Second
+		} else {
+			config.HTTPResponseHeaderTimeout = DefaultHTTPResponseHeaderTimeout
+		}
+	}
 	if config.SwitchTries > MaxTries {
 		return UpdaterConfig{}, fmt.Errorf("switch_tries %d exceeds %d", config.SwitchTries, MaxTries)
 	}
@@ -164,7 +175,12 @@ func NewUpdater(config UpdaterConfig, reboot func() error) (*Updater, error) {
 	if err != nil {
 		return nil, err
 	}
-	u := &Updater{config: config, reboot: reboot, currentSlot: currentSlotFromProcCmdline}
+	u := &Updater{
+		config:      config,
+		reboot:      reboot,
+		currentSlot: currentSlotFromProcCmdline,
+		httpClient:  newOTAHTTPClient(config.HTTPResponseHeaderTimeout),
+	}
 	u.writeABData = u.writeABDataFile
 	return u, nil
 }
@@ -551,7 +567,7 @@ func (u *Updater) Status() (State, ABData, error) {
 func (u *Updater) VerifyManifestFile(path string) (Manifest, error) {
 	ctx, cancel := u.httpContext(context.Background())
 	defer cancel()
-	data, err := readLocalOrRemoteManifest(ctx, path)
+	data, err := readLocalOrRemoteManifest(ctx, u.httpClient, path)
 	if err != nil {
 		return Manifest{}, err
 	}
@@ -570,10 +586,10 @@ func (u *Updater) httpContext(parent context.Context) (context.Context, context.
 	return context.WithTimeout(parent, timeout)
 }
 
-func readLocalOrRemoteManifest(ctx context.Context, path string) ([]byte, error) {
+func readLocalOrRemoteManifest(ctx context.Context, client *http.Client, path string) ([]byte, error) {
 	parsed, err := url.Parse(path)
 	if err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") {
-		return fetchBytesWithTokenLimit(ctx, path, "", MaxRemoteManifestBytes)
+		return fetchBytesWithTokenLimitWithClient(ctx, client, path, "", MaxRemoteManifestBytes)
 	}
 	return os.ReadFile(path)
 }
@@ -697,13 +713,13 @@ func (u *Updater) partitionSizes() map[string]int64 {
 func (u *Updater) fetchLatestReleaseAssets(parent context.Context, releaseURL string, token string) (map[string]string, error) {
 	ctx, cancel := u.httpContext(parent)
 	defer cancel()
-	return FetchLatestReleaseAssets(ctx, releaseURL, token)
+	return FetchLatestReleaseAssetsWithClient(ctx, u.httpClient, releaseURL, token)
 }
 
 func (u *Updater) fetchBytesWithTokenLimit(parent context.Context, url string, token string, limit int64) ([]byte, error) {
 	ctx, cancel := u.httpContext(parent)
 	defer cancel()
-	return fetchBytesWithTokenLimit(ctx, url, token, limit)
+	return fetchBytesWithTokenLimitWithClient(ctx, u.httpClient, url, token, limit)
 }
 
 func (u *Updater) downloadFileWithToken(parent context.Context, url string, dst string, expectedSize int64, token string) error {
@@ -712,6 +728,7 @@ func (u *Updater) downloadFileWithToken(parent context.Context, url string, dst 
 	return DownloadFileWithOptions(ctx, url, dst, expectedSize, DownloadOptions{
 		BearerToken: token,
 		Progress:    u.logDownloadProgress,
+		HTTPClient:  u.httpClient,
 	})
 }
 
@@ -744,6 +761,21 @@ func (u *Updater) logf(format string, args ...any) {
 	if u.config.Logger != nil {
 		u.config.Logger.Printf(format, args...)
 	}
+}
+
+var defaultOTAHTTPClient = newOTAHTTPClient(DefaultHTTPResponseHeaderTimeout)
+
+func newOTAHTTPClient(responseHeaderTimeout time.Duration) *http.Client {
+	if responseHeaderTimeout <= 0 {
+		responseHeaderTimeout = DefaultHTTPResponseHeaderTimeout
+	}
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Client{Transport: http.DefaultTransport}
+	}
+	clone := transport.Clone()
+	clone.ResponseHeaderTimeout = responseHeaderTimeout
+	return &http.Client{Transport: clone}
 }
 
 func (u *Updater) logDownloadProgress(progress DownloadProgress) {
@@ -839,6 +871,10 @@ func fetchBytesWithToken(ctx context.Context, url string, bearerToken string) ([
 }
 
 func fetchBytesWithTokenLimit(ctx context.Context, url string, bearerToken string, limit int64) ([]byte, error) {
+	return fetchBytesWithTokenLimitWithClient(ctx, defaultOTAHTTPClient, url, bearerToken, limit)
+}
+
+func fetchBytesWithTokenLimitWithClient(ctx context.Context, client *http.Client, url string, bearerToken string, limit int64) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -846,7 +882,10 @@ func fetchBytesWithTokenLimit(ctx context.Context, url string, bearerToken strin
 	if bearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+bearerToken)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	if client == nil {
+		client = defaultOTAHTTPClient
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/src/agent/internal/ota/updater_test.go
+++ b/src/agent/internal/ota/updater_test.go
@@ -1,6 +1,7 @@
 package ota
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -8,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -485,6 +487,50 @@ func TestUpdaterUsesGitHubTokenForManifestAndImageDownloads(t *testing.T) {
 	}
 	if !result.Updated {
 		t.Fatalf("CheckOnce() = %+v, want update", result)
+	}
+}
+
+func TestUpdaterLogsVisibleCheckProgress(t *testing.T) {
+	env := newUpdaterTestEnv(t)
+	var logs bytes.Buffer
+	env.config.Logger = log.New(&logs, "", 0)
+	manifest := env.signedManifest(map[string][]byte{
+		"boot_a.img": []byte("boot-a-v2"),
+		"boot_b.img": []byte("boot-b-v2"),
+		"oem_a.img":  []byte("oem-a-v2"),
+		"oem_b.img":  []byte("oem-b-v2"),
+		"rootfs.img": []byte("rootfs-v2"),
+	}, nil)
+	server := env.releaseServer(t, manifest, map[string][]byte{
+		"boot_b.img": []byte("boot-b-v2"),
+		"oem_b.img":  []byte("oem-b-v2"),
+		"rootfs.img": []byte("rootfs-v2"),
+	})
+	env.config.APIBase = server.URL
+
+	result, err := env.updater().CheckOnce(context.Background())
+	if err != nil {
+		t.Fatalf("CheckOnce() error = %v", err)
+	}
+	if !result.Updated {
+		t.Fatalf("CheckOnce() = %+v, want update", result)
+	}
+
+	output := logs.String()
+	for _, want := range []string{
+		"ota check: start repo=owner/repo channel=stable",
+		"ota release: fetching",
+		"ota manifest: verified version=20260521-120000-abcdef0",
+		"ota download: boot_b.img start size=9 B",
+		"ota download: boot_b.img complete 9 B/9 B",
+		"ota verify: boot_b.img sha256 ok",
+		"ota write: boot -> boot_b start",
+		"ota write: boot -> boot_b complete",
+		"ota reboot: requested after switching to slot b",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("logs missing %q:\n%s", want, output)
+		}
 	}
 }
 

--- a/src/agent/internal/ota/updater_test.go
+++ b/src/agent/internal/ota/updater_test.go
@@ -86,6 +86,16 @@ func TestDefaultHTTPResponseHeaderTimeoutIsShort(t *testing.T) {
 	}
 }
 
+func TestOTAHTTPClientUsesDefaultResponseHeaderTimeout(t *testing.T) {
+	transport, ok := newOTAHTTPClient().Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("newOTAHTTPClient transport = %T, want *http.Transport", newOTAHTTPClient().Transport)
+	}
+	if transport.ResponseHeaderTimeout != DefaultHTTPResponseHeaderTimeout {
+		t.Fatalf("ResponseHeaderTimeout = %s, want %s", transport.ResponseHeaderTimeout, DefaultHTTPResponseHeaderTimeout)
+	}
+}
+
 func TestUpdaterUsesPerRequestHTTPTimeout(t *testing.T) {
 	env := newUpdaterTestEnv(t)
 	env.config.HTTPTimeout = 120 * time.Millisecond
@@ -131,28 +141,6 @@ func TestUpdaterUsesPerRequestHTTPTimeout(t *testing.T) {
 
 	if _, err := env.updater().CheckOnce(context.Background()); err != nil {
 		t.Fatalf("CheckOnce() error = %v", err)
-	}
-}
-
-func TestUpdaterUsesResponseHeaderTimeout(t *testing.T) {
-	env := newUpdaterTestEnv(t)
-	env.config.HTTPTimeout = 5 * time.Second
-	env.config.HTTPResponseHeaderTimeout = 25 * time.Millisecond
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(200 * time.Millisecond)
-		_, _ = w.Write([]byte(`{"assets":[]}`))
-	}))
-	t.Cleanup(server.Close)
-	env.config.APIBase = server.URL
-
-	start := time.Now()
-	_, err := env.updater().CheckOnce(context.Background())
-	elapsed := time.Since(start)
-	if err == nil || !strings.Contains(err.Error(), "timeout") {
-		t.Fatalf("CheckOnce() error = %v, want response header timeout", err)
-	}
-	if elapsed > 500*time.Millisecond {
-		t.Fatalf("CheckOnce() elapsed = %s, want response header timeout before total request timeout", elapsed)
 	}
 }
 

--- a/src/agent/internal/ota/updater_test.go
+++ b/src/agent/internal/ota/updater_test.go
@@ -80,6 +80,12 @@ func TestDefaultHTTPTimeoutAllowsLargeImageDownloads(t *testing.T) {
 	}
 }
 
+func TestDefaultHTTPResponseHeaderTimeoutIsShort(t *testing.T) {
+	if DefaultHTTPResponseHeaderTimeout != 30*time.Second {
+		t.Fatalf("DefaultHTTPResponseHeaderTimeout = %s, want 30s", DefaultHTTPResponseHeaderTimeout)
+	}
+}
+
 func TestUpdaterUsesPerRequestHTTPTimeout(t *testing.T) {
 	env := newUpdaterTestEnv(t)
 	env.config.HTTPTimeout = 120 * time.Millisecond
@@ -125,6 +131,28 @@ func TestUpdaterUsesPerRequestHTTPTimeout(t *testing.T) {
 
 	if _, err := env.updater().CheckOnce(context.Background()); err != nil {
 		t.Fatalf("CheckOnce() error = %v", err)
+	}
+}
+
+func TestUpdaterUsesResponseHeaderTimeout(t *testing.T) {
+	env := newUpdaterTestEnv(t)
+	env.config.HTTPTimeout = 5 * time.Second
+	env.config.HTTPResponseHeaderTimeout = 25 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"assets":[]}`))
+	}))
+	t.Cleanup(server.Close)
+	env.config.APIBase = server.URL
+
+	start := time.Now()
+	_, err := env.updater().CheckOnce(context.Background())
+	elapsed := time.Since(start)
+	if err == nil || !strings.Contains(err.Error(), "timeout") {
+		t.Fatalf("CheckOnce() error = %v, want response header timeout", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("CheckOnce() elapsed = %s, want response header timeout before total request timeout", elapsed)
 	}
 }
 

--- a/src/agent/internal/ota/writer.go
+++ b/src/agent/internal/ota/writer.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 const (
@@ -28,7 +29,20 @@ type PartitionWriter struct {
 	PartitionSizes map[string]int64
 }
 
+type WriteProgress struct {
+	Part      string
+	BlockName string
+	ImagePath string
+	Bytes     int64
+	Total     int64
+	Complete  bool
+}
+
 func (w PartitionWriter) WritePart(part string, targetSlot Slot, imagePath string) error {
+	return w.WritePartWithProgress(part, targetSlot, imagePath, nil)
+}
+
+func (w PartitionWriter) WritePartWithProgress(part string, targetSlot Slot, imagePath string, progress func(WriteProgress)) error {
 	blockName, err := w.ResolveBlockName(part, targetSlot)
 	if err != nil {
 		return err
@@ -56,14 +70,23 @@ func (w PartitionWriter) WritePart(part string, targetSlot Slot, imagePath strin
 		return fmt.Errorf("open target partition %s: %w", dstPath, err)
 	}
 	copyErr := error(nil)
-	if _, copyErr = io.Copy(dst, src); copyErr == nil {
+	reporter := newWriteProgressReporter(progress, part, blockName, imagePath, info.Size(), defaultProgressInterval)
+	reader := &cumulativeProgressReader{
+		reader: src,
+		onRead: reporter.maybeReport,
+	}
+	if _, copyErr = io.Copy(dst, reader); copyErr == nil {
 		copyErr = dst.Sync()
 	}
 	closeErr := dst.Close()
 	if copyErr != nil {
 		return copyErr
 	}
-	return closeErr
+	if closeErr != nil {
+		return closeErr
+	}
+	reporter.complete(info.Size())
+	return nil
 }
 
 func (w PartitionWriter) partitionSizes() map[string]int64 {
@@ -89,4 +112,71 @@ func (w PartitionWriter) ResolveBlockName(part string, targetSlot Slot) (string,
 		return "", err
 	}
 	return part + "_" + targetSlotName, nil
+}
+
+type writeProgressReporter struct {
+	progress    func(WriteProgress)
+	part        string
+	blockName   string
+	imagePath   string
+	total       int64
+	interval    time.Duration
+	lastReport  time.Time
+	nextPercent int64
+}
+
+func newWriteProgressReporter(progress func(WriteProgress), part string, blockName string, imagePath string, total int64, interval time.Duration) *writeProgressReporter {
+	if interval <= 0 {
+		interval = defaultProgressInterval
+	}
+	return &writeProgressReporter{
+		progress:    progress,
+		part:        part,
+		blockName:   blockName,
+		imagePath:   imagePath,
+		total:       total,
+		interval:    interval,
+		lastReport:  time.Now(),
+		nextPercent: 10,
+	}
+}
+
+func (r *writeProgressReporter) maybeReport(bytes int64) {
+	if r.progress == nil {
+		return
+	}
+	now := time.Now()
+	shouldReport := now.Sub(r.lastReport) >= r.interval
+	if r.total > 0 {
+		percent := bytes * 100 / r.total
+		if percent >= r.nextPercent && percent < 100 {
+			shouldReport = true
+			for r.nextPercent <= percent {
+				r.nextPercent += 10
+			}
+		}
+	}
+	if !shouldReport {
+		return
+	}
+	r.lastReport = now
+	reportWriteProgress(r.progress, r.part, r.blockName, r.imagePath, bytes, r.total, false)
+}
+
+func (r *writeProgressReporter) complete(bytes int64) {
+	reportWriteProgress(r.progress, r.part, r.blockName, r.imagePath, bytes, r.total, true)
+}
+
+func reportWriteProgress(progress func(WriteProgress), part string, blockName string, imagePath string, bytes int64, total int64, complete bool) {
+	if progress == nil {
+		return
+	}
+	progress(WriteProgress{
+		Part:      part,
+		BlockName: blockName,
+		ImagePath: imagePath,
+		Bytes:     bytes,
+		Total:     total,
+		Complete:  complete,
+	})
 }

--- a/src/agent/internal/ota/writer_test.go
+++ b/src/agent/internal/ota/writer_test.go
@@ -44,6 +44,38 @@ func TestWriterWritesOnlyInactiveCanonicalPartitions(t *testing.T) {
 	}
 }
 
+func TestWriterReportsProgressAndCompletion(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "boot_b"), []byte{}, 0o644); err != nil {
+		t.Fatalf("WriteFile(block) error = %v", err)
+	}
+	src := filepath.Join(dir, "boot_b.img")
+	if err := os.WriteFile(src, []byte("boot image"), 0o644); err != nil {
+		t.Fatalf("WriteFile(src) error = %v", err)
+	}
+	w := PartitionWriter{BlockDir: dir, ActiveSlot: SlotA, PartitionSizes: map[string]int64{"boot_b": 100}}
+	var reports []WriteProgress
+	err := w.WritePartWithProgress("boot", SlotB, src, func(progress WriteProgress) {
+		reports = append(reports, progress)
+	})
+	if err != nil {
+		t.Fatalf("WritePartWithProgress() error = %v", err)
+	}
+	if len(reports) == 0 {
+		t.Fatalf("no progress reports")
+	}
+	last := reports[len(reports)-1]
+	if !last.Complete {
+		t.Fatalf("last progress report = %+v, want Complete", last)
+	}
+	if last.Part != "boot" || last.BlockName != "boot_b" || last.ImagePath != src {
+		t.Fatalf("last progress report identity = %+v", last)
+	}
+	if last.Bytes != int64(len("boot image")) || last.Total != int64(len("boot image")) {
+		t.Fatalf("last progress report = %+v, want full byte count", last)
+	}
+}
+
 func TestWriterRejectsMissingPartitionPath(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "boot_b.img")


### PR DESCRIPTION
## Summary
- Add visible OTA stage logs for release lookup, manifest verification, downloads, verification, partition writes, slot switching, reboot, and daemon sleeps
- Add download and partition write progress callbacks with periodic percentage/byte reporting
- Cover the new progress logging behavior with OTA tests

## Testing
- go test ./...
- git diff --check
- GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -o /tmp/aiden-ota-test ./cmd/ota

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress reporting for OTA downloads and partition writes with improved tracking at configurable intervals and percentage thresholds.
  * Enhanced observability with structured logging throughout OTA update check lifecycle, including asset downloads, verification stages, and health monitoring.

* **Tests**
  * Added tests for progress and completion reporting during downloads and partition writes.
  * Added tests for OTA update check logging output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->