### PR TITLE
fix(agent): improve TTS reliability and add memory summary diagnostics

### DIFF
--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -14,7 +14,7 @@ import (
 
 type TurnInput = AudioInputResult
 
-const toolDescriptionSpeechTimeout = 5 * time.Second
+const toolDescriptionSpeechTimeout = 15 * time.Second
 
 var (
 	recordingStartRetryTimeout  = 5 * time.Second

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -197,7 +197,7 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 	extractionCfg := LoadMemoryExtractionConfig(cfg.ConfigDir)
 	modelManager := NewModelManager(cfg.Model, proxy)
 	summarizeFn := buildLLMSummarizeFn(modelManager)
-	structuredSummarizeFn := buildLLMStructuredSummarizeFn(modelManager)
+	structuredSummarizeFn := buildLLMStructuredSummarizeFn(modelManager, logger)
 	profileFn := buildLLMProfileFn(modelManager)
 	contextWindowFn := func() int { return modelManager.Spec().ContextWindow }
 
@@ -1015,10 +1015,13 @@ const (
 	structuredSummaryMaxSummaryRune = 480
 )
 
-func buildLLMStructuredSummarizeFn(models ModelResolver) StructuredSummarizeFn {
+func buildLLMStructuredSummarizeFn(models ModelResolver, logger *Logger) StructuredSummarizeFn {
 	return func(ctx context.Context, events []SessionEvent) ChunkStructuredSummary {
 		model, err := models.Get()
 		if err != nil {
+			if logger != nil {
+				logger.Warn("[memory] structured summary: failed to get model: %v", err)
+			}
 			return ChunkStructuredSummary{}
 		}
 		var transcript strings.Builder
@@ -1034,10 +1037,16 @@ func buildLLMStructuredSummarizeFn(models ModelResolver) StructuredSummarizeFn {
 		}
 		result, err := llms.GenerateFromSinglePrompt(ctx, model, structuredSummarizerPrompt+transcript.String(), llms.WithMaxTokens(800))
 		if err != nil {
+			if logger != nil {
+				logger.Warn("[memory] structured summary: LLM generation failed: %v", err)
+			}
 			return ChunkStructuredSummary{}
 		}
 		structured, err := parseChunkStructuredSummaryJSON(result)
 		if err != nil {
+			if logger != nil {
+				logger.Warn("[memory] structured summary: JSON parse failed: %v", err)
+			}
 			return ChunkStructuredSummary{}
 		}
 		return structured

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -521,7 +521,7 @@ func TestBuildLLMStructuredSummarizeFnParsesStrictJSON(t *testing.T) {
 		"risks_or_pitfalls":["不要替换主模型"],
 		"memory_candidates":["语音模型和 VLM 分离配置"]
 	}`}}}}}
-	fn := buildLLMStructuredSummarizeFn(&testModelResolver{model: model})
+	fn := buildLLMStructuredSummarizeFn(&testModelResolver{model: model}, nil)
 	got := fn(context.Background(), []SessionEvent{{Role: "user", Content: "测试 MiniCPM"}})
 	if got.Summary != "讨论 MiniCPM 局域网 VLM" {
 		t.Fatalf("summary = %q", got.Summary)
@@ -533,7 +533,7 @@ func TestBuildLLMStructuredSummarizeFnParsesStrictJSON(t *testing.T) {
 
 func TestBuildLLMStructuredSummarizeFnFallsBackOnInvalidJSON(t *testing.T) {
 	model := &scriptedModel{responses: []*llms.ContentResponse{{Choices: []*llms.ContentChoice{{Content: `not json`}}}}}
-	fn := buildLLMStructuredSummarizeFn(&testModelResolver{model: model})
+	fn := buildLLMStructuredSummarizeFn(&testModelResolver{model: model}, nil)
 	got := fn(context.Background(), []SessionEvent{{Role: "user", Content: "hello"}})
 	if !got.Empty() {
 		t.Fatalf("expected empty structured summary on invalid JSON, got %#v", got)

--- a/src/agent/internal/agent/tts_helpers.go
+++ b/src/agent/internal/agent/tts_helpers.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"strings"
+	"time"
 
 	"aiden-agent/internal/agent/tts"
 )
@@ -138,18 +139,73 @@ func speakWithTTSManager(ctx context.Context, manager *tts.ProviderManager, audi
 	if text == "" || manager == nil || audio == nil {
 		return false, nil
 	}
-	stream, err := beginManagedTTSStream(ctx, manager, audio, cfg)
-	if err != nil {
-		return false, err
+
+	// Retry transient network errors
+	maxRetries := 2
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			// Short backoff between retries
+			select {
+			case <-ctx.Done():
+				return false, ctx.Err()
+			case <-time.After(time.Duration(attempt) * 500 * time.Millisecond):
+			}
+		}
+
+		stream, err := beginManagedTTSStream(ctx, manager, audio, cfg)
+		if err != nil {
+			lastErr = err
+			if isTransientTTSError(err) && attempt < maxRetries {
+				continue
+			}
+			return false, err
+		}
+
+		if _, err := stream.Write([]byte(text)); err != nil {
+			_ = stream.closeAndWait()
+			lastErr = err
+			if isTransientTTSError(err) && attempt < maxRetries {
+				continue
+			}
+			return false, err
+		}
+
+		if err := stream.closeAndWait(); err != nil {
+			lastErr = err
+			if isTransientTTSError(err) && attempt < maxRetries {
+				continue
+			}
+			return false, err
+		}
+
+		return stream.spoke, nil
 	}
-	if _, err := stream.Write([]byte(text)); err != nil {
-		_ = stream.closeAndWait()
-		return false, err
+	return false, lastErr
+}
+
+// isTransientTTSError checks if an error is transient and should be retried.
+func isTransientTTSError(err error) bool {
+	if err == nil {
+		return false
 	}
-	if err := stream.closeAndWait(); err != nil {
-		return false, err
+	msg := strings.ToLower(err.Error())
+	for _, fragment := range []string{
+		"connection refused",
+		"connection reset by peer",
+		"broken pipe",
+		"temporary failure",
+		"temporarily unavailable",
+		"i/o timeout",
+		"eof",
+		"dial tcp",
+		"context deadline exceeded",
+	} {
+		if strings.Contains(msg, fragment) {
+			return true
+		}
 	}
-	return stream.spoke, nil
+	return false
 }
 
 // lookupCredentials does a case-insensitive map lookup so users don't have to


### PR DESCRIPTION
1. Add retry logic for transient TTS network errors
   - Retry up to 2 times with 500ms backoff
   - Handle connection reset, timeout, and dial errors
   - Improves reliability when TTS provider has intermittent issues

2. Increase TTS tool description timeout from 5s to 15s
   - Gives slow TTS providers (volcengine) more time to connect
   - Reduces false timeout errors during normal operation

3. Add detailed error logging for structured LLM summary
   - Log when model retrieval fails
   - Log when LLM generation fails
   - Log when JSON parsing fails
   - Helps diagnose "structured LLM summary failed, falling back" issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retry logic for text-to-speech on transient network errors.
  * Extended timeout for spoken tool descriptions.
  * Improved error handling in memory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->