### PR TITLE
feat(agent): bind HTTP server to 0.0.0.0 for LAN access

### DIFF
--- a/overlay/etc/init.d/S53agent
+++ b/overlay/etc/init.d/S53agent
@@ -5,7 +5,7 @@
 AGENT_BIN=/oem/usr/bin/agent
 ENV_RUN_BIN=${ENV_RUN_BIN:-/oem/usr/bin/aiden-env-run}
 CONFIG_DIR=/userdata/agent
-ADDR=:8080
+ADDR=0.0.0.0:8080
 LOG_PATH=/var/log/agent/agent.log
 PID_FILE=/run/agent/agent.pid
 WATCHDOG_PID_FILE=/run/agent/agent_watchdog.pid

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -77,8 +77,6 @@ func main() {
 	fmt.Printf("📂 Config directory: %s\n", *configDir)
 	if _, port, err := net.SplitHostPort(*addr); err == nil && port != "" {
 		fmt.Printf("🌐 Web UI: http://localhost:%s\n", port)
-	} else {
-		fmt.Printf("🌐 Web UI: http://localhost%s\n", *addr)
 	}
 	fmt.Printf("📝 Logs: %s/log/\n", *configDir)
 

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/signal"
 	"sync"
@@ -27,7 +28,7 @@ var wakeupGPIOPins = []int{33, 32}
 func main() {
 	var (
 		configDir = flag.String("config", "", "path to config directory (required)")
-		addr      = flag.String("addr", ":8080", "HTTP server address")
+		addr      = flag.String("addr", "0.0.0.0:8080", "HTTP server address")
 	)
 	flag.Parse()
 
@@ -74,7 +75,11 @@ func main() {
 
 	fmt.Printf("🚀 Aiden Agent daemon starting on %s\n", *addr)
 	fmt.Printf("📂 Config directory: %s\n", *configDir)
-	fmt.Printf("🌐 Web UI: http://localhost%s\n", *addr)
+	if _, port, err := net.SplitHostPort(*addr); err == nil && port != "" {
+		fmt.Printf("🌐 Web UI: http://localhost:%s\n", port)
+	} else {
+		fmt.Printf("🌐 Web UI: http://localhost%s\n", *addr)
+	}
 	fmt.Printf("📝 Logs: %s/log/\n", *configDir)
 
 	if err := server.Start(); err != nil {


### PR DESCRIPTION
The agent HTTP server was only reachable via usb0 (192.168.42.1) because Go's `:8080` notation bound to IPv6-only on this kernel. Explicitly bind to 0.0.0.0:8080 so the agent Web UI and API are accessible from wlan0 (LAN) as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent now binds to all network interfaces by default, allowing access from other machines.
  * Web UI startup message now displays the localhost URL in a clearer format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->