### PR TITLE
fix(ci): restore workspace ownership when Docker build is signal-killed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,23 @@ jobs:
     runs-on: ${{ inputs.runner }}
 
     steps:
+    - name: Reclaim workspace ownership (self-hosted)
+      # The Docker build runs as root and a normal exit hands ownership back to
+      # the runner user via build_image.sh's EXIT trap. Trap handlers cannot run
+      # if the previous build was killed by SIGKILL or the host crashed, leaving
+      # root-owned files that block actions/checkout's clean phase with EACCES.
+      # This step is a defence-in-depth no-op when the trap already ran.
+      if: ${{ inputs.runner == 'self-hosted' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -z "${GITHUB_WORKSPACE:-}" ] || [ ! -d "$GITHUB_WORKSPACE" ]; then
+          exit 0
+        fi
+        # Use numeric uid:gid so this does not depend on the runner user's
+        # account name being resolvable inside any nested context.
+        sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE"
+
     - name: Repair stale pico-sdk submodule metadata
       if: ${{ inputs.runner == 'self-hosted' }}
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,14 @@ jobs:
         fi
         # Use numeric uid:gid so this does not depend on the runner user's
         # account name being resolvable inside any nested context.
-        sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE"
+        owner="$(id -u):$(id -g)"
+        if command -v sudo >/dev/null 2>&1; then
+          sudo chown -R "$owner" "$GITHUB_WORKSPACE"
+        elif [ "$(id -u)" -eq 0 ]; then
+          chown -R "$owner" "$GITHUB_WORKSPACE"
+        else
+          echo "::warning::Skipping workspace ownership reclaim because sudo is unavailable and the current user is not root"
+        fi
 
     - name: Repair stale pico-sdk submodule metadata
       if: ${{ inputs.runner == 'self-hosted' }}

--- a/build_image.sh
+++ b/build_image.sh
@@ -48,9 +48,20 @@ restore_docker_output_ownership() {
   done
 
   if [ "${#paths[@]}" -gt 0 ]; then
-    sudo chown -R "$(id -u):$(id -g)" "${paths[@]}"
+    # Errors here must not mask the original docker exit status, hence `|| true`.
+    sudo chown -R "$(id -u):$(id -g)" "${paths[@]}" || true
   fi
 }
+
+# Always restore ownership on exit, even when the script is interrupted by a
+# signal (CI cancellation, runner restart, ^C). Without this, root-owned build
+# artifacts get left behind and the next actions/checkout clean step fails with
+# EACCES. Forwarding SIGINT/SIGTERM/SIGHUP through `exit` ensures the EXIT trap
+# fires for signal-induced terminations as well as normal returns.
+trap restore_docker_output_ownership EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 
 docker_run_args=(
   --platform linux/amd64
@@ -76,5 +87,5 @@ docker_run_args+=(
 docker_status=0
 docker run "${docker_run_args[@]}" || docker_status=$?
 
-restore_docker_output_ownership
+# Ownership restore happens in the EXIT trap above.
 exit "$docker_status"

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -130,6 +130,21 @@ if [ -z "$setup_go_line" ] || [ -z "$run_build_line" ] || [ "$setup_go_line" -ge
     exit 1
 fi
 
+if grep -Fq 'sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE"' "$WORKFLOW"; then
+    echo "self-hosted workspace reclaim must not require sudo unconditionally" >&2
+    exit 1
+fi
+
+if ! grep -Fq 'owner="$(id -u):$(id -g)"' "$WORKFLOW" || \
+   ! grep -Fq 'command -v sudo >/dev/null 2>&1' "$WORKFLOW" || \
+   ! grep -Fq 'sudo chown -R "$owner" "$GITHUB_WORKSPACE"' "$WORKFLOW" || \
+   ! grep -Fq '[ "$(id -u)" -eq 0 ]' "$WORKFLOW" || \
+   ! grep -Eq '^[[:space:]]+chown -R "\$owner" "\$GITHUB_WORKSPACE"' "$WORKFLOW" || \
+   ! grep -Fq '::warning::Skipping workspace ownership reclaim' "$WORKFLOW"; then
+    echo "self-hosted workspace reclaim must handle sudo, root, and non-root runners without failing" >&2
+    exit 1
+fi
+
 if ! grep -q 'go env GOROOT' "$BUILD_IMAGE_SH"; then
     echo "build_image.sh must discover the host Go root with go env GOROOT" >&2
     exit 1

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -170,6 +170,11 @@ if ! grep -q 'chown -R' "$BUILD_IMAGE_SH" || ! grep -q 'pico-sdk/output' "$BUILD
     exit 1
 fi
 
+if ! grep -Eq '^trap[[:space:]]+restore_docker_output_ownership[[:space:]]+EXIT' "$BUILD_IMAGE_SH"; then
+    echo "build_image.sh must restore Docker output ownership in an EXIT trap so signal-killed builds do not leave root-owned files for the next CI checkout" >&2
+    exit 1
+fi
+
 if ! grep -q 'exec "\$@"' "$BUILD_IMAGE_SH"; then
     echo "build_image.sh must allow CI to run a Dockerized repack command" >&2
     exit 1


### PR DESCRIPTION
## Summary

Self-hosted runner builds were failing at `actions/checkout@v4`'s clean phase with:

```
##[error]File was unable to be removed Error: EACCES: permission denied,
unlink '.../aiden-hardware-demo/build/CMakeCache.txt'
```

(Example: [run 26993544236](https://github.com/AidenAI-IO/aiden-hardware-demo/actions/runs/26993544236/job/79658580805).)

## Root cause

`build_image.sh` runs the packaging Docker container as `-u 0:0`, so build outputs (`build/`, `overlay/oem`, `overlay/userdata`, `pico-sdk/output`) land owned by root. The script restores ownership at the end via `restore_docker_output_ownership` — but as a plain trailing call. If the previous build was cancelled, OOM-killed, the runner restarted, or the host crashed, that line never ran, root-owned files survived, and the next `actions/checkout` clean failed with EACCES.

## Fix

Two layers, root-cause first plus defence-in-depth:

1. **`build_image.sh`** — install `restore_docker_output_ownership` as an `EXIT` trap and route `INT`/`TERM`/`HUP` through `exit <code>` so the trap also fires on signal-induced termination. `chown` is now `|| true` so a chown failure cannot mask the original docker exit status.

2. **`.github/workflows/build.yml`** — prepend a self-hosted-only `Reclaim workspace ownership` step that `sudo chown -R`s `$GITHUB_WORKSPACE` back to the runner user before checkout runs. This handles the cases where even the EXIT trap cannot fire (SIGKILL of the shell, host crash). Hosted runners are unaffected.

3. **`scripts/test_build_scripts.sh`** — new assertion that pins the EXIT-trap requirement to prevent regression.

## Verification

- `bash -n build_image.sh` — syntax OK
- `python3 -c 'import yaml; yaml.safe_load(...)'` on `build.yml` — OK
- `bash scripts/test_build_scripts.sh` — passes (including the new assertion)
- `bash scripts/test_github_actions_self_hosted_safety.sh` — passes
- `sh scripts/test_release_ci_scripts.sh` + `bash scripts/test_github_release_upload.sh` — pass
- Simulated `docker exit 137` (container SIGKILL): trap fires, `sudo chown` runs, exit code preserved as 137
- Simulated `SIGTERM` to `build_image.sh` itself: trap chain `TERM → exit 143 → EXIT trap`, `sudo chown` runs, exit code 143

## Operational note

The pre-existing root-owned residue on the runner has been cleaned manually. After this PR merges, the EXIT trap plus the workflow pre-clean step prevent recurrence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline reliability by ensuring proper file ownership handling during builds
  * Enhanced handling of interrupted or cancelled build processes to prevent permission-related issues in subsequent runs
  * Added validation tests for build script ownership restoration mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->