### PR TITLE
fix(ci): recover stale pico-sdk submodule checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,23 @@ jobs:
           echo "::warning::Skipping workspace ownership reclaim because sudo is unavailable and the current user is not root"
         fi
 
+    - name: Remove unusable pico-sdk submodule checkout
+      if: ${{ inputs.runner == 'self-hosted' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        sdk_dir="$GITHUB_WORKSPACE/pico-sdk"
+        sdk_git_dir="$GITHUB_WORKSPACE/.git/modules/pico-sdk"
+        if [ ! -e "$sdk_dir" ] && [ ! -e "$sdk_git_dir" ]; then
+          exit 0
+        fi
+
+        if [ -d "$sdk_dir" ] && git -C "$sdk_dir" rev-parse --verify HEAD >/dev/null 2>&1; then
+          exit 0
+        fi
+
+        rm -rf -- "$sdk_dir" "$sdk_git_dir"
+
     - name: Repair stale pico-sdk submodule metadata
       if: ${{ inputs.runner == 'self-hosted' }}
       shell: bash

--- a/scripts/test_github_actions_self_hosted_safety.sh
+++ b/scripts/test_github_actions_self_hosted_safety.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+build_workflow="$repo_root/.github/workflows/build.yml"
 
 ruby - "$repo_root" <<'RUBY'
 require "yaml"
@@ -72,3 +73,17 @@ end
 
 puts "GitHub Actions self-hosted repo-branch safety check passed."
 RUBY
+
+sanitize_line="$(grep -n 'Remove unusable pico-sdk submodule checkout' "$build_workflow" | sed 's/:.*//' | head -n 1 || true)"
+checkout_line="$(grep -n 'uses: actions/checkout@v4' "$build_workflow" | sed 's/:.*//' | head -n 1 || true)"
+if [[ -z "$sanitize_line" || -z "$checkout_line" || "$sanitize_line" -ge "$checkout_line" ]]; then
+  echo "self-hosted build workflow must remove unusable pico-sdk submodule checkouts before actions/checkout" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'git -C "$sdk_dir" rev-parse --verify HEAD' "$build_workflow" || \
+   ! grep -Fq 'sdk_git_dir="$GITHUB_WORKSPACE/.git/modules/pico-sdk"' "$build_workflow" || \
+   ! grep -Fq 'rm -rf -- "$sdk_dir" "$sdk_git_dir"' "$build_workflow"; then
+  echo "self-hosted build workflow must detect and remove pico-sdk checkouts whose current revision is unavailable" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- remove unusable pico-sdk submodule worktrees and git metadata before self-hosted checkout
- add a self-hosted safety regression check for the pre-checkout cleanup

## Root cause
A previous self-hosted build was cancelled while cloning pico-sdk, leaving a half-initialized submodule checkout without a resolvable HEAD.

## Verification
- bash scripts/test_github_actions_self_hosted_safety.sh
- sh scripts/test_release_ci_scripts.sh
- sh scripts/test_build_scripts.sh
- git diff --check

## Runner validation
- confirmed the stale runner checkout failed git -C pico-sdk rev-parse --verify HEAD
- removed the stale pico-sdk worktree and .git/modules/pico-sdk metadata on the self-hosted runner
- verified git clean -ffdx and git reset --hard HEAD recover without the submodule revision fatal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Improved build pipeline reliability by enhancing cleanup and validation of submodule dependencies to prevent stale state issues during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->