### PR TITLE
ci: fix persistent-workspace submodule conflict on self-hosted runners

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -14,7 +14,15 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
+      - name: Clean leftover submodule state
+        continue-on-error: true
+        run: |
+          cd "${{ github.workspace }}" 2>/dev/null || exit 0
+          git submodule deinit --all -f 2>/dev/null || true
+
       - uses: actions/checkout@v4
+        with:
+          submodules: false
       - id: should_run
         name: Skip scheduled run if no new commit in the last hour
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,23 @@ jobs:
     runs-on: ${{ inputs.runner }}
 
     steps:
+    # Self-hosted runners reuse the workspace across runs. The pico-sdk
+    # submodule has a malformed nested entry (sysdrv/tools/board/ubuntu is a
+    # gitlink with no .gitmodules URL), which makes actions/checkout's
+    # "git submodule foreach --recursive" auth step fail. Deinitializing all
+    # submodules before checkout avoids that recursion. Harmless on hosted
+    # runners where the workspace is empty.
+    - name: Clean leftover submodule state
+      continue-on-error: true
+      run: |
+        cd "${{ github.workspace }}" 2>/dev/null || exit 0
+        git submodule deinit --all -f 2>/dev/null || true
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         submodules: false
+        clean: true
 
     - name: Fetch pico-sdk submodule
       run: git submodule update --init --depth=1 pico-sdk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        submodules: false
 
     - name: Fetch pico-sdk submodule
       run: git submodule update --init --depth=1 pico-sdk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: src/agent/go.mod
-        cache-dependency-path: src/agent/go.sum
+        cache: false  # Disabled on self-hosted; HOME not set in runner service env
 
     - name: Prepare OTA public key
       env:
@@ -128,3 +128,11 @@ jobs:
         target_commitish: ${{ github.sha }}
         files: pico-sdk/output/image/*
         fail_on_unmatched_files: true
+
+    # Deinit submodules again before job cleanup to avoid Post Checkout warnings.
+    # The Post step runs 'git submodule foreach --recursive' which fails on
+    # pico-sdk's malformed nested submodule if pico-sdk is still registered.
+    - name: Clean submodule state for next run
+      if: always()
+      continue-on-error: true
+      run: git submodule deinit --all -f 2>/dev/null || true


### PR DESCRIPTION
## 问题

PR #89 合入 `submodules: false` 后,self-hosted 构建仍在 checkout 失败:
```
/usr/bin/git submodule foreach --recursive ...
Entering 'pico-sdk'
fatal: No url found for submodule path 'pico-sdk/sysdrv/tools/board/ubuntu' in .gitmodules
fatal: run_command returned non-zero status while recursing in the nested submodules of pico-sdk
```

然后 setup-go 报错:
```
build cache is required, but could not be located: GOCACHE is not defined and neither \$XDG_CACHE_HOME nor \$HOME are defined
```

## 根因

1. **Submodule 问题**: `submodules: false` 阻止 checkout **初始化新** submodule,但不阻止它操作**已注册的** submodule。self-hosted runner 的 workspace 持久化,上次运行的 pico-sdk 注册状态还在 `.git/config` 里。checkout 的 "Setting up auth" 阶段跑 `git submodule foreach --recursive`,递归进已注册的 pico-sdk,撞上损坏的嵌套 gitlink(sysdrv/tools/board/ubuntu 是 mode 160000 但无 .gitmodules URL) → exit 128。

2. **HOME 问题**: runner 的 systemd service 默认不设置 `HOME` 环境变量。setup-go 执行 `go env` 读取 GOCACHE 时,Go 要求 HOME 或 XDG_CACHE_HOME 至少一个存在 → 失败。

## 修复

### Workflow 层面(此 PR)

1. **checkout 前 deinit**: 在 `actions/checkout` 前加预步骤 `git submodule deinit --all -f`,清空注册状态,让 `foreach --recursive` 无东西可递归。在 `build.yml` 和 `build-nightly.yml` 的 check job 都加了。

2. **build 后再 deinit**: job 结束前再 deinit 一次(`if: always()`),让 Post Checkout cleanup 不再报警告,且 workspace 干净备下次使用。

3. **禁用 setup-go cache**: 设 `cache: false`,避免 cache 逻辑触发额外的 `go env` 调用(虽然 HOME 已在 runner 层面修了,但 cache 在 self-hosted 上本来就不如持久化文件系统)。

### Runner 层面(已在 runner 操作)

在 `/root/actions-runner/.env` 加 `HOME=/root`,重启 runner service。这是官方推荐的给 runner jobs 设置环境变量的方法。

## 验证

在 self-hosted runner(192.168.50.5)上:

1. **Submodule 机制验证**: 手动复现 exit-128 failure → `git submodule deinit --all -f` → `git reset --hard` → `git submodule foreach --recursive` → exit 0 ✅

2. **端到端 workflow 验证**(run 26802201641):
   - ✅ check job: success
   - ✅ Clean leftover submodule state: success
   - ✅ Checkout code: success
   - ✅ Fetch pico-sdk submodule: success
   - ✅ Set up Go: success(之前这步 fail)
   - ✅ Prepare OTA public key: success
   - ✅ Generate release name: success
   - 🚧 Run build script: in_progress(1.5h 长构建,核心修复已验证)

## Commits

- `1d27c73` ci: disable checkout submodule auto-handling
- `4ccc83b` ci: deinit submodules before checkout on persistent runners
- `e83241d` ci: clean submodule state in nightly check job too
- `db317f6` ci: disable go cache on self-hosted and clean submodules post-build

🤖 Generated with [Claude Code](https://claude.com/claude-code)