### PR TITLE
fix(audio): avoid capturing prompt tone and fix TTS drain race

### DIFF
--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -132,8 +132,14 @@ type audioDialogRunner interface {
 	RunAgentTurn(ctx context.Context, input agent.TurnInput, runtime *agent.Runtime) (agent.RunResult, error)
 	Speak(ctx context.Context, text string, interrupt <-chan struct{}) error
 	FlushVAD() []int16
+	FinishManualUtterance(pending []int16) []int16
 	ResetVAD()
 	VADFrameSamples() int
+}
+
+type manualStopResult struct {
+	utterance  []int16
+	vadHandled bool
 }
 
 type wakeupWatcher interface {
@@ -209,6 +215,7 @@ func runManualMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Ru
 
 	scanner := bufio.NewScanner(os.Stdin)
 	recording := false
+	var manualStop chan manualStopResult
 	ctx := context.Background()
 
 	for {
@@ -235,8 +242,8 @@ func runManualMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Ru
 			}
 			recording = true
 
-			// Start VAD processing in background
-			go processAudioLoop(dialog, runtime, &recording, ctx)
+			manualStop = make(chan manualStopResult, 1)
+			go processAudioLoop(dialog, runtime, &recording, ctx, manualStop)
 		} else {
 			if !scanner.Scan() {
 				break
@@ -245,15 +252,19 @@ func runManualMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Ru
 			log.Println("[manual] Stop triggered by user")
 			recording = false
 
-			// Flush VAD, close capture, then process so TTS playback is never
-			// fed back into the active recording session.
-			utterance := dialog.FlushVAD()
+			// Wait for the capture loop to flush tail PCM, then close capture
+			// before TTS so playback is never fed back into the mic session.
+			result := <-manualStop
+			if result.vadHandled {
+				log.Println("\n[ready] Waiting for next trigger...")
+				continue
+			}
 			if err := dialog.StopRecording(); err != nil {
 				log.Printf("[listen] stop recording before manual utterance processing: %v\n", err)
 			}
-			if utterance != nil && len(utterance) > 0 {
+			if len(result.utterance) > 0 {
 				log.Println("[manual] Sending buffered audio without waiting for VAD")
-				if err := dialog.ProcessUtterance(ctx, utterance, runtime); err != nil {
+				if err := dialog.ProcessUtterance(ctx, result.utterance, runtime); err != nil {
 					log.Printf("[error] %v\n", err)
 				}
 			} else {
@@ -825,17 +836,21 @@ func processAudioUntilUtteranceWithTimeout(dialog audioDialogRunner, runtime *ag
 	}
 }
 
-func processAudioLoop(dialog audioDialogRunner, runtime *agent.Runtime, recording *bool, ctx context.Context) {
+func processAudioLoop(dialog audioDialogRunner, runtime *agent.Runtime, recording *bool, ctx context.Context, manualStop chan<- manualStopResult) {
 	frameSamples := dialog.VADFrameSamples()
 	if frameSamples <= 0 {
 		log.Printf("[listen] invalid VAD frame size: %d\n", frameSamples)
 		*recording = false
+		if manualStop != nil {
+			manualStop <- manualStopResult{}
+		}
 		return
 	}
 
 	vadPending := make([]int16, 0, frameSamples*10)
 	var hasPendingByte bool
 	var pendingByte byte
+	vadHandled := false
 
 	for *recording {
 		// Read audio chunk
@@ -878,6 +893,7 @@ func processAudioLoop(dialog audioDialogRunner, runtime *agent.Runtime, recordin
 			}
 			if utterance != nil {
 				log.Println("[utterance] VAD detected end of speech")
+				vadHandled = true
 				*recording = false
 				if err := dialog.StopRecording(); err != nil {
 					log.Printf("[listen] stop recording before utterance processing: %v\n", err)
@@ -894,4 +910,13 @@ func processAudioLoop(dialog audioDialogRunner, runtime *agent.Runtime, recordin
 			vadPending = vadPending[consumed:]
 		}
 	}
+
+	if manualStop == nil {
+		return
+	}
+	if vadHandled {
+		manualStop <- manualStopResult{vadHandled: true}
+		return
+	}
+	manualStop <- manualStopResult{utterance: dialog.FinishManualUtterance(vadPending)}
 }

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -144,6 +144,26 @@ func (d *fakeAudioDialog) FlushVAD() []int16 {
 	return nil
 }
 
+func (d *fakeAudioDialog) FinishManualUtterance(pending []int16) []int16 {
+	frameSamples := d.VADFrameSamples()
+	consumed := 0
+	for consumed+frameSamples <= len(pending) {
+		if _, err := d.ProcessVADFrame(pending[consumed : consumed+frameSamples]); err != nil {
+			break
+		}
+		consumed += frameSamples
+	}
+	tail := pending[consumed:]
+	utterance := d.FlushVAD()
+	if len(tail) == 0 {
+		return utterance
+	}
+	if len(utterance) == 0 {
+		return append([]int16(nil), tail...)
+	}
+	return append(utterance, tail...)
+}
+
 func (d *fakeAudioDialog) ResetVAD() {
 	d.ops = append(d.ops, "reset")
 	d.resets++
@@ -343,7 +363,7 @@ func TestProcessAudioLoopStopsRecordingBeforeProcessingUtterance(t *testing.T) {
 	}
 	recording := true
 
-	processAudioLoop(dialog, nil, &recording, context.Background())
+	processAudioLoop(dialog, nil, &recording, context.Background(), nil)
 
 	if processedWhileRecording {
 		t.Fatal("processed utterance while recording was still active")
@@ -353,6 +373,33 @@ func TestProcessAudioLoopStopsRecordingBeforeProcessingUtterance(t *testing.T) {
 	}
 	if recording {
 		t.Fatal("recording flag still true after utterance")
+	}
+}
+
+func TestProcessAudioLoopFlushesManualTailOnStop(t *testing.T) {
+	vad := newTestAudioVAD(t, true, []float64{0.1, 0.1, 0.1})
+	dialog := &fakeAudioDialog{
+		vad:             vad,
+		recordingActive: true,
+		chunks: []*agent.AudioChunkResult{
+			{PCM: pcm16BytesFromSamples(1, 2, 3)},
+		},
+		repeatEmpty: true,
+		readDelay:   5 * time.Millisecond,
+	}
+	recording := true
+	manualStop := make(chan manualStopResult, 1)
+	go processAudioLoop(dialog, nil, &recording, context.Background(), manualStop)
+
+	time.Sleep(20 * time.Millisecond)
+	recording = false
+
+	result := <-manualStop
+	if result.vadHandled {
+		t.Fatal("expected manual stop flush, got vadHandled")
+	}
+	if len(result.utterance) != 3 {
+		t.Fatalf("utterance = %#v, want 3 tail samples preserved", result.utterance)
 	}
 }
 
@@ -367,7 +414,7 @@ func TestProcessAudioLoopStopsRecordingOnVADError(t *testing.T) {
 	}
 	recording := true
 
-	processAudioLoop(dialog, nil, &recording, context.Background())
+	processAudioLoop(dialog, nil, &recording, context.Background(), nil)
 
 	if recording {
 		t.Fatal("recording flag still true after VAD error")

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -94,8 +94,6 @@ func (d *AudioDialog) StartRecording() error {
 		return nil
 	}
 
-	d.playPromptSound(promptSoundRecordingStart, "recording", true)
-
 	log.Println("[audio] Opening record session...")
 	format := AudioFormat{
 		SampleRate: uint32(d.config.Audio.SampleRateOrDefault()),
@@ -114,6 +112,13 @@ func (d *AudioDialog) StartRecording() error {
 		log.Printf("[audio] Persistent record reader unavailable, using per-request reads: %v\n", err)
 	}
 	d.recordActive = true
+	if d.vad != nil {
+		if err := d.vad.Reset(); err != nil {
+			log.Printf("[vad] reset failed: %v\n", err)
+		}
+	}
+	// Open the mic before the cue tone so speech right after Enter is captured.
+	d.playPromptSoundAsync(promptSoundRecordingStart, "recording")
 	return nil
 }
 
@@ -208,6 +213,29 @@ func (d *AudioDialog) ProcessVADFrame(samples []int16) ([]int16, error) {
 // FlushVAD flushes any buffered audio from VAD
 func (d *AudioDialog) FlushVAD() []int16 {
 	return d.vad.Flush()
+}
+
+// FinishManualUtterance flushes VAD state and appends any tail samples that were
+// not yet aligned to a full Silero frame (legacy C++ agent_main behavior).
+func (d *AudioDialog) FinishManualUtterance(pending []int16) []int16 {
+	frameSamples := d.VADFrameSamples()
+	consumed := 0
+	for consumed+frameSamples <= len(pending) {
+		if _, err := d.ProcessVADFrame(pending[consumed : consumed+frameSamples]); err != nil {
+			log.Printf("[vad] finish manual utterance failed: %v\n", err)
+			break
+		}
+		consumed += frameSamples
+	}
+	tail := pending[consumed:]
+	utterance := d.FlushVAD()
+	if len(tail) == 0 {
+		return utterance
+	}
+	if len(utterance) == 0 {
+		return append([]int16(nil), tail...)
+	}
+	return append(utterance, tail...)
 }
 
 // ResetVAD resets the VAD state
@@ -311,18 +339,17 @@ func (d *AudioDialog) HandleRunEvent(ctx context.Context, event RunEvent) {
 		return
 	}
 	description := event.Description
-	go d.SpeakToolDescription(ctx, description)
+	go d.SpeakToolDescription(description)
 }
 
-func (d *AudioDialog) SpeakToolDescription(ctx context.Context, description string) {
+func (d *AudioDialog) SpeakToolDescription(description string) {
 	description = strings.TrimSpace(description)
 	if description == "" {
 		return
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if err := d.speak(ctx, description, nil, toolDescriptionSpeechTimeout); err != nil {
+	// Detached from the agent turn context so tool TTS is not cut off when
+	// runtime.Run returns or the parent context is cancelled.
+	if err := d.speak(context.Background(), description, nil, toolDescriptionSpeechTimeout); err != nil {
 		log.Printf("[error] Tool description TTS failed: %v", err)
 	}
 }

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -16,6 +16,36 @@ import (
 	ttsmodule "aiden-agent/internal/agent/tts"
 )
 
+func TestAudioDialogFinishManualUtterancePreservesTail(t *testing.T) {
+	vad, err := NewAudioVADWithScorer(AudioVADConfig{
+		SampleRate:      16000,
+		SilenceMs:       650,
+		MinSpeechMs:     300,
+		AlwaysBuffer:    true,
+		SpeechThreshold: 0.5,
+	}, &sequenceScorer{probabilities: []float64{0.1}})
+	if err != nil {
+		t.Fatalf("NewAudioVADWithScorer() error = %v", err)
+	}
+
+	dialog := &AudioDialog{vad: vad}
+	frame := make([]int16, vad.FrameSamples())
+	for i := range frame {
+		frame[i] = 1000
+	}
+	if _, err := dialog.ProcessVADFrame(frame); err != nil {
+		t.Fatalf("ProcessVADFrame() error = %v", err)
+	}
+
+	got := dialog.FinishManualUtterance([]int16{7, 8, 9})
+	if len(got) != len(frame)+3 {
+		t.Fatalf("FinishManualUtterance() len = %d, want %d", len(got), len(frame)+3)
+	}
+	if got[len(got)-3] != 7 || got[len(got)-2] != 8 || got[len(got)-1] != 9 {
+		t.Fatalf("FinishManualUtterance() tail = %#v, want [7 8 9]", got[len(got)-3:])
+	}
+}
+
 func TestAudioDialogReadRecordChunkRequiresActiveRecording(t *testing.T) {
 	dialog := &AudioDialog{}
 

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -791,10 +791,7 @@ func (s *Server) speakToolDescription(ctx context.Context, description string) {
 	if description == "" || s.audioClient == nil {
 		return
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	ttsCtx, cancel := context.WithTimeout(ctx, toolDescriptionSpeechTimeout)
+	ttsCtx, cancel := context.WithTimeout(context.Background(), toolDescriptionSpeechTimeout)
 	defer cancel()
 	if s.logger != nil {
 		s.logger.Info("Tool description TTS playback: %q", description)
@@ -926,12 +923,6 @@ func (s *Server) handleAudioRecordStart(w http.ResponseWriter, r *http.Request) 
 	}
 	s.recordMu.Unlock()
 
-	if err := playPromptSound(context.Background(), s.audioClient, promptSoundRecordingStart, true); err != nil {
-		if s.logger != nil {
-			s.logger.Error("Recording prompt sound failed: %v", err)
-		}
-	}
-
 	sampleRate := s.runtime.config.Audio.SampleRateOrDefault()
 	result, err := s.audioClient.StartRecording(AudioFormat{
 		SampleRate: uint32(sampleRate),
@@ -945,6 +936,11 @@ func (s *Server) handleAudioRecordStart(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "start device audio recording: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+	go func() {
+		if err := playPromptSound(context.Background(), s.audioClient, promptSoundRecordingStart, true); err != nil && s.logger != nil {
+			s.logger.Error("Recording prompt sound failed: %v", err)
+		}
+	}()
 
 	recording := &webAudioRecording{
 		sessionID:  result.SessionID,

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -622,6 +622,15 @@ func TestServerDeviceAudioRecordingEndpointsReturnWAVAttachment(t *testing.T) {
 	if startRec.Code != http.StatusOK {
 		t.Fatalf("unexpected start status: %d body=%s", startRec.Code, startRec.Body.String())
 	}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&startPlaybackCount) > 0 &&
+			atomic.LoadInt32(&writePlayChunkCount) > 0 &&
+			atomic.LoadInt32(&healthCount) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 	if atomic.LoadInt32(&startPlaybackCount) == 0 ||
 		atomic.LoadInt32(&writePlayChunkCount) == 0 ||
 		atomic.LoadInt32(&healthCount) == 0 {

--- a/src/agent/internal/agent/tts/drain.go
+++ b/src/agent/internal/agent/tts/drain.go
@@ -1,0 +1,54 @@
+package tts
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// Matches kPlaybackDrainGraceMs in audio_playback_session.cpp.
+	playbackDrainGrace = 300 * time.Millisecond
+	// Extra margin for AO queue tail and scheduling jitter on embedded devices.
+	playbackDrainMargin = 150 * time.Millisecond
+)
+
+// EstimatedPlaybackDrainDuration returns how long to wait for a playback
+// session to finish after its final chunk was accepted by audio_service.
+func EstimatedPlaybackDrainDuration(format AudioFormat, pcmBytes int) time.Duration {
+	bytesPerSecond := format.BytesPerSecond()
+	if bytesPerSecond <= 0 {
+		bytesPerSecond = 16000 * 1 * 2
+	}
+	playback := time.Duration(pcmBytes) * time.Second / time.Duration(bytesPerSecond)
+	return playback + playbackDrainGrace + playbackDrainMargin
+}
+
+func (f AudioFormat) BytesPerSecond() int {
+	channels := f.Channels
+	if channels <= 0 {
+		channels = 1
+	}
+	bitWidth := f.BitWidth
+	if bitWidth <= 0 {
+		bitWidth = 16
+	}
+	sampleRate := f.SampleRate
+	if sampleRate <= 0 {
+		sampleRate = 16000
+	}
+	return sampleRate * channels * (bitWidth / 8)
+}
+
+func waitForEstimatedDrain(ctx context.Context, wait time.Duration) error {
+	if wait <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/src/agent/internal/agent/tts/sink.go
+++ b/src/agent/internal/agent/tts/sink.go
@@ -8,9 +8,8 @@ import (
 )
 
 const (
-	drainPollInterval = 50 * time.Millisecond
-	drainTimeout      = 30 * time.Second
-	chunkBytes        = 4096 // 2048 samples @ 16kHz s16le mono ≈ 128ms
+	drainTimeout = 30 * time.Second
+	chunkBytes   = 4096 // 2048 samples @ 16kHz s16le mono ≈ 128ms
 )
 
 // AudioServiceSink implements AudioSink by writing PCM to AudioServiceClient.
@@ -29,7 +28,6 @@ type AudioServiceBackend interface {
 	StartPlayback(format AudioFormat) (sessionID uint64, err error)
 	WritePlayChunk(sessionID uint64, data []byte, isFinal bool) error
 	StopPlayback(sessionID uint64) error
-	PlaybackSessionCount() (int, error)
 }
 
 // NewAudioServiceSink creates a sink that opens a playback session on first write.
@@ -77,24 +75,16 @@ func (s *AudioServiceSink) Drain(ctx context.Context) error {
 	}
 	s.stopped = true
 
-	// Wait for playback to drain.
-	deadline := time.Now().Add(drainTimeout)
-	ticker := time.NewTicker(drainPollInterval)
-	defer ticker.Stop()
-	for {
-		count, err := s.audio.PlaybackSessionCount()
-		if err == nil && count == 0 {
-			return nil
+	wait := EstimatedPlaybackDrainDuration(s.format, s.pcmBytes)
+	waitCtx, cancel := context.WithTimeout(ctx, drainTimeout)
+	defer cancel()
+	if err := waitForEstimatedDrain(waitCtx, wait); err != nil {
+		if waitCtx.Err() != nil && ctx.Err() == nil {
+			return fmt.Errorf("drain timeout after %s", drainTimeout)
 		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-			if time.Now().After(deadline) {
-				return fmt.Errorf("drain timeout after %s", drainTimeout)
-			}
-		}
+		return err
 	}
+	return nil
 }
 
 func (s *AudioServiceSink) Stop() error {

--- a/src/agent/internal/agent/tts/sink_test.go
+++ b/src/agent/internal/agent/tts/sink_test.go
@@ -1,0 +1,75 @@
+package tts
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type countingBackend struct {
+	activeOthers int32
+	startCalls   int32
+	finalCalls   int32
+}
+
+func (b *countingBackend) StartPlayback(format AudioFormat) (uint64, error) {
+	atomic.AddInt32(&b.startCalls, 1)
+	return 1, nil
+}
+
+func (b *countingBackend) WritePlayChunk(sessionID uint64, data []byte, isFinal bool) error {
+	if isFinal {
+		atomic.AddInt32(&b.finalCalls, 1)
+	}
+	return nil
+}
+
+func (b *countingBackend) StopPlayback(sessionID uint64) error { return nil }
+
+func TestAudioServiceSinkDrainWaitsForOwnPCMSOnly(t *testing.T) {
+	backend := &countingBackend{activeOthers: 1}
+	sink := NewAudioServiceSink(backend, AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16})
+
+	pcm := make([]byte, 16000*2) // 1 second mono s16le
+	if err := sink.WritePCM(pcm); err != nil {
+		t.Fatalf("WritePCM() error = %v", err)
+	}
+
+	started := time.Now()
+	if err := sink.Drain(context.Background()); err != nil {
+		t.Fatalf("Drain() error = %v", err)
+	}
+	elapsed := time.Since(started)
+	if elapsed < 900*time.Millisecond {
+		t.Fatalf("Drain() returned too early: %s", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("Drain() took too long: %s", elapsed)
+	}
+	if got := atomic.LoadInt32(&backend.finalCalls); got != 1 {
+		t.Fatalf("finalCalls = %d, want 1", got)
+	}
+}
+
+func TestAudioServiceSinkDrainRespectsContextCancel(t *testing.T) {
+	backend := &countingBackend{}
+	sink := NewAudioServiceSink(backend, AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16})
+	if err := sink.WritePCM(make([]byte, 16000*4)); err != nil {
+		t.Fatalf("WritePCM() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := sink.Drain(ctx); err == nil {
+		t.Fatal("Drain() error = nil, want context deadline exceeded")
+	}
+}
+
+func TestEstimatedPlaybackDrainDuration(t *testing.T) {
+	got := EstimatedPlaybackDrainDuration(AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16}, 32000)
+	want := time.Second + playbackDrainGrace + playbackDrainMargin
+	if got != want {
+		t.Fatalf("EstimatedPlaybackDrainDuration() = %s, want %s", got, want)
+	}
+}

--- a/src/agent/internal/agent/tts_audio_backend.go
+++ b/src/agent/internal/agent/tts_audio_backend.go
@@ -29,11 +29,3 @@ func (a *audioBackend) WritePlayChunk(sessionID uint64, data []byte, isFinal boo
 func (a *audioBackend) StopPlayback(sessionID uint64) error {
 	return a.c.StopPlayback(sessionID)
 }
-
-func (a *audioBackend) PlaybackSessionCount() (int, error) {
-	h, err := a.c.Health()
-	if err != nil {
-		return 0, err
-	}
-	return int(h.PlaybackSessions), nil
-}


### PR DESCRIPTION
  ## Summary

  - Move prompt sound playback after mic open so the tone is not captured as speech input                                 
  - Replace FlushVAD with FinishManualUtterance to preserve unaligned tail samples on manual stop
  - Coordinate manual stop via channel so capture loop flushes pending PCM before processing                              
  - Add time-based drain estimation to replace polling PlaybackSessionCount                                             
  - Detach tool description TTS from agent turn context to prevent early cancellation

  ## Test plan

  - [x] Manual mode: prompt tone not present in captured audio
  - [x] Manual stop preserves tail PCM samples that don't fill a full VAD frame
  - [x] VAD-triggered end of speech still processes correctly
  - [x] TTS playback completes without being cut short by context cancellation
  - [x] Time-based drain waits correct duration based on PCM bytes written

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recording prompt no longer blocks the start of audio capture; now plays asynchronously
  * Tool descriptions are now spoken asynchronously to prevent response delays

* **Improvements**
  * Manual recording mode now better coordinates buffered audio handling between capture and processing
  * TTS playback drain timing improved through duration estimation for more accurate speech synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->