### PR TITLE
fix(config-web): restart ota when system env changes

### DIFF
--- a/docs/03-services/config-web.md
+++ b/docs/03-services/config-web.md
@@ -54,14 +54,14 @@ config_web [--bind=IP] [--port=PORT] [--config=PATH] [--wifi-config=PATH] [--sys
 - `system_env`: general shell-style environment text written to `/userdata/system/env`
 - Wi-Fi：SSID / PSK 等（写入 `/userdata/wpa_supplicant.conf`）
 
-## 使用建议
+## Runtime apply behavior
 
-1. 通过 USB 网络或 Wi-Fi 访问设备 IP；
-2. 在网页中修改 Agent 配置；
-3. 保存后重启 Agent：
+Config Web writes Agent, Wi-Fi, and system environment files. Saving Agent
+config still schedules an Agent restart. OTA is restarted only when the
+effective `/userdata/system/env` file changes, because OTA reads proxy settings
+from that file at process startup:
 
 ```bash
 /etc/init.d/S53agent restart
+/etc/init.d/S54ota restart  # only when /userdata/system/env changes
 ```
-
-Config Web 本身只负责配置文件写入，不替代对应服务的重启逻辑。

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -108,6 +108,7 @@ volatile sig_atomic_t g_should_stop = 0;
 const char* kUsbBindAddress = "192.168.42.1";
 const char* kLoopbackBindAddress = "127.0.0.1";
 const char* kAgentInitScript = "/etc/init.d/S53agent";
+const char* kOtaInitScript = "/etc/init.d/S54ota";
 const char* kAgentLogPath = "/var/log/agent/agent.log";
 const char* kAgentPortHost = "127.0.0.1";
 const int kDefaultAgentPort = 8080;
@@ -1157,9 +1158,21 @@ void restart_wpa_supplicant(const Options& options, std::ostringstream& log) {
         << " -c " << options.wifi_config_path << "\n" << start.output;
 }
 
-void schedule_agent_restart() {
-    int rc = system("/etc/init.d/S53agent restart >/dev/null 2>&1 &");
+void schedule_init_script_restart(const char* init_script) {
+    if (!init_script || init_script[0] == '\0') {
+        return;
+    }
+    std::string cmd = shell_quote(init_script) + " restart >/dev/null 2>&1 &";
+    int rc = system(cmd.c_str());
     (void)rc;
+}
+
+void schedule_agent_restart() {
+    schedule_init_script_restart(kAgentInitScript);
+}
+
+void schedule_ota_restart() {
+    schedule_init_script_restart(kOtaInitScript);
 }
 
 CommandResult apply_wifi_config(const Options& options) {
@@ -1976,17 +1989,26 @@ ApiResponse handle_post_system_env(const Options& options, const std::string& bo
     std::string system_env = env_item->valuestring;
     cJSON_Delete(root);
 
+    std::string original_system_env = read_file_contents(options.system_env_path.c_str(), kMaxSystemEnvSize);
     std::string save_error;
     if (!save_system_env_content(options.system_env_path, system_env, &save_error)) {
         return make_json_error(400, save_error);
     }
 
+    std::string updated_system_env = read_file_contents(options.system_env_path.c_str(), kMaxSystemEnvSize);
+    bool system_env_changed = original_system_env != updated_system_env;
     schedule_agent_restart();
+    if (system_env_changed) {
+        schedule_ota_restart();
+    }
 
     cJSON* response = cJSON_CreateObject();
     cJSON_AddBoolToObject(response, "ok", 1);
-    cJSON_AddStringToObject(response, "message", "system env saved; agent restarting");
+    cJSON_AddStringToObject(response, "message",
+                            system_env_changed ? "system env saved; services restarting"
+                                               : "system env saved; agent restarting");
     cJSON_AddBoolToObject(response, "agent_restart_scheduled", 1);
+    cJSON_AddBoolToObject(response, "ota_restart_scheduled", system_env_changed ? 1 : 0);
     cJSON_AddStringToObject(response, "system_env",
                             read_file_contents(options.system_env_path.c_str(), kMaxSystemEnvSize).c_str());
     cJSON* paths = add_object(response, "paths");
@@ -2033,6 +2055,7 @@ ApiResponse handle_post_config(const Options& options, const std::string& body) 
 
     cJSON_Delete(root);
 
+    std::string original_system_env = read_file_contents(options.system_env_path.c_str(), kMaxSystemEnvSize);
     std::string save_error;
     if (!save_system_env_with_proxy(options.system_env_path, system_proxy, &save_error)) {
         return make_json_error(400, save_error);
@@ -2047,12 +2070,20 @@ ApiResponse handle_post_config(const Options& options, const std::string& body) 
         return make_json_error(500, save_error);
     }
 
+    std::string updated_system_env = read_file_contents(options.system_env_path.c_str(), kMaxSystemEnvSize);
+    bool system_env_changed = original_system_env != updated_system_env;
     schedule_agent_restart();
+    if (system_env_changed) {
+        schedule_ota_restart();
+    }
 
     cJSON* response = cJSON_CreateObject();
     cJSON_AddBoolToObject(response, "ok", 1);
-    cJSON_AddStringToObject(response, "message", "config saved; agent restarting");
+    cJSON_AddStringToObject(response, "message",
+                            system_env_changed ? "config saved; agent and ota restarting"
+                                               : "config saved; agent restarting");
     cJSON_AddBoolToObject(response, "agent_restart_scheduled", 1);
+    cJSON_AddBoolToObject(response, "ota_restart_scheduled", system_env_changed ? 1 : 0);
     cJSON_AddItemToObject(response, "config", config_to_json(config, system_proxy));
 
     cJSON* paths = add_object(response, "paths");

--- a/tests/config_web_source_test.cpp
+++ b/tests/config_web_source_test.cpp
@@ -148,3 +148,23 @@ TEST_CASE("config web persists proxy through system env") {
     CHECK(html.find("system_env_content") != std::string::npos);
     CHECK(html.find("saveSystemEnv") != std::string::npos);
 }
+
+TEST_CASE("config web restarts ota only when system env changes") {
+    const std::string source_path = std::string(AIDEN_SOURCE_DIR) + "/src/config_web.cpp";
+    std::ifstream source_in(source_path.c_str());
+    REQUIRE(source_in.good());
+
+    std::ostringstream source_buffer;
+    source_buffer << source_in.rdbuf();
+    const std::string source = source_buffer.str();
+
+    CHECK(source.find("kAgentInitScript") != std::string::npos);
+    CHECK(source.find("kOtaInitScript") != std::string::npos);
+    CHECK(source.find("schedule_agent_restart") != std::string::npos);
+    CHECK(source.find("schedule_ota_restart") != std::string::npos);
+    CHECK(source.find("bool system_env_changed = original_system_env != updated_system_env;") != std::string::npos);
+    CHECK(source.find("if (system_env_changed)") != std::string::npos);
+    CHECK(source.find("system env saved; services restarting") != std::string::npos);
+    CHECK(source.find("config saved; agent restarting") != std::string::npos);
+    CHECK(source.find("config saved; agent and ota restarting") != std::string::npos);
+}


### PR DESCRIPTION
## Summary
- restart OTA only when the effective system env file changes
- keep Agent restart behavior for config and system env saves
- document the conditional OTA restart behavior

## Tests
- make test
- c++ -std=c++11 -I src -I third_party/doctest -c src/config_web.cpp -o /tmp/config_web.o