### PR TITLE
feat(agent): persist chat history with episode traces

### DIFF
--- a/src/agent/internal/agent/chat_history.go
+++ b/src/agent/internal/agent/chat_history.go
@@ -1,0 +1,180 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const maxChatHistoryContentRunes = 8000
+
+type ChatHistoryStore struct {
+	mu      sync.Mutex
+	rootDir string
+}
+
+func NewChatHistoryStore(rootDir string) *ChatHistoryStore {
+	if strings.TrimSpace(rootDir) == "" {
+		return nil
+	}
+	return &ChatHistoryStore{rootDir: rootDir}
+}
+
+func (s *ChatHistoryStore) Append(ctx context.Context, message Message) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	if s == nil || s.rootDir == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if message.Timestamp.IsZero() {
+		message.Timestamp = time.Now()
+	}
+	message = compactMessageForChatHistory(message)
+	if err := os.MkdirAll(s.rootDir, 0o755); err != nil {
+		return fmt.Errorf("create chat history directory: %w", err)
+	}
+	file, err := os.OpenFile(s.eventsPath(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open chat history events: %w", err)
+	}
+	defer file.Close()
+	if err := json.NewEncoder(file).Encode(message); err != nil {
+		return fmt.Errorf("append chat history event: %w", err)
+	}
+	return nil
+}
+
+func (s *ChatHistoryStore) Load(ctx context.Context) ([]Message, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	if s == nil || s.rootDir == "" {
+		return nil, nil
+	}
+	file, err := os.Open(s.eventsPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open chat history events: %w", err)
+	}
+	defer file.Close()
+
+	var messages []Message
+	validData := make([]byte, 0)
+	repairedTruncatedTail := false
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0), 8<<20)
+	for scanner.Scan() {
+		line := bytes.Trim(scanner.Bytes(), "\x00 \t\r\n")
+		if len(line) == 0 {
+			continue
+		}
+		var message Message
+		if err := json.Unmarshal(line, &message); err != nil {
+			if isTruncatedJSONLineError(err) {
+				repairedTruncatedTail = true
+				break
+			}
+			return nil, fmt.Errorf("decode chat history event: %w", err)
+		}
+		validData = append(validData, line...)
+		validData = append(validData, '\n')
+		messages = append(messages, message)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan chat history events: %w", err)
+	}
+	if repairedTruncatedTail {
+		_ = writeFileAtomic(s.eventsPath(), validData, 0o644)
+	}
+	return messages, nil
+}
+
+func (s *ChatHistoryStore) Clear() error {
+	if s == nil || s.rootDir == "" {
+		return nil
+	}
+	if err := os.RemoveAll(s.rootDir); err != nil {
+		return fmt.Errorf("remove chat history: %w", err)
+	}
+	return nil
+}
+
+func (s *ChatHistoryStore) eventsPath() string {
+	return filepath.Join(s.rootDir, "events.jsonl")
+}
+
+func compactMessageForChatHistory(message Message) Message {
+	if message.Type == "tool_result" {
+		message.Content = compactToolResultForChatHistory(message.Content)
+	}
+	message.Attachments = compactAttachmentsForChatHistory(message.Attachments)
+	message.Content = truncateChatHistoryRunes(message.Content, maxChatHistoryContentRunes)
+	message.ToolInput = truncateChatHistoryRunes(message.ToolInput, maxChatHistoryContentRunes)
+	message.Description = truncateChatHistoryRunes(message.Description, maxChatHistoryContentRunes)
+	return message
+}
+
+func compactAttachmentsForChatHistory(attachments []MessageAttachment) []MessageAttachment {
+	if len(attachments) == 0 {
+		return nil
+	}
+	out := make([]MessageAttachment, 0, len(attachments))
+	for _, attachment := range attachments {
+		attachment.Data = ""
+		out = append(out, attachment)
+	}
+	return out
+}
+
+func compactToolResultForChatHistory(content string) string {
+	var result postActionScreenshotResult
+	if err := json.Unmarshal([]byte(content), &result); err != nil || result.Data == "" {
+		return content
+	}
+	format := strings.TrimSpace(result.Format)
+	if format == "" {
+		format = "jpeg"
+	}
+	compact := map[string]interface{}{
+		"width":  result.Width,
+		"height": result.Height,
+		"format": format,
+		"size":   result.Size,
+	}
+	if strings.TrimSpace(result.ActionOutput) != "" {
+		compact["action_output"] = strings.TrimSpace(result.ActionOutput)
+	}
+	data, err := json.Marshal(compact)
+	if err != nil {
+		return content
+	}
+	return string(data)
+}
+
+func truncateChatHistoryRunes(value string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return value
+	}
+	runes := []rune(value)
+	if len(runes) <= maxRunes {
+		return value
+	}
+	return string(runes[:maxRunes]) + fmt.Sprintf("\n...[truncated %d chars]", len(runes)-maxRunes)
+}

