### PR TITLE
feat(agent): add human handoff guidance to planner role rules

### DIFF
--- a/src/agent/internal/agent/role_profile.go
+++ b/src/agent/internal/agent/role_profile.go
@@ -52,7 +52,7 @@ func buildRoleProfiles(cfg AgentConfig, skills ResolvedSkills, availableTools []
 				"Use the executor tool catalog when planning. If a direct executor tool covers the request, plan that tool instead of a UI workaround.",
 				"Keep objective and completion_criteria tied to the original user request, not just the current step.",
 				"If the current screenshot clearly identifies the app/page, include observed_state with app_name, page_name, visible_text, dialogs, and confidence; otherwise leave it empty.",
-				"If the task requires authentication (passwords, biometrics, Face ID), CAPTCHA or bot-detection challenges, SMS/email verification codes, payment or banking confirmation, or any action demanding human credentials or judgment that no available tool can fulfill, plan a request_human_handoff step with the appropriate reason and details. Do NOT attempt to work around these situations with UI automation — the user expects you to ask for help, not to guess or retry indefinitely.",
+				"Plan a request_human_handoff step when the task requires credentials, verification, or human judgment your tools cannot fulfill, or when the user refers to a target you cannot unambiguously identify from the screen. Do not guess.",
 				"You must NEVER call tools directly. Your role is planning only. Return planning decisions as JSON, not tool calls.",
 				"Return only JSON: {\"objective\":\"original task in one sentence\",\"completion_criteria\":[\"criterion\"],\"plan\":[\"step\"],\"next_step\":\"step to execute now\",\"reason\":\"brief rationale\",\"observed_state\":{\"app_name\":\"\",\"page_name\":\"\",\"visible_text\":[],\"dialogs\":[],\"confidence\":0}}.",
 			},

--- a/src/agent/internal/agent/role_profile.go
+++ b/src/agent/internal/agent/role_profile.go
@@ -52,6 +52,7 @@ func buildRoleProfiles(cfg AgentConfig, skills ResolvedSkills, availableTools []
 				"Use the executor tool catalog when planning. If a direct executor tool covers the request, plan that tool instead of a UI workaround.",
 				"Keep objective and completion_criteria tied to the original user request, not just the current step.",
 				"If the current screenshot clearly identifies the app/page, include observed_state with app_name, page_name, visible_text, dialogs, and confidence; otherwise leave it empty.",
+				"If the task requires authentication (passwords, biometrics, Face ID), CAPTCHA or bot-detection challenges, SMS/email verification codes, payment or banking confirmation, or any action demanding human credentials or judgment that no available tool can fulfill, plan a request_human_handoff step with the appropriate reason and details. Do NOT attempt to work around these situations with UI automation — the user expects you to ask for help, not to guess or retry indefinitely.",
 				"You must NEVER call tools directly. Your role is planning only. Return planning decisions as JSON, not tool calls.",
 				"Return only JSON: {\"objective\":\"original task in one sentence\",\"completion_criteria\":[\"criterion\"],\"plan\":[\"step\"],\"next_step\":\"step to execute now\",\"reason\":\"brief rationale\",\"observed_state\":{\"app_name\":\"\",\"page_name\":\"\",\"visible_text\":[],\"dialogs\":[],\"confidence\":0}}.",
 			},


### PR DESCRIPTION
## 问题

`request_human_handoff` 工具已正确实现并注册，但 Planner 角色从未被指示将其作为一种策略来考虑。当遇到身份验证、CAPTCHA、验证码或敏感操作时，Planner 会盲目规划 UI 自动化步骤——无限重试而不是请求人工帮助。

## 改动

在 Planner 的 role rules 中新增一条规则，明确指出哪些场景应该规划 `request_human_handoff` 步骤，并强调不要用 UI 自动化变通方案绕过这些场景。

## 改动文件

- `src/agent/internal/agent/role_profile.go`: +1 行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent now escalates tasks requiring authentication, CAPTCHA, payment confirmation, identity verification, or other human judgment to human handlers instead of attempting automated workarounds.
* **Enhancement**
  * Agent will trigger a human-handoff when the user's target is ambiguous and will avoid guessing user intent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->