### PR TITLE
refactor(agent): convert human handoff to non-blocking conversation flow

### DIFF
--- a/docs/04-agent/human-handoff.md
+++ b/docs/04-agent/human-handoff.md
@@ -355,4 +355,3 @@ Agent: "登录成功。正在搜索《三体》..."
 - `src/agent/internal/agent/tools_human_handoff.go` - 核心实现
 - `src/agent/internal/agent/tools_human_handoff_test.go` - 单元测试
 - `src/agent/internal/agent/tools.go` - ToolSet 集成
-- `docs/04-agent/human-handoff-examples.go` - 集成示例（已过期，待更新）

--- a/docs/04-agent/human-handoff.md
+++ b/docs/04-agent/human-handoff.md
@@ -1,0 +1,358 @@
+# Human Handoff Feature
+
+## 概述
+
+Human Handoff（人工接管）功能允许 Agent 在遇到需要人类判断、输入凭证或执行超出其能力范围的操作时，主动请求人工介入。
+
+这个功能参考了 [Open-AutoGLM](https://github.com/zai-org/Open-AutoGLM) 项目的 `take_over` 机制，但采用了**非阻塞的对话流程设计**，更适合语音连续对话场景。
+
+## 核心设计
+
+与传统的阻塞回调不同，这个实现采用**自然对话流程**：
+
+1. Agent 调用 `request_human_handoff` 工具
+2. **工具立即返回**，告诉 Agent 需要通知用户什么
+3. Agent 通过 TTS 或文本告诉用户需要做什么
+4. **对话轮次结束**，等待用户的下一条消息
+5. 用户完成任务后说"好了"/"继续"等
+6. **新的对话轮次开始**，Agent 截图验证并继续执行
+
+这就像人与人对话一样自然：
+```
+用户: "帮我登录 App Store"
+Agent: "我需要你的帮助。请在屏幕上输入你的 Apple ID 密码，然后点击登录。完成后告诉我继续。"
+[用户输入密码]
+用户: "好了"
+Agent: [截图] "好的，我看到已经成功登录了。现在..."
+```
+
+## 使用场景
+
+Agent 可以在以下场景下请求人工接管：
+
+### 1. **认证场景** (`authentication`)
+- 登录界面需要用户名和密码
+- 需要输入 Agent 无法获取的凭证
+- 需要多因素认证
+
+### 2. **验证码场景** (`captcha`, `verification_code`)
+- 图形验证码（CAPTCHA）
+- 短信验证码
+- 邮箱验证码
+- 身份验证挑战
+
+### 3. **敏感操作** (`sensitive_operation`)
+- 支付确认
+- 银行转账
+- 删除重要数据
+- 权限变更
+
+### 4. **屏幕不可见** (`black_screen`)
+- 截图返回黑屏
+- 敏感页面（支付、银行应用）自动屏蔽截图
+- 无法获取屏幕内容
+
+### 5. **模糊情况** (`ambiguous_situation`)
+- 不确定应该选择哪个选项
+- 需要用户偏好决策
+- 多个可能的操作路径
+
+### 6. **不支持的操作** (`unsupported_action`)
+- 需要的功能超出工具能力
+- 硬件限制
+- 系统限制
+
+### 7. **卡住** (`stuck`)
+- 多次尝试后仍然无法继续
+- 遇到未知错误
+- 界面状态异常
+
+### 8. **其他** (`other`)
+- 其他需要人工介入的情况
+
+## 工具使用
+
+### Tool 名称
+`request_human_handoff`
+
+### 输入格式
+
+```json
+{
+  "reason": "authentication",
+  "details": "Login screen requires password for user@example.com",
+  "suggested_action": "Please enter your password in the password field"
+}
+```
+
+### 参数说明
+
+- **reason** (必需): 请求接管的原因类别，可选值见上述使用场景
+- **details** (必需): 详细描述当前情况，让人类了解发生了什么
+- **suggested_action** (可选): 建议人类采取的操作
+
+### 输出
+
+工具**立即返回**，不会阻塞。返回格式：
+
+```
+HUMAN_HANDOFF_REQUESTED. You need to ask the user to perform a manual action. 
+Reason: Login screen requires password for user@example.com. 
+Tell the user: "Please enter your password in the password field" 
+Then ask the user to tell you when they have completed the task (e.g., say 'done', 'continue', or 'finished'). 
+After the user confirms, take a screenshot to verify the current state before proceeding.
+```
+
+Agent 会理解这个返回值，并将其转化为对用户的语音或文本提示。
+
+## 代码集成
+
+### 简单集成（推荐）
+
+不需要任何回调函数，工具会自动注册：
+
+```go
+package main
+
+import (
+    "agent/internal/agent"
+)
+
+func main() {
+    // 直接创建 ToolSet，human_handoff 工具会自动注册
+    toolSet := agent.NewBuiltinToolSet(
+        hidCfg,
+        audioCfg,
+        searchCfg,
+        proxyCfg,
+    )
+    
+    // 验证工具已注册
+    if tool, ok := toolSet.Get("request_human_handoff"); ok {
+        fmt.Printf("Human handoff tool ready: %s\n", tool.Name())
+    }
+}
+```
+
+### 在 Agent 提示词中说明
+
+在系统提示词中告知 Agent 可以使用这个工具：
+
+```
+When you encounter situations that require human intervention, use the request_human_handoff tool:
+- Login screens requiring passwords
+- CAPTCHA or verification codes
+- Sensitive operations like payments
+- Black screens or inaccessible content
+- Situations where you're stuck after multiple attempts
+
+The tool returns immediately with instructions. Communicate these instructions to the user through your response,
+then wait for the user to tell you they have completed the task in their next message.
+After they confirm, take a screenshot to verify the result before continuing.
+```
+
+## 交互流程示例
+
+### 语音模式
+
+**Turn 1 - Agent 请求接管**:
+```
+用户 (语音): "帮我登录微信"
+Agent: [截图分析] → [判断需要密码] → [调用 request_human_handoff]
+       Tool 返回: "HUMAN_HANDOFF_REQUESTED. Tell user to enter password..."
+Agent (TTS): "我需要你的帮助。微信登录需要输入密码。请在屏幕上输入你的密码并点击登录。完成后告诉我'继续'。"
+[对话轮次结束]
+```
+
+**用户操作**:
+```
+[用户在手机上输入密码，点击登录]
+```
+
+**Turn 2 - 用户确认完成**:
+```
+用户 (语音): "好了" / "继续" / "我登录完了"
+Agent: [截图] → [分析验证]
+Agent (TTS): "很好，我看到已经成功登录了。现在我帮你..."
+[继续执行后续任务]
+```
+
+### 文本对话模式
+
+同样的流程，只是用文字代替语音：
+
+```
+用户: 帮我打开支付宝并充值话费
+Agent: [导航到支付宝充值页面] → [发现需要支付密码]
+Agent: 我需要你的帮助。支付页面需要输入支付密码来确认充值 50 元话费。请在手机上输入你的支付密码并确认。完成后告诉我"继续"。
+[等待用户输入]
+用户: 好了
+Agent: [截图验证] 支付成功！话费已经充值到你的手机号。
+```
+
+## Agent 行为指导
+
+在 Agent 的系统提示词中，建议包含以下指导：
+
+```markdown
+## Human Handoff Guidelines
+
+Use the request_human_handoff tool when:
+
+1. You need credentials you don't have (passwords, API keys, etc.)
+2. You encounter CAPTCHA or verification challenges
+3. The screen shows a black image or is not accessible
+4. You're performing sensitive operations that need human approval
+5. You've tried multiple approaches and are stuck
+6. The task fundamentally requires human judgment
+
+Always provide:
+- Clear reason category
+- Detailed explanation of the situation
+- Specific suggestion of what the human should do
+
+**Important**: This tool returns immediately with instructions for you to communicate.
+After you tell the user what to do:
+1. End your response and wait for their next message
+2. When they say they're done (e.g., "continue", "done", "finished"), take a screenshot
+3. Verify the result before proceeding with the task
+```
+
+## 测试
+
+运行单元测试：
+
+```bash
+cd src/agent/internal/agent
+go test -v -run TestHumanHandoff
+```
+
+## 示例场景
+
+### 场景 1: 登录需要密码
+
+```json
+{
+  "tool": "request_human_handoff",
+  "input": {
+    "reason": "authentication",
+    "details": "App Store 登录界面要求输入 Apple ID 密码。我无法访问用户的密码。",
+    "suggested_action": "请在密码输入框中输入您的 Apple ID 密码，然后点击登录按钮。"
+  }
+}
+```
+
+**Agent 的响应流程**：
+1. 调用工具，工具立即返回指令
+2. Agent 对用户说："我需要你的帮助。App Store 登录界面要求输入 Apple ID 密码。请在密码输入框中输入您的 Apple ID 密码，然后点击登录按钮。完成后告诉我'继续'。"
+3. 等待用户回复
+4. 用户说"好了"后，Agent 截图验证登录状态
+
+### 场景 2: 遇到验证码
+
+```json
+{
+  "tool": "request_human_handoff",
+  "input": {
+    "reason": "captcha",
+    "details": "网站显示图形验证码，需要识别并输入图片中的字符。",
+    "suggested_action": "请查看屏幕上的验证码图片，输入正确的字符。"
+  }
+}
+```
+
+**交互流程**：
+```
+Agent: "我遇到了验证码。请查看屏幕上的验证码图片，输入正确的字符。完成后告诉我。"
+[用户输入验证码]
+用户: "输完了"
+Agent: [截图验证] "好的，验证码已通过，继续..."
+```
+
+### 场景 3: 支付确认
+
+```json
+{
+  "tool": "request_human_handoff",
+  "input": {
+    "reason": "sensitive_operation",
+    "details": "即将执行支付操作，金额为 ¥299。这是敏感操作，需要用户确认。",
+    "suggested_action": "请检查支付金额和收款方是否正确，然后确认支付。"
+  }
+}
+```
+
+**交互流程**：
+```
+Agent: "我需要你确认一个支付操作。即将支付 ¥299。请检查支付金额和收款方是否正确，然后确认支付。完成后告诉我。"
+[用户检查并确认支付]
+用户: "支付完了"
+Agent: [截图验证] "支付成功！订单已确认。"
+```
+
+### 场景 4: 黑屏
+
+```json
+{
+  "tool": "request_human_handoff",
+  "input": {
+    "reason": "black_screen",
+    "details": "屏幕截图返回全黑图像，可能是银行应用启用了防截屏保护。",
+    "suggested_action": "请手动完成银行应用中的操作，完成后通知我继续。"
+  }
+}
+```
+
+**交互流程**：
+```
+Agent: "我无法看到屏幕内容，可能是银行应用启用了防截屏保护。请手动完成银行应用中的操作，完成后通知我继续。"
+[用户完成操作]
+用户: "完成了"
+Agent: [尝试截图或执行下一步操作]
+```
+
+## 与阻塞模式的区别
+
+### 阻塞模式（Open-AutoGLM 原始设计）
+适合**脚本式一次性任务执行**：
+```python
+agent.run("在京东买一本《三体》")
+# → 遇到登录
+# → 工具调用阻塞
+# → 用户按 Enter
+# → 继续执行
+# → 完成购买
+```
+
+### 非阻塞模式（本实现）
+适合**连续语音/文本对话**：
+```
+用户: "在京东买一本《三体》"
+Agent: "好的，正在打开京东... 我需要你的帮助。请输入你的京东账号密码。完成后告诉我。"
+[对话轮次结束，等待用户]
+用户: "好了"
+[新对话轮次开始]
+Agent: "登录成功。正在搜索《三体》..."
+```
+
+## 优势
+
+1. **自然对话流程**：符合人类对话习惯
+2. **适合语音交互**：通过 TTS 告知用户，用户语音回复即可
+3. **无需回调实现**：简化集成，只需注册工具即可
+4. **状态清晰**：每个对话轮次都是独立的，不会出现"卡住"的感觉
+5. **易于理解**：对于用户来说，就像和真人助手对话一样
+
+## 注意事项
+
+1. **验证结果**：Agent 在用户确认完成后，务必截图验证结果
+2. **提示词指导**：需要在系统提示词中明确告诉 Agent 这个工具的工作方式
+3. **用户确认关键词**：Agent 应该能识别多种确认表达（"好了"/"继续"/"完成了"/"OK"等）
+4. **超时处理**：如果用户长时间没有回复，应该有合理的超时机制
+
+## 相关文件
+
+- `src/agent/internal/agent/tools_human_handoff.go` - 核心实现
+- `src/agent/internal/agent/tools_human_handoff_test.go` - 单元测试
+- `src/agent/internal/agent/tools.go` - ToolSet 集成
+- `docs/04-agent/human-handoff-examples.go` - 集成示例（已过期，待更新）

--- a/src/agent/internal/agent/tools.go
+++ b/src/agent/internal/agent/tools.go
@@ -65,6 +65,9 @@ func NewBuiltinToolSet(hidCfg HIDConfig, audioCfg AudioConfig, searchCfg SearchC
 		tools["enter_sleep"] = NewEnterSleepTool(toolOptions.sleepController)
 	}
 
+	// Always register human handoff tool - no callback needed for non-blocking version
+	tools["request_human_handoff"] = NewHumanHandoffTool()
+
 	return &ToolSet{tools: tools, screen: screen}
 }
 

