### PR TITLE
fix(ci): keep scheduled builds from canceling releases

### DIFF
--- a/.github/workflows/build-scheduled.yml
+++ b/.github/workflows/build-scheduled.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: scheduled-build
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check:

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -3,6 +3,7 @@ set -eu
 
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 WORKFLOW="$ROOT_DIR/.github/workflows/build.yml"
+SCHEDULED_WORKFLOW="$ROOT_DIR/.github/workflows/build-scheduled.yml"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/ci.yml"
 
 if ! grep -q 'scripts/create_github_release.sh' "$WORKFLOW"; then
@@ -27,6 +28,11 @@ fi
 
 if ! grep -q 'GH_DEBUG' "$WORKFLOW"; then
     echo "build workflow must enable GitHub CLI debug output for release creation" >&2
+    exit 1
+fi
+
+if ! grep -q 'cancel-in-progress: false' "$SCHEDULED_WORKFLOW"; then
+    echo "scheduled build workflow must not cancel an in-progress release build" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Disable in-progress cancellation for the scheduled release build concurrency group
- Add a release CI script check to prevent regressing this behavior

## Tests
- sh scripts/test_release_ci_scripts.sh
- bash scripts/test_github_actions_self_hosted_safety.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated scheduled build workflow configuration.
  * Added validation tests for build workflow settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->