### PR TITLE
fix: prevent buildroot tar owner restore failures

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -58,6 +58,7 @@ docker_run_args=(
   -u 0:0
   --rm
   -e OTA_PUBLIC_KEY_PATH
+  -e TAR_OPTIONS=--no-same-owner
 )
 if [ "${#docker_go_args[@]}" -gt 0 ]; then
   docker_run_args+=("${docker_go_args[@]}")

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -154,6 +154,11 @@ if ! grep -Eq -- '-u 0:0|--user 0:0' "$BUILD_IMAGE_SH"; then
     exit 1
 fi
 
+if ! grep -q 'TAR_OPTIONS=--no-same-owner' "$BUILD_IMAGE_SH"; then
+    echo "build_image.sh must prevent tar from restoring archived owners in Dockerized Buildroot" >&2
+    exit 1
+fi
+
 if ! grep -q '/usr/local/go/bin:$PATH' "$BUILD_IMAGE_SH"; then
     echo "build_image.sh must prepend mounted Go to Docker PATH" >&2
     exit 1


### PR DESCRIPTION
## Summary
- Pass TAR_OPTIONS=--no-same-owner into the Dockerized image build
- Add a build script guard so the Buildroot tar ownership workaround remains in place

## Verification
- scripts/test_build_scripts.sh
- Reproduced the self-hosted runner tar owner failure with a uid/gid 197609 archive and confirmed TAR_OPTIONS=--no-same-owner extracts successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build configuration to modify tar archive handling during container operations.

* **Tests**
  * Added test assertion to verify tar archive handling is correctly configured in build tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->