--- a/src/agent/internal/agent/tools_human_handoff.go
+++ b/src/agent/internal/agent/tools_human_handoff.go
@@ -1,0 +1,144 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// HumanHandoffTool allows the agent to request human intervention when it encounters
+// situations that require human judgment, input, or actions beyond its capabilities.
+//
+// Inspired by Open-AutoGLM's take_over mechanism, this tool enables the agent to
+// gracefully hand off control to a human operator in scenarios such as:
+// - Authentication/login requiring credentials
+// - CAPTCHA or verification code input
+// - Sensitive operations (payment, banking)
+// - Ambiguous situations requiring human judgment
+// - Black screen or inaccessible UI elements
+//
+// Unlike blocking callback approaches, this tool returns immediately with instructions
+// for the agent to communicate to the user. The agent will naturally wait for the user's
+// next message in the conversation flow.
+type HumanHandoffTool struct{}
+
+// HumanHandoffRequest contains details about why human intervention is needed.
+type HumanHandoffRequest struct {
+	// Reason is a brief category of why handoff is needed
+	Reason string `json:"reason"`
+
+	// Details provides specific context about the situation
+	Details string `json:"details"`
+
+	// SuggestedAction optionally suggests what the human should do
+	SuggestedAction string `json:"suggested_action,omitempty"`
+}
+
+// HandoffReason defines common categories for human handoff requests
+type HandoffReason string
+
+const (
+	HandoffReasonAuthentication HandoffReason = "authentication"
+	HandoffReasonCAPTCHA        HandoffReason = "captcha"
+	HandoffReasonVerification   HandoffReason = "verification_code"
+	HandoffReasonSensitive      HandoffReason = "sensitive_operation"
+	HandoffReasonBlackScreen    HandoffReason = "black_screen"
+	HandoffReasonAmbiguous      HandoffReason = "ambiguous_situation"
+	HandoffReasonUnsupported    HandoffReason = "unsupported_action"
+	HandoffReasonStuck          HandoffReason = "stuck"
+	HandoffReasonOther          HandoffReason = "other"
+)
+
+// NewHumanHandoffTool creates a new HumanHandoffTool
+func NewHumanHandoffTool() *HumanHandoffTool {
+	return &HumanHandoffTool{}
+}
+
+func (t *HumanHandoffTool) Name() string {
+	return "request_human_handoff"
+}
+
+func (t *HumanHandoffTool) Description() string {
+	return `Request human intervention when you encounter a situation that requires human judgment, credentials, or actions beyond your capabilities. ` +
+		`Input JSON: {"reason": "authentication", "details": "Login screen requires password", "suggested_action": "Please enter your credentials"}. ` +
+		`Valid reasons: "authentication" (login/credentials required), "captcha" (CAPTCHA challenge), "verification_code" (SMS/email code needed), ` +
+		`"sensitive_operation" (payment/banking/security), "black_screen" (screen not visible), "ambiguous_situation" (unclear what to do), ` +
+		`"unsupported_action" (action not possible with available tools), "stuck" (unable to make progress), "other" (specify in details). ` +
+		`The "details" field should clearly explain the situation. The "suggested_action" field optionally tells the human what to do. ` +
+		`This tool returns immediately with instructions for you to communicate to the user. Wait for the user to complete the task and tell you to continue in their next message. ` +
+		`Use this when: you need credentials you don't have, encounter CAPTCHA, need verification codes, face sensitive operations requiring human approval, ` +
+		`see a black/blank screen preventing progress, are genuinely stuck after multiple attempts, or the task fundamentally requires human judgment. ` +
+		`After the user confirms completion in their next message, take a screenshot to verify the result before continuing.`
+}
+
+func (t *HumanHandoffTool) Call(ctx context.Context, input string) (string, error) {
+	var args struct {
+		Reason          string `json:"reason"`
+		Details         string `json:"details"`
+		SuggestedAction string `json:"suggested_action"`
+	}
+
+	if err := json.Unmarshal([]byte(input), &args); err != nil {
+		return "", fmt.Errorf("invalid input: %w", err)
+	}
+
+	// Validate required fields
+	if args.Reason == "" {
+		return "", fmt.Errorf("reason is required")
+	}
+	if args.Details == "" {
+		return "", fmt.Errorf("details is required")
+	}
+
+	// Normalize reason
+	reason := strings.ToLower(strings.TrimSpace(args.Reason))
+	validReasons := map[string]bool{
+		"authentication":      true,
+		"captcha":             true,
+		"verification_code":   true,
+		"sensitive_operation": true,
+		"black_screen":        true,
+		"ambiguous_situation": true,
+		"unsupported_action":  true,
+		"stuck":               true,
+		"other":               true,
+	}
+	if !validReasons[reason] {
+		return "", fmt.Errorf("invalid reason: %q, must be one of: authentication, captcha, verification_code, sensitive_operation, black_screen, ambiguous_situation, unsupported_action, stuck, other", args.Reason)
+	}
+
+	details := strings.TrimSpace(args.Details)
+	suggestedAction := strings.TrimSpace(args.SuggestedAction)
+
+	// Build response message for the agent to communicate to the user
+	var response strings.Builder
+	response.WriteString("HUMAN_HANDOFF_REQUESTED. You need to ask the user to perform a manual action. ")
+
+	// Add context about why handoff is needed
+	response.WriteString(fmt.Sprintf("Reason: %s. ", details))
+
+	// Add suggested action if provided
+	if suggestedAction != "" {
+		response.WriteString(fmt.Sprintf("Tell the user: \"%s\" ", suggestedAction))
+	} else {
+		// Provide default instruction based on reason
+		switch reason {
+		case "authentication":
+			response.WriteString("Tell the user to enter their credentials. ")
+		case "captcha", "verification_code":
+			response.WriteString("Tell the user to complete the verification. ")
+		case "sensitive_operation":
+			response.WriteString("Tell the user to review and confirm the sensitive operation. ")
+		case "black_screen":
+			response.WriteString("Tell the user to manually complete the action on the screen. ")
+		default:
+			response.WriteString("Tell the user to handle this situation manually. ")
+		}
+	}
+
+	response.WriteString("Then ask the user to tell you when they have completed the task (e.g., say 'done', 'continue', or 'finished'). ")
+	response.WriteString("After the user confirms, take a screenshot to verify the current state before proceeding.")
+
+	return response.String(), nil
+}

