### PR TITLE
feat(agent): bind HTTP server to 0.0.0.0 for LAN access

### DIFF
--- a/overlay/etc/init.d/S53agent
+++ b/overlay/etc/init.d/S53agent
@@ -5,7 +5,7 @@
 AGENT_BIN=/oem/usr/bin/agent
 ENV_RUN_BIN=${ENV_RUN_BIN:-/oem/usr/bin/aiden-env-run}
 CONFIG_DIR=/userdata/agent
-ADDR=:8080
+ADDR=0.0.0.0:8080
 LOG_PATH=/var/log/agent/agent.log
 PID_FILE=/run/agent/agent.pid
 WATCHDOG_PID_FILE=/run/agent/agent_watchdog.pid

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -77,8 +77,6 @@ func main() {
 	fmt.Printf("📂 Config directory: %s\n", *configDir)
 	if _, port, err := net.SplitHostPort(*addr); err == nil && port != "" {
 		fmt.Printf("🌐 Web UI: http://localhost:%s\n", port)
-	} else {
-		fmt.Printf("🌐 Web UI: http://localhost%s\n", *addr)
 	}
 	fmt.Printf("📝 Logs: %s/log/\n", *configDir)
 

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/signal"
 	"sync"
@@ -27,7 +28,7 @@ var wakeupGPIOPins = []int{33, 32}
 func main() {
 	var (
 		configDir = flag.String("config", "", "path to config directory (required)")
-		addr      = flag.String("addr", ":8080", "HTTP server address")
+		addr      = flag.String("addr", "0.0.0.0:8080", "HTTP server address")
 	)
 	flag.Parse()
 
@@ -74,7 +75,11 @@ func main() {
 
 	fmt.Printf("🚀 Aiden Agent daemon starting on %s\n", *addr)
 	fmt.Printf("📂 Config directory: %s\n", *configDir)
-	fmt.Printf("🌐 Web UI: http://localhost%s\n", *addr)
+	if _, port, err := net.SplitHostPort(*addr); err == nil && port != "" {
+		fmt.Printf("🌐 Web UI: http://localhost:%s\n", port)
+	} else {
+		fmt.Printf("🌐 Web UI: http://localhost%s\n", *addr)
+	}
 	fmt.Printf("📝 Logs: %s/log/\n", *configDir)
 
 	if err := server.Start(); err != nil {


### PR DESCRIPTION
  修改 agent HTTP 服务器绑定地址，从默认的 `:8080` 改为显式的 `0.0.0.0:8080`，使得 agent Web UI 和 API 能通过板子的 wlan0（局域网）访问，而不仅限于 usb0（192.168.42.1）。

  在这个内核上，Go 的 `:8080` 绑定行为默认只监听 IPv6，导致局域网无法访问。显式绑定到 `0.0.0.0:8080` 解决了这个问题。