### PR TITLE
fix: package benchmark runner in image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 !/overlay/oem/usr/bin/RkLunch.sh
 /overlay/oem/usr/lib/*
 !/overlay/oem/usr/lib/librknnmrt.so
+/overlay/userdata/agent/benchmark/
 
 # Secrets
 agent.conf

--- a/_build_image.sh
+++ b/_build_image.sh
@@ -51,6 +51,8 @@ rsync -a --delete "${BENCHMARK_RSYNC_EXCLUDES[@]}" "$BENCHMARK_SRC/runner/" "$BE
 rsync -a --delete "${BENCHMARK_RSYNC_EXCLUDES[@]}" "$BENCHMARK_SRC/suites/" "$BENCHMARK_DEST/suites/"
 if [ -f "$BENCHMARK_SRC/pyproject.toml" ]; then
     cp "$BENCHMARK_SRC/pyproject.toml" "$BENCHMARK_DEST/pyproject.toml"
+else
+    rm -f "$BENCHMARK_DEST/pyproject.toml"
 fi
 echo "  ✓ Benchmark runner and suites staged to overlay/userdata/agent/benchmark"
 

--- a/_build_image.sh
+++ b/_build_image.sh
@@ -39,6 +39,21 @@ mkdir -p "$OVERLAY/oem/usr/bin" "$OVERLAY/oem/usr/lib" "$OVERLAY/oem/etc"
 cp -a "$SCRIPT_DIR/build/bin"/. "$OVERLAY/oem/usr/bin/"
 echo "  ✓ Binaries copied to overlay/oem/usr/bin"
 
+BENCHMARK_SRC="$SCRIPT_DIR/benchmark"
+BENCHMARK_DEST="$OVERLAY/userdata/agent/benchmark"
+BENCHMARK_RSYNC_EXCLUDES=(--exclude '__pycache__/' --exclude '*.pyc' --exclude '.DS_Store' --exclude '._*')
+if [ ! -d "$BENCHMARK_SRC/runner" ] || [ ! -d "$BENCHMARK_SRC/suites" ]; then
+    echo "  ✗ Error: benchmark runner or suites missing under $BENCHMARK_SRC" >&2
+    exit 1
+fi
+mkdir -p "$BENCHMARK_DEST/runner" "$BENCHMARK_DEST/suites"
+rsync -a --delete "${BENCHMARK_RSYNC_EXCLUDES[@]}" "$BENCHMARK_SRC/runner/" "$BENCHMARK_DEST/runner/"
+rsync -a --delete "${BENCHMARK_RSYNC_EXCLUDES[@]}" "$BENCHMARK_SRC/suites/" "$BENCHMARK_DEST/suites/"
+if [ -f "$BENCHMARK_SRC/pyproject.toml" ]; then
+    cp "$BENCHMARK_SRC/pyproject.toml" "$BENCHMARK_DEST/pyproject.toml"
+fi
+echo "  ✓ Benchmark runner and suites staged to overlay/userdata/agent/benchmark"
+
 RKNNMRT_OVERLAY="$OVERLAY/oem/usr/lib/librknnmrt.so"
 RKNNMRT_SOURCE="$PICO_SDK/media/iva/iva/librockiva/rockiva-rv1106-Linux/lib/librknnmrt.so"
 if [ -f "$RKNNMRT_OVERLAY" ]; then

--- a/build_image.sh
+++ b/build_image.sh
@@ -41,7 +41,7 @@ restore_docker_output_ownership() {
   fi
 
   paths=()
-  for path in build overlay/oem pico-sdk/output; do
+  for path in build overlay/oem overlay/userdata pico-sdk/output; do
     if [ -e "$path" ]; then
       paths+=("$path")
     fi

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -52,7 +52,8 @@ if ! grep -Fq 'BENCHMARK_SRC="$SCRIPT_DIR/benchmark"' "$ROOT_DIR/_build_image.sh
    ! grep -Fq -- "--exclude '*.pyc'" "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq -- "--exclude '._*'" "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq 'rsync -a --delete "${BENCHMARK_RSYNC_EXCLUDES[@]}" "$BENCHMARK_SRC/runner/" "$BENCHMARK_DEST/runner/"' "$ROOT_DIR/_build_image.sh" || \
-   ! grep -Fq 'rsync -a --delete "${BENCHMARK_RSYNC_EXCLUDES[@]}" "$BENCHMARK_SRC/suites/" "$BENCHMARK_DEST/suites/"' "$ROOT_DIR/_build_image.sh"; then
+   ! grep -Fq 'rsync -a --delete "${BENCHMARK_RSYNC_EXCLUDES[@]}" "$BENCHMARK_SRC/suites/" "$BENCHMARK_DEST/suites/"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'rm -f "$BENCHMARK_DEST/pyproject.toml"' "$ROOT_DIR/_build_image.sh"; then
     echo "_build_image.sh must stage benchmark runner and suites into userdata" >&2
     exit 1
 fi

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -50,6 +50,7 @@ if ! grep -Fq 'BENCHMARK_SRC="$SCRIPT_DIR/benchmark"' "$ROOT_DIR/_build_image.sh
    ! grep -Fq 'BENCHMARK_DEST="$OVERLAY/userdata/agent/benchmark"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq -- "--exclude '__pycache__/'" "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq -- "--exclude '*.pyc'" "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq -- "--exclude '.DS_Store'" "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq -- "--exclude '._*'" "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq 'rsync -a --delete "${BENCHMARK_RSYNC_EXCLUDES[@]}" "$BENCHMARK_SRC/runner/" "$BENCHMARK_DEST/runner/"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq 'rsync -a --delete "${BENCHMARK_RSYNC_EXCLUDES[@]}" "$BENCHMARK_SRC/suites/" "$BENCHMARK_DEST/suites/"' "$ROOT_DIR/_build_image.sh" || \

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -6,6 +6,7 @@ BUILD_SH="$ROOT_DIR/_build.sh"
 BUILD_IMAGE_SH="$ROOT_DIR/build_image.sh"
 WORKFLOW="$ROOT_DIR/.github/workflows/build.yml"
 REPACK_SCRIPT="$ROOT_DIR/scripts/repack_ota_update_image.sh"
+GITIGNORE="$ROOT_DIR/.gitignore"
 
 if grep -Eq 'go\.dev/dl|wget .*go|curl .*go|tar .*go\$|GO_TARBALL|GO_TARBALL_SHA256' "$BUILD_SH" "$BUILD_IMAGE_SH"; then
     echo "build scripts must not download or extract Go toolchains" >&2
@@ -42,6 +43,27 @@ if ! grep -q './build.sh sysdrv' "$ROOT_DIR/_build_image.sh" || \
    ! grep -q './build.sh app' "$ROOT_DIR/_build_image.sh" || \
    ! grep -q './build.sh firmware' "$ROOT_DIR/_build_image.sh"; then
     echo "_build_image.sh must build components first, inject overlay, then package firmware once" >&2
+    exit 1
+fi
+
+if ! grep -Fq 'BENCHMARK_SRC="$SCRIPT_DIR/benchmark"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'BENCHMARK_DEST="$OVERLAY/userdata/agent/benchmark"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq -- "--exclude '__pycache__/'" "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq -- "--exclude '*.pyc'" "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq -- "--exclude '._*'" "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'rsync -a --delete "${BENCHMARK_RSYNC_EXCLUDES[@]}" "$BENCHMARK_SRC/runner/" "$BENCHMARK_DEST/runner/"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'rsync -a --delete "${BENCHMARK_RSYNC_EXCLUDES[@]}" "$BENCHMARK_SRC/suites/" "$BENCHMARK_DEST/suites/"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must stage benchmark runner and suites into userdata" >&2
+    exit 1
+fi
+
+if ! grep -q 'overlay/userdata' "$BUILD_IMAGE_SH"; then
+    echo "build_image.sh must restore ownership of Docker-staged overlay userdata" >&2
+    exit 1
+fi
+
+if ! grep -q '^/overlay/userdata/agent/benchmark/$' "$GITIGNORE"; then
+    echo "generated benchmark userdata staging directory must be gitignored" >&2
     exit 1
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced build tooling to stage benchmark assets into the image overlay, preserve expected packaging files where present, apply exclusion rules for unwanted artifacts, and restore ownership for generated overlay content (including userdata) during cleanup.
  * Updated ignore rules to exclude the generated benchmark staging directory.

* **Tests**
  * Added assertions validating benchmark asset staging, exclusion patterns, presence/absence of packaging files, and ownership-restoration behavior in the build workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->