--- a/src/agent/internal/agent/tools_human_handoff.go
+++ b/src/agent/internal/agent/tools_human_handoff.go
@@ -83,11 +83,12 @@ func (t *HumanHandoffTool) Call(ctx context.Context, input string) (string, erro
 		return "", fmt.Errorf("invalid input: %w", err)
 	}
 
-	// Validate required fields
-	if args.Reason == "" {
+	// Validate required fields. Trim first so whitespace-only values are
+	// rejected as missing rather than slipping through to the reason allowlist.
+	if strings.TrimSpace(args.Reason) == "" {
 		return "", fmt.Errorf("reason is required")
 	}
-	if args.Details == "" {
+	if strings.TrimSpace(args.Details) == "" {
 		return "", fmt.Errorf("details is required")
 	}
 

--- a/src/agent/internal/agent/tools_human_handoff_test.go
+++ b/src/agent/internal/agent/tools_human_handoff_test.go
@@ -1,0 +1,260 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestHumanHandoffTool_Name(t *testing.T) {
+	tool := NewHumanHandoffTool()
+	if got := tool.Name(); got != "request_human_handoff" {
+		t.Errorf("Name() = %q, want %q", got, "request_human_handoff")
+	}
+}
+
+func TestHumanHandoffTool_Description(t *testing.T) {
+	tool := NewHumanHandoffTool()
+	desc := tool.Description()
+	if desc == "" {
+		t.Error("Description() returned empty string")
+	}
+	if !strings.Contains(desc, "human intervention") {
+		t.Error("Description() doesn't mention human intervention")
+	}
+	if !strings.Contains(desc, "returns immediately") {
+		t.Error("Description() doesn't mention non-blocking behavior")
+	}
+}
+
+func TestHumanHandoffTool_Call_Success(t *testing.T) {
+	tool := NewHumanHandoffTool()
+
+	input := `{
+		"reason": "authentication",
+		"details": "Login screen requires password",
+		"suggested_action": "Please enter your credentials"
+	}`
+
+	ctx := context.Background()
+	result, err := tool.Call(ctx, input)
+
+	if err != nil {
+		t.Fatalf("Call() error = %v, want nil", err)
+	}
+
+	if !strings.Contains(result, "HUMAN_HANDOFF_REQUESTED") {
+		t.Errorf("Result doesn't contain handoff marker: %q", result)
+	}
+
+	if !strings.Contains(result, "Login screen requires password") {
+		t.Errorf("Result doesn't contain details: %q", result)
+	}
+
+	if !strings.Contains(result, "Please enter your credentials") {
+		t.Errorf("Result doesn't contain suggested action: %q", result)
+	}
+
+	if !strings.Contains(result, "tell you when they have completed") {
+		t.Errorf("Result doesn't contain continuation instruction: %q", result)
+	}
+}
+
+func TestHumanHandoffTool_Call_AllReasons(t *testing.T) {
+	validReasons := []string{
+		"authentication",
+		"captcha",
+		"verification_code",
+		"sensitive_operation",
+		"black_screen",
+		"ambiguous_situation",
+		"unsupported_action",
+		"stuck",
+		"other",
+	}
+
+	for _, reason := range validReasons {
+		t.Run(reason, func(t *testing.T) {
+			tool := NewHumanHandoffTool()
+
+			input := map[string]string{
+				"reason":  reason,
+				"details": "Test details for " + reason,
+			}
+			inputJSON, _ := json.Marshal(input)
+
+			ctx := context.Background()
+			result, err := tool.Call(ctx, string(inputJSON))
+
+			if err != nil {
+				t.Errorf("Call() error = %v, want nil for reason %q", err, reason)
+			}
+
+			if !strings.Contains(result, "HUMAN_HANDOFF_REQUESTED") {
+				t.Errorf("Result doesn't contain handoff marker for reason %q: %q", reason, result)
+			}
+		})
+	}
+}
+
+func TestHumanHandoffTool_Call_MissingReason(t *testing.T) {
+	tool := NewHumanHandoffTool()
+
+	input := `{
+		"details": "Some details"
+	}`
+
+	ctx := context.Background()
+	_, err := tool.Call(ctx, input)
+
+	if err == nil {
+		t.Error("Call() error = nil, want error for missing reason")
+	}
+
+	if !strings.Contains(err.Error(), "reason") {
+		t.Errorf("Error message doesn't mention reason: %v", err)
+	}
+}
+
+func TestHumanHandoffTool_Call_MissingDetails(t *testing.T) {
+	tool := NewHumanHandoffTool()
+
+	input := `{
+		"reason": "authentication"
+	}`
+
+	ctx := context.Background()
+	_, err := tool.Call(ctx, input)
+
+	if err == nil {
+		t.Error("Call() error = nil, want error for missing details")
+	}
+
+	if !strings.Contains(err.Error(), "details") {
+		t.Errorf("Error message doesn't mention details: %v", err)
+	}
+}
+
+func TestHumanHandoffTool_Call_InvalidReason(t *testing.T) {
+	tool := NewHumanHandoffTool()
+
+	input := `{
+		"reason": "invalid_reason",
+		"details": "Some details"
+	}`
+
+	ctx := context.Background()
+	_, err := tool.Call(ctx, input)
+
+	if err == nil {
+		t.Error("Call() error = nil, want error for invalid reason")
+	}
+
+	if !strings.Contains(err.Error(), "invalid reason") {
+		t.Errorf("Error message doesn't indicate invalid reason: %v", err)
+	}
+}
+
+func TestHumanHandoffTool_Call_InvalidJSON(t *testing.T) {
+	tool := NewHumanHandoffTool()
+
+	input := `not valid json`
+
+	ctx := context.Background()
+	_, err := tool.Call(ctx, input)
+
+	if err == nil {
+		t.Error("Call() error = nil, want error for invalid JSON")
+	}
+}
+
+func TestHumanHandoffTool_Call_OptionalFields(t *testing.T) {
+	tool := NewHumanHandoffTool()
+
+	input := `{
+		"reason": "stuck",
+		"details": "Unable to proceed"
+	}`
+
+	ctx := context.Background()
+	result, err := tool.Call(ctx, input)
+
+	if err != nil {
+		t.Fatalf("Call() error = %v, want nil", err)
+	}
+
+	if !strings.Contains(result, "HUMAN_HANDOFF_REQUESTED") {
+		t.Errorf("Result doesn't contain handoff marker: %q", result)
+	}
+
+	// Should have default instruction when no suggested_action is provided
+	if !strings.Contains(result, "Tell the user") {
+		t.Errorf("Result doesn't contain default instruction: %q", result)
+	}
+}
+
+func TestHumanHandoffTool_Call_DefaultInstructions(t *testing.T) {
+	tests := []struct {
+		reason           string
+		expectedPhrase   string
+	}{
+		{"authentication", "enter their credentials"},
+		{"captcha", "complete the verification"},
+		{"verification_code", "complete the verification"},
+		{"sensitive_operation", "review and confirm"},
+		{"black_screen", "manually complete the action"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.reason, func(t *testing.T) {
+			tool := NewHumanHandoffTool()
+
+			input := map[string]string{
+				"reason":  tt.reason,
+				"details": "Test details",
+			}
+			inputJSON, _ := json.Marshal(input)
+
+			ctx := context.Background()
+			result, err := tool.Call(ctx, string(inputJSON))
+
+			if err != nil {
+				t.Fatalf("Call() error = %v, want nil", err)
+			}
+
+			if !strings.Contains(result, tt.expectedPhrase) {
+				t.Errorf("Result for %q doesn't contain expected phrase %q: %q",
+					tt.reason, tt.expectedPhrase, result)
+			}
+		})
+	}
+}
+
+func TestHumanHandoffTool_Call_ReturnsImmediately(t *testing.T) {
+	tool := NewHumanHandoffTool()
+
+	input := `{
+		"reason": "authentication",
+		"details": "Test handoff",
+		"suggested_action": "Test action"
+	}`
+
+	ctx := context.Background()
+
+	// Should return immediately without blocking
+	result, err := tool.Call(ctx, input)
+
+	if err != nil {
+		t.Fatalf("Call() error = %v, want nil", err)
+	}
+
+	if result == "" {
+		t.Error("Call() returned empty result")
+	}
+
+	// Verify it contains instruction to wait for user
+	if !strings.Contains(result, "take a screenshot to verify") {
+		t.Errorf("Result doesn't mention verification after user confirms: %q", result)
+	}
+}

--- a/src/agent/internal/agent/tools_human_handoff_test.go
+++ b/src/agent/internal/agent/tools_human_handoff_test.go
@@ -136,6 +136,39 @@ func TestHumanHandoffTool_Call_MissingDetails(t *testing.T) {
 	}
 }
 
+func TestHumanHandoffTool_Call_WhitespaceOnlyRequiredFields(t *testing.T) {
+	tool := NewHumanHandoffTool()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantInErr string
+	}{
+		{
+			name:      "whitespace reason",
+			input:     `{"reason":"   ","details":"some details"}`,
+			wantInErr: "reason",
+		},
+		{
+			name:      "whitespace details",
+			input:     `{"reason":"authentication","details":"   "}`,
+			wantInErr: "details",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tool.Call(context.Background(), tt.input)
+			if err == nil {
+				t.Fatalf("Call() error = nil, want validation error")
+			}
+			if !strings.Contains(err.Error(), tt.wantInErr) {
+				t.Errorf("Error message doesn't mention %q: %v", tt.wantInErr, err)
+			}
+		})
+	}
+}
+
 func TestHumanHandoffTool_Call_InvalidReason(t *testing.T) {
 	tool := NewHumanHandoffTool()
 
@@ -196,8 +229,8 @@ func TestHumanHandoffTool_Call_OptionalFields(t *testing.T) {
 
 func TestHumanHandoffTool_Call_DefaultInstructions(t *testing.T) {
 	tests := []struct {
-		reason           string
-		expectedPhrase   string
+		reason         string
+		expectedPhrase string
 	}{
 		{"authentication", "enter their credentials"},
 		{"captcha", "complete the verification"},


### PR DESCRIPTION
## 概述

将 Human Handoff（人工接管）功能从**阻塞回调模式**重构为**非阻塞的对话流程模式**，更适合语音连续对话场景。

## 核心变化

### 之前（阻塞模式）
- 需要实现 `HumanHandoffCallback` 回调函数
- 工具调用阻塞，等待回调返回
- 适合脚本式一次性任务执行（类似 Open-AutoGLM）

```go
callback := func(ctx context.Context, request HumanHandoffRequest) error {
    fmt.Println("请完成操作...")
    fmt.Scanln(&input)  // 阻塞等待
    return nil
}
toolSet := agent.NewBuiltinToolSet(..., WithHumanHandoffCallback(callback))
```

### 现在（非阻塞模式）
- 工具立即返回指令，不阻塞
- Agent 通过自然对话告知用户需要做什么
- 等待用户下一轮对话确认
- 适合连续语音/文本对话场景

```go
// 无需回调，工具自动注册
toolSet := agent.NewBuiltinToolSet(...)
```

## 交互流程示例

### 语音对话模式

**Turn 1 - Agent 请求接管**:
```
用户 (语音): "帮我登录微信"
Agent: [截图分析] → [判断需要密码] → [调用 request_human_handoff]
       Tool 返回: "HUMAN_HANDOFF_REQUESTED. Tell user to enter password..."
Agent (TTS): "我需要你的帮助。微信登录需要输入密码。请在屏幕上输入你的密码并点击登录。完成后告诉我'继续'。"
[对话轮次结束，等待用户]
```

**用户操作**:
```
[用户在手机上输入密码，点击登录]
```

**Turn 2 - 用户确认完成**:
```
用户 (语音): "好了" / "继续" / "我登录完了"
Agent: [截图验证]
Agent (TTS): "很好，我看到已经成功登录了。现在我帮你..."
[继续执行后续任务]
```

## 代码改动

### 移除
- ❌ `HumanHandoffCallback` 回调函数接口
- ❌ `HandoffManager` 并发管理器  
- ❌ `WithHumanHandoffCallback` 配置选项
- ❌ 阻塞等待逻辑
- ❌ `tools_human_handoff_integration_test.go`（基于阻塞模式的测试）

### 保留
- ✅ 9 种场景分类（authentication、captcha、sensitive_operation 等）
- ✅ 参数验证逻辑
- ✅ 完整的单元测试（已适配非阻塞模式）

### 新增
- ✨ 工具返回明确的指令给 Agent
- ✨ 根据不同场景提供默认指导语
- ✨ 提示 Agent 在用户确认后截图验证
- 📝 完整的文档说明对话流程

## 为什么需要这个改动？

### 问题
原本的阻塞模式在工具调用中等待回调返回，这在**语音连续对话**场景下体验不佳：
- Agent 无法输出任何内容（卡在工具调用中）
- 用户不知道发生了什么
- 不符合自然对话流程

### 解决方案
采用 Claude 式的对话流程：
- Agent 调用工具获得指令
- Agent 将指令转化为对用户的语音/文本提示
- 对话轮次自然结束
- 等待用户下一条消息
- 用户确认后开启新轮次，Agent 验证结果并继续

就像人与人对话一样自然！

## 测试

✅ 所有 11 个单元测试通过
```bash
cd src/agent/internal/agent
go test -v -run TestHumanHandoff
```

## 适用场景

| 场景 | 示例 |
|------|------|
| **认证** | 登录需要密码、多因素认证 |
| **验证码** | 图形验证码、短信验证码 |
| **敏感操作** | 支付确认、银行转账 |
| **黑屏** | 银行应用防截屏保护 |
| **卡住** | 多次尝试后无法继续 |

## 文档

- 📝 `docs/04-agent/human-handoff.md` - 完整的功能说明、集成指南、场景示例

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Human Handoff flow so the agent can request human intervention (authentication, CAPTCHA, verification, sensitive actions, ambiguous/unsupported/stuck cases). The agent issues a human-request prompt, returns immediately, then waits for user confirmation before continuing.

* **Documentation**
  * Added a comprehensive guide with integration notes, interaction examples, and scenario walkthroughs.

* **Tests**
  * Added extensive test coverage validating handoff prompts, validation, defaults, and wait-for-user behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->