### PR TITLE
fix(ci): harden GitHub release publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,5 +135,6 @@ jobs:
           --tag-name "${{ steps.release_info.outputs.tag_name }}" \
           --target-commitish "${{ github.sha }}" \
           --asset-glob 'pico-sdk/output/image/*' \
+          --required-assets 'boot_a.img boot_b.img oem_a.img oem_b.img rootfs_a.img rootfs_b.img userdata.img update.img manifest.json' \
           --retry-count 5 \
-          --retry-delay-seconds 20
+          --retry-delay-seconds 30

--- a/scripts/create_github_release.sh
+++ b/scripts/create_github_release.sh
@@ -9,6 +9,7 @@ Usage:
     --release-name NAME \
     --target-commitish SHA \
     --asset-glob 'path/to/assets/*' \
+    [--required-assets 'FILE ...'] \
     [--retry-count N] \
     [--retry-delay-seconds N]
 EOF
@@ -23,10 +24,13 @@ die() {
   exit 1
 }
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 tag_name=""
 release_name=""
 target_commitish=""
 asset_glob=""
+required_assets=""
 retry_count=5
 retry_delay_seconds=20
 
@@ -46,6 +50,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --asset-glob)
       asset_glob="${2:-}"
+      shift 2
+      ;;
+    --required-assets)
+      required_assets="${2:-}"
       shift 2
       ;;
     --retry-count)
@@ -107,6 +115,30 @@ if [ "${#asset_files[@]}" -eq 0 ]; then
   die "no release assets matched: $asset_glob"
 fi
 
