### PR TITLE
fix: repair stale pico-sdk checkout state

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -14,6 +14,20 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
+      - name: Repair stale pico-sdk submodule metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          sdk_dir="$GITHUB_WORKSPACE/pico-sdk"
+          if [ ! -d "$sdk_dir" ]; then
+            exit 0
+          fi
+
+          if git -C "$sdk_dir" ls-files -s sysdrv/tools/board/ubuntu 2>/dev/null | grep -q '^160000 '; then
+            git -C "$sdk_dir" config -f .gitmodules submodule.ubuntu.path sysdrv/tools/board/ubuntu
+            git -C "$sdk_dir" config -f .gitmodules submodule.ubuntu.url https://github.com/luckfox-eng33/pico_ubuntu.git
+          fi
+
       - uses: actions/checkout@v4
       - id: should_run
         name: Skip scheduled run if no new commit in the last hour

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,30 @@ jobs:
     runs-on: ${{ inputs.runner }}
 
     steps:
+    - name: Repair stale pico-sdk submodule metadata
+      if: ${{ inputs.runner == 'self-hosted' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        sdk_dir="$GITHUB_WORKSPACE/pico-sdk"
+        if [ ! -d "$sdk_dir" ]; then
+          exit 0
+        fi
+
+        if git -C "$sdk_dir" ls-files -s sysdrv/tools/board/ubuntu 2>/dev/null | grep -q '^160000 '; then
+          git -C "$sdk_dir" config -f .gitmodules submodule.ubuntu.path sysdrv/tools/board/ubuntu
+          git -C "$sdk_dir" config -f .gitmodules submodule.ubuntu.url https://github.com/luckfox-eng33/pico_ubuntu.git
+        fi
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         submodules: false
 
     - name: Fetch pico-sdk submodule
-      run: git submodule update --init --depth=1 pico-sdk
+      run: |
+        git submodule update --init --depth=1 pico-sdk
+        git -C pico-sdk clean -f -- .gitmodules
 
     - name: Free hosted runner disk space
       if: ${{ inputs.free_disk_space }}


### PR DESCRIPTION
## Summary
- update pico-sdk to the aiden-sdk merge commit that removes the stale Ubuntu gitlink
- add a minimal pre-checkout migration step for persistent self-hosted runner workspaces that still contain the old broken pico-sdk checkout
- remove the temporary .gitmodules metadata after pico-sdk is refreshed

## Context
The root cause was fixed in AidenAI-IO/aiden-sdk#9 by deleting the stale sysdrv/tools/board/ubuntu gitlink. This repository now points pico-sdk at the merged SDK commit a055de5a811fdfaec71292429ee50bd7ec2ebbdb.

## Verification
- real self-hosted workflow run reached and passed both checkout phases and Fetch pico-sdk submodule before the final submodule pointer update
- runner workspace confirmed pico-sdk no longer has sysdrv/tools/board/ubuntu and recursive submodule status succeeds