--- a/src/agent/internal/agent/chat_history_memory.go
+++ b/src/agent/internal/agent/chat_history_memory.go
@@ -1,0 +1,281 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/tmc/langchaingo/schema"
+)
+
+const (
+	maxPlannerChatHistoryMessages     = 20
+	maxPlannerChatHistoryContentRunes = 1200
+	maxPlannerChatHistoryRunes        = 7000
+)
+
+type chatHistoryPlannerMemory struct {
+	inner schema.Memory
+	store *ChatHistoryStore
+}
+
+func newChatHistoryPlannerMemory(inner schema.Memory, store *ChatHistoryStore) schema.Memory {
+	if inner == nil || store == nil {
+		return inner
+	}
+	return &chatHistoryPlannerMemory{inner: inner, store: store}
+}
+
+func (m *chatHistoryPlannerMemory) GetMemoryKey(ctx context.Context) string {
+	return m.inner.GetMemoryKey(ctx)
+}
+
+func (m *chatHistoryPlannerMemory) MemoryVariables(ctx context.Context) []string {
+	return m.inner.MemoryVariables(ctx)
+}
+
+func (m *chatHistoryPlannerMemory) LoadMemoryVariables(ctx context.Context, inputs map[string]any) (map[string]any, error) {
+	values, err := m.inner.LoadMemoryVariables(ctx, inputs)
+	if err != nil {
+		return nil, err
+	}
+	messages, err := m.store.Load(ctx)
+	if err != nil {
+		return nil, err
+	}
+	extra := formatChatHistoryForPlanner(messages, currentInputFromMemoryInputs(inputs))
+	if strings.TrimSpace(extra) == "" {
+		return values, nil
+	}
+	if values == nil {
+		values = map[string]any{}
+	}
+	key := m.inner.GetMemoryKey(ctx)
+	existingValue, hasExisting := values[key]
+	existing, ok := existingValue.(string)
+	if hasExisting && !ok {
+		return values, nil
+	}
+	existing = strings.TrimSpace(existing)
+	if existing == "" {
+		values[key] = "Recent persisted chat history:\n" + extra
+	} else {
+		values[key] = existing + "\n\nRecent persisted chat history:\n" + extra
+	}
+	return values, nil
+}
+
+func (m *chatHistoryPlannerMemory) SaveContext(ctx context.Context, inputs map[string]any, outputs map[string]any) error {
+	return m.inner.SaveContext(ctx, inputs, outputs)
+}
+
+func (m *chatHistoryPlannerMemory) Clear(ctx context.Context) error {
+	return m.inner.Clear(ctx)
+}
+
+func chatHistoryStoreForConfigDir(configDir string) *ChatHistoryStore {
+	configDir = strings.TrimSpace(configDir)
+	if configDir == "" {
+		return nil
+	}
+	return NewChatHistoryStore(filepath.Join(configDir, "memory", "chat_history"))
+}
+
+func formatChatHistoryForPlanner(messages []Message, currentInput string) string {
+	if len(messages) == 0 {
+		return ""
+	}
+	currentInput = strings.TrimSpace(currentInput)
+	currentUserIndex := latestMatchingUserMessageIndex(messages, currentInput)
+
+	completedEpisodes := map[string]bool{}
+	for _, message := range messages {
+		if message.Type != "assistant" {
+			continue
+		}
+		if episodeID := strings.TrimSpace(message.EpisodeID); episodeID != "" {
+			completedEpisodes[episodeID] = true
+		}
+	}
+
+	var lines []string
+	for i, message := range messages {
+		if !chatHistoryMessageUsefulForPlanner(message, completedEpisodes) {
+			continue
+		}
+		if i == currentUserIndex {
+			continue
+		}
+		line := formatChatHistoryMessageLine(message)
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) > maxPlannerChatHistoryMessages {
+		lines = lines[len(lines)-maxPlannerChatHistoryMessages:]
+	}
+	return truncateChatHistoryRunes(strings.Join(lines, "\n"), maxPlannerChatHistoryRunes)
+}
+
+func latestMatchingUserMessageIndex(messages []Message, currentInput string) int {
+	if currentInput == "" {
+		return -1
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		message := messages[i]
+		if message.Type == "user" && strings.TrimSpace(message.Content) == currentInput {
+			return i
+		}
+	}
+	return -1
+}
+
+func chatHistoryMessageUsefulForPlanner(message Message, completedEpisodes map[string]bool) bool {
+	episodeID := strings.TrimSpace(message.EpisodeID)
+	switch message.Type {
+	case "episode_status":
+		return !strings.EqualFold(strings.TrimSpace(message.Status), "completed")
+	case "user", "role_output", "tool_call":
+		return episodeID != "" && !completedEpisodes[episodeID]
+	default:
+		return false
+	}
+}
+
+func formatChatHistoryMessageLine(message Message) string {
+	episodeSuffix := ""
+	if episodeID := strings.TrimSpace(message.EpisodeID); episodeID != "" {
+		episodeSuffix = " (episode " + episodeID + ")"
+	}
+	content := truncateChatHistoryRunes(strings.TrimSpace(message.Content), maxPlannerChatHistoryContentRunes)
+	switch message.Type {
+	case "episode_status":
+		status := strings.TrimSpace(message.Status)
+		if status == "" {
+			status = "unknown"
+		}
+		if content == "" {
+			content = "status=" + status
+		}
+		return "Task episode" + episodeSuffix + " [" + status + "]: " + singleLineHistoryText(content)
+	case "user":
+		if content == "" {
+			return ""
+		}
+		return "User" + episodeSuffix + ": " + singleLineHistoryText(content)
+	case "role_output":
+		role := strings.TrimSpace(message.Role)
+		if role == "" {
+			role = "role"
+		}
+		if content == "" {
+			return ""
+		}
+		return titleHistoryLabel(role) + episodeSuffix + ": " + singleLineHistoryText(content)
+	case "tool_call":
+		toolName := strings.TrimSpace(message.ToolName)
+		if toolName == "" {
+			toolName = "tool"
+		}
+		description := firstNonEmptyString([]string{message.Description, content, message.ToolInput})
+		if strings.TrimSpace(description) == "" {
+			return "Tool call" + episodeSuffix + ": " + toolName
+		}
+		return "Tool call" + episodeSuffix + ": " + toolName + " - " + singleLineHistoryText(truncateChatHistoryRunes(description, maxPlannerChatHistoryContentRunes))
+	default:
+		return ""
+	}
+}
+
+func currentInputFromMemoryInputs(inputs map[string]any) string {
+	if inputs == nil {
+		return ""
+	}
+	value, ok := inputs["input"]
+	if !ok {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func singleLineHistoryText(value string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+}
+
+func titleHistoryLabel(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	return strings.ToUpper(value[:1]) + value[1:]
+}
+
+func interruptedEpisodeStatusMessage(episode TaskEpisode) Message {
+	timestamp := time.Now()
+	if parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(episode.EndedAt)); err == nil {
+		timestamp = parsed
+	}
+	return Message{
+		Type:      "episode_status",
+		EpisodeID: episode.ID,
+		Status:    "interrupted",
+		Content:   interruptedEpisodeHistoryContent(episode),
+		Timestamp: timestamp,
+		IsError:   true,
+	}
+}
+
+func interruptedEpisodeHistoryContent(episode TaskEpisode) string {
+	var lines []string
+	episodeID := strings.TrimSpace(episode.ID)
+	if episodeID != "" {
+		lines = append(lines, "Task episode "+episodeID+" was interrupted before completion.")
+	} else {
+		lines = append(lines, "Task episode was interrupted before completion.")
+	}
+	if goal := strings.TrimSpace(episode.UserGoal); goal != "" {
+		lines = append(lines, "Goal: "+truncateChatHistoryRunes(goal, maxPlannerChatHistoryContentRunes))
+	}
+	if last := summarizeLastEpisodeEventForHistory(episode.Events); last != "" {
+		lines = append(lines, "Last recorded step: "+last)
+	}
+	reason := firstNonEmptyString([]string{episode.Outcome.FailureReason, firstNonEmptyString(episode.FailureCauses)})
+	if reason != "" {
+		lines = append(lines, "Reason: "+truncateChatHistoryRunes(reason, maxPlannerChatHistoryContentRunes))
+	}
+	if startedAt := strings.TrimSpace(episode.StartedAt); startedAt != "" {
+		lines = append(lines, "Started at: "+startedAt)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func summarizeLastEpisodeEventForHistory(events []TaskEpisodeEvent) string {
+	for i := len(events) - 1; i >= 0; i-- {
+		event := events[i]
+		if next := strings.TrimSpace(event.NextStep); next != "" {
+			return event.Type + " next_step=" + truncateChatHistoryRunes(next, maxPlannerChatHistoryContentRunes)
+		}
+		if toolName := strings.TrimSpace(event.ToolName); toolName != "" {
+			description := firstNonEmptyString([]string{event.ToolDescription, event.ToolInput, event.Observation})
+			if description == "" {
+				return event.Type + " tool=" + toolName
+			}
+			return event.Type + " tool=" + toolName + " detail=" + truncateChatHistoryRunes(description, maxPlannerChatHistoryContentRunes)
+		}
+		if content := strings.TrimSpace(event.Content); content != "" {
+			return event.Type + " content=" + truncateChatHistoryRunes(content, maxPlannerChatHistoryContentRunes)
+		}
+		if reason := strings.TrimSpace(event.Reason); reason != "" {
+			return event.Type + " reason=" + truncateChatHistoryRunes(reason, maxPlannerChatHistoryContentRunes)
+		}
+	}
+	return ""
+}

--- a/src/agent/internal/agent/chat_history_memory_test.go
+++ b/src/agent/internal/agent/chat_history_memory_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	langtools "github.com/tmc/langchaingo/tools"
+)
+
+func TestRuntimeStartupPersistsInterruptedEpisodeStatusToChatHistory(t *testing.T) {
+	ctx := context.Background()
+	configDir := t.TempDir()
+	memoryDir := filepath.Join(configDir, "memory")
+	store := NewTaskEpisodeStore(filepath.Join(memoryDir, "episodes"))
+	recorder := NewPersistentEpisodeRecorder(MemoryRetrieveRequest{
+		Input:     "打开设置",
+		EpisodeID: "ep_restart_context",
+	}, MemoryContext{}, store)
+
+	if err := recorder.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	recorder.RecordPlannerDecision(plannerDecision{
+		Objective: "打开设置",
+		Plan:      []string{"打开设置"},
+		NextStep:  "点击设置",
+	})
+
+	NewRuntimeWithDeps(
+		Config{ConfigDir: configDir, Model: ModelConfig{Provider: "fake"}},
+		&testModelResolver{model: &scriptedModel{}},
+		NewMemoryManager(memoryDir),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+
+	messages, err := NewChatHistoryStore(filepath.Join(memoryDir, "chat_history")).Load(ctx)
+	if err != nil {
+		t.Fatalf("Load chat history: %v", err)
+	}
+	status, ok := firstMessageOfType(messages, "episode_status")
+	if !ok {
+		t.Fatalf("missing episode_status in chat history: %#v", messages)
+	}
+	if status.EpisodeID != "ep_restart_context" || status.Status != "interrupted" {
+		t.Fatalf("unexpected episode status message: %#v", status)
+	}
+	for _, want := range []string{"打开设置", "点击设置", "agent restarted before the task episode completed"} {
+		if !strings.Contains(status.Content, want) {
+			t.Fatalf("episode status missing %q:\n%s", want, status.Content)
+		}
+	}
+}
+
+func TestRuntimeRunIncludesPersistedInterruptedEpisodeInPlannerHistory(t *testing.T) {
+	ctx := context.Background()
+	configDir := t.TempDir()
+	memoryDir := filepath.Join(configDir, "memory")
+	historyStore := NewChatHistoryStore(filepath.Join(memoryDir, "chat_history"))
+
+	if err := historyStore.Append(ctx, Message{
+		Type:      "user",
+		EpisodeID: "ep_resume_context",
+		Content:   "打开设置",
+	}); err != nil {
+		t.Fatalf("Append user history: %v", err)
+	}
+	if err := historyStore.Append(ctx, Message{
+		Type:      "episode_status",
+		EpisodeID: "ep_resume_context",
+		Status:    "interrupted",
+		Content:   "Task episode ep_resume_context was interrupted before completion.\nGoal: 打开设置\nLast recorded step: planner_decision next_step=点击设置",
+		IsError:   true,
+	}); err != nil {
+		t.Fatalf("Append episode status: %v", err)
+	}
+
+	model := &scriptedModel{responses: roleDirectResponses("继续完成")}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			ConfigDir:     configDir,
+			Model:         ModelConfig{Provider: "fake"},
+			Instruction:   "Answer directly.",
+			MaxIterations: 1,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(memoryDir),
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+
+	if _, err := runtime.Run(ctx, RunRequest{Input: "继续"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(model.messages) == 0 {
+		t.Fatalf("expected planner model call")
+	}
+	plannerPrompt := messageText(model.messages[0])
+	for _, want := range []string{"Recent persisted chat history", "ep_resume_context", "打开设置", "点击设置"} {
+		if !strings.Contains(plannerPrompt, want) {
+			t.Fatalf("planner prompt missing %q:\n%s", want, plannerPrompt)
+		}
+	}
+}

--- a/src/agent/internal/agent/chat_history_test.go
+++ b/src/agent/internal/agent/chat_history_test.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestChatHistoryStorePersistsLightweightMessages(t *testing.T) {
+	store := NewChatHistoryStore(t.TempDir())
+	ctx := context.Background()
+
+	if err := store.Append(ctx, Message{
+		Type:      "user",
+		Content:   "see attached",
+		Timestamp: time.Now(),
+		Attachments: []MessageAttachment{{
+			Kind:     AttachmentKindImage,
+			MIMEType: "image/png",
+			Data:     "large-base64",
+			Size:     12,
+		}},
+	}); err != nil {
+		t.Fatalf("Append user: %v", err)
+	}
+	if err := store.Append(ctx, Message{
+		Type:    "tool_result",
+		Content: `{"format":"jpeg","width":10,"height":20,"size":30,"data":"screenshot-base64"}`,
+	}); err != nil {
+		t.Fatalf("Append tool result: %v", err)
+	}
+
+	messages, err := store.Load(ctx)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("messages = %d, want 2", len(messages))
+	}
+	if messages[0].Attachments[0].Data != "" {
+		t.Fatalf("attachment data should be omitted: %#v", messages[0].Attachments[0])
+	}
+	if strings.Contains(messages[1].Content, "screenshot-base64") || strings.Contains(messages[1].Content, `"data"`) {
+		t.Fatalf("tool result screenshot data should be omitted: %s", messages[1].Content)
+	}
+}

--- a/src/agent/internal/agent/episode_exporter.go
+++ b/src/agent/internal/agent/episode_exporter.go
@@ -71,9 +71,7 @@ func (e *EpisodeExporter) ExportEpisodeDir(ctx context.Context, episodeDir strin
 		return fmt.Errorf("read episode events: %w", err)
 	}
 	stored.Events = events
-	if strings.TrimSpace(stored.ID) == "" {
-		stored.ID = episode.ID
-	}
+	stored = mergeEpisodeForExport(stored, episode)
 	var prompts []telemetryPromptCall
 	if len(promptCalls) > 0 {
 		prompts = promptCalls[0]
@@ -112,6 +110,50 @@ func (e *EpisodeExporter) ingestWithRetry(ctx context.Context, batch []langfuseI
 		}
 	}
 	return lastErr
+}
+
+func mergeEpisodeForExport(stored TaskEpisode, supplied TaskEpisode) TaskEpisode {
+	if strings.TrimSpace(stored.ID) == "" {
+		stored.ID = supplied.ID
+	}
+	if strings.TrimSpace(stored.Status) == "" {
+		stored.Status = supplied.Status
+	}
+	if strings.TrimSpace(stored.StartedAt) == "" {
+		stored.StartedAt = supplied.StartedAt
+	}
+	if strings.TrimSpace(stored.EndedAt) == "" {
+		stored.EndedAt = supplied.EndedAt
+	}
+	if strings.TrimSpace(stored.UserGoal) == "" {
+		stored.UserGoal = supplied.UserGoal
+	}
+	if len(stored.NormalizedGoal) == 0 {
+		stored.NormalizedGoal = cloneStringMap(supplied.NormalizedGoal)
+	}
+	if len(stored.DeviceScope) == 0 {
+		stored.DeviceScope = cloneStringMap(supplied.DeviceScope)
+	}
+	if len(stored.Tags) == 0 {
+		stored.Tags = append([]string(nil), supplied.Tags...)
+	} else if len(supplied.Tags) > 0 {
+		stored.Tags = uniqueNonEmpty(append(stored.Tags, supplied.Tags...))
+	}
+	if len(stored.Entities) == 0 {
+		stored.Entities = append([]string(nil), supplied.Entities...)
+	} else if len(supplied.Entities) > 0 {
+		stored.Entities = uniqueNonEmpty(append(stored.Entities, supplied.Entities...))
+	}
+	if len(stored.Events) == 0 {
+		stored.Events = append([]TaskEpisodeEvent(nil), supplied.Events...)
+	}
+	if stored.Extra == nil && supplied.Extra != nil {
+		stored.Extra = map[string]interface{}{}
+	}
+	for key, value := range supplied.Extra {
+		stored.Extra[key] = value
+	}
+	return stored
 }
 
 func (e *EpisodeExporter) buildLangfuseBatch(ctx context.Context, episode TaskEpisode, episodeDir string, promptCalls ...[]telemetryPromptCall) ([]langfuseIngestionEvent, error) {
@@ -791,6 +833,12 @@ func (e *EpisodeExporter) uploadScreenshot(ctx context.Context, traceID, observa
 func (e *EpisodeExporter) traceTags(episode TaskEpisode) []string {
 	tags := append([]string(nil), e.cfg.Tags...)
 	tags = append(tags, episode.Tags...)
+	if status := strings.TrimSpace(episode.Status); status != "" {
+		tags = append(tags, "status:"+status)
+		if status == "interrupted" {
+			tags = append(tags, "interrupted")
+		}
+	}
 	if model := extraString(episode.Extra, "model"); model != "" {
 		tags = append(tags, "model:"+model)
 	}
@@ -805,6 +853,9 @@ func (e *EpisodeExporter) traceTags(episode TaskEpisode) []string {
 func (e *EpisodeExporter) traceMetadata(episode TaskEpisode) map[string]interface{} {
 	meta := map[string]interface{}{
 		"episode_id":       episode.ID,
+		"status":           episode.Status,
+		"started_at":       episode.StartedAt,
+		"ended_at":         episode.EndedAt,
 		"normalized_goal":  episode.NormalizedGoal,
 		"device_scope":     episode.DeviceScope,
 		"failure_reason":   episode.Outcome.FailureReason,

--- a/src/agent/internal/agent/episode_exporter_test.go
+++ b/src/agent/internal/agent/episode_exporter_test.go
@@ -552,3 +552,140 @@ outcome:
 		t.Fatalf("media observationId = %q, want tool result id %q", mediaObservationID, toolResultID)
 	}
 }
+
+func TestRuntimeStartupExportsInterruptedEpisodeToLangfuse(t *testing.T) {
+	ctx := context.Background()
+	configDir := t.TempDir()
+	memoryDir := filepath.Join(configDir, "memory")
+	store := NewTaskEpisodeStore(filepath.Join(memoryDir, "episodes"))
+	recorder := NewPersistentEpisodeRecorder(MemoryRetrieveRequest{
+		Input:     "打开设置",
+		EpisodeID: "ep_langfuse_interrupted",
+	}, MemoryContext{}, store)
+
+	if err := recorder.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	recorder.RecordPlannerDecision(plannerDecision{
+		Objective: "打开设置",
+		Plan:      []string{"打开设置"},
+		NextStep:  "点击设置",
+	})
+
+	done := make(chan map[string]interface{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/public/ingestion" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "pk-test" || pass != "sk-test" {
+			t.Errorf("unexpected auth: ok=%v user=%q pass=%q", ok, user, pass)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req langfuseIngestionRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Errorf("decode ingestion request: %v", err)
+		}
+		var traceBody map[string]interface{}
+		var scoreBody map[string]interface{}
+		for _, event := range req.Batch {
+			var eventBody map[string]interface{}
+			if err := json.Unmarshal(event.Body, &eventBody); err != nil {
+				t.Errorf("decode event body: %v", err)
+				continue
+			}
+			switch event.Type {
+			case "trace-create":
+				traceBody = eventBody
+			case "score-create":
+				scoreBody = eventBody
+			}
+		}
+		select {
+		case done <- map[string]interface{}{"trace": traceBody, "score": scoreBody}:
+		default:
+		}
+		w.WriteHeader(http.StatusMultiStatus)
+		_, _ = w.Write([]byte(`{"successes":[{"id":"ok","status":201}],"errors":[]}`))
+	}))
+	defer server.Close()
+
+	NewRuntimeWithDeps(
+		Config{
+			ConfigDir: configDir,
+			Model: ModelConfig{
+				Provider: "fake",
+				Model:    "test-model",
+			},
+			Telemetry: TelemetryConfig{
+				Enabled:   boolPtr(true),
+				BaseURL:   server.URL,
+				PublicKey: "pk-test",
+				SecretKey: "sk-test",
+				MaxRetry:  0,
+			},
+		},
+		&testModelResolver{model: &scriptedModel{}},
+		NewMemoryManager(memoryDir),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+
+	var payload map[string]interface{}
+	select {
+	case payload = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for langfuse ingestion")
+	}
+
+	traceBody, ok := payload["trace"].(map[string]interface{})
+	if !ok || traceBody == nil {
+		t.Fatalf("missing trace-create body: %#v", payload)
+	}
+	scoreBody, ok := payload["score"].(map[string]interface{})
+	if !ok || scoreBody == nil {
+		t.Fatalf("missing score-create body: %#v", payload)
+	}
+	meta, ok := traceBody["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("trace metadata = %#v", traceBody["metadata"])
+	}
+	if meta["episode_id"] != "ep_langfuse_interrupted" {
+		t.Fatalf("metadata.episode_id = %v", meta["episode_id"])
+	}
+	if meta["status"] != "interrupted" {
+		t.Fatalf("metadata.status = %v", meta["status"])
+	}
+	if meta["failure_reason"] != "agent restarted before the task episode completed" {
+		t.Fatalf("metadata.failure_reason = %v", meta["failure_reason"])
+	}
+	if meta["model"] != "fake/test-model" {
+		t.Fatalf("metadata.model = %v", meta["model"])
+	}
+	if meta["interruption_source"] != "agent_restart" {
+		t.Fatalf("metadata.interruption_source = %v", meta["interruption_source"])
+	}
+	if scoreBody["value"] != float64(0) {
+		t.Fatalf("score value = %v, want 0", scoreBody["value"])
+	}
+	tags, ok := traceBody["tags"].([]interface{})
+	if !ok {
+		t.Fatalf("trace tags = %#v", traceBody["tags"])
+	}
+	for _, want := range []string{"interrupted", "status:interrupted", "failure"} {
+		if !jsonListContains(tags, want) {
+			t.Fatalf("trace tags missing %q: %#v", want, tags)
+		}
+	}
+}
+
+func jsonListContains(values []interface{}, want string) bool {
+	for _, value := range values {
+		if got, _ := value.(string); got == want {
+			return true
+		}
+	}
+	return false
+}

--- a/src/agent/internal/agent/memory_plane.go
+++ b/src/agent/internal/agent/memory_plane.go
@@ -33,6 +33,7 @@ type MemoryRetrieveRequest struct {
 	Attachments  []InputAttachment
 	Skills       []string
 	ToolNames    []string
+	EpisodeID    string
 	DeviceID     string
 	CurrentHints CurrentEnvironmentHints
 }
@@ -185,7 +186,7 @@ func (p *FilesystemMemoryPlane) Retrieve(ctx context.Context, req MemoryRetrieve
 }
 
 func (p *FilesystemMemoryPlane) NewEpisodeRecorder(req MemoryRetrieveRequest, retrieved MemoryContext) *EpisodeRecorder {
-	return NewEpisodeRecorder(req, retrieved)
+	return NewPersistentEpisodeRecorder(req, retrieved, p.episodes)
 }
 
 func (p *FilesystemMemoryPlane) CommitEpisode(ctx context.Context, episode TaskEpisode) error {
@@ -715,7 +716,6 @@ func (p *FilesystemMemoryPlane) recordCoordinateCalibration(ctx context.Context,
 	}
 	return nil
 }
-
 
 func (p *FilesystemMemoryPlane) updateReferencedMemoryOutcomes(ctx context.Context, episode TaskEpisode) error {
 	refs := uniqueNonEmpty(episode.RetrievedMemoryRefs)
@@ -1255,4 +1255,3 @@ func appendUniqueMemoryRef(refs []MemorySourceRef, ref MemorySourceRef) []Memory
 	}
 	return append(refs, ref)
 }
-

--- a/src/agent/internal/agent/memory_plane_test.go
+++ b/src/agent/internal/agent/memory_plane_test.go
@@ -246,6 +246,54 @@ func TestRuntimeRunWritesTaskEpisodeTrace(t *testing.T) {
 	}
 }
 
+func TestPersistentEpisodeRecorderWritesIncrementalEventsAndMarksInterrupted(t *testing.T) {
+	ctx := context.Background()
+	store := NewTaskEpisodeStore(filepath.Join(t.TempDir(), "episodes"))
+	recorder := NewPersistentEpisodeRecorder(MemoryRetrieveRequest{
+		Input:     "打开设置",
+		EpisodeID: "ep_incremental",
+	}, MemoryContext{}, store)
+
+	if err := recorder.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	recorder.RecordPlannerDecision(plannerDecision{
+		Objective: "打开设置",
+		Plan:      []string{"打开设置"},
+		NextStep:  "点击设置",
+	})
+
+	eventPaths, err := filepath.Glob(filepath.Join(store.rootDir, "*", "ep_incremental", "events.jsonl"))
+	if err != nil || len(eventPaths) != 1 {
+		t.Fatalf("episode events glob paths=%#v err=%v", eventPaths, err)
+	}
+	data, err := os.ReadFile(eventPaths[0])
+	if err != nil {
+		t.Fatalf("read incremental events: %v", err)
+	}
+	if !strings.Contains(string(data), `"planner_decision"`) {
+		t.Fatalf("incremental event not persisted:\n%s", data)
+	}
+
+	marked, err := store.MarkRunningEpisodesInterrupted(ctx, "restart")
+	if err != nil {
+		t.Fatalf("MarkRunningEpisodesInterrupted() error = %v", err)
+	}
+	if marked != 1 {
+		t.Fatalf("marked = %d, want 1", marked)
+	}
+	episode, err := store.Get(ctx, "ep_incremental")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if episode.Status != "interrupted" || episode.Outcome.FailureReason != "restart" {
+		t.Fatalf("episode not marked interrupted: %#v", episode)
+	}
+	if len(episode.Events) != 1 || episode.Events[0].Type != "planner_decision" {
+		t.Fatalf("unexpected persisted events: %#v", episode.Events)
+	}
+}
+
 func TestTaskEpisodeIndexSummaryOmitsScreenshotBase64(t *testing.T) {
 	ctx := context.Background()
 	memoryDir := filepath.Join(t.TempDir(), "memory")

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -287,12 +287,31 @@ func (r *Runtime) markInterruptedEpisodesBestEffort() {
 	if !ok || plane == nil || plane.episodes == nil {
 		return
 	}
-	if count, err := plane.episodes.MarkRunningEpisodesInterrupted(context.Background(), "agent restarted before the task episode completed"); err != nil {
+	episodes, err := plane.episodes.MarkRunningEpisodesInterruptedWithDetails(context.Background(), "agent restarted before the task episode completed")
+	if err != nil {
 		if r.logger != nil {
 			r.logger.Warn("[memory] mark interrupted episodes failed: %v", err)
 		}
-	} else if count > 0 && r.logger != nil {
-		r.logger.Warn("[memory] marked %d running task episode(s) as interrupted", count)
+		return
+	}
+	if len(episodes) == 0 {
+		return
+	}
+	r.persistInterruptedEpisodeHistoryBestEffort(plane, episodes)
+	if r.logger != nil {
+		r.logger.Warn("[memory] marked %d running task episode(s) as interrupted", len(episodes))
+	}
+}
+
+func (r *Runtime) persistInterruptedEpisodeHistoryBestEffort(plane *FilesystemMemoryPlane, episodes []TaskEpisode) {
+	if plane == nil || strings.TrimSpace(plane.memoryDir) == "" || len(episodes) == 0 {
+		return
+	}
+	store := NewChatHistoryStore(filepath.Join(plane.memoryDir, "chat_history"))
+	for _, episode := range episodes {
+		if err := store.Append(context.Background(), interruptedEpisodeStatusMessage(episode)); err != nil && r.logger != nil {
+			r.logger.Warn("[memory] persist interrupted episode history failed: episode_id=%s error=%v", episode.ID, err)
+		}
 	}
 }
 
@@ -411,7 +430,11 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		executorHandler = streamCallbackHandler
 	}
 	profiles := r.buildRoleProfiles(resolvedSkills, availableTools, memoryContext, req.RuntimeContext)
-	executor := newRoleCollaborativeExecutor(model, profiles, availableTools, memoryHandle.Memory, maxIterations, req.Attachments, executorHandler, episodeRecorder, r.config.ScreenshotPruningOrDefault())
+	plannerMemory := memoryHandle.Memory
+	if historyStore := chatHistoryStoreForConfigDir(r.config.ConfigDir); historyStore != nil {
+		plannerMemory = newChatHistoryPlannerMemory(plannerMemory, historyStore)
+	}
+	executor := newRoleCollaborativeExecutor(model, profiles, availableTools, plannerMemory, maxIterations, req.Attachments, executorHandler, episodeRecorder, r.config.ScreenshotPruningOrDefault())
 
 	output, err := chains.Run(ctx, executor, normalizedInput, callOptions...)
 	if err != nil {

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -298,6 +298,7 @@ func (r *Runtime) markInterruptedEpisodesBestEffort() {
 		return
 	}
 	r.persistInterruptedEpisodeHistoryBestEffort(plane, episodes)
+	r.exportInterruptedEpisodesBestEffort(episodes)
 	if r.logger != nil {
 		r.logger.Warn("[memory] marked %d running task episode(s) as interrupted", len(episodes))
 	}
@@ -312,6 +313,21 @@ func (r *Runtime) persistInterruptedEpisodeHistoryBestEffort(plane *FilesystemMe
 		if err := store.Append(context.Background(), interruptedEpisodeStatusMessage(episode)); err != nil && r.logger != nil {
 			r.logger.Warn("[memory] persist interrupted episode history failed: episode_id=%s error=%v", episode.ID, err)
 		}
+	}
+}
+
+func (r *Runtime) exportInterruptedEpisodesBestEffort(episodes []TaskEpisode) {
+	if len(episodes) == 0 {
+		return
+	}
+	for _, episode := range episodes {
+		enrichEpisodeTelemetry(&episode, r.config)
+		r.enrichEpisodeRuntimeTelemetry(&episode)
+		if episode.Extra == nil {
+			episode.Extra = map[string]interface{}{}
+		}
+		episode.Extra["interruption_source"] = "agent_restart"
+		r.exportEpisodeBestEffort(episode, nil)
 	}
 }
 

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -55,6 +55,7 @@ type RunRequest struct {
 	Input       string
 	Attachments []InputAttachment
 	Skills      []string
+	EpisodeID   string
 	// RuntimeContext is dynamic per-turn system context, such as connected
 	// hardware/app state. It is not persisted as user configuration.
 	RuntimeContext string
@@ -66,6 +67,7 @@ type RunRequest struct {
 type RunResult struct {
 	Output         string          `json:"output"`
 	Skills         []string        `json:"skills"`
+	EpisodeID      string          `json:"episode_id,omitempty"`
 	Memory         []MessageRecord `json:"memory,omitempty"`
 	Metrics        *RunMetrics     `json:"metrics,omitempty"`
 	SleepRequested bool            `json:"sleep_requested,omitempty"`
@@ -90,6 +92,7 @@ type RunMetrics struct {
 type RunEvent struct {
 	Type        string    `json:"type"`
 	Role        string    `json:"role,omitempty"`
+	EpisodeID   string    `json:"episode_id,omitempty"`
 	ToolName    string    `json:"tool_name,omitempty"`
 	ToolInput   string    `json:"tool_input,omitempty"`
 	Description string    `json:"description,omitempty"`
@@ -238,6 +241,7 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 	}
 
 	rt.memoryPlane = NewFilesystemMemoryPlane(memoryDir, extractionCfg, logger)
+	rt.markInterruptedEpisodesBestEffort()
 	return rt, nil
 }
 
@@ -266,8 +270,30 @@ func NewRuntimeWithDeps(cfg Config, models ModelResolver, memories *MemoryManage
 	}
 	if cfg.ConfigDir != "" {
 		rt.memoryPlane = NewFilesystemMemoryPlane(filepath.Join(cfg.ConfigDir, "memory"), LoadMemoryExtractionConfig(cfg.ConfigDir), nil)
+		rt.markInterruptedEpisodesBestEffort()
 	}
 	return rt
+}
+
+func (r *Runtime) NewEpisodeID() string {
+	if r == nil || r.memoryPlane == nil {
+		return ""
+	}
+	return newTaskEpisodeID(time.Now().UTC())
+}
+
+func (r *Runtime) markInterruptedEpisodesBestEffort() {
+	plane, ok := r.memoryPlane.(*FilesystemMemoryPlane)
+	if !ok || plane == nil || plane.episodes == nil {
+		return
+	}
+	if count, err := plane.episodes.MarkRunningEpisodesInterrupted(context.Background(), "agent restarted before the task episode completed"); err != nil {
+		if r.logger != nil {
+			r.logger.Warn("[memory] mark interrupted episodes failed: %v", err)
+		}
+	} else if count > 0 && r.logger != nil {
+		r.logger.Warn("[memory] marked %d running task episode(s) as interrupted", count)
+	}
 }
 
 func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
@@ -329,6 +355,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		Attachments:  req.Attachments,
 		Skills:       skillNames,
 		ToolNames:    toolNamesFromTools(availableTools),
+		EpisodeID:    req.EpisodeID,
 		DeviceID:     defaultMemoryDeviceID,
 		CurrentHints: r.currentEnvironmentHints(),
 	}
@@ -346,6 +373,16 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	var episodeRecorder *EpisodeRecorder
 	if r.memoryPlane != nil {
 		episodeRecorder = r.memoryPlane.NewEpisodeRecorder(retrieveReq, memoryContext)
+		if episodeRecorder != nil {
+			retrieveReq.EpisodeID = episodeRecorder.ID()
+			if err := episodeRecorder.Start(context.Background()); err != nil && r.logger != nil {
+				r.logger.Warn("[memory] start episode failed: %v", err)
+			}
+		}
+	}
+	episodeID := ""
+	if episodeRecorder != nil {
+		episodeID = episodeRecorder.ID()
 	}
 
 	maxIterations := effectiveMaxIterations(r.config.MaxIterations)
@@ -362,6 +399,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			startTime:    startTime,
 			logger:       r.logger,
 			eventHandler: req.EventHandler,
+			episodeID:    episodeID,
 		}
 	}
 	if streamCallbackHandler != nil {
@@ -416,6 +454,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	return RunResult{
 		Output:         output,
 		Skills:         runSkills.GetActivatedSkills(),
+		EpisodeID:      episodeID,
 		Memory:         memorySnapshot,
 		Metrics:        metrics,
 		SleepRequested: sleepRequested,
@@ -713,6 +752,7 @@ type runtimeCallbackHandler struct {
 	firstTokenSeen bool
 	logger         *Logger
 	eventHandler   func(RunEvent)
+	episodeID      string
 	mu             sync.Mutex
 	pendingActions []schema.AgentAction
 }
@@ -791,6 +831,7 @@ func (h *runtimeCallbackHandler) HandleToolEnd(ctx context.Context, output strin
 		if ok {
 			h.eventHandler(RunEvent{
 				Type:      "tool_result",
+				EpisodeID: h.episodeID,
 				ToolName:  action.Tool,
 				ToolInput: normalizeToolInput(action.ToolInput),
 				Content:   output,
@@ -809,6 +850,7 @@ func (h *runtimeCallbackHandler) HandleToolError(ctx context.Context, err error)
 		if ok {
 			h.eventHandler(RunEvent{
 				Type:      "tool_result",
+				EpisodeID: h.episodeID,
 				ToolName:  action.Tool,
 				ToolInput: normalizeToolInput(action.ToolInput),
 				Content:   "error: " + err.Error(),
@@ -830,6 +872,7 @@ func (h *runtimeCallbackHandler) HandleNamedToolEnd(ctx context.Context, name, i
 	if h.eventHandler != nil {
 		h.eventHandler(RunEvent{
 			Type:      "tool_result",
+			EpisodeID: h.episodeID,
 			ToolName:  name,
 			ToolInput: input,
 			Content:   output,
@@ -848,6 +891,7 @@ func (h *runtimeCallbackHandler) HandleNamedToolError(ctx context.Context, name,
 	if h.eventHandler != nil {
 		h.eventHandler(RunEvent{
 			Type:      "tool_result",
+			EpisodeID: h.episodeID,
 			ToolName:  name,
 			ToolInput: input,
 			Content:   "error: " + err.Error(),
@@ -872,6 +916,7 @@ func (h *runtimeCallbackHandler) HandleAgentAction(ctx context.Context, action s
 		h.pushPendingAction(action)
 		h.eventHandler(RunEvent{
 			Type:        "tool_call",
+			EpisodeID:   h.episodeID,
 			ToolName:    action.Tool,
 			ToolInput:   action.ToolInput,
 			Description: description,
@@ -892,6 +937,7 @@ func (h *runtimeCallbackHandler) HandleRoleOutput(ctx context.Context, role, con
 		h.eventHandler(RunEvent{
 			Type:      "role_output",
 			Role:      role,
+			EpisodeID: h.episodeID,
 			Content:   content,
 			Timestamp: time.Now(),
 		})

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -34,6 +34,8 @@ type Server struct {
 	logger           *Logger
 	mu               sync.Mutex
 	history          []Message
+	historyStore     *ChatHistoryStore
+	episodeStore     *TaskEpisodeStore
 	sttClient        STTClient
 	ttsManager       *tts.ProviderManager
 	ttsMu            sync.RWMutex
@@ -80,6 +82,9 @@ type MessageAttachment struct {
 type Message struct {
 	Type        string              `json:"type"` // "user", "assistant", "tool_call", "tool_result", "role_output"
 	Role        string              `json:"role,omitempty"`
+	EpisodeID   string              `json:"episode_id,omitempty"`
+	RequestID   string              `json:"request_id,omitempty"`
+	Status      string              `json:"status,omitempty"`
 	Content     string              `json:"content"`
 	ToolName    string              `json:"tool_name,omitempty"`
 	ToolInput   string              `json:"tool_input,omitempty"`
@@ -132,6 +137,10 @@ type ChatStreamEvent struct {
 	Error    string    `json:"error,omitempty"`
 }
 
+type EpisodeResponse struct {
+	Episode TaskEpisode `json:"episode"`
+}
+
 type ToolCatalogResponse struct {
 	Tools []ToolDescriptor `json:"tools"`
 }
@@ -165,6 +174,11 @@ func NewServer(runtime *Runtime, addr string) *Server {
 		history:        make([]Message, 0),
 		bridge:         bridge,
 		pendingResults: make(map[string]*chatPendingResult),
+	}
+	if runtime.config.ConfigDir != "" {
+		memoryDir := filepath.Join(runtime.config.ConfigDir, "memory")
+		s.historyStore = NewChatHistoryStore(filepath.Join(memoryDir, "chat_history"))
+		s.episodeStore = NewTaskEpisodeStore(filepath.Join(memoryDir, "episodes"))
 	}
 	loadAppMappingForConfig(runtime.config.ConfigDir, runtime.logger)
 	runtime.tools.RegisterPhoneBridge(bridge)
@@ -206,6 +220,7 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/api/chat", s.handleChat)
 	mux.HandleFunc("/api/chat/result", s.handleChatResult)
 	mux.HandleFunc("/api/history", s.handleHistory)
+	mux.HandleFunc("/api/episodes/", s.handleEpisodes)
 	mux.HandleFunc("/api/clear", s.handleClear)
 	mux.HandleFunc("/api/clear-all", s.handleClearAll)
 	mux.HandleFunc("/api/tools", s.handleTools)
@@ -310,10 +325,13 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Invalid request: "+err.Error(), http.StatusBadRequest)
 		return
 	}
+	episodeID := s.runtime.NewEpisodeID()
 
 	// Add user message to history
 	userMsg := Message{
 		Type:        "user",
+		EpisodeID:   episodeID,
+		RequestID:   req.RequestID,
 		Content:     inputText,
 		Attachments: historyAttachments,
 		Timestamp:   time.Now(),
@@ -327,7 +345,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Sync path — legacy behaviour for web UI and clients without request_id
-	s.handleChatSync(w, r, req, inputText, runAttachments)
+	s.handleChatSync(w, r, req, inputText, runAttachments, userMsg.EpisodeID)
 }
 
 // handleChatAsync runs the agent in a background goroutine and returns
@@ -389,9 +407,15 @@ func (s *Server) handleChatAsync(
 		// Event handler pushes intermediate messages into the pending result
 		// so the client can poll them in near-realtime.
 		eventHandler := func(event RunEvent) {
+			episodeID := event.EpisodeID
+			if episodeID == "" {
+				episodeID = userMsg.EpisodeID
+			}
 			msg := Message{
 				Type:        event.Type,
 				Role:        event.Role,
+				EpisodeID:   episodeID,
+				RequestID:   requestID,
 				Content:     event.Content,
 				ToolName:    event.ToolName,
 				ToolInput:   event.ToolInput,
@@ -414,6 +438,7 @@ func (s *Server) handleChatAsync(
 			Input:          inputText,
 			Attachments:    runAttachments,
 			Skills:         req.Skills,
+			EpisodeID:      userMsg.EpisodeID,
 			RuntimeContext: s.runtimeContext(),
 			EventHandler:   eventHandler,
 		}
@@ -446,6 +471,18 @@ func (s *Server) handleChatAsync(
 
 		pending.mu.Lock()
 		if err != nil {
+			errorMsg := Message{
+				Type:      "episode_status",
+				EpisodeID: userMsg.EpisodeID,
+				RequestID: requestID,
+				Status:    "failed",
+				Content:   "Agent error: " + err.Error(),
+				Timestamp: time.Now(),
+				IsError:   true,
+			}
+			s.appendHistory(errorMsg)
+			pending.history = append(pending.history, errorMsg)
+			pending.messages = append(pending.messages, errorMsg)
 			pending.err = err.Error()
 			pending.done = true
 			pending.mu.Unlock()
@@ -458,6 +495,9 @@ func (s *Server) handleChatAsync(
 		// Add assistant message
 		assistantMsg := Message{
 			Type:      "assistant",
+			EpisodeID: firstNonEmptyString([]string{result.EpisodeID, userMsg.EpisodeID}),
+			RequestID: requestID,
+			Status:    "completed",
 			Content:   result.Output,
 			Timestamp: time.Now(),
 		}
@@ -585,6 +625,7 @@ func (s *Server) handleChatSync(
 	req ChatRequest,
 	inputText string,
 	runAttachments []InputAttachment,
+	episodeID string,
 ) {
 	ctx := r.Context()
 
@@ -598,11 +639,17 @@ func (s *Server) handleChatSync(
 		Input:          inputText,
 		Attachments:    runAttachments,
 		Skills:         req.Skills,
+		EpisodeID:      episodeID,
 		RuntimeContext: s.runtimeContext(),
 		EventHandler: func(event RunEvent) {
+			eventEpisodeID := event.EpisodeID
+			if eventEpisodeID == "" {
+				eventEpisodeID = episodeID
+			}
 			s.appendHistory(Message{
 				Type:        event.Type,
 				Role:        event.Role,
+				EpisodeID:   eventEpisodeID,
 				Content:     event.Content,
 				ToolName:    event.ToolName,
 				ToolInput:   event.ToolInput,
@@ -643,6 +690,14 @@ func (s *Server) handleChatSync(
 	}
 
 	if err != nil {
+		s.appendHistory(Message{
+			Type:      "episode_status",
+			EpisodeID: episodeID,
+			Status:    "failed",
+			Content:   "Agent error: " + err.Error(),
+			Timestamp: time.Now(),
+			IsError:   true,
+		})
 		if s.logger != nil {
 			s.logger.Error("Agent run failed: %v", err)
 		}
@@ -652,6 +707,8 @@ func (s *Server) handleChatSync(
 
 	s.appendHistory(Message{
 		Type:      "assistant",
+		EpisodeID: firstNonEmptyString([]string{result.EpisodeID, episodeID}),
+		Status:    "completed",
 		Content:   result.Output,
 		Timestamp: time.Now(),
 	})
@@ -707,8 +764,10 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	episodeID := s.runtime.NewEpisodeID()
 	userMessage := Message{
 		Type:        "user",
+		EpisodeID:   episodeID,
 		Content:     inputText,
 		Attachments: historyAttachments,
 		Timestamp:   time.Now(),
@@ -727,11 +786,17 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 		Input:          inputText,
 		Attachments:    runAttachments,
 		Skills:         req.Skills,
+		EpisodeID:      episodeID,
 		RuntimeContext: s.runtimeContext(),
 		EventHandler: func(event RunEvent) {
+			eventEpisodeID := event.EpisodeID
+			if eventEpisodeID == "" {
+				eventEpisodeID = episodeID
+			}
 			message := Message{
 				Type:        event.Type,
 				Role:        event.Role,
+				EpisodeID:   eventEpisodeID,
 				Content:     event.Content,
 				ToolName:    event.ToolName,
 				ToolInput:   event.ToolInput,
@@ -747,6 +812,16 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 	if err != nil {
+		errorMessage := Message{
+			Type:      "episode_status",
+			EpisodeID: episodeID,
+			Status:    "failed",
+			Content:   "Agent error: " + err.Error(),
+			Timestamp: time.Now(),
+			IsError:   true,
+		}
+		s.appendHistory(errorMessage)
+		stream.Write(ChatStreamEvent{Type: "message", Message: &errorMessage})
 		if s.logger != nil {
 			s.logger.Error("Agent run failed: %v", err)
 		}
@@ -756,6 +831,8 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 
 	assistantMessage := Message{
 		Type:      "assistant",
+		EpisodeID: firstNonEmptyString([]string{result.EpisodeID, episodeID}),
+		Status:    "completed",
 		Content:   result.Output,
 		Timestamp: time.Now(),
 	}
@@ -875,6 +952,34 @@ func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(historySnapshot)
 }
 
+func (s *Server) handleEpisodes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	store := s.episodeStore
+	if store == nil && s.runtime != nil && s.runtime.config.ConfigDir != "" {
+		store = NewTaskEpisodeStore(filepath.Join(s.runtime.config.ConfigDir, "memory", "episodes"))
+	}
+	if store == nil {
+		http.Error(w, "Episode store is not configured", http.StatusNotFound)
+		return
+	}
+	id := strings.TrimPrefix(r.URL.Path, "/api/episodes/")
+	id = strings.Trim(id, "/")
+	if id == "" || strings.Contains(id, "/") {
+		http.Error(w, "Invalid episode id", http.StatusBadRequest)
+		return
+	}
+	episode, err := store.Get(r.Context(), id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(EpisodeResponse{Episode: episode})
+}
+
 // handleClear clears the conversation history
 func (s *Server) handleClear(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -888,6 +993,15 @@ func (s *Server) handleClear(w http.ResponseWriter, r *http.Request) {
 
 	if s.logger != nil {
 		s.logger.Info("Conversation history cleared")
+	}
+	if s.historyStore != nil {
+		if err := s.historyStore.Clear(); err != nil {
+			if s.logger != nil {
+				s.logger.Error("Clear chat history failed: %v", err)
+			}
+			http.Error(w, fmt.Sprintf("Clear chat history failed: %v", err), http.StatusInternalServerError)
+			return
+		}
 	}
 	if err := s.runtime.ClearMemory(r.Context()); err != nil {
 		if s.logger != nil {
@@ -918,6 +1032,15 @@ func (s *Server) handleClearAll(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	s.history = make([]Message, 0)
 	s.mu.Unlock()
+	if s.historyStore != nil {
+		if err := s.historyStore.Clear(); err != nil {
+			if s.logger != nil {
+				s.logger.Error("Clear chat history failed: %v", err)
+			}
+			http.Error(w, fmt.Sprintf("Clear chat history failed: %v", err), http.StatusInternalServerError)
+			return
+		}
+	}
 	if s.logger != nil {
 		s.logger.Info("All memory cleared")
 	}
@@ -1309,8 +1432,13 @@ func toolOutputLooksLikeError(output string) bool {
 
 func (s *Server) appendHistory(message Message) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.history = append(s.history, message)
+	s.mu.Unlock()
+	if s.historyStore != nil {
+		if err := s.historyStore.Append(context.Background(), message); err != nil && s.logger != nil {
+			s.logger.Warn("Persist chat history failed: %v", err)
+		}
+	}
 }
 
 func (s *Server) historySnapshot() []Message {
@@ -1325,6 +1453,13 @@ func (s *Server) loadHistoryFromDisk() {
 	if s.runtime.config.ConfigDir == "" {
 		return
 	}
+	if s.historyStore != nil {
+		messages, err := s.historyStore.Load(context.Background())
+		if err == nil && len(messages) > 0 {
+			s.history = append(s.history, messages...)
+			return
+		}
+	}
 	eventsPath := filepath.Join(s.runtime.config.ConfigDir, "memory", "session", "events.jsonl")
 	store := NewSessionMemoryStore(filepath.Join(s.runtime.config.ConfigDir, "memory", "session"))
 	events, err := store.readEvents(eventsPath)
@@ -1333,12 +1468,19 @@ func (s *Server) loadHistoryFromDisk() {
 	}
 	for _, evt := range events {
 		msgType := "user"
-		if evt.Role == "assistant" {
+		switch evt.Role {
+		case "assistant":
 			msgType = "assistant"
+		case "tool":
+			msgType = "tool_result"
+		case "system":
+			msgType = "system"
 		}
 		ts, _ := time.Parse(time.RFC3339Nano, evt.Ts)
 		s.history = append(s.history, Message{
 			Type:      msgType,
+			ToolName:  evt.Source,
+			ToolInput: evt.ToolCallID,
 			Content:   evt.Content,
 			Timestamp: ts,
 		})
@@ -2137,6 +2279,62 @@ const webUI = `<!DOCTYPE html>
             font-size: 0.84rem;
         }
 
+        .episode-link {
+            margin-top: 0.65rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 0.42rem 0.7rem;
+            border: 1px solid var(--line);
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.82);
+            color: var(--muted-strong);
+            cursor: pointer;
+            font-size: 0.78rem;
+            font-weight: 600;
+        }
+
+        .episode-panel {
+            margin-top: 0.7rem;
+            padding: 12px;
+            border-radius: 14px;
+            background: var(--surface-soft);
+            border: 1px solid rgba(52, 56, 49, 0.08);
+            display: grid;
+            gap: 10px;
+        }
+
+        .episode-meta {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .episode-events {
+            display: grid;
+            gap: 8px;
+        }
+
+        .episode-event {
+            padding: 9px 10px;
+            border-radius: 12px;
+            background: rgba(255, 255, 255, 0.78);
+            border: 1px solid rgba(52, 56, 49, 0.06);
+        }
+
+        .episode-event-title {
+            font-size: 0.75rem;
+            font-weight: 700;
+            color: var(--muted-strong);
+        }
+
+        .episode-event-content {
+            margin-top: 0.35rem;
+            font-size: 0.82rem;
+            line-height: 1.45;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+
         .composer {
             padding: 10px 18px 18px;
             border-top: 1px solid rgba(52, 56, 49, 0.08);
@@ -2531,6 +2729,7 @@ const webUI = `<!DOCTYPE html>
         let recorderState = createRecorderState();
         let toolCatalog = [];
         let toolSkills = [];
+        let episodeCache = {};
 
         loadHistory();
         loadToolCatalog();
@@ -3032,6 +3231,11 @@ const webUI = `<!DOCTYPE html>
                 }
             }
 
+            const episodeLink = renderEpisodeLink(msg);
+            if (episodeLink) {
+                body.appendChild(episodeLink);
+            }
+
             const timeDiv = document.createElement('div');
             timeDiv.className = 'message-time';
             timeDiv.textContent = formatTime(msg.timestamp);
@@ -3041,6 +3245,106 @@ const webUI = `<!DOCTYPE html>
             shell.appendChild(body);
             card.appendChild(shell);
             return card;
+        }
+
+        function renderEpisodeLink(msg) {
+            if (!msg.episode_id) return null;
+            if (msg.type !== 'user' && msg.type !== 'assistant' && msg.type !== 'episode_status') return null;
+
+            const wrap = document.createElement('div');
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'episode-link';
+            button.textContent = 'Trace' + (msg.status ? ' · ' + msg.status : '');
+            wrap.appendChild(button);
+
+            let panel = null;
+            button.addEventListener('click', async function() {
+                if (panel) {
+                    panel.classList.toggle('hidden');
+                    return;
+                }
+                panel = document.createElement('div');
+                panel.className = 'episode-panel';
+                panel.textContent = 'Loading trace...';
+                wrap.appendChild(panel);
+
+                try {
+                    const episode = await loadEpisode(msg.episode_id);
+                    renderEpisodePanel(panel, episode);
+                } catch (err) {
+                    panel.textContent = 'Trace unavailable: ' + err.message;
+                }
+            });
+            return wrap;
+        }
+
+        async function loadEpisode(id) {
+            if (episodeCache[id]) return episodeCache[id];
+            const res = await fetch('/api/episodes/' + encodeURIComponent(id));
+            if (!res.ok) {
+                throw new Error(await res.text() || 'Episode not found');
+            }
+            const data = await res.json();
+            episodeCache[id] = data.episode;
+            return data.episode;
+        }
+
+        function renderEpisodePanel(panel, episode) {
+            panel.innerHTML = '';
+            const meta = document.createElement('div');
+            meta.className = 'episode-meta';
+            const outcome = episode.outcome || {};
+            meta.textContent = [
+                episode.id || 'episode',
+                episode.status || 'unknown',
+                outcome.success ? 'success' : (outcome.failure_reason ? 'failed' : 'pending')
+            ].join(' · ');
+            panel.appendChild(meta);
+
+            const events = (episode.events || []).slice(-12);
+            if (events.length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'episode-meta';
+                empty.textContent = 'No trace events recorded.';
+                panel.appendChild(empty);
+                return;
+            }
+
+            const list = document.createElement('div');
+            list.className = 'episode-events';
+            events.forEach(function(event) {
+                list.appendChild(renderEpisodeEvent(event));
+            });
+            panel.appendChild(list);
+        }
+
+        function renderEpisodeEvent(event) {
+            const item = document.createElement('div');
+            item.className = 'episode-event';
+
+            const title = document.createElement('div');
+            title.className = 'episode-event-title';
+            const parts = [event.type || 'event'];
+            if (event.role) parts.push(event.role);
+            if (event.tool_name) parts.push(event.tool_name);
+            title.textContent = parts.join(' · ');
+            item.appendChild(title);
+
+            const content = document.createElement('div');
+            content.className = 'episode-event-content';
+            content.textContent = episodeEventText(event);
+            item.appendChild(content);
+            return item;
+        }
+
+        function episodeEventText(event) {
+            if (event.next_step) return event.next_step;
+            if (event.content) return event.content;
+            if (event.observation) return formatToolPayload(event.observation);
+            if (event.reason) return event.reason;
+            if (event.plan && event.plan.length) return event.plan.join('\n');
+            return '';
         }
 
         function updateEmptyState() {
@@ -3070,6 +3374,7 @@ const webUI = `<!DOCTYPE html>
 
         function getRoleLabel(type, toolName, role) {
             if (type === 'user') return 'You';
+            if (type === 'episode_status') return 'Task Trace';
             if (type === 'role_output') return 'Role · ' + (role || 'agent');
             if (type === 'tool_call') return toolName ? 'Tool Call · ' + toolName : 'Tool Call';
             if (type === 'tool_result') return toolName ? 'Tool Result · ' + toolName : 'Tool Result';
@@ -3078,6 +3383,7 @@ const webUI = `<!DOCTYPE html>
 
         function getAvatarLabel(type) {
             if (type === 'user') return 'You';
+            if (type === 'episode_status') return 'Task';
             if (type === 'role_output') return 'Role';
             if (type === 'tool_call') return 'Call';
             if (type === 'tool_result') return 'Tool';

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -114,6 +114,79 @@ func TestServerHandleChatReturnsToolHistory(t *testing.T) {
 	}
 }
 
+func TestServerPersistsChatHistoryWithEpisodeReference(t *testing.T) {
+	configDir := t.TempDir()
+	memoryDir := filepath.Join(configDir, "memory")
+	model := &scriptedModel{
+		responses: roleDirectResponses("已完成"),
+	}
+	streamingDisabled := false
+	runtime := NewRuntimeWithDeps(
+		Config{
+			ConfigDir:                configDir,
+			Model:                    ModelConfig{Provider: "fake"},
+			Instruction:              "Answer directly.",
+			VoiceStreamingTTSEnabled: &streamingDisabled,
+			VoiceToolCallSpeech:      &streamingDisabled,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(memoryDir),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+	server := NewServer(runtime, ":0")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"做一个任务"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.handleChat(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp ChatResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	assistant, ok := firstMessageOfType(resp.History, "assistant")
+	if !ok || assistant.EpisodeID == "" {
+		t.Fatalf("assistant missing episode reference: %#v", resp.History)
+	}
+	if resp.History[0].EpisodeID != assistant.EpisodeID {
+		t.Fatalf("user and assistant episode ids differ: %#v", resp.History)
+	}
+
+	reloaded := NewServer(runtime, ":0")
+	historyReq := httptest.NewRequest(http.MethodGet, "/api/history", nil)
+	historyRec := httptest.NewRecorder()
+	reloaded.handleHistory(historyRec, historyReq)
+	if historyRec.Code != http.StatusOK {
+		t.Fatalf("unexpected history status: %d body=%s", historyRec.Code, historyRec.Body.String())
+	}
+	var restored []Message
+	if err := json.NewDecoder(historyRec.Body).Decode(&restored); err != nil {
+		t.Fatalf("decode restored history: %v", err)
+	}
+	restoredAssistant, ok := firstMessageOfType(restored, "assistant")
+	if !ok || restoredAssistant.EpisodeID != assistant.EpisodeID {
+		t.Fatalf("restored assistant missing episode reference: %#v", restored)
+	}
+
+	episodeReq := httptest.NewRequest(http.MethodGet, "/api/episodes/"+assistant.EpisodeID, nil)
+	episodeRec := httptest.NewRecorder()
+	server.handleEpisodes(episodeRec, episodeReq)
+	if episodeRec.Code != http.StatusOK {
+		t.Fatalf("unexpected episode status: %d body=%s", episodeRec.Code, episodeRec.Body.String())
+	}
+	var episodeResp EpisodeResponse
+	if err := json.NewDecoder(episodeRec.Body).Decode(&episodeResp); err != nil {
+		t.Fatalf("decode episode response: %v", err)
+	}
+	if episodeResp.Episode.ID != assistant.EpisodeID || len(episodeResp.Episode.Events) == 0 {
+		t.Fatalf("unexpected episode response: %#v", episodeResp.Episode)
+	}
+}
+
 func TestServerHandleChatStreamsRoleToolAndAssistantMessages(t *testing.T) {
 	model := &scriptedModel{
 		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我先读取当前音量。"}`, "The current audio volume is 42."),

--- a/src/agent/internal/agent/task_episode.go
+++ b/src/agent/internal/agent/task_episode.go
@@ -114,11 +114,15 @@ type episodeIndexEntry struct {
 
 type EpisodeRecorder struct {
 	mu        sync.Mutex
+	id        string
 	startedAt time.Time
 	request   MemoryRetrieveRequest
 	retrieved MemoryContext
 	events    []TaskEpisodeEvent
 	counter   int
+	store     *TaskEpisodeStore
+	started   bool
+	startErr  error
 }
 
 func NewTaskEpisodeStore(rootDir string) *TaskEpisodeStore {
@@ -140,11 +144,66 @@ func (w *TaskEpisodeWriter) Write(ctx context.Context, episode TaskEpisode) erro
 }
 
 func NewEpisodeRecorder(req MemoryRetrieveRequest, retrieved MemoryContext) *EpisodeRecorder {
+	return newEpisodeRecorder(req, retrieved, nil)
+}
+
+func NewPersistentEpisodeRecorder(req MemoryRetrieveRequest, retrieved MemoryContext, store *TaskEpisodeStore) *EpisodeRecorder {
+	return newEpisodeRecorder(req, retrieved, store)
+}
+
+func newEpisodeRecorder(req MemoryRetrieveRequest, retrieved MemoryContext, store *TaskEpisodeStore) *EpisodeRecorder {
+	startedAt := time.Now().UTC()
+	id := strings.TrimSpace(req.EpisodeID)
+	if id == "" {
+		id = newTaskEpisodeID(startedAt)
+	}
 	return &EpisodeRecorder{
-		startedAt: time.Now().UTC(),
+		id:        id,
+		startedAt: startedAt,
 		request:   req,
 		retrieved: retrieved,
+		store:     store,
 	}
+}
+
+func newTaskEpisodeID(ts time.Time) string {
+	return "ep_" + strconvTimeID(ts)
+}
+
+func (r *EpisodeRecorder) ID() string {
+	if r == nil {
+		return ""
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.id
+}
+
+func (r *EpisodeRecorder) Start(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	if r.started {
+		err := r.startErr
+		r.mu.Unlock()
+		return err
+	}
+	r.started = true
+	if r.store == nil {
+		r.mu.Unlock()
+		return nil
+	}
+	episode := r.baseEpisodeLocked("running", time.Time{})
+	r.mu.Unlock()
+
+	if _, err := r.store.StartEpisode(ctx, episode); err != nil {
+		r.mu.Lock()
+		r.startErr = err
+		r.mu.Unlock()
+		return err
+	}
+	return nil
 }
 
 func (r *EpisodeRecorder) RecordPlannerDecision(decision plannerDecision) {
@@ -230,19 +289,10 @@ func (r *EpisodeRecorder) Finish(output string, metrics *RunMetrics, runErr erro
 	defer r.mu.Unlock()
 
 	now := time.Now().UTC()
-	episode := TaskEpisode{
-		ID:                  "ep_" + strconvTimeID(r.startedAt),
-		Status:              "active",
-		StartedAt:           r.startedAt.Format(time.RFC3339Nano),
-		EndedAt:             now.Format(time.RFC3339Nano),
-		UserGoal:            strings.TrimSpace(r.request.Input),
-		DeviceScope:         r.deviceScope(),
-		Outcome:             TaskEpisodeOutcome{Success: runErr == nil, FinalAnswer: strings.TrimSpace(output)},
-		RetrievedMemoryRefs: r.retrieved.ReferenceIDs(),
-		Tags:                uniqueNonEmpty(tags),
-		Entities:            uniqueNonEmpty(entities),
-		Events:              append([]TaskEpisodeEvent(nil), r.events...),
-	}
+	episode := r.baseEpisodeLocked("active", now)
+	episode.Outcome = TaskEpisodeOutcome{Success: runErr == nil, FinalAnswer: strings.TrimSpace(output)}
+	episode.Tags = uniqueNonEmpty(tags)
+	episode.Entities = uniqueNonEmpty(entities)
 	if metrics != nil {
 		episode.Extra = map[string]interface{}{
 			"total_duration_ms": metrics.TotalDuration,
@@ -282,7 +332,6 @@ func (r *EpisodeRecorder) Finish(output string, metrics *RunMetrics, runErr erro
 
 func (r *EpisodeRecorder) append(event TaskEpisodeEvent) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.counter++
 	now := time.Now().UTC()
 	if event.EventID == "" {
@@ -292,6 +341,30 @@ func (r *EpisodeRecorder) append(event TaskEpisodeEvent) {
 		event.Ts = now.Format(time.RFC3339Nano)
 	}
 	r.events = append(r.events, event)
+	store := r.store
+	episode := r.baseEpisodeLocked("running", time.Time{})
+	step := len(r.events)
+	r.mu.Unlock()
+
+	if store != nil {
+		_ = store.AppendEpisodeEvent(context.Background(), episode, event, step)
+	}
+}
+
+func (r *EpisodeRecorder) baseEpisodeLocked(status string, endedAt time.Time) TaskEpisode {
+	episode := TaskEpisode{
+		ID:                  r.id,
+		Status:              status,
+		StartedAt:           r.startedAt.Format(time.RFC3339Nano),
+		UserGoal:            strings.TrimSpace(r.request.Input),
+		DeviceScope:         r.deviceScope(),
+		RetrievedMemoryRefs: r.retrieved.ReferenceIDs(),
+		Events:              append([]TaskEpisodeEvent(nil), r.events...),
+	}
+	if !endedAt.IsZero() {
+		episode.EndedAt = endedAt.Format(time.RFC3339Nano)
+	}
+	return episode
 }
 
 func (r *EpisodeRecorder) deviceScope() map[string]string {
@@ -376,6 +449,174 @@ func (s *TaskEpisodeStore) AddEpisode(ctx context.Context, episode TaskEpisode) 
 		return "", err
 	}
 	return episode.ID, nil
+}
+
+func (s *TaskEpisodeStore) StartEpisode(ctx context.Context, episode TaskEpisode) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+	if s == nil || s.rootDir == "" {
+		return "", nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+	if strings.TrimSpace(episode.ID) == "" {
+		episode.ID = newTaskEpisodeID(now)
+	}
+	if strings.TrimSpace(episode.Status) == "" {
+		episode.Status = "running"
+	}
+	if strings.TrimSpace(episode.StartedAt) == "" {
+		episode.StartedAt = now.Format(time.RFC3339Nano)
+	}
+
+	dir := s.episodeDir(episode)
+	if err := os.MkdirAll(filepath.Join(dir, "artifacts"), 0o755); err != nil {
+		return "", fmt.Errorf("create episode dir: %w", err)
+	}
+	episode.Events = nil
+	if err := writeYAMLAtomic(filepath.Join(dir, "episode.yaml"), episode); err != nil {
+		return "", fmt.Errorf("write episode metadata: %w", err)
+	}
+	if err := writeEpisodeEventsJSONL(filepath.Join(dir, "events.jsonl"), nil); err != nil {
+		return "", err
+	}
+	if err := s.upsertIndexEntry(episode, dir, nil); err != nil {
+		return "", err
+	}
+	return episode.ID, nil
+}
+
+func (s *TaskEpisodeStore) AppendEpisodeEvent(ctx context.Context, episode TaskEpisode, event TaskEpisodeEvent, step int) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	if s == nil || s.rootDir == "" || strings.TrimSpace(episode.ID) == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if strings.TrimSpace(episode.Status) == "" {
+		episode.Status = "running"
+	}
+	if strings.TrimSpace(episode.StartedAt) == "" {
+		episode.StartedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	dir := s.episodeDir(episode)
+	if err := os.MkdirAll(filepath.Join(dir, "artifacts"), 0o755); err != nil {
+		return fmt.Errorf("create episode dir: %w", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "episode.yaml")); os.IsNotExist(err) {
+		episode.Events = nil
+		if err := writeYAMLAtomic(filepath.Join(dir, "episode.yaml"), episode); err != nil {
+			return fmt.Errorf("write episode metadata: %w", err)
+		}
+		if err := s.upsertIndexEntry(episode, dir, nil); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	if step <= 0 {
+		step = 1
+	}
+	if err := s.materializeEventArtifact(dir, &event, step); err != nil {
+		return err
+	}
+	event.RawObservation = ""
+	file, err := os.OpenFile(filepath.Join(dir, "events.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open episode events: %w", err)
+	}
+	defer file.Close()
+	if err := json.NewEncoder(file).Encode(event); err != nil {
+		return fmt.Errorf("append episode event: %w", err)
+	}
+	return nil
+}
+
+func (s *TaskEpisodeStore) MarkRunningEpisodesInterrupted(ctx context.Context, reason string) (int, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+	if s == nil || s.rootDir == "" {
+		return 0, nil
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = "agent stopped before the task episode completed"
+	}
+	if _, err := os.Stat(s.indexPath()); os.IsNotExist(err) {
+		if err := s.RebuildIndex(ctx); err != nil {
+			return 0, err
+		}
+	} else if err != nil {
+		return 0, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	index, err := s.loadIndex()
+	if err != nil {
+		return 0, err
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	changed := false
+	count := 0
+	for i := range index.Episodes {
+		entry := index.Episodes[i]
+		if entry.Status != "running" {
+			continue
+		}
+		path := filepath.Join(s.rootDir, entry.File)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return count, err
+		}
+		var episode TaskEpisode
+		if err := yaml.Unmarshal(data, &episode); err != nil {
+			return count, err
+		}
+		episode.Status = "interrupted"
+		episode.EndedAt = now
+		episode.Outcome.Success = false
+		if strings.TrimSpace(episode.Outcome.FailureReason) == "" {
+			episode.Outcome.FailureReason = reason
+		}
+		if len(episode.FailureCauses) == 0 {
+			episode.FailureCauses = []string{reason}
+		}
+		dir := filepath.Dir(path)
+		eventsPath := filepath.Join(dir, "events.jsonl")
+		var events []TaskEpisodeEvent
+		if _, err := os.Stat(eventsPath); err == nil {
+			events, _ = readEpisodeEvents(eventsPath)
+		}
+		episode.Events = nil
+		if err := writeYAMLAtomic(path, episode); err != nil {
+			return count, err
+		}
+		index.Episodes[i] = s.indexEntryForEpisode(episode, dir, events)
+		count++
+		changed = true
+	}
+	if changed {
+		index.UpdatedAt = now
+		if err := writeYAMLAtomic(s.indexPath(), index); err != nil {
+			return count, err
+		}
+	}
+	return count, nil
 }
 
 func (s *TaskEpisodeStore) Search(ctx context.Context, query EpisodeQuery) ([]MemoryHit, error) {
@@ -702,6 +943,8 @@ func readEpisodeEvents(path string) ([]TaskEpisodeEvent, error) {
 	}
 	defer file.Close()
 	var events []TaskEpisodeEvent
+	validData := make([]byte, 0)
+	repairedTruncatedTail := false
 	scanner := bufio.NewScanner(file)
 	scanner.Buffer(make([]byte, 0), 1<<20)
 	for scanner.Scan() {
@@ -711,11 +954,23 @@ func readEpisodeEvents(path string) ([]TaskEpisodeEvent, error) {
 		}
 		var event TaskEpisodeEvent
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			if isTruncatedJSONLineError(err) {
+				repairedTruncatedTail = true
+				break
+			}
 			return nil, err
 		}
+		validData = append(validData, line...)
+		validData = append(validData, '\n')
 		events = append(events, event)
 	}
-	return events, scanner.Err()
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if repairedTruncatedTail {
+		_ = writeFileAtomic(path, validData, 0o644)
+	}
+	return events, nil
 }
 
 func summarizeEpisodeForIndex(episode TaskEpisode, events []TaskEpisodeEvent) string {

--- a/src/agent/internal/agent/task_episode.go
+++ b/src/agent/internal/agent/task_episode.go
@@ -544,23 +544,28 @@ func (s *TaskEpisodeStore) AppendEpisodeEvent(ctx context.Context, episode TaskE
 }
 
 func (s *TaskEpisodeStore) MarkRunningEpisodesInterrupted(ctx context.Context, reason string) (int, error) {
+	episodes, err := s.MarkRunningEpisodesInterruptedWithDetails(ctx, reason)
+	return len(episodes), err
+}
+
+func (s *TaskEpisodeStore) MarkRunningEpisodesInterruptedWithDetails(ctx context.Context, reason string) ([]TaskEpisode, error) {
 	select {
 	case <-ctx.Done():
-		return 0, ctx.Err()
+		return nil, ctx.Err()
 	default:
 	}
 	if s == nil || s.rootDir == "" {
-		return 0, nil
+		return nil, nil
 	}
 	if strings.TrimSpace(reason) == "" {
 		reason = "agent stopped before the task episode completed"
 	}
 	if _, err := os.Stat(s.indexPath()); os.IsNotExist(err) {
 		if err := s.RebuildIndex(ctx); err != nil {
-			return 0, err
+			return nil, err
 		}
 	} else if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	s.mu.Lock()
@@ -568,11 +573,11 @@ func (s *TaskEpisodeStore) MarkRunningEpisodesInterrupted(ctx context.Context, r
 
 	index, err := s.loadIndex()
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	changed := false
-	count := 0
+	var interrupted []TaskEpisode
 	for i := range index.Episodes {
 		entry := index.Episodes[i]
 		if entry.Status != "running" {
@@ -581,11 +586,11 @@ func (s *TaskEpisodeStore) MarkRunningEpisodesInterrupted(ctx context.Context, r
 		path := filepath.Join(s.rootDir, entry.File)
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return count, err
+			return interrupted, err
 		}
 		var episode TaskEpisode
 		if err := yaml.Unmarshal(data, &episode); err != nil {
-			return count, err
+			return interrupted, err
 		}
 		episode.Status = "interrupted"
 		episode.EndedAt = now
@@ -602,21 +607,23 @@ func (s *TaskEpisodeStore) MarkRunningEpisodesInterrupted(ctx context.Context, r
 		if _, err := os.Stat(eventsPath); err == nil {
 			events, _ = readEpisodeEvents(eventsPath)
 		}
+		record := episode
+		record.Events = append([]TaskEpisodeEvent(nil), events...)
 		episode.Events = nil
 		if err := writeYAMLAtomic(path, episode); err != nil {
-			return count, err
+			return interrupted, err
 		}
 		index.Episodes[i] = s.indexEntryForEpisode(episode, dir, events)
-		count++
+		interrupted = append(interrupted, record)
 		changed = true
 	}
 	if changed {
 		index.UpdatedAt = now
 		if err := writeYAMLAtomic(s.indexPath(), index); err != nil {
-			return count, err
+			return interrupted, err
 		}
 	}
-	return count, nil
+	return interrupted, nil
 }
 
 func (s *TaskEpisodeStore) Search(ctx context.Context, query EpisodeQuery) ([]MemoryHit, error) {


### PR DESCRIPTION
## Summary
- persist lightweight chat history entries with episode references
- write task episodes incrementally and mark unfinished episodes interrupted on restart
- add episode detail API and Web UI trace loading

## Tests
- cd src/agent && go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat history persists to disk (JSONL), is compacted for lightweight storage, and is restored across sessions.
  * Episodes receive stable IDs surfaced in API responses and UI; per-message "Trace" links open an episode panel.
  * Runtime supports episode IDs for runs and can generate new episode IDs; planner memory loads persisted history.

* **Bug Fixes / Reliability**
  * Best-effort recovery marks interrupted episodes and preserves interrupted-status in planner prompts.

* **Tests**
  * Added tests for persistence, compaction, interrupted-episode handling, episode retrieval, and telemetry export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->