### PR TITLE
Remove legacy energy threshold config check

### DIFF
--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -1660,8 +1660,29 @@ ApiResponse handle_config_test(const Options& options, const std::string& body) 
             cJSON_AddItemToArray(results, r);
         }
 
+        cJSON* vad_item = cJSON_GetObjectItem(values, "vad_speech_threshold");
+        cJSON* vad_r = cJSON_CreateObject();
+        cJSON_AddStringToObject(vad_r, "check", "vad_speech_threshold");
+        if (json_is_number(vad_item)) {
+            double n = vad_item->valuedouble;
+            if (n < 0.0 || n > 1.0) {
+                cJSON_AddBoolToObject(vad_r, "passed", 0);
+                std::string msg = "must be in range [0.0, 1.0], got " + std::to_string(n);
+                cJSON_AddStringToObject(vad_r, "detail", msg.c_str());
+                all_passed = false;
+            } else {
+                cJSON_AddBoolToObject(vad_r, "passed", 1);
+                cJSON_AddStringToObject(vad_r, "detail", std::to_string(n).c_str());
+            }
+        } else {
+            cJSON_AddBoolToObject(vad_r, "passed", 0);
+            cJSON_AddStringToObject(vad_r, "detail", "not a number");
+            all_passed = false;
+        }
+        cJSON_AddItemToArray(results, vad_r);
+
         const char* numeric_keys[] = {
-            "energy_threshold", "silence_ms", "min_speech_ms",
+            "silence_ms", "min_speech_ms",
             "voice_followup_timeout_ms", "voice_first_turn_timeout_ms",
             "voice_max_turns", "voice_max_response_tokens", NULL
         };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,6 +85,7 @@ add_executable(aiden_tests
     frame_processing_test.cpp
     terminal_input_test.cpp
     service_status_test.cpp
+    config_web_source_test.cpp
     audio_service_protocol_test.cpp
     audio_service_client_test.cpp
     ${AIDEN_IMAGE_TEST_SOURCES}
@@ -93,6 +94,10 @@ add_executable(aiden_tests
 
 target_include_directories(aiden_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/src
+)
+
+target_compile_definitions(aiden_tests PRIVATE
+    AIDEN_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
 )
 
 target_link_libraries(aiden_tests PRIVATE doctest)

--- a/tests/config_web_source_test.cpp
+++ b/tests/config_web_source_test.cpp
@@ -1,0 +1,19 @@
+#include <doctest.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+TEST_CASE("config web agent tests do not reference legacy energy threshold") {
+    const std::string path = std::string(AIDEN_SOURCE_DIR) + "/src/config_web.cpp";
+    std::ifstream in(path.c_str());
+    REQUIRE(in.good());
+
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    const std::string source = buffer.str();
+
+    const std::string legacy_key = "\"energy_" "threshold\"";
+    CHECK(source.find(legacy_key) == std::string::npos);
+    CHECK(source.find("\"vad_speech_threshold\"") != std::string::npos);
+}


### PR DESCRIPTION
Summary:\n- Remove the stale energy_threshold check from config web agent validation.\n- Validate vad_speech_threshold as the real VAD probability threshold with a 0.0-1.0 range.\n- Add a regression test to prevent the legacy key from returning.\n\nTests:\n- ctest --test-dir build-tests --output-on-failure -R aiden_tests