+asset_file_for_name() {
+  local name="$1"
+  local asset
+
+  for asset in "${asset_files[@]}"; do
+    if [ "$(basename "$asset")" = "$name" ]; then
+      printf '%s' "$asset"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+validate_required_assets() {
+  local required_asset
+
+  for required_asset in $required_assets; do
+    if ! asset_file_for_name "$required_asset" >/dev/null; then
+      die "missing required release asset: $required_asset"
+    fi
+  done
+}
+
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1" | awk '{print $1}'
@@ -117,12 +149,30 @@ sha256_of() {
   fi
 }
 
+release_notes_for_target() {
+  local commit_title=""
+
+  if command -v git >/dev/null 2>&1; then
+    commit_title="$(git -C "$repo_root" show -s --format=%s "$target_commitish" 2>/dev/null || true)"
+  fi
+
+  if [ -n "$commit_title" ]; then
+    printf 'Automated build for %s' "$commit_title"
+  else
+    printf 'Automated build for %s' "$target_commitish"
+  fi
+}
+
+release_notes="$(release_notes_for_target)"
+validate_required_assets
+
 log "Release upload context"
 log "  repository: ${GITHUB_REPOSITORY:-unknown}"
 log "  tag_name: $tag_name"
 log "  release_name: $release_name"
 log "  target_commitish: $target_commitish"
 log "  asset_glob: $asset_glob"
+log "  required_assets: ${required_assets:-none}"
 log "  retry_count: $retry_count"
 log "  retry_delay_seconds: $retry_delay_seconds"
 log "  gh_debug: ${GH_DEBUG:-unset}"
@@ -148,6 +198,7 @@ run_with_retry() {
   local status=0
   local tmp_base="${RUNNER_TEMP:-/tmp}"
   local err_file
+  local retry_wait_seconds
 
   while true; do
     err_file="$(mktemp "$tmp_base/github-release.XXXXXX")"
@@ -164,10 +215,11 @@ run_with_retry() {
       return "$status"
     fi
 
-    log "Retrying $label after failure; waiting ${retry_delay_seconds}s before attempt $((attempt + 1))/$retry_count"
+    retry_wait_seconds=$((retry_delay_seconds * attempt))
+    log "Retrying $label after failure; waiting ${retry_wait_seconds}s before attempt $((attempt + 1))/$retry_count"
     rm -f "$err_file"
-    if [ "$retry_delay_seconds" -gt 0 ]; then
-      sleep "$retry_delay_seconds"
+    if [ "$retry_wait_seconds" -gt 0 ]; then
+      sleep "$retry_wait_seconds"
     fi
     attempt=$((attempt + 1))
   done
@@ -183,6 +235,7 @@ ensure_release() {
   local status=0
   local tmp_base="${RUNNER_TEMP:-/tmp}"
   local err_file
+  local retry_wait_seconds
 
   while true; do
     err_file="$(mktemp "$tmp_base/github-release.XXXXXX")"
@@ -191,7 +244,7 @@ ensure_release() {
       --draft \
       --title "$release_name" \
       --target "$target_commitish" \
-      --notes "Automated build for $target_commitish" \
+      --notes "$release_notes" \
       2> >(tee "$err_file" >&2); then
       rm -f "$err_file"
       return 0
@@ -210,10 +263,11 @@ ensure_release() {
       return "$status"
     fi
 
-    log "Retrying release draft creation $tag_name after failure; waiting ${retry_delay_seconds}s before attempt $((attempt + 1))/$retry_count"
+    retry_wait_seconds=$((retry_delay_seconds * attempt))
+    log "Retrying release draft creation $tag_name after failure; waiting ${retry_wait_seconds}s before attempt $((attempt + 1))/$retry_count"
     rm -f "$err_file"
-    if [ "$retry_delay_seconds" -gt 0 ]; then
-      sleep "$retry_delay_seconds"
+    if [ "$retry_wait_seconds" -gt 0 ]; then
+      sleep "$retry_wait_seconds"
     fi
     attempt=$((attempt + 1))
   done

--- a/scripts/test_github_release_upload.sh
+++ b/scripts/test_github_release_upload.sh
@@ -12,6 +12,9 @@ mkdir -p "$assets_dir" "$fake_bin" "$state_dir"
 
 printf 'firmware image\n' > "$assets_dir/update.img"
 printf '{"version":"v-test"}\n' > "$assets_dir/manifest.json"
+for image in boot_a.img boot_b.img oem_a.img oem_b.img rootfs_a.img rootfs_b.img userdata.img; do
+  printf '%s\n' "$image" > "$assets_dir/$image"
+done
 
 cat > "$fake_bin/gh" <<'SH'
 #!/usr/bin/env bash
@@ -86,7 +89,7 @@ case "${2:-}" in
     count=$((count + 1))
     printf '%s\n' "$count" > "$count_file"
     printf 'upload:%s:%s\n' "$name" "$count" >> "$state_dir/events"
-    if [ "$name" = "update.img" ] && [ "$count" -eq 1 ]; then
+    if [ "$name" = "update.img" ] && [ "$count" -le 2 ]; then
       echo "write EPIPE" >&2
       exit 1
     fi
@@ -100,7 +103,18 @@ esac
 SH
 chmod +x "$fake_bin/gh"
 
+cat > "$fake_bin/sleep" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state_dir="${FAKE_GH_STATE_DIR:?}"
+printf '%s\n' "$*" >> "$state_dir/sleeps"
+SH
+chmod +x "$fake_bin/sleep"
+
 log_file="$tmp_dir/release.log"
+target_commitish="$(git -C "$repo_root" rev-parse HEAD)"
+expected_commit_title="$(git -C "$repo_root" show -s --format=%s "$target_commitish")"
 if ! PATH="$fake_bin:$PATH" \
   FAKE_GH_STATE_DIR="$state_dir" \
   GH_TOKEN="test-token" \
@@ -108,10 +122,11 @@ if ! PATH="$fake_bin:$PATH" \
     "$repo_root/scripts/create_github_release.sh" \
       --tag-name v-test \
       --release-name "Test Release" \
-      --target-commitish abc123 \
+      --target-commitish "$target_commitish" \
       --asset-glob "$assets_dir/*" \
-      --retry-count 3 \
-      --retry-delay-seconds 0 \
+      --required-assets 'boot_a.img boot_b.img oem_a.img oem_b.img rootfs_a.img rootfs_b.img userdata.img update.img manifest.json' \
+      --retry-count 4 \
+      --retry-delay-seconds 15 \
       >"$log_file" 2>&1; then
   cat "$log_file" >&2
   exit 1
@@ -132,13 +147,36 @@ if ! grep -q 'Retrying release asset upload.*update.img' "$log_file"; then
   exit 1
 fi
 
-if [ "$(grep -c '^upload:update.img:' "$state_dir/events")" -ne 2 ]; then
-  echo "release script must retry failed update.img upload once" >&2
+if [ "$(grep -c '^upload:update.img:' "$state_dir/events")" -ne 3 ]; then
+  echo "release script must retry failed update.img upload until it succeeds" >&2
+  exit 1
+fi
+
+if ! grep -q 'waiting 15s before attempt 2/4' "$log_file" || \
+   ! grep -q 'waiting 30s before attempt 3/4' "$log_file"; then
+  echo "release script must increase retry delay between failed upload attempts" >&2
+  exit 1
+fi
+
+if [ "$(cat "$state_dir/sleeps")" != "$(printf '15\n30')" ]; then
+  echo "release script must sleep with increasing retry delays" >&2
   exit 1
 fi
 
 if [ "$(grep -c '^upload:manifest.json:' "$state_dir/events")" -ne 1 ]; then
   echo "release script must not retry successful manifest upload" >&2
+  exit 1
+fi
+
+for image in boot_a.img boot_b.img oem_a.img oem_b.img rootfs_a.img rootfs_b.img userdata.img; do
+  if [ "$(grep -c "^upload:$image:" "$state_dir/events")" -ne 1 ]; then
+    echo "release script must upload required OTA image: $image" >&2
+    exit 1
+  fi
+done
+
+if ! grep -F -q -- "--notes Automated build for $expected_commit_title" "$state_dir/calls"; then
+  echo "release script must include the target commit title in release notes" >&2
   exit 1
 fi
 
@@ -154,7 +192,7 @@ if [ "$publish_line" -le "$last_upload_line" ]; then
   exit 1
 fi
 
-rm -f "$state_dir/events" "$state_dir/calls" "$state_dir/release-exists" "$state_dir"/upload-* "$state_dir/create-count"
+rm -f "$state_dir/events" "$state_dir/calls" "$state_dir/sleeps" "$state_dir/release-exists" "$state_dir"/upload-* "$state_dir/create-count"
 if ! PATH="$fake_bin:$PATH" \
   FAKE_GH_STATE_DIR="$state_dir" \
   FAKE_GH_CREATE_PARTIAL_FAILURE=1 \
@@ -165,6 +203,7 @@ if ! PATH="$fake_bin:$PATH" \
       --release-name "Test Release" \
       --target-commitish abc123 \
       --asset-glob "$assets_dir/*" \
+      --required-assets 'boot_a.img boot_b.img oem_a.img oem_b.img rootfs_a.img rootfs_b.img userdata.img update.img manifest.json' \
       --retry-count 3 \
       --retry-delay-seconds 0 \
       >"$log_file" 2>&1; then
@@ -184,6 +223,34 @@ fi
 
 if ! grep -q '^publish:v-test$' "$state_dir/events"; then
   echo "release script must continue and publish after recovering an existing draft release" >&2
+  exit 1
+fi
+
+rm -f "$assets_dir/oem_b.img" "$state_dir/events" "$state_dir/calls" "$state_dir/release-exists" "$state_dir"/upload-* "$state_dir/create-count"
+if PATH="$fake_bin:$PATH" \
+  FAKE_GH_STATE_DIR="$state_dir" \
+  GH_TOKEN="test-token" \
+  GITHUB_REPOSITORY="owner/repo" \
+    "$repo_root/scripts/create_github_release.sh" \
+      --tag-name v-test \
+      --release-name "Test Release" \
+      --target-commitish abc123 \
+      --asset-glob "$assets_dir/*" \
+      --required-assets 'boot_a.img boot_b.img oem_a.img oem_b.img rootfs_a.img rootfs_b.img userdata.img update.img manifest.json' \
+      --retry-count 3 \
+      --retry-delay-seconds 0 \
+      >"$log_file" 2>&1; then
+  echo "release script must fail when a required OTA image is missing" >&2
+  exit 1
+fi
+
+if ! grep -q 'missing required release asset: oem_b.img' "$log_file"; then
+  echo "release script must identify the missing required OTA image" >&2
+  exit 1
+fi
+
+if [ -f "$state_dir/events" ]; then
+  echo "release script must fail before creating a release when required assets are missing" >&2
   exit 1
 fi
 

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -26,6 +26,23 @@ if ! grep -q -- '--retry-count' "$WORKFLOW" || ! grep -q -- '--retry-delay-secon
     exit 1
 fi
 
+if ! grep -q -- '--retry-delay-seconds 30' "$WORKFLOW"; then
+    echo "build workflow must use a longer release upload retry base delay" >&2
+    exit 1
+fi
+
+if ! grep -q -- '--required-assets' "$WORKFLOW"; then
+    echo "build workflow must require OTA release assets before publishing" >&2
+    exit 1
+fi
+
+for asset in boot_a.img boot_b.img oem_a.img oem_b.img rootfs_a.img rootfs_b.img userdata.img update.img manifest.json; do
+    if ! grep -q "$asset" "$WORKFLOW"; then
+        echo "build workflow must require release asset: $asset" >&2
+        exit 1
+    fi
+done
+
 if ! grep -q 'GH_DEBUG' "$WORKFLOW"; then
     echo "build workflow must enable GitHub CLI debug output for release creation" >&2
     exit 1


### PR DESCRIPTION
## Summary
- Restore release notes to include the target commit title.
- Require OTA release assets before creating/publishing a release.
- Increase release retry base delay and use incremental retry waits.

## Tests
- bash scripts/test_github_release_upload.sh
- sh scripts/test_release_ci_scripts.sh
- sh scripts/test_build_scripts.sh
- bash -n scripts/create_github_release.sh scripts/test_github_release_upload.sh
- sh -n scripts/test_release_ci_scripts.sh scripts/test_build_scripts.sh
- git diff --check