### PR TITLE
fix(vad): use PyTorch LSTM gate order

### DIFF
--- a/src/vad_common.h
+++ b/src/vad_common.h
@@ -547,9 +547,9 @@ public:
         }
         for (int i = 0; i < kHidden; ++i) {
             const float ig = sigmoid(gates_[i]);
-            const float og = sigmoid(gates_[kHidden + i]);
-            const float fg = sigmoid(gates_[2 * kHidden + i]);
-            const float cg = std::tanh(gates_[3 * kHidden + i]);
+            const float fg = sigmoid(gates_[kHidden + i]);
+            const float cg = std::tanh(gates_[2 * kHidden + i]);
+            const float og = sigmoid(gates_[3 * kHidden + i]);
             c_[i] = fg * c_[i] + ig * cg;
             h_[i] = og * std::tanh(c_[i]);
             relu_h_[i] = h_[i] > 0.0f ? h_[i] : 0.0f;

--- a/tests/vad_common_test.cpp
+++ b/tests/vad_common_test.cpp
@@ -99,3 +99,22 @@ TEST_CASE("SileroWeights rejects unknown SVLW versions with the version number")
 
     std::remove(path.c_str());
 }
+
+TEST_CASE("SileroLSTMDecoder uses PyTorch LSTMCell gate order") {
+    aiden_vad::RecurrentWeights weights;
+    weights.lstm_B[0] = 10.0f;                         // input gate
+    weights.lstm_B[aiden_vad::kHidden] = -10.0f;        // forget gate
+    weights.lstm_B[2 * aiden_vad::kHidden] = 1.0f;      // cell gate
+    weights.lstm_B[3 * aiden_vad::kHidden] = 10.0f;     // output gate
+    weights.dec_weight[0] = 10.0f;
+    weights.dec_bias = -5.0f;
+
+    aiden_vad::SileroLSTMDecoder decoder;
+    std::string err;
+    REQUIRE(decoder.init(&weights, &err));
+
+    std::vector<float> encoder_out(aiden_vad::kHidden, 0.0f);
+    const float probability = decoder.infer(encoder_out.data());
+
+    CHECK(probability > 0.5f);
+}


### PR DESCRIPTION
## Summary
- fix Silero LSTM decoder gate order to match PyTorch LSTMCell (`i, f, g, o`)
- add regression coverage for the decoder gate interpretation

## Verification
- `git diff --check`
- `ctest --test-dir build-host-tests --output-on-failure`
- Board 192.168.50.70: official 16 kHz speech sample via deployed `/oem/usr/bin/rknn_vad` produced max P≈0.999998 with 1437/1875 frames above 0.5
- Board 192.168.50.70: deployed `/oem/usr/bin/cpu_vad` produced max P≈0.999999 with 1452/1875 frames above 0.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected LSTM gate ordering in voice activity detection to match standard algorithm specifications, ensuring proper computation of internal state updates during inference and improving detection accuracy.

* **Tests**
  * Added verification test for LSTM gate order implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->