### PR TITLE
fix(web): prevent Enter key from sending message during IME composition

### DIFF
--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -2120,7 +2120,7 @@ const webUI = `<!DOCTYPE html>
         toolSelectEl.addEventListener('change', syncSelectedTool);
         skillSelectEl.addEventListener('change', syncSelectedSkill);
         inputEl.addEventListener('keydown', function(event) {
-            if (event.key === 'Enter' && !event.shiftKey) {
+            if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
                 event.preventDefault();
                 sendMessage();
             }


### PR DESCRIPTION
## Problem

When using Chinese IME to type English text in the web chat interface (port 8080), pressing Enter key immediately sends the message instead of confirming the IME input first. This breaks the normal input workflow.

## Root Cause

The keydown event handler only checked for `!event.shiftKey` but didn't check the IME composition state (`event.isComposing`).

## Solution

Added `!event.isComposing` check to the Enter key handler. Now:
- When IME is composing: Enter confirms the input (expected behavior)
- When IME is not composing: Enter sends the message

## Changes

- Modified `src/agent/internal/agent/server.go` line 2123
- Added `&& !event.isComposing` to the Enter key condition

## Testing

Tested with Chinese IME:
1. Type English text (e.g., "hello")
2. Press Enter → IME confirms input (not sent)
3. Press Enter again → Message is sent

## Compatibility

`event.isComposing` is a standard Web API supported by all modern browsers:
- Chrome/Edge 53+
- Firefox 31+
- Safari 10.1+

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat input to prevent accidental message submission when composing text with input method editors or holding the Shift modifier key while pressing Enter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->