### PR TITLE
dev: persist ssh config

### DIFF
--- a/overlay/etc/init.d/S50sshd
+++ b/overlay/etc/init.d/S50sshd
@@ -35,6 +35,10 @@ copy_if_missing() {
 generate_host_key() {
 	type="$1"
 	path="$2"
+	if [ ! -x "$SSH_KEYGEN_BIN" ]; then
+		echo "ssh-keygen not found: $SSH_KEYGEN_BIN" >&2
+		return 1
+	fi
 	case "$type" in
 		rsa) "$SSH_KEYGEN_BIN" -t rsa -b 3072 -N '' -f "$path" >/dev/null 2>&1 ;;
 		ecdsa) "$SSH_KEYGEN_BIN" -t ecdsa -N '' -f "$path" >/dev/null 2>&1 ;;
@@ -57,7 +61,10 @@ ensure_persistent_ssh_state() {
 		copy_if_missing "$etc_key-cert.pub" "$persistent_key-cert.pub"
 
 		if [ ! -f "$persistent_key" ]; then
-			generate_host_key "$type" "$persistent_key" || true
+			if ! generate_host_key "$type" "$persistent_key"; then
+				echo "failed to generate SSH host key: $persistent_key" >&2
+				return 1
+			fi
 		fi
 
 		if [ -f "$persistent_key" ]; then
@@ -77,9 +84,23 @@ ensure_persistent_ssh_state() {
 		return 1
 	fi
 
-	copy_if_missing "$ROOT_HOME/.ssh/authorized_keys" "$PERSISTENT_ROOT_DIR/authorized_keys"
-	touch "$PERSISTENT_ROOT_DIR/authorized_keys"
-	ln -sf "$PERSISTENT_ROOT_DIR/authorized_keys" "$ROOT_HOME/.ssh/authorized_keys"
+	if [ -f "$ROOT_HOME/.ssh/authorized_keys" ] && [ ! -f "$PERSISTENT_ROOT_DIR/authorized_keys" ]; then
+		if ! copy_if_missing "$ROOT_HOME/.ssh/authorized_keys" "$PERSISTENT_ROOT_DIR/authorized_keys" ||
+			[ ! -f "$PERSISTENT_ROOT_DIR/authorized_keys" ]; then
+			echo "failed to persist authorized_keys" >&2
+			return 1
+		fi
+	fi
+	if [ ! -f "$PERSISTENT_ROOT_DIR/authorized_keys" ]; then
+		if ! touch "$PERSISTENT_ROOT_DIR/authorized_keys"; then
+			echo "failed to create persistent authorized_keys: $PERSISTENT_ROOT_DIR/authorized_keys" >&2
+			return 1
+		fi
+	fi
+	if ! ln -sf "$PERSISTENT_ROOT_DIR/authorized_keys" "$ROOT_HOME/.ssh/authorized_keys"; then
+		echo "failed to link persistent authorized_keys" >&2
+		return 1
+	fi
 
 	chmod 600 "$PERSISTENT_HOST_DIR"/ssh_host_*_key "$PERSISTENT_ROOT_DIR/authorized_keys" 2>/dev/null || true
 	chmod 644 "$PERSISTENT_HOST_DIR"/ssh_host_*_key.pub "$PERSISTENT_HOST_DIR"/ssh_host_*_key-cert.pub 2>/dev/null || true
@@ -108,10 +129,6 @@ start() {
 
 	if [ ! -x "$SSHD_BIN" ]; then
 		echo "sshd binary not found: $SSHD_BIN"
-		return 1
-	fi
-	if [ ! -x "$SSH_KEYGEN_BIN" ]; then
-		echo "ssh-keygen not found: $SSH_KEYGEN_BIN"
 		return 1
 	fi
 

--- a/overlay/etc/init.d/S50sshd
+++ b/overlay/etc/init.d/S50sshd
@@ -1,7 +1,17 @@
 #!/bin/sh
 # Aiden override: optional sshd startup.
 
-BOOT_CONF=/etc/aiden_boot.conf
+BOOT_CONF=${BOOT_CONF:-/etc/aiden_boot.conf}
+SSHD_BIN=${SSHD_BIN:-/usr/sbin/sshd}
+SSH_KEYGEN_BIN=${SSH_KEYGEN_BIN:-/usr/bin/ssh-keygen}
+PIDOF_BIN=${PIDOF_BIN:-pidof}
+KILLALL_BIN=${KILLALL_BIN:-killall}
+ETC_SSH_DIR=${ETC_SSH_DIR:-/etc/ssh}
+ROOT_HOME=${ROOT_HOME:-/root}
+PERSISTENT_SSH_DIR=${PERSISTENT_SSH_DIR:-/userdata/ssh}
+PERSISTENT_HOST_DIR=${PERSISTENT_HOST_DIR:-$PERSISTENT_SSH_DIR/host}
+PERSISTENT_ROOT_DIR=${PERSISTENT_ROOT_DIR:-$PERSISTENT_SSH_DIR/root}
+LOCK_FILE=${LOCK_FILE:-/var/lock/sshd}
 
 if [ -f "$BOOT_CONF" ]; then
 	. "$BOOT_CONF"
@@ -11,7 +21,78 @@ fi
 umask 077
 
 is_running() {
-	pidof sshd >/dev/null 2>&1
+	"$PIDOF_BIN" sshd >/dev/null 2>&1
+}
+
+copy_if_missing() {
+	src="$1"
+	dst="$2"
+	if [ ! -f "$dst" ] && [ -f "$src" ]; then
+		cp -p "$src" "$dst" 2>/dev/null || cp "$src" "$dst"
+	fi
+}
+
+generate_host_key() {
+	type="$1"
+	path="$2"
+	case "$type" in
+		rsa) "$SSH_KEYGEN_BIN" -t rsa -b 3072 -N '' -f "$path" >/dev/null 2>&1 ;;
+		ecdsa) "$SSH_KEYGEN_BIN" -t ecdsa -N '' -f "$path" >/dev/null 2>&1 ;;
+		ed25519) "$SSH_KEYGEN_BIN" -t ed25519 -N '' -f "$path" >/dev/null 2>&1 ;;
+		*) return 1 ;;
+	esac
+}
+
+ensure_persistent_ssh_state() {
+	mkdir -p "$PERSISTENT_HOST_DIR" "$PERSISTENT_ROOT_DIR" "$ETC_SSH_DIR" "$ROOT_HOME/.ssh"
+	chmod 700 "$PERSISTENT_SSH_DIR" "$PERSISTENT_HOST_DIR" "$PERSISTENT_ROOT_DIR" "$ROOT_HOME/.ssh" 2>/dev/null || true
+
+	for type in rsa ecdsa ed25519; do
+		name="ssh_host_${type}_key"
+		persistent_key="$PERSISTENT_HOST_DIR/$name"
+		etc_key="$ETC_SSH_DIR/$name"
+
+		copy_if_missing "$etc_key" "$persistent_key"
+		copy_if_missing "$etc_key.pub" "$persistent_key.pub"
+		copy_if_missing "$etc_key-cert.pub" "$persistent_key-cert.pub"
+
+		if [ ! -f "$persistent_key" ]; then
+			generate_host_key "$type" "$persistent_key" || true
+		fi
+
+		if [ -f "$persistent_key" ]; then
+			ln -sf "$persistent_key" "$etc_key"
+			[ -f "$persistent_key.pub" ] && ln -sf "$persistent_key.pub" "$etc_key.pub"
+			[ -f "$persistent_key-cert.pub" ] && ln -sf "$persistent_key-cert.pub" "$etc_key-cert.pub"
+		fi
+	done
+
+	host_key_count=0
+	for key in "$PERSISTENT_HOST_DIR"/ssh_host_*_key; do
+		[ -f "$key" ] || continue
+		host_key_count=$((host_key_count + 1))
+	done
+	if [ "$host_key_count" -eq 0 ]; then
+		echo "no SSH host keys available in $PERSISTENT_HOST_DIR"
+		return 1
+	fi
+
+	copy_if_missing "$ROOT_HOME/.ssh/authorized_keys" "$PERSISTENT_ROOT_DIR/authorized_keys"
+	touch "$PERSISTENT_ROOT_DIR/authorized_keys"
+	ln -sf "$PERSISTENT_ROOT_DIR/authorized_keys" "$ROOT_HOME/.ssh/authorized_keys"
+
+	chmod 600 "$PERSISTENT_HOST_DIR"/ssh_host_*_key "$PERSISTENT_ROOT_DIR/authorized_keys" 2>/dev/null || true
+	chmod 644 "$PERSISTENT_HOST_DIR"/ssh_host_*_key.pub "$PERSISTENT_HOST_DIR"/ssh_host_*_key-cert.pub 2>/dev/null || true
+	chown -R root:root "$PERSISTENT_SSH_DIR" "$ROOT_HOME/.ssh" 2>/dev/null || true
+}
+
+host_certificate_options() {
+	opts=""
+	for cert in "$PERSISTENT_HOST_DIR"/ssh_host_*_key-cert.pub; do
+		[ -f "$cert" ] || continue
+		opts="$opts -o HostCertificate=$cert"
+	done
+	echo "$opts"
 }
 
 start() {
@@ -25,19 +106,23 @@ start() {
 		return 0
 	fi
 
-	if [ ! -x /usr/sbin/sshd ]; then
-		echo "sshd binary not found: /usr/sbin/sshd"
+	if [ ! -x "$SSHD_BIN" ]; then
+		echo "sshd binary not found: $SSHD_BIN"
 		return 1
 	fi
-	if [ ! -x /usr/bin/ssh-keygen ]; then
-		echo "ssh-keygen not found: /usr/bin/ssh-keygen"
+	if [ ! -x "$SSH_KEYGEN_BIN" ]; then
+		echo "ssh-keygen not found: $SSH_KEYGEN_BIN"
 		return 1
 	fi
 
 	chown root:root /var/empty/ 2>/dev/null || true
-	/usr/bin/ssh-keygen -A >/dev/null 2>&1 || true
+	if ! ensure_persistent_ssh_state; then
+		echo "FAIL (persistent ssh state)"
+		return 1
+	fi
+	host_cert_opts=$(host_certificate_options)
 	printf "Starting sshd: "
-	/usr/sbin/sshd >/dev/null 2>&1
+	"$SSHD_BIN" $host_cert_opts >/dev/null 2>&1
 	rc="$?"
 	if [ "$rc" -ne 0 ]; then
 		echo "FAIL (exit=$rc)"
@@ -47,7 +132,7 @@ start() {
 		echo "FAIL (not running after start)"
 		return 1
 	fi
-	touch /var/lock/sshd
+	touch "$LOCK_FILE" 2>/dev/null || true
 	echo "OK"
 	return 0
 }
@@ -55,10 +140,10 @@ start() {
 stop() {
 	printf "Stopping sshd: "
 	if is_running; then
-		killall sshd 2>/dev/null || true
+		"$KILLALL_BIN" sshd 2>/dev/null || true
 		sleep 1
 	fi
-	rm -f /var/lock/sshd
+	rm -f "$LOCK_FILE"
 	if is_running; then
 		echo "FAIL (still running)"
 		return 1

--- a/scripts/test_sshd_persistence.sh
+++ b/scripts/test_sshd_persistence.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SCRIPT="$ROOT_DIR/overlay/etc/init.d/S50sshd"
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "missing $SCRIPT" >&2
+    exit 1
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+BIN_DIR="$TMP_DIR/bin"
+ETC_SSH_DIR="$TMP_DIR/etc/ssh"
+ROOT_HOME="$TMP_DIR/root"
+PERSISTENT_SSH_DIR="$TMP_DIR/userdata/ssh"
+SSHD_RUNNING="$TMP_DIR/sshd.running"
+SSHD_ARGS_LOG="$TMP_DIR/sshd.args"
+LOCK_FILE="$TMP_DIR/sshd.lock"
+
+mkdir -p "$BIN_DIR" "$ETC_SSH_DIR" "$ROOT_HOME/.ssh"
+
+cat > "$BIN_DIR/ssh-keygen" <<'EOF'
+#!/bin/sh
+out=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-f" ]; then
+        shift
+        out="${1:-}"
+    fi
+    shift || break
+done
+[ -n "$out" ] || exit 1
+echo "generated private $out" > "$out"
+echo "generated public $out" > "$out.pub"
+EOF
+chmod +x "$BIN_DIR/ssh-keygen"
+
+cat > "$BIN_DIR/sshd" <<'EOF'
+#!/bin/sh
+echo "$*" > "$SSHD_ARGS_LOG"
+touch "$SSHD_RUNNING"
+EOF
+chmod +x "$BIN_DIR/sshd"
+
+cat > "$BIN_DIR/pidof" <<'EOF'
+#!/bin/sh
+[ "${1:-}" = "sshd" ] && [ -f "$SSHD_RUNNING" ]
+EOF
+chmod +x "$BIN_DIR/pidof"
+
+cat > "$BIN_DIR/killall" <<'EOF'
+#!/bin/sh
+[ "${1:-}" = "sshd" ] && rm -f "$SSHD_RUNNING"
+EOF
+chmod +x "$BIN_DIR/killall"
+
+echo "old private ed25519" > "$ETC_SSH_DIR/ssh_host_ed25519_key"
+echo "old public ed25519" > "$ETC_SSH_DIR/ssh_host_ed25519_key.pub"
+echo "old host cert ed25519" > "$ETC_SSH_DIR/ssh_host_ed25519_key-cert.pub"
+echo "old authorized key" > "$ROOT_HOME/.ssh/authorized_keys"
+
+BOOT_CONF="$TMP_DIR/missing.conf" \
+SSHD_BIN="$BIN_DIR/sshd" \
+SSH_KEYGEN_BIN="$BIN_DIR/ssh-keygen" \
+PIDOF_BIN="$BIN_DIR/pidof" \
+KILLALL_BIN="$BIN_DIR/killall" \
+ETC_SSH_DIR="$ETC_SSH_DIR" \
+ROOT_HOME="$ROOT_HOME" \
+PERSISTENT_SSH_DIR="$PERSISTENT_SSH_DIR" \
+SSHD_RUNNING="$SSHD_RUNNING" \
+SSHD_ARGS_LOG="$SSHD_ARGS_LOG" \
+LOCK_FILE="$LOCK_FILE" \
+"$SCRIPT" start >/dev/null
+
+if [ "$(cat "$PERSISTENT_SSH_DIR/host/ssh_host_ed25519_key")" != "old private ed25519" ]; then
+    echo "existing host key was not migrated to userdata" >&2
+    exit 1
+fi
+
+if [ "$(cat "$PERSISTENT_SSH_DIR/root/authorized_keys")" != "old authorized key" ]; then
+    echo "existing authorized_keys was not migrated to userdata" >&2
+    exit 1
+fi
+
+if [ "$(readlink "$ETC_SSH_DIR/ssh_host_ed25519_key")" != "$PERSISTENT_SSH_DIR/host/ssh_host_ed25519_key" ]; then
+    echo "host key was not linked back into /etc/ssh" >&2
+    exit 1
+fi
+
+if [ "$(readlink "$ROOT_HOME/.ssh/authorized_keys")" != "$PERSISTENT_SSH_DIR/root/authorized_keys" ]; then
+    echo "authorized_keys was not linked back into /root/.ssh" >&2
+    exit 1
+fi
+
+if [ ! -f "$PERSISTENT_SSH_DIR/host/ssh_host_rsa_key" ] || [ ! -f "$PERSISTENT_SSH_DIR/host/ssh_host_ecdsa_key" ]; then
+    echo "missing host keys were not generated in userdata" >&2
+    exit 1
+fi
+
+if ! grep -q "HostCertificate=$PERSISTENT_SSH_DIR/host/ssh_host_ed25519_key-cert.pub" "$SSHD_ARGS_LOG"; then
+    echo "sshd was not started with persistent host certificate" >&2
+    cat "$SSHD_ARGS_LOG" >&2
+    exit 1
+fi
+
+BOOT_CONF="$TMP_DIR/missing.conf" \
+SSHD_BIN="$BIN_DIR/sshd" \
+SSH_KEYGEN_BIN="$BIN_DIR/ssh-keygen" \
+PIDOF_BIN="$BIN_DIR/pidof" \
+KILLALL_BIN="$BIN_DIR/killall" \
+ETC_SSH_DIR="$ETC_SSH_DIR" \
+ROOT_HOME="$ROOT_HOME" \
+PERSISTENT_SSH_DIR="$PERSISTENT_SSH_DIR" \
+SSHD_RUNNING="$SSHD_RUNNING" \
+SSHD_ARGS_LOG="$SSHD_ARGS_LOG" \
+LOCK_FILE="$LOCK_FILE" \
+"$SCRIPT" stop >/dev/null
+
+if [ -f "$SSHD_RUNNING" ]; then
+    echo "sshd stop did not invoke killall" >&2
+    exit 1
+fi
+
+echo "S50sshd persistence tests passed"

--- a/scripts/test_sshd_persistence.sh
+++ b/scripts/test_sshd_persistence.sh
@@ -19,6 +19,7 @@ PERSISTENT_SSH_DIR="$TMP_DIR/userdata/ssh"
 SSHD_RUNNING="$TMP_DIR/sshd.running"
 SSHD_ARGS_LOG="$TMP_DIR/sshd.args"
 LOCK_FILE="$TMP_DIR/sshd.lock"
+REAL_CP=$(command -v cp)
 
 mkdir -p "$BIN_DIR" "$ETC_SSH_DIR" "$ROOT_HOME/.ssh"
 
@@ -33,6 +34,11 @@ while [ "$#" -gt 0 ]; do
     shift || break
 done
 [ -n "$out" ] || exit 1
+if [ -n "${FAIL_KEYGEN_FOR:-}" ]; then
+    case "$out" in
+        *"$FAIL_KEYGEN_FOR"*) exit 42 ;;
+    esac
+fi
 echo "generated private $out" > "$out"
 echo "generated public $out" > "$out.pub"
 EOF
@@ -56,6 +62,19 @@ cat > "$BIN_DIR/killall" <<'EOF'
 [ "${1:-}" = "sshd" ] && rm -f "$SSHD_RUNNING"
 EOF
 chmod +x "$BIN_DIR/killall"
+
+cat > "$BIN_DIR/cp" <<'EOF'
+#!/bin/sh
+if [ -n "${FAIL_CP_FOR:-}" ]; then
+    for arg in "$@"; do
+        case "$arg" in
+            *"$FAIL_CP_FOR"*) exit 43 ;;
+        esac
+    done
+fi
+exec "$REAL_CP" "$@"
+EOF
+chmod +x "$BIN_DIR/cp"
 
 echo "old private ed25519" > "$ETC_SSH_DIR/ssh_host_ed25519_key"
 echo "old public ed25519" > "$ETC_SSH_DIR/ssh_host_ed25519_key.pub"
@@ -123,5 +142,130 @@ if [ -f "$SSHD_RUNNING" ]; then
     echo "sshd stop did not invoke killall" >&2
     exit 1
 fi
+
+FAIL_DIR="$TMP_DIR/failcase"
+FAIL_ETC_SSH_DIR="$FAIL_DIR/etc/ssh"
+FAIL_ROOT_HOME="$FAIL_DIR/root"
+FAIL_PERSISTENT_SSH_DIR="$FAIL_DIR/userdata/ssh"
+mkdir -p "$FAIL_ETC_SSH_DIR" "$FAIL_ROOT_HOME/.ssh"
+echo "existing ed25519" > "$FAIL_ETC_SSH_DIR/ssh_host_ed25519_key"
+
+if BOOT_CONF="$TMP_DIR/missing.conf" \
+SSHD_BIN="$BIN_DIR/sshd" \
+SSH_KEYGEN_BIN="$BIN_DIR/ssh-keygen" \
+PIDOF_BIN="$BIN_DIR/pidof" \
+KILLALL_BIN="$BIN_DIR/killall" \
+ETC_SSH_DIR="$FAIL_ETC_SSH_DIR" \
+ROOT_HOME="$FAIL_ROOT_HOME" \
+PERSISTENT_SSH_DIR="$FAIL_PERSISTENT_SSH_DIR" \
+SSHD_RUNNING="$SSHD_RUNNING" \
+SSHD_ARGS_LOG="$SSHD_ARGS_LOG" \
+LOCK_FILE="$LOCK_FILE" \
+FAIL_KEYGEN_FOR="ssh_host_rsa_key" \
+"$SCRIPT" start >/dev/null 2>"$TMP_DIR/failcase.err"; then
+    echo "sshd start succeeded despite failed host-key generation" >&2
+    exit 1
+fi
+
+if ! grep -q "failed to generate SSH host key" "$TMP_DIR/failcase.err"; then
+    echo "missing host-key generation failure message" >&2
+    cat "$TMP_DIR/failcase.err" >&2
+    exit 1
+fi
+
+if [ -f "$SSHD_RUNNING" ]; then
+    echo "sshd was started despite failed host-key generation" >&2
+    exit 1
+fi
+
+AUTH_FAIL_DIR="$TMP_DIR/authfail"
+AUTH_FAIL_ETC_SSH_DIR="$AUTH_FAIL_DIR/etc/ssh"
+AUTH_FAIL_ROOT_HOME="$AUTH_FAIL_DIR/root"
+AUTH_FAIL_PERSISTENT_SSH_DIR="$AUTH_FAIL_DIR/userdata/ssh"
+mkdir -p "$AUTH_FAIL_ETC_SSH_DIR" "$AUTH_FAIL_ROOT_HOME/.ssh"
+echo "working authorized key" > "$AUTH_FAIL_ROOT_HOME/.ssh/authorized_keys"
+
+if PATH="$BIN_DIR:$PATH" \
+REAL_CP="$REAL_CP" \
+BOOT_CONF="$TMP_DIR/missing.conf" \
+SSHD_BIN="$BIN_DIR/sshd" \
+SSH_KEYGEN_BIN="$BIN_DIR/ssh-keygen" \
+PIDOF_BIN="$BIN_DIR/pidof" \
+KILLALL_BIN="$BIN_DIR/killall" \
+ETC_SSH_DIR="$AUTH_FAIL_ETC_SSH_DIR" \
+ROOT_HOME="$AUTH_FAIL_ROOT_HOME" \
+PERSISTENT_SSH_DIR="$AUTH_FAIL_PERSISTENT_SSH_DIR" \
+SSHD_RUNNING="$SSHD_RUNNING" \
+SSHD_ARGS_LOG="$SSHD_ARGS_LOG" \
+LOCK_FILE="$LOCK_FILE" \
+FAIL_CP_FOR="authorized_keys" \
+"$SCRIPT" start >/dev/null 2>"$TMP_DIR/authfail.err"; then
+    echo "sshd start succeeded despite failed authorized_keys persistence" >&2
+    exit 1
+fi
+
+if ! grep -q "failed to persist authorized_keys" "$TMP_DIR/authfail.err"; then
+    echo "missing authorized_keys persistence failure message" >&2
+    cat "$TMP_DIR/authfail.err" >&2
+    exit 1
+fi
+
+if [ -L "$AUTH_FAIL_ROOT_HOME/.ssh/authorized_keys" ]; then
+    echo "authorized_keys was replaced with a symlink after failed persistence" >&2
+    exit 1
+fi
+
+if [ "$(cat "$AUTH_FAIL_ROOT_HOME/.ssh/authorized_keys")" != "working authorized key" ]; then
+    echo "existing authorized_keys was modified after failed persistence" >&2
+    exit 1
+fi
+
+if [ -f "$SSHD_RUNNING" ]; then
+    echo "sshd was started despite failed authorized_keys persistence" >&2
+    exit 1
+fi
+
+NO_KEYGEN_DIR="$TMP_DIR/no-keygen"
+NO_KEYGEN_ETC_SSH_DIR="$NO_KEYGEN_DIR/etc/ssh"
+NO_KEYGEN_ROOT_HOME="$NO_KEYGEN_DIR/root"
+NO_KEYGEN_PERSISTENT_SSH_DIR="$NO_KEYGEN_DIR/userdata/ssh"
+NO_KEYGEN_HOST_DIR="$NO_KEYGEN_PERSISTENT_SSH_DIR/host"
+mkdir -p "$NO_KEYGEN_ETC_SSH_DIR" "$NO_KEYGEN_ROOT_HOME/.ssh" "$NO_KEYGEN_HOST_DIR" "$NO_KEYGEN_PERSISTENT_SSH_DIR/root"
+for type in rsa ecdsa ed25519; do
+    echo "provisioned $type" > "$NO_KEYGEN_HOST_DIR/ssh_host_${type}_key"
+    echo "provisioned $type pub" > "$NO_KEYGEN_HOST_DIR/ssh_host_${type}_key.pub"
+done
+echo "provisioned authorized key" > "$NO_KEYGEN_PERSISTENT_SSH_DIR/root/authorized_keys"
+
+BOOT_CONF="$TMP_DIR/missing.conf" \
+SSHD_BIN="$BIN_DIR/sshd" \
+SSH_KEYGEN_BIN="$BIN_DIR/missing-ssh-keygen" \
+PIDOF_BIN="$BIN_DIR/pidof" \
+KILLALL_BIN="$BIN_DIR/killall" \
+ETC_SSH_DIR="$NO_KEYGEN_ETC_SSH_DIR" \
+ROOT_HOME="$NO_KEYGEN_ROOT_HOME" \
+PERSISTENT_SSH_DIR="$NO_KEYGEN_PERSISTENT_SSH_DIR" \
+SSHD_RUNNING="$SSHD_RUNNING" \
+SSHD_ARGS_LOG="$SSHD_ARGS_LOG" \
+LOCK_FILE="$LOCK_FILE" \
+"$SCRIPT" start >/dev/null
+
+if [ ! -f "$SSHD_RUNNING" ]; then
+    echo "sshd did not start with provisioned host keys and missing ssh-keygen" >&2
+    exit 1
+fi
+
+BOOT_CONF="$TMP_DIR/missing.conf" \
+SSHD_BIN="$BIN_DIR/sshd" \
+SSH_KEYGEN_BIN="$BIN_DIR/missing-ssh-keygen" \
+PIDOF_BIN="$BIN_DIR/pidof" \
+KILLALL_BIN="$BIN_DIR/killall" \
+ETC_SSH_DIR="$NO_KEYGEN_ETC_SSH_DIR" \
+ROOT_HOME="$NO_KEYGEN_ROOT_HOME" \
+PERSISTENT_SSH_DIR="$NO_KEYGEN_PERSISTENT_SSH_DIR" \
+SSHD_RUNNING="$SSHD_RUNNING" \
+SSHD_ARGS_LOG="$SSHD_ARGS_LOG" \
+LOCK_FILE="$LOCK_FILE" \
+"$SCRIPT" stop >/dev/null
 
 echo "S50sshd persistence tests passed"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH daemon startup now preserves and uses persistent host keys and certificates across restarts, with configurable paths for binaries and storage.
  * Improved startup/shutdown behavior and clearer error reporting when key provisioning or persistence fails.

* **Tests**
  * Added an integration test suite covering key migration, certificate handling, authorized_keys persistence, start/stop flows, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->