### PR TITLE
ci: remove unused docker buildx setup step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,6 @@ jobs:
         docker system prune -af || true
         df -h
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
     - name: Set up Go
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
## Changes

Removed the `Set up Docker Buildx` step from the reusable build workflow.

## Why

- The build process uses `docker run` with a prebuilt image (`luckfoxtech/luckfox_pico:1.0`) and never builds images, so buildx is not used.
- This step was causing failures on the self-hosted runner where podman's docker compatibility layer does not support the `--name` flag for `docker buildx create`.

## Verification

- YAML validated
- Confirmed no other steps reference buildx
- Tested on self-hosted runner with real Docker Engine installed

## Related

Unblocks the self-hosted build workflow after installing Docker CE to replace podman on the runner (192.168.50.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the build workflow configuration by removing an unused setup step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->