### PR TITLE
fix(ci): improve nightly build trigger logic

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: nightly-build
+  cancel-in-progress: true
+
 jobs:
   check:
     if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
@@ -15,37 +19,79 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - name: Repair stale pico-sdk submodule metadata
-        shell: bash
-        run: |
-          set -euo pipefail
-          sdk_dir="$GITHUB_WORKSPACE/pico-sdk"
-          if [ ! -d "$sdk_dir" ]; then
-            exit 0
-          fi
-
-          if git -C "$sdk_dir" ls-files -s sysdrv/tools/board/ubuntu 2>/dev/null | grep -q '^160000 '; then
-            git -C "$sdk_dir" config -f .gitmodules submodule.ubuntu.path sysdrv/tools/board/ubuntu
-            git -C "$sdk_dir" config -f .gitmodules submodule.ubuntu.url https://github.com/luckfox-eng33/pico_ubuntu.git
-          fi
-
-      - uses: actions/checkout@v4
       - id: should_run
-        name: Skip scheduled run if no new commit in the last hour
+        name: Skip scheduled run if no new commit since last release
         env:
           EVENT_NAME: ${{ github.event_name }}
-          HEAD_SHA: ${{ github.sha }}
+          CURRENT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          # Manual dispatch always builds; scheduled runs build only when HEAD is recent.
+          set -uo pipefail
+          # Manual dispatch always builds; scheduled runs build only when there are new commits.
           if [ "$EVENT_NAME" != "schedule" ]; then
+            echo "Manual dispatch triggered; running build."
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [ -n "$(git rev-list --after='1 hour' -n 1 "$HEAD_SHA")" ]; then
+
+          echo "Checking for new commits since last release..."
+          # Compare against the release tag rather than targetCommitish: GitHub may
+          # normalize targetCommitish to a branch name (e.g. "main"), which never
+          # equals a commit SHA and would defeat the skip check. The tag is immutable
+          # and always resolves back to the exact commit the release was built from.
+          err_log="$RUNNER_TEMP/gh_err"
+          LATEST_TAG=$(gh release view --json tagName -q .tagName 2>"$err_log") || {
+            echo "gh release view failed; running build to be safe:"
+            cat "$err_log" || true
             echo "should_run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No new commit in the last hour; skipping build."
+            exit 0
+          }
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No previous release found; running build."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Resolve the tag ref to a SHA via the API (no checkout required).
+          # Use gh's built-in -q (jq) expressions so no external jq binary is needed
+          # on the self-hosted runner.
+          OBJ_TYPE=$(gh api "repos/$GH_REPO/git/refs/tags/$LATEST_TAG" -q '.object.type' 2>"$err_log") || {
+            echo "Could not resolve tag '$LATEST_TAG' to a ref; running build to be safe:"
+            cat "$err_log" || true
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          LATEST_RELEASE_SHA=$(gh api "repos/$GH_REPO/git/refs/tags/$LATEST_TAG" -q '.object.sha' 2>"$err_log") || {
+            echo "Could not resolve tag '$LATEST_TAG' to a SHA; running build to be safe:"
+            cat "$err_log" || true
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          # Annotated tags point at a tag object; dereference it to the commit SHA.
+          if [ "$OBJ_TYPE" = "tag" ]; then
+            LATEST_RELEASE_SHA=$(gh api "repos/$GH_REPO/git/tags/$LATEST_RELEASE_SHA" -q '.object.sha' 2>"$err_log") || {
+              echo "Could not dereference annotated tag '$LATEST_TAG'; running build to be safe:"
+              cat "$err_log" || true
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            }
+          fi
+
+          if [ -z "$LATEST_RELEASE_SHA" ] || [ "$LATEST_RELEASE_SHA" = "null" ]; then
+            echo "Empty SHA for tag '$LATEST_TAG'; running build to be safe."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$CURRENT_SHA" = "$LATEST_RELEASE_SHA" ]; then
+            echo "No new commits since last release (tag=$LATEST_TAG sha=$LATEST_RELEASE_SHA); skipping build."
             echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New commits detected (current=$CURRENT_SHA, last release=$LATEST_RELEASE_SHA); running build."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           fi
 
   build:


### PR DESCRIPTION
## Changes

- **Smarter build triggering**: Compare current SHA against the last release tag instead of using time-based checks
- **Concurrency control**: Prevent multiple nightly builds from running simultaneously
- **Annotated tag support**: Properly dereference annotated tags to commit SHAs
- **Enhanced error handling**: Fail-safe defaults ensure builds run when API calls fail

## Testing

Manual dispatch and scheduled runs will now correctly:
- Skip builds when no new commits exist since the last release
- Always build on manual dispatch
- Handle edge cases (no releases, API failures) safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly build workflow with concurrency control to cancel redundant in-progress builds.
  * Modified build trigger logic to use release-based comparison instead of time-based checks for determining when to run scheduled builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->