### PR TITLE
fix(ci): retry GitHub release uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,10 +126,14 @@ jobs:
       run: ./build_image.sh bash ./scripts/repack_ota_update_image.sh
 
     - name: Create Release
-      uses: softprops/action-gh-release@v2
-      with:
-        name: ${{ steps.release_info.outputs.release_name }}
-        tag_name: ${{ steps.release_info.outputs.tag_name }}
-        target_commitish: ${{ github.sha }}
-        files: pico-sdk/output/image/*
-        fail_on_unmatched_files: true
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_DEBUG: api
+      run: |
+        bash scripts/create_github_release.sh \
+          --release-name "${{ steps.release_info.outputs.release_name }}" \
+          --tag-name "${{ steps.release_info.outputs.tag_name }}" \
+          --target-commitish "${{ github.sha }}" \
+          --asset-glob 'pico-sdk/output/image/*' \
+          --retry-count 5 \
+          --retry-delay-seconds 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Verify self-hosted runner safety
         run: bash scripts/test_github_actions_self_hosted_safety.sh
+      - name: Fetch pico-sdk submodule
+        run: |
+          git submodule update --init --depth=1 pico-sdk
+          git -C pico-sdk clean -f -- .gitmodules
       - name: Verify build and release scripts
         run: |
           bash scripts/test_build_scripts.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Verify self-hosted runner safety
         run: bash scripts/test_github_actions_self_hosted_safety.sh
+      - name: Verify build and release scripts
+        run: |
+          bash scripts/test_build_scripts.sh
+          bash scripts/test_github_release_upload.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Verify self-hosted runner safety
         run: bash scripts/test_github_actions_self_hosted_safety.sh
-      - name: Fetch pico-sdk submodule
+      - name: Verify release scripts
         run: |
-          git submodule update --init --depth=1 pico-sdk
-          git -C pico-sdk clean -f -- .gitmodules
-      - name: Verify build and release scripts
-        run: |
-          bash scripts/test_build_scripts.sh
+          sh scripts/test_release_ci_scripts.sh
           bash scripts/test_github_release_upload.sh

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .toolchains/
 .worktrees/
 .claude/
+CLAUDE.md
+AGENTS.md
 *.pcm
 /pico-sdk/
 /overlay/oem/usr/bin/*

--- a/scripts/create_github_release.sh
+++ b/scripts/create_github_release.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  create_github_release.sh \
+    --tag-name TAG \
+    --release-name NAME \
+    --target-commitish SHA \
+    --asset-glob 'path/to/assets/*' \
+    [--retry-count N] \
+    [--retry-delay-seconds N]
+EOF
+}
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+die() {
+  log "$*"
+  exit 1
+}
+
+tag_name=""
+release_name=""
+target_commitish=""
+asset_glob=""
+retry_count=5
+retry_delay_seconds=20
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tag-name)
+      tag_name="${2:-}"
+      shift 2
+      ;;
+    --release-name)
+      release_name="${2:-}"
+      shift 2
+      ;;
+    --target-commitish)
+      target_commitish="${2:-}"
+      shift 2
+      ;;
+    --asset-glob)
+      asset_glob="${2:-}"
+      shift 2
+      ;;
+    --retry-count)
+      retry_count="${2:-}"
+      shift 2
+      ;;
+    --retry-delay-seconds)
+      retry_delay_seconds="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "$tag_name" ] || die "missing --tag-name"
+[ -n "$release_name" ] || die "missing --release-name"
+[ -n "$target_commitish" ] || die "missing --target-commitish"
+[ -n "$asset_glob" ] || die "missing --asset-glob"
+
+case "$retry_count" in
+  ''|*[!0-9]*)
+    die "--retry-count must be a positive integer"
+    ;;
+esac
+
+case "$retry_delay_seconds" in
+  ''|*[!0-9]*)
+    die "--retry-delay-seconds must be a non-negative integer"
+    ;;
+esac
+
+if [ "$retry_count" -lt 1 ]; then
+  die "--retry-count must be at least 1"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  die "gh CLI is required to create GitHub releases"
+fi
+
+if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
+  die "GH_TOKEN or GITHUB_TOKEN is required for GitHub release creation"
+fi
+
+asset_files=()
+while IFS= read -r asset; do
+  if [ -f "$asset" ]; then
+    asset_files+=("$asset")
+  fi
+done < <(compgen -G "$asset_glob" | sort || true)
+
+if [ "${#asset_files[@]}" -eq 0 ]; then
+  die "no release assets matched: $asset_glob"
+fi
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    printf 'unavailable'
+  fi
+}
+
+log "Release upload context"
+log "  repository: ${GITHUB_REPOSITORY:-unknown}"
+log "  tag_name: $tag_name"
+log "  release_name: $release_name"
+log "  target_commitish: $target_commitish"
+log "  asset_glob: $asset_glob"
+log "  retry_count: $retry_count"
+log "  retry_delay_seconds: $retry_delay_seconds"
+log "  gh_debug: ${GH_DEBUG:-unset}"
+gh --version >&2 || true
+
+if command -v df >/dev/null 2>&1; then
+  log "Release upload disk context"
+  df -h . >&2 || true
+fi
+
+log "Release assets"
+for asset in "${asset_files[@]}"; do
+  size_bytes="$(wc -c < "$asset" | tr -d '[:space:]')"
+  checksum="$(sha256_of "$asset")"
+  log "  $(basename "$asset") size=${size_bytes} sha256=${checksum}"
+done
+
+run_with_retry() {
+  local label="$1"
+  shift
+
+  local attempt=1
+  local status=0
+  local tmp_base="${RUNNER_TEMP:-/tmp}"
+  local err_file
+
+  while true; do
+    err_file="$(mktemp "$tmp_base/github-release.XXXXXX")"
+    log "$label attempt $attempt/$retry_count"
+    if "$@" 2> >(tee "$err_file" >&2); then
+      rm -f "$err_file"
+      return 0
+    fi
+
+    status=$?
+    if [ "$attempt" -ge "$retry_count" ]; then
+      log "$label failed after $attempt attempt(s)"
+      rm -f "$err_file"
+      return "$status"
+    fi
+
+    log "Retrying $label after failure; waiting ${retry_delay_seconds}s before attempt $((attempt + 1))/$retry_count"
+    rm -f "$err_file"
+    if [ "$retry_delay_seconds" -gt 0 ]; then
+      sleep "$retry_delay_seconds"
+    fi
+    attempt=$((attempt + 1))
+  done
+}
+
+ensure_release() {
+  if gh release view "$tag_name" >/dev/null 2>&1; then
+    log "Release already exists for tag $tag_name; assets will be uploaded with --clobber"
+    return 0
+  fi
+
+  local attempt=1
+  local status=0
+  local tmp_base="${RUNNER_TEMP:-/tmp}"
+  local err_file
+
+  while true; do
+    err_file="$(mktemp "$tmp_base/github-release.XXXXXX")"
+    log "release draft creation $tag_name attempt $attempt/$retry_count"
+    if gh release create "$tag_name" \
+      --draft \
+      --title "$release_name" \
+      --target "$target_commitish" \
+      --notes "Automated build for $target_commitish" \
+      2> >(tee "$err_file" >&2); then
+      rm -f "$err_file"
+      return 0
+    fi
+
+    status=$?
+    if gh release view "$tag_name" >/dev/null 2>&1; then
+      log "Release exists after failed creation attempt for tag $tag_name; continuing with asset uploads"
+      rm -f "$err_file"
+      return 0
+    fi
+
+    if [ "$attempt" -ge "$retry_count" ]; then
+      log "release draft creation $tag_name failed after $attempt attempt(s)"
+      rm -f "$err_file"
+      return "$status"
+    fi
+
+    log "Retrying release draft creation $tag_name after failure; waiting ${retry_delay_seconds}s before attempt $((attempt + 1))/$retry_count"
+    rm -f "$err_file"
+    if [ "$retry_delay_seconds" -gt 0 ]; then
+      sleep "$retry_delay_seconds"
+    fi
+    attempt=$((attempt + 1))
+  done
+}
+
+ensure_release
+
+for asset in "${asset_files[@]}"; do
+  run_with_retry \
+    "release asset upload $(basename "$asset")" \
+    gh release upload "$tag_name" "$asset" --clobber
+done
+
+run_with_retry \
+  "release publish $tag_name" \
+  gh release edit "$tag_name" --draft=false --latest
+
+log "Release upload completed for $tag_name"

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -225,9 +225,14 @@ if ! grep -q 'GH_DEBUG' "$WORKFLOW"; then
     exit 1
 fi
 
-if ! grep -q 'scripts/test_build_scripts.sh' "$CI_WORKFLOW" || \
+if grep -q 'git submodule update.*pico-sdk' "$CI_WORKFLOW"; then
+    echo "CI release script checks must not fetch the large pico-sdk submodule" >&2
+    exit 1
+fi
+
+if ! grep -q 'scripts/test_release_ci_scripts.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_github_release_upload.sh' "$CI_WORKFLOW"; then
-    echo "CI must run build workflow and release upload script tests" >&2
+    echo "CI must run repo-only release workflow and upload script tests" >&2
     exit 1
 fi
 

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -6,6 +6,7 @@ BUILD_SH="$ROOT_DIR/_build.sh"
 LOCAL_BUILD_SH="$ROOT_DIR/build.sh"
 BUILD_IMAGE_SH="$ROOT_DIR/build_image.sh"
 WORKFLOW="$ROOT_DIR/.github/workflows/build.yml"
+CI_WORKFLOW="$ROOT_DIR/.github/workflows/ci.yml"
 REPACK_SCRIPT="$ROOT_DIR/scripts/repack_ota_update_image.sh"
 GITIGNORE="$ROOT_DIR/.gitignore"
 
@@ -196,6 +197,37 @@ release_line=$(grep -n 'Create Release' "$WORKFLOW" | sed 's/:.*//' | head -n 1)
 if [ -z "$manifest_line" ] || [ -z "$config_line" ] || [ -z "$repack_line" ] || [ -z "$release_line" ] || \
     [ "$manifest_line" -ge "$config_line" ] || [ "$config_line" -ge "$repack_line" ] || [ "$repack_line" -ge "$release_line" ]; then
     echo "workflow must generate manifest, write device config, repack update.img, then create release" >&2
+    exit 1
+fi
+
+if ! grep -q 'scripts/create_github_release.sh' "$WORKFLOW"; then
+    echo "build workflow must create releases through the retry-capable local script" >&2
+    exit 1
+fi
+
+if grep -q 'softprops/action-gh-release' "$WORKFLOW"; then
+    echo "build workflow must not rely on action-gh-release for release uploads" >&2
+    exit 1
+fi
+
+if [ ! -x "$ROOT_DIR/scripts/create_github_release.sh" ]; then
+    echo "release creation script must exist and be executable" >&2
+    exit 1
+fi
+
+if ! grep -q -- '--retry-count' "$WORKFLOW" || ! grep -q -- '--retry-delay-seconds' "$WORKFLOW"; then
+    echo "build workflow must configure release upload retry count and delay" >&2
+    exit 1
+fi
+
+if ! grep -q 'GH_DEBUG' "$WORKFLOW"; then
+    echo "build workflow must enable GitHub CLI debug output for release creation" >&2
+    exit 1
+fi
+
+if ! grep -q 'scripts/test_build_scripts.sh' "$CI_WORKFLOW" || \
+   ! grep -q 'scripts/test_github_release_upload.sh' "$CI_WORKFLOW"; then
+    echo "CI must run build workflow and release upload script tests" >&2
     exit 1
 fi
 

--- a/scripts/test_github_release_upload.sh
+++ b/scripts/test_github_release_upload.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+assets_dir="$tmp_dir/assets"
+fake_bin="$tmp_dir/bin"
+state_dir="$tmp_dir/state"
+mkdir -p "$assets_dir" "$fake_bin" "$state_dir"
+
+printf 'firmware image\n' > "$assets_dir/update.img"
+printf '{"version":"v-test"}\n' > "$assets_dir/manifest.json"
+
+cat > "$fake_bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state_dir="${FAKE_GH_STATE_DIR:?}"
+printf '%s\n' "$*" >> "$state_dir/calls"
+
+if [ "${1:-}" = "--version" ]; then
+  echo "gh version 2.0.0"
+  exit 0
+fi
+
+if [ "${1:-}" != "release" ]; then
+  echo "unexpected gh command: $*" >&2
+  exit 2
+fi
+
+case "${2:-}" in
+  view)
+    if [ -f "$state_dir/release-exists" ]; then
+      echo "release exists"
+      exit 0
+    fi
+    echo "release not found" >&2
+    exit 1
+    ;;
+  create)
+    create_count_file="$state_dir/create-count"
+    create_count=0
+    if [ -f "$create_count_file" ]; then
+      create_count="$(cat "$create_count_file")"
+    fi
+    create_count=$((create_count + 1))
+    printf '%s\n' "$create_count" > "$create_count_file"
+    case " $* " in
+      *" --draft "*)
+        ;;
+      *)
+        echo "release must be created as draft" >&2
+        exit 1
+        ;;
+    esac
+    touch "$state_dir/release-exists"
+    printf 'create:%s\n' "${3:-}" >> "$state_dir/events"
+    if [ "${FAKE_GH_CREATE_PARTIAL_FAILURE:-0}" = "1" ] && [ "$create_count" -eq 1 ]; then
+      echo "connection reset after release creation" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  edit)
+    case " $* " in
+      *" --draft=false "*)
+        printf 'publish:%s\n' "${3:-}" >> "$state_dir/events"
+        exit 0
+        ;;
+      *)
+        echo "unexpected release edit arguments: $*" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  upload)
+    asset="${4:-}"
+    name="${asset##*/}"
+    count_file="$state_dir/upload-$name"
+    count=0
+    if [ -f "$count_file" ]; then
+      count="$(cat "$count_file")"
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$count_file"
+    printf 'upload:%s:%s\n' "$name" "$count" >> "$state_dir/events"
+    if [ "$name" = "update.img" ] && [ "$count" -eq 1 ]; then
+      echo "write EPIPE" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  *)
+    echo "unexpected gh release command: $*" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$fake_bin/gh"
+
+log_file="$tmp_dir/release.log"
+if ! PATH="$fake_bin:$PATH" \
+  FAKE_GH_STATE_DIR="$state_dir" \
+  GH_TOKEN="test-token" \
+  GITHUB_REPOSITORY="owner/repo" \
+    "$repo_root/scripts/create_github_release.sh" \
+      --tag-name v-test \
+      --release-name "Test Release" \
+      --target-commitish abc123 \
+      --asset-glob "$assets_dir/*" \
+      --retry-count 3 \
+      --retry-delay-seconds 0 \
+      >"$log_file" 2>&1; then
+  cat "$log_file" >&2
+  exit 1
+fi
+
+if ! grep -q 'Release upload context' "$log_file"; then
+  echo "release script must print upload context debug logs" >&2
+  exit 1
+fi
+
+if ! grep -q 'write EPIPE' "$log_file"; then
+  echo "release script must include failed gh stderr in logs" >&2
+  exit 1
+fi
+
+if ! grep -q 'Retrying release asset upload.*update.img' "$log_file"; then
+  echo "release script must log retry attempts for failed uploads" >&2
+  exit 1
+fi
+
+if [ "$(grep -c '^upload:update.img:' "$state_dir/events")" -ne 2 ]; then
+  echo "release script must retry failed update.img upload once" >&2
+  exit 1
+fi
+
+if [ "$(grep -c '^upload:manifest.json:' "$state_dir/events")" -ne 1 ]; then
+  echo "release script must not retry successful manifest upload" >&2
+  exit 1
+fi
+
+if ! grep -q '^publish:v-test$' "$state_dir/events"; then
+  echo "release script must publish the draft release after uploading assets" >&2
+  exit 1
+fi
+
+last_upload_line="$(grep -n '^upload:' "$state_dir/events" | tail -n 1 | cut -d: -f1)"
+publish_line="$(grep -n '^publish:v-test$' "$state_dir/events" | cut -d: -f1)"
+if [ "$publish_line" -le "$last_upload_line" ]; then
+  echo "release script must publish only after all assets are uploaded" >&2
+  exit 1
+fi
+
+rm -f "$state_dir/events" "$state_dir/calls" "$state_dir/release-exists" "$state_dir"/upload-* "$state_dir/create-count"
+if ! PATH="$fake_bin:$PATH" \
+  FAKE_GH_STATE_DIR="$state_dir" \
+  FAKE_GH_CREATE_PARTIAL_FAILURE=1 \
+  GH_TOKEN="test-token" \
+  GITHUB_REPOSITORY="owner/repo" \
+    "$repo_root/scripts/create_github_release.sh" \
+      --tag-name v-test \
+      --release-name "Test Release" \
+      --target-commitish abc123 \
+      --asset-glob "$assets_dir/*" \
+      --retry-count 3 \
+      --retry-delay-seconds 0 \
+      >"$log_file" 2>&1; then
+  cat "$log_file" >&2
+  exit 1
+fi
+
+if ! grep -q 'connection reset after release creation' "$log_file"; then
+  echo "release script must log partial release creation failures" >&2
+  exit 1
+fi
+
+if [ "$(grep -c '^create:v-test$' "$state_dir/events")" -ne 1 ]; then
+  echo "release script must not retry release creation after the release already exists" >&2
+  exit 1
+fi
+
+if ! grep -q '^publish:v-test$' "$state_dir/events"; then
+  echo "release script must continue and publish after recovering an existing draft release" >&2
+  exit 1
+fi
+
+echo "GitHub release upload retry test passed."

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+WORKFLOW="$ROOT_DIR/.github/workflows/build.yml"
+CI_WORKFLOW="$ROOT_DIR/.github/workflows/ci.yml"
+
+if ! grep -q 'scripts/create_github_release.sh' "$WORKFLOW"; then
+    echo "build workflow must create releases through the retry-capable local script" >&2
+    exit 1
+fi
+
+if grep -q 'softprops/action-gh-release' "$WORKFLOW"; then
+    echo "build workflow must not rely on action-gh-release for release uploads" >&2
+    exit 1
+fi
+
+if [ ! -x "$ROOT_DIR/scripts/create_github_release.sh" ]; then
+    echo "release creation script must exist and be executable" >&2
+    exit 1
+fi
+
+if ! grep -q -- '--retry-count' "$WORKFLOW" || ! grep -q -- '--retry-delay-seconds' "$WORKFLOW"; then
+    echo "build workflow must configure release upload retry count and delay" >&2
+    exit 1
+fi
+
+if ! grep -q 'GH_DEBUG' "$WORKFLOW"; then
+    echo "build workflow must enable GitHub CLI debug output for release creation" >&2
+    exit 1
+fi
+
+if grep -q 'git submodule update.*pico-sdk' "$CI_WORKFLOW"; then
+    echo "CI release script checks must not fetch the large pico-sdk submodule" >&2
+    exit 1
+fi
+
+if grep -q 'scripts/test_build_scripts.sh' "$CI_WORKFLOW"; then
+    echo "CI must not run submodule-dependent build script checks for release script coverage" >&2
+    exit 1
+fi
+
+if ! grep -q 'scripts/test_release_ci_scripts.sh' "$CI_WORKFLOW" || \
+   ! grep -q 'scripts/test_github_release_upload.sh' "$CI_WORKFLOW"; then
+    echo "CI must run repo-only release workflow and upload script tests" >&2
+    exit 1
+fi
+
+echo "release CI script tests passed"


### PR DESCRIPTION
## Summary
- Replace action-gh-release with a local gh-based release script that retries asset uploads and publishes only after uploads complete
- Recover when release creation succeeds remotely but the gh command returns a transient failure
- Add lightweight CI coverage for release workflow wiring and upload retry behavior without fetching the large pico-sdk submodule
- Ignore local CLAUDE/AGENTS instruction files to avoid accidental commits

## Tests
- scripts/test_release_ci_scripts.sh
- scripts/test_github_release_upload.sh
- scripts/test_build_scripts.sh
- bash scripts/test_github_actions_self_hosted_safety.sh
- make test
- git diff --check
- bash -n scripts/create_github_release.sh
- bash -n scripts/test_github_release_upload.sh
- sh -n scripts/test_release_ci_scripts.sh
- sh -n scripts/test_build_scripts.sh
- ruby -ryaml workflow parse check