### PR TITLE
feat(ota): support compressed release image assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,8 @@ jobs:
           --tag-name "${{ steps.release_info.outputs.tag_name }}" \
           --target-commitish "${{ github.sha }}" \
           --asset-glob 'pico-sdk/output/image/*' \
-          --required-assets 'boot_a.img boot_b.img oem.img rootfs.img userdata.img update.img manifest.json' \
+          --required-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+          --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
           --retry-count 5 \
           --retry-delay-seconds 30 \
           $PRERELEASE_FLAG

--- a/docs/09-ota/architecture.md
+++ b/docs/09-ota/architecture.md
@@ -68,6 +68,8 @@ Manifest 中 `parts[].name` 只能是 `boot`、`oem`、`rootfs`。每个 part �
 - `asset`：slot-neutral `{name,size,sha256}`，只适用于两边字节完全一致的镜像。
 - `asset_a` 和 `asset_b`：slot-specific `{name,size,sha256}`。
 
+For `.img.tar.gz` assets, `size` and `sha256` describe the downloaded archive. The required `image_sha256` field describes the extracted `.img`; OTA state and `requires_partitions` compare this extracted image hash.
+
 `boot` 必须使用 `asset_a` 和 `asset_b`，因为 boot image 内包含 slot-specific DTB bootargs。`oem` 和 `rootfs` 可以使用 slot-specific assets，也可以在确认为 byte-identical 时使用 slot-neutral asset。
 
 ## Factory baseline

--- a/docs/09-ota/ota-external-developers.md
+++ b/docs/09-ota/ota-external-developers.md
@@ -209,6 +209,8 @@ When you use `--base-url`, the manifest includes direct download URLs:
 }
 ```
 
+Compressed assets can use a `.img.tar.gz` name. For those assets, `size` and `sha256` identify the downloaded archive, and the required `image_sha256` field identifies the extracted `.img` that is written to the partition. Use `image_sha256` in `requires_partitions`.
+
 ## Persistent Configuration
 
 Instead of passing parameters every time, configure the device permanently:

--- a/scripts/create_github_release.sh
+++ b/scripts/create_github_release.sh
@@ -10,6 +10,7 @@ Usage:
     --target-commitish SHA \
     --asset-glob 'path/to/assets/*' \
     [--required-assets 'FILE ...'] \
+    [--upload-assets 'FILE ...'] \
     [--prerelease] \
     [--retry-count N] \
     [--retry-delay-seconds N]
@@ -32,6 +33,7 @@ release_name=""
 target_commitish=""
 asset_glob=""
 required_assets=""
+upload_assets=""
 prerelease="false"
 retry_count=5
 retry_delay_seconds=20
@@ -56,6 +58,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --required-assets)
       required_assets="${2:-}"
+      shift 2
+      ;;
+    --upload-assets)
+      upload_assets="${2:-}"
       shift 2
       ;;
     --prerelease)
@@ -145,6 +151,24 @@ validate_required_assets() {
   done
 }
 
+upload_files=()
+select_upload_assets() {
+  local upload_asset
+  local upload_file
+
+  if [ -z "$upload_assets" ]; then
+    upload_files=("${asset_files[@]}")
+    return 0
+  fi
+
+  for upload_asset in $upload_assets; do
+    if ! upload_file="$(asset_file_for_name "$upload_asset")"; then
+      die "missing release upload asset: $upload_asset"
+    fi
+    upload_files+=("$upload_file")
+  done
+}
+
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1" | awk '{print $1}'
@@ -171,6 +195,7 @@ release_notes_for_target() {
 
 release_notes="$(release_notes_for_target)"
 validate_required_assets
+select_upload_assets
 
 log "Release upload context"
 log "  repository: ${GITHUB_REPOSITORY:-unknown}"
@@ -179,6 +204,7 @@ log "  release_name: $release_name"
 log "  target_commitish: $target_commitish"
 log "  asset_glob: $asset_glob"
 log "  required_assets: ${required_assets:-none}"
+log "  upload_assets: ${upload_assets:-all matched assets}"
 log "  retry_count: $retry_count"
 log "  retry_delay_seconds: $retry_delay_seconds"
 log "  gh_debug: ${GH_DEBUG:-unset}"
@@ -194,6 +220,11 @@ for asset in "${asset_files[@]}"; do
   size_bytes="$(wc -c < "$asset" | tr -d '[:space:]')"
   checksum="$(sha256_of "$asset")"
   log "  $(basename "$asset") size=${size_bytes} sha256=${checksum}"
+done
+
+log "Release upload assets"
+for asset in "${upload_files[@]}"; do
+  log "  $(basename "$asset")"
 done
 
 run_with_retry() {
@@ -289,7 +320,7 @@ ensure_release() {
 
 ensure_release
 
-for asset in "${asset_files[@]}"; do
+for asset in "${upload_files[@]}"; do
   run_with_retry \
     "release asset upload $(basename "$asset")" \
     gh release upload "$tag_name" "$asset" --clobber

--- a/scripts/generate_ota_device_config.sh
+++ b/scripts/generate_ota_device_config.sh
@@ -74,14 +74,20 @@ jq -e -S \
   --arg channel "$channel" \
   '
   def part($name): .parts[] | select(.name == $name);
+  def partition_hash($asset):
+    if ($asset.image_sha256 // "") != "" then
+      $asset.image_sha256
+    else
+      $asset.sha256
+    end;
   def hash_for($name; $slot):
     (part($name)) as $part |
     if $part.asset != null then
-      $part.asset.sha256
+      partition_hash($part.asset)
     elif $slot == "a" and $part.asset_a != null then
-      $part.asset_a.sha256
+      partition_hash($part.asset_a)
     elif $slot == "b" and $part.asset_b != null then
-      $part.asset_b.sha256
+      partition_hash($part.asset_b)
     else
       error("missing asset hash for " + $name + " slot " + $slot)
     end;

--- a/scripts/test_github_release_upload.sh
+++ b/scripts/test_github_release_upload.sh
@@ -16,6 +16,7 @@ printf '{"version":"v-test"}\n' > "$assets_dir/manifest.json"
 for image in boot_a.img boot_b.img oem.img rootfs.img userdata.img; do
   printf '%s\n' "$image" > "$assets_dir/$image"
 done
+printf 'extra debug asset\n' > "$assets_dir/debug.log"
 # Note: symlinks oem_a/oem_b/rootfs_a/rootfs_b should NOT exist
 # (they're cleaned up after update.img packaging in build.sh)
 
@@ -127,7 +128,8 @@ if ! PATH="$fake_bin:$PATH" \
       --release-name "Test Release" \
       --target-commitish "$target_commitish" \
       --asset-glob "$assets_dir/*" \
-      --required-assets 'boot_a.img boot_b.img oem.img rootfs.img userdata.img update.img manifest.json' \
+      --required-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+      --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
       --retry-count 4 \
       --retry-delay-seconds 15 \
       >"$log_file" 2>&1; then
@@ -171,9 +173,16 @@ if [ "$(grep -c '^upload:manifest.json:' "$state_dir/events")" -ne 1 ]; then
   exit 1
 fi
 
-for image in boot_a.img boot_b.img oem.img rootfs.img userdata.img; do
+for image in boot_a.img boot_b.img oem.img rootfs.img; do
   if [ "$(grep -c "^upload:$image:" "$state_dir/events")" -ne 1 ]; then
     echo "release script must upload required OTA image: $image" >&2
+    exit 1
+  fi
+done
+
+for skipped_asset in userdata.img debug.log; do
+  if grep -q "^upload:$skipped_asset:" "$state_dir/events"; then
+    echo "release script must skip non-allowlisted release asset: $skipped_asset" >&2
     exit 1
   fi
 done
@@ -206,7 +215,8 @@ if ! PATH="$fake_bin:$PATH" \
       --release-name "Test Release" \
       --target-commitish abc123 \
       --asset-glob "$assets_dir/*" \
-      --required-assets 'boot_a.img boot_b.img oem.img rootfs.img userdata.img update.img manifest.json' \
+      --required-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+      --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
       --retry-count 3 \
       --retry-delay-seconds 0 \
       >"$log_file" 2>&1; then
@@ -239,7 +249,8 @@ if PATH="$fake_bin:$PATH" \
       --release-name "Test Release" \
       --target-commitish abc123 \
       --asset-glob "$assets_dir/*" \
-      --required-assets 'boot_a.img boot_b.img oem.img rootfs.img userdata.img update.img manifest.json' \
+      --required-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+      --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
       --retry-count 3 \
       --retry-delay-seconds 0 \
       >"$log_file" 2>&1; then

--- a/scripts/test_ota_device_config.sh
+++ b/scripts/test_ota_device_config.sh
@@ -19,9 +19,9 @@ cat > "$TMP_DIR/manifest.json" <<'JSON'
   "version": "20260523-120000-abcdef0",
   "build_time": "2026-05-23T12:00:00Z",
   "parts": [
-    {"name":"boot","asset_a":{"name":"boot_a.img","size":1,"sha256":"boot-a-hash"},"asset_b":{"name":"boot_b.img","size":1,"sha256":"boot-b-hash"}},
+    {"name":"boot","asset_a":{"name":"boot_a.img","size":1,"sha256":"boot-a-hash"},"asset_b":{"name":"boot_b.img.tar.gz","size":1,"sha256":"boot-b-archive-hash","image_sha256":"boot-b-image-hash"}},
     {"name":"oem","asset_a":{"name":"oem_a.img","size":1,"sha256":"oem-a-hash"},"asset_b":{"name":"oem_b.img","size":1,"sha256":"oem-b-hash"}},
-    {"name":"rootfs","asset":{"name":"rootfs.img","size":1,"sha256":"rootfs-neutral-hash"}}
+    {"name":"rootfs","asset":{"name":"rootfs.img.tar.gz","size":1,"sha256":"rootfs-archive-hash","image_sha256":"rootfs-image-hash"}}
   ],
   "signature": {"algorithm":"ed25519","value":"unused"}
 }
@@ -40,10 +40,10 @@ jq -e '
   .factory_build_time == "2026-05-23T12:00:00Z" and
   .factory_partition_hashes.a.boot == "boot-a-hash" and
   .factory_partition_hashes.a.oem == "oem-a-hash" and
-  .factory_partition_hashes.a.rootfs == "rootfs-neutral-hash" and
-  .factory_partition_hashes.b.boot == "boot-b-hash" and
+  .factory_partition_hashes.a.rootfs == "rootfs-image-hash" and
+  .factory_partition_hashes.b.boot == "boot-b-image-hash" and
   .factory_partition_hashes.b.oem == "oem-b-hash" and
-  .factory_partition_hashes.b.rootfs == "rootfs-neutral-hash"
+  .factory_partition_hashes.b.rootfs == "rootfs-image-hash"
 ' "$TMP_DIR/config.json" >/dev/null
 
 for repo in \

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -36,12 +36,26 @@ if ! grep -q -- '--required-assets' "$WORKFLOW"; then
     exit 1
 fi
 
-for asset in boot_a.img boot_b.img oem.img rootfs.img userdata.img update.img manifest.json; do
-    if ! grep -q "$asset" "$WORKFLOW"; then
-        echo "build workflow must require release asset: $asset" >&2
-        exit 1
-    fi
-done
+release_assets='boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json'
+if ! grep -q -- "--required-assets '$release_assets'" "$WORKFLOW"; then
+    echo "build workflow must require only allowlisted release assets" >&2
+    exit 1
+fi
+
+if ! grep -q -- '--upload-assets' "$WORKFLOW"; then
+    echo "build workflow must pass an explicit release upload asset allowlist" >&2
+    exit 1
+fi
+
+if ! grep -q -- "--upload-assets '$release_assets'" "$WORKFLOW"; then
+    echo "build workflow must upload only allowlisted release assets" >&2
+    exit 1
+fi
+
+if grep -q 'userdata.img' "$WORKFLOW"; then
+    echo "build workflow must not upload userdata.img to GitHub releases" >&2
+    exit 1
+fi
 
 if ! grep -q 'GH_DEBUG' "$WORKFLOW"; then
     echo "build workflow must enable GitHub CLI debug output for release creation" >&2

--- a/src/agent/internal/ota/manifest.go
+++ b/src/agent/internal/ota/manifest.go
@@ -146,8 +146,8 @@ func validateManifestAsset(field string, asset ManifestAsset, expectedName strin
 	if asset.Name == "" || !assetNameRE.MatchString(asset.Name) || strings.Contains(asset.Name, "..") || strings.HasPrefix(asset.Name, "/") {
 		return fmt.Errorf("%s has invalid name %q", field, asset.Name)
 	}
-	if asset.Name != expectedName {
-		return fmt.Errorf("%s name %q, want %q", field, asset.Name, expectedName)
+	if asset.Name != expectedName && asset.Name != compressedManifestAssetName(expectedName) {
+		return fmt.Errorf("%s name %q, want %q or %q", field, asset.Name, expectedName, compressedManifestAssetName(expectedName))
 	}
 	if asset.URL != "" {
 		parsed, err := url.ParseRequestURI(asset.URL)
@@ -177,6 +177,14 @@ func validateManifestAsset(field string, asset ManifestAsset, expectedName strin
 		return fmt.Errorf("%s has invalid sha256: %w", field, err)
 	}
 	return nil
+}
+
+func compressedManifestAssetName(name string) string {
+	return name + ".tar.gz"
+}
+
+func isCompressedImageAssetName(name string) bool {
+	return strings.HasSuffix(strings.ToLower(name), ".img.tar.gz")
 }
 
 func VerifyManifestJSON(encoded []byte, publicKey ed25519.PublicKey) (Manifest, error) {

--- a/src/agent/internal/ota/manifest.go
+++ b/src/agent/internal/ota/manifest.go
@@ -40,10 +40,11 @@ type ManifestPart struct {
 }
 
 type ManifestAsset struct {
-	Name   string `json:"name"`
-	URL    string `json:"url,omitempty"`
-	Size   int64  `json:"size"`
-	SHA256 string `json:"sha256"`
+	Name        string `json:"name"`
+	URL         string `json:"url,omitempty"`
+	Size        int64  `json:"size"`
+	SHA256      string `json:"sha256"`
+	ImageSHA256 string `json:"image_sha256,omitempty"`
 }
 
 var (
@@ -167,14 +168,33 @@ func validateManifestAsset(field string, asset ManifestAsset, expectedName strin
 	if asset.Size <= 0 {
 		return fmt.Errorf("%s size %d must be positive", field, asset.Size)
 	}
-	if len(asset.SHA256) != 64 {
-		return fmt.Errorf("%s sha256 length %d, want 64", field, len(asset.SHA256))
+	if err := validateSHA256Hex(field+".sha256", asset.SHA256); err != nil {
+		return err
 	}
-	if asset.SHA256 != strings.ToLower(asset.SHA256) {
-		return fmt.Errorf("%s sha256 must be lowercase", field)
+	if asset.Name == compressedManifestAssetName(expectedName) {
+		if asset.ImageSHA256 == "" {
+			return fmt.Errorf("%s image_sha256 is required for compressed image assets", field)
+		}
+		if err := validateSHA256Hex(field+".image_sha256", asset.ImageSHA256); err != nil {
+			return err
+		}
+		return nil
 	}
-	if _, err := hex.DecodeString(asset.SHA256); err != nil {
-		return fmt.Errorf("%s has invalid sha256: %w", field, err)
+	if asset.ImageSHA256 != "" {
+		return fmt.Errorf("%s image_sha256 is only allowed for compressed image assets", field)
+	}
+	return nil
+}
+
+func validateSHA256Hex(field string, value string) error {
+	if len(value) != 64 {
+		return fmt.Errorf("%s length %d, want 64", field, len(value))
+	}
+	if value != strings.ToLower(value) {
+		return fmt.Errorf("%s must be lowercase", field)
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return fmt.Errorf("%s is invalid: %w", field, err)
 	}
 	return nil
 }
@@ -185,6 +205,13 @@ func compressedManifestAssetName(name string) string {
 
 func isCompressedImageAssetName(name string) bool {
 	return strings.HasSuffix(strings.ToLower(name), ".img.tar.gz")
+}
+
+func partitionSHA256ForAsset(asset ManifestAsset) string {
+	if asset.ImageSHA256 != "" {
+		return asset.ImageSHA256
+	}
+	return asset.SHA256
 }
 
 func VerifyManifestJSON(encoded []byte, publicKey ed25519.PublicKey) (Manifest, error) {

--- a/src/agent/internal/ota/manifest_test.go
+++ b/src/agent/internal/ota/manifest_test.go
@@ -165,13 +165,27 @@ func TestManifestValidationAllowsOnlyCanonicalPartNames(t *testing.T) {
 func TestManifestValidationAllowsTarGzCompressedImageAssets(t *testing.T) {
 	manifest := validTestManifest()
 	manifest.Parts[0].AssetA.Name = "boot_a.img.tar.gz"
+	manifest.Parts[0].AssetA.ImageSHA256 = testHashA
 	manifest.Parts[0].AssetB.Name = "boot_b.img.tar.gz"
+	manifest.Parts[0].AssetB.ImageSHA256 = testHashB
 	manifest.Parts[1].AssetA.Name = "oem_a.img.tar.gz"
+	manifest.Parts[1].AssetA.ImageSHA256 = testHashA
 	manifest.Parts[1].AssetB.Name = "oem_b.img.tar.gz"
+	manifest.Parts[1].AssetB.ImageSHA256 = testHashB
 	manifest.Parts[2].Asset.Name = "rootfs.img.tar.gz"
+	manifest.Parts[2].Asset.ImageSHA256 = testHashC
 
 	if err := manifest.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestManifestValidationRequiresImageSHA256ForTarGzAssets(t *testing.T) {
+	manifest := validTestManifest()
+	manifest.Parts[0].AssetB.Name = "boot_b.img.tar.gz"
+
+	if err := manifest.Validate(); err == nil || !strings.Contains(err.Error(), "image_sha256") {
+		t.Fatalf("Validate() error = %v, want missing image_sha256 rejection", err)
 	}
 }
 

--- a/src/agent/internal/ota/manifest_test.go
+++ b/src/agent/internal/ota/manifest_test.go
@@ -162,6 +162,19 @@ func TestManifestValidationAllowsOnlyCanonicalPartNames(t *testing.T) {
 	}
 }
 
+func TestManifestValidationAllowsTarGzCompressedImageAssets(t *testing.T) {
+	manifest := validTestManifest()
+	manifest.Parts[0].AssetA.Name = "boot_a.img.tar.gz"
+	manifest.Parts[0].AssetB.Name = "boot_b.img.tar.gz"
+	manifest.Parts[1].AssetA.Name = "oem_a.img.tar.gz"
+	manifest.Parts[1].AssetB.Name = "oem_b.img.tar.gz"
+	manifest.Parts[2].Asset.Name = "rootfs.img.tar.gz"
+
+	if err := manifest.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
 func TestManifestValidationRejectsDuplicateParts(t *testing.T) {
 	manifest := validTestManifest()
 	manifest.Parts = append(manifest.Parts, manifest.Parts[0])
@@ -410,7 +423,7 @@ func TestManifestAssetWithURL(t *testing.T) {
 	manifest := validTestManifest()
 	manifest.Parts[0].AssetA.URL = "https://example.com/boot_a.img"
 	manifest.Parts[0].AssetB.URL = "https://example.com/boot_b.img"
-	
+
 	if err := manifest.Validate(); err != nil {
 		t.Fatalf("Validate() with URLs error = %v", err)
 	}
@@ -429,7 +442,7 @@ func TestManifestAssetURLValidation(t *testing.T) {
 		{"with whitespace", "https://example.com/file .img", true},
 		{"empty is ok", "", false},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			asset := ManifestAsset{
@@ -451,11 +464,11 @@ func TestManifestWithURLsSignatureVerification(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
-	
+
 	manifest := validTestManifest()
 	manifest.Parts[0].AssetA.URL = "https://cdn.example.com/firmware/boot_a.img"
 	manifest.Parts[0].AssetB.URL = "https://cdn.example.com/firmware/boot_b.img"
-	
+
 	canonical, err := CanonicalManifestJSON(manifest)
 	if err != nil {
 		t.Fatalf("CanonicalManifestJSON() error = %v", err)
@@ -464,17 +477,17 @@ func TestManifestWithURLsSignatureVerification(t *testing.T) {
 		Algorithm: "ed25519",
 		Value:     hex.EncodeToString(ed25519.Sign(priv, canonical)),
 	}
-	
+
 	manifestBytes, err := json.Marshal(manifest)
 	if err != nil {
 		t.Fatalf("Marshal(manifest) error = %v", err)
 	}
-	
+
 	verified, err := VerifyManifestJSON(manifestBytes, pub)
 	if err != nil {
 		t.Fatalf("VerifyManifestJSON() error = %v", err)
 	}
-	
+
 	if verified.Parts[0].AssetA.URL != "https://cdn.example.com/firmware/boot_a.img" {
 		t.Errorf("URL not preserved: got %q", verified.Parts[0].AssetA.URL)
 	}

--- a/src/agent/internal/ota/state.go
+++ b/src/agent/internal/ota/state.go
@@ -222,7 +222,7 @@ func (s *State) CommitUpdate(manifest Manifest, targetSlot Slot, assets map[stri
 		slotState.Partitions = map[string]PartitionVersion{}
 	}
 	for part, asset := range assets {
-		slotState.Partitions[part] = PartitionVersion{Version: manifest.Version, Hash: asset.SHA256}
+		slotState.Partitions[part] = PartitionVersion{Version: manifest.Version, Hash: partitionSHA256ForAsset(asset)}
 	}
 	s.Slots[slot] = slotState
 	s.LastCommittedVersion = manifest.Version

--- a/src/agent/internal/ota/updater.go
+++ b/src/agent/internal/ota/updater.go
@@ -336,6 +336,10 @@ func (u *Updater) checkOnceLocked(ctx context.Context) (UpdateResult, error) {
 		}
 		dst := filepath.Join(u.config.DownloadDir, asset.Name)
 		if u.cachedDownloadVerified(dst, asset) {
+			if err := u.verifyDownloadedImage(dst, asset); err != nil {
+				u.recordError("verify", err)
+				return UpdateResult{}, err
+			}
 			selectedAssets[part.Name] = asset
 			downloaded[part.Name] = dst
 			continue
@@ -354,6 +358,10 @@ func (u *Updater) checkOnceLocked(ctx context.Context) (UpdateResult, error) {
 			return UpdateResult{}, err
 		}
 		u.logf("ota verify: %s sha256 ok", asset.Name)
+		if err := u.verifyDownloadedImage(dst, asset); err != nil {
+			u.recordError("verify", err)
+			return UpdateResult{}, err
+		}
 		selectedAssets[part.Name] = asset
 		downloaded[part.Name] = dst
 	}
@@ -369,7 +377,7 @@ func (u *Updater) checkOnceLocked(ctx context.Context) (UpdateResult, error) {
 	state.DownloadedAssets = downloaded
 	state.DownloadedHashes = map[string]string{}
 	for part, asset := range selectedAssets {
-		state.DownloadedHashes[part] = asset.SHA256
+		state.DownloadedHashes[part] = partitionSHA256ForAsset(asset)
 	}
 	if state.Slots == nil {
 		state.Slots = map[string]SlotPartitionInfo{}
@@ -480,6 +488,17 @@ func (u *Updater) cachedDownloadVerified(path string, asset ManifestAsset) bool 
 	}
 	u.logf("ota download: %s skipped; cached file verified dst=%s", asset.Name, path)
 	return true
+}
+
+func (u *Updater) verifyDownloadedImage(path string, asset ManifestAsset) error {
+	if asset.ImageSHA256 == "" {
+		return nil
+	}
+	if err := verifyPartitionImage(path, asset.ImageSHA256); err != nil {
+		return fmt.Errorf("%s image_sha256: %w", asset.Name, err)
+	}
+	u.logf("ota verify: %s image_sha256 ok", asset.Name)
+	return nil
 }
 
 func (u *Updater) ProcessPendingHealth(ctx context.Context) error {

--- a/src/agent/internal/ota/updater.go
+++ b/src/agent/internal/ota/updater.go
@@ -794,6 +794,9 @@ func isGitHubURL(rawURL string) bool {
 }
 
 func (u *Updater) validateAssetFitsPartition(partName string, target Slot, asset ManifestAsset) error {
+	if isCompressedImageAssetName(asset.Name) {
+		return nil
+	}
 	blockName := partitionBlockName(partName, target)
 	if max, ok := u.partitionSizes()[blockName]; ok && asset.Size > max {
 		return fmt.Errorf("asset %s size %d is larger than partition %s size %d", asset.Name, asset.Size, blockName, max)

--- a/src/agent/internal/ota/updater_test.go
+++ b/src/agent/internal/ota/updater_test.go
@@ -92,9 +92,9 @@ func TestUpdaterDownloadsTarGzAssetsAndWritesExtractedImages(t *testing.T) {
 		"oem_b.img":  oemImage,
 		"rootfs.img": rootfsImage,
 	}, func(m *Manifest) {
-		m.Parts[0].AssetB = testManifestAsset("boot_b.img.tar.gz", bootArchive)
-		m.Parts[1].AssetB = testManifestAsset("oem_b.img.tar.gz", oemArchive)
-		m.Parts[2].Asset = testManifestAsset("rootfs.img.tar.gz", rootfsArchive)
+		m.Parts[0].AssetB = testCompressedManifestAsset("boot_b.img.tar.gz", bootArchive, bootImage)
+		m.Parts[1].AssetB = testCompressedManifestAsset("oem_b.img.tar.gz", oemArchive, oemImage)
+		m.Parts[2].Asset = testCompressedManifestAsset("rootfs.img.tar.gz", rootfsArchive, rootfsImage)
 	})
 	server := env.releaseServer(t, manifest, map[string][]byte{
 		"boot_b.img.tar.gz": bootArchive,
@@ -117,6 +117,52 @@ func TestUpdaterDownloadsTarGzAssetsAndWritesExtractedImages(t *testing.T) {
 		t.Fatalf("ReadFile(downloaded archive) error = %v", err)
 	} else if !bytes.Equal(got, rootfsArchive) {
 		t.Fatalf("downloaded archive was modified before verification")
+	}
+	state, err := LoadState(filepath.Join(env.stateDir, "state.json"))
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if got := state.DownloadedHashes["boot"]; got != testSHA256Hex(bootImage) {
+		t.Fatalf("state.DownloadedHashes[boot] = %s, want extracted image hash", got)
+	}
+	if got := state.DownloadedHashes["oem"]; got != testSHA256Hex(oemImage) {
+		t.Fatalf("state.DownloadedHashes[oem] = %s, want extracted image hash", got)
+	}
+	if got := state.DownloadedHashes["rootfs"]; got != testSHA256Hex(rootfsImage) {
+		t.Fatalf("state.DownloadedHashes[rootfs] = %s, want extracted image hash", got)
+	}
+}
+
+func TestUpdaterRejectsTarGzImageSHA256MismatchBeforeWriting(t *testing.T) {
+	env := newUpdaterTestEnv(t)
+	bootImage := []byte("boot-b-v2")
+	bootArchive := testTarGzImage(t, "boot_b.img", bootImage)
+	manifest := env.signedManifest(map[string][]byte{
+		"boot_a.img": []byte("boot-a-v2"),
+		"boot_b.img": bootImage,
+		"oem_a.img":  []byte("oem-a-v2"),
+		"oem_b.img":  []byte("oem-b-v2"),
+		"rootfs.img": []byte("rootfs-v2"),
+	}, func(m *Manifest) {
+		m.Parts[0].AssetB = testCompressedManifestAsset("boot_b.img.tar.gz", bootArchive, bootImage)
+		m.Parts[0].AssetB.ImageSHA256 = strings.Repeat("d", 64)
+	})
+	server := env.releaseServer(t, manifest, map[string][]byte{
+		"boot_b.img.tar.gz": bootArchive,
+		"oem_b.img":         []byte("oem-b-v2"),
+		"rootfs.img":        []byte("rootfs-v2"),
+	})
+	env.config.ReleaseURL = server.URL + "/repos/AidenAI-IO/aiden-hardware-demo/releases/latest"
+
+	_, err := env.updater().CheckOnce(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "image_sha256") {
+		t.Fatalf("CheckOnce() error = %v, want image_sha256 mismatch", err)
+	}
+	assertFileContent(t, filepath.Join(env.blockDir, "boot_b"), "old-boot-b")
+	assertFileContent(t, filepath.Join(env.blockDir, "oem_b"), "old-oem-b")
+	assertFileContent(t, filepath.Join(env.blockDir, "rootfs_b"), "old-rootfs-b")
+	if env.reboots != 0 {
+		t.Fatalf("reboots = %d, want 0", env.reboots)
 	}
 }
 
@@ -1202,8 +1248,18 @@ func (e *updaterTestEnv) manifestValue(assetBytes map[string][]byte, mutate func
 }
 
 func testManifestAsset(name string, body []byte) *ManifestAsset {
+	return &ManifestAsset{Name: name, Size: int64(len(body)), SHA256: testSHA256Hex(body)}
+}
+
+func testCompressedManifestAsset(name string, archive []byte, image []byte) *ManifestAsset {
+	asset := testManifestAsset(name, archive)
+	asset.ImageSHA256 = testSHA256Hex(image)
+	return asset
+}
+
+func testSHA256Hex(body []byte) string {
 	sum := sha256.Sum256(body)
-	return &ManifestAsset{Name: name, Size: int64(len(body)), SHA256: hex.EncodeToString(sum[:])}
+	return hex.EncodeToString(sum[:])
 }
 
 func testTarGzImage(t *testing.T, imageName string, image []byte) []byte {

--- a/src/agent/internal/ota/updater_test.go
+++ b/src/agent/internal/ota/updater_test.go
@@ -1,7 +1,9 @@
 package ota
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -72,6 +74,49 @@ func TestUpdaterHappyPathDownloadsWritesSwitchesAndReboots(t *testing.T) {
 	}
 	if pending.TargetSlot != "b" || pending.TargetVersion != env.version || pending.Nonce == "" {
 		t.Fatalf("pending boot = %+v", pending)
+	}
+}
+
+func TestUpdaterDownloadsTarGzAssetsAndWritesExtractedImages(t *testing.T) {
+	env := newUpdaterTestEnv(t)
+	bootImage := []byte("boot-b-v2")
+	oemImage := []byte("oem-b-v2")
+	rootfsImage := []byte("rootfs-v2")
+	bootArchive := testTarGzImage(t, "boot_b.img", bootImage)
+	oemArchive := testTarGzImage(t, "oem_b.img", oemImage)
+	rootfsArchive := testTarGzImage(t, "rootfs.img", rootfsImage)
+	manifest := env.signedManifest(map[string][]byte{
+		"boot_a.img": []byte("boot-a-v2"),
+		"boot_b.img": bootImage,
+		"oem_a.img":  []byte("oem-a-v2"),
+		"oem_b.img":  oemImage,
+		"rootfs.img": rootfsImage,
+	}, func(m *Manifest) {
+		m.Parts[0].AssetB = testManifestAsset("boot_b.img.tar.gz", bootArchive)
+		m.Parts[1].AssetB = testManifestAsset("oem_b.img.tar.gz", oemArchive)
+		m.Parts[2].Asset = testManifestAsset("rootfs.img.tar.gz", rootfsArchive)
+	})
+	server := env.releaseServer(t, manifest, map[string][]byte{
+		"boot_b.img.tar.gz": bootArchive,
+		"oem_b.img.tar.gz":  oemArchive,
+		"rootfs.img.tar.gz": rootfsArchive,
+	})
+	env.config.ReleaseURL = server.URL + "/repos/AidenAI-IO/aiden-hardware-demo/releases/latest"
+
+	result, err := env.updater().CheckOnce(context.Background())
+	if err != nil {
+		t.Fatalf("CheckOnce() error = %v", err)
+	}
+	if !result.Updated || result.TargetSlot != SlotB {
+		t.Fatalf("CheckOnce() = %+v, want update to slot B", result)
+	}
+	assertFileContent(t, filepath.Join(env.blockDir, "boot_b"), string(bootImage))
+	assertFileContent(t, filepath.Join(env.blockDir, "oem_b"), string(oemImage))
+	assertFileContent(t, filepath.Join(env.blockDir, "rootfs_b"), string(rootfsImage))
+	if got, err := os.ReadFile(filepath.Join(env.downloadDir, "rootfs.img.tar.gz")); err != nil {
+		t.Fatalf("ReadFile(downloaded archive) error = %v", err)
+	} else if !bytes.Equal(got, rootfsArchive) {
+		t.Fatalf("downloaded archive was modified before verification")
 	}
 }
 
@@ -1154,6 +1199,31 @@ func (e *updaterTestEnv) manifestValue(assetBytes map[string][]byte, mutate func
 	}
 	manifest.Signature.Value = hex.EncodeToString(ed25519.Sign(e.priv, canonical))
 	return manifest
+}
+
+func testManifestAsset(name string, body []byte) *ManifestAsset {
+	sum := sha256.Sum256(body)
+	return &ManifestAsset{Name: name, Size: int64(len(body)), SHA256: hex.EncodeToString(sum[:])}
+}
+
+func testTarGzImage(t *testing.T, imageName string, image []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: imageName, Mode: 0o644, Size: int64(len(image))}); err != nil {
+		t.Fatalf("WriteHeader(%s) error = %v", imageName, err)
+	}
+	if _, err := tw.Write(image); err != nil {
+		t.Fatalf("Write(%s) error = %v", imageName, err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Close(tar) error = %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("Close(gzip) error = %v", err)
+	}
+	return buf.Bytes()
 }
 
 func (e *updaterTestEnv) releaseServer(t *testing.T, manifest []byte, assets map[string][]byte) *httptest.Server {

--- a/src/agent/internal/ota/writer.go
+++ b/src/agent/internal/ota/writer.go
@@ -3,6 +3,8 @@ package ota
 import (
 	"archive/tar"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -117,6 +119,11 @@ func openTarGzPartitionImage(path string) (io.ReadCloser, int64, error) {
 	if err != nil {
 		return nil, 0, err
 	}
+	expectedImageName := expectedTarGzImageName(path)
+	if !strings.HasSuffix(strings.ToLower(expectedImageName), ".img") {
+		_ = file.Close()
+		return nil, 0, fmt.Errorf("tar.gz image %s does not name an .img file", path)
+	}
 	gz, err := gzip.NewReader(file)
 	if err != nil {
 		_ = file.Close()
@@ -143,13 +150,40 @@ func openTarGzPartitionImage(path string) (io.ReadCloser, int64, error) {
 			_ = file.Close()
 			return nil, 0, fmt.Errorf("tar.gz image %s contains unsupported entry %q", path, header.Name)
 		}
-		if !strings.HasSuffix(strings.ToLower(filepath.Base(header.Name)), ".img") {
+		if filepath.Base(header.Name) != expectedImageName {
 			_ = gz.Close()
 			_ = file.Close()
-			return nil, 0, fmt.Errorf("tar.gz image %s entry %q is not an .img file", path, header.Name)
+			return nil, 0, fmt.Errorf("tar.gz image %s entry %q, want %s", path, header.Name, expectedImageName)
 		}
 		return &tarGzImageReader{path: path, file: file, gz: gz, tar: tr}, header.Size, nil
 	}
+}
+
+func expectedTarGzImageName(path string) string {
+	base := filepath.Base(path)
+	return base[:len(base)-len(".tar.gz")]
+}
+
+func verifyPartitionImage(path string, expectedSHA256 string) error {
+	src, _, err := openPartitionImage(path)
+	if err != nil {
+		return err
+	}
+	h := sha256.New()
+	copyErr := error(nil)
+	if _, copyErr = io.Copy(h, src); copyErr == nil {
+		copyErr = src.Close()
+	} else {
+		_ = src.Close()
+	}
+	if copyErr != nil {
+		return copyErr
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != expectedSHA256 {
+		return fmt.Errorf("image sha256 %s, want %s", got, expectedSHA256)
+	}
+	return nil
 }
 
 type tarGzImageReader struct {

--- a/src/agent/internal/ota/writer.go
+++ b/src/agent/internal/ota/writer.go
@@ -1,10 +1,13 @@
 package ota
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -51,26 +54,23 @@ func (w PartitionWriter) WritePartWithProgress(part string, targetSlot Slot, ima
 		targetSlotName, _ := slotName(targetSlot)
 		return fmt.Errorf("refusing to write active slot %s", targetSlotName)
 	}
-	info, err := os.Stat(imagePath)
+	src, imageSize, err := openPartitionImage(imagePath)
 	if err != nil {
 		return err
 	}
-	if max, ok := w.partitionSizes()[blockName]; ok && info.Size() > max {
-		return fmt.Errorf("image %s size %d is larger than partition %s size %d", imagePath, info.Size(), blockName, max)
+	if max, ok := w.partitionSizes()[blockName]; ok && imageSize > max {
+		_ = src.Close()
+		return fmt.Errorf("image %s size %d is larger than partition %s size %d", imagePath, imageSize, blockName, max)
 	}
 
-	src, err := os.Open(imagePath)
-	if err != nil {
-		return err
-	}
-	defer src.Close()
 	dstPath := filepath.Join(w.BlockDir, blockName)
 	dst, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_TRUNC, 0)
 	if err != nil {
+		_ = src.Close()
 		return fmt.Errorf("open target partition %s: %w", dstPath, err)
 	}
 	copyErr := error(nil)
-	reporter := newWriteProgressReporter(progress, part, blockName, imagePath, info.Size(), defaultProgressInterval)
+	reporter := newWriteProgressReporter(progress, part, blockName, imagePath, imageSize, defaultProgressInterval)
 	reader := &cumulativeProgressReader{
 		reader: src,
 		onRead: reporter.maybeReport,
@@ -78,15 +78,142 @@ func (w PartitionWriter) WritePartWithProgress(part string, targetSlot Slot, ima
 	if _, copyErr = io.Copy(dst, reader); copyErr == nil {
 		copyErr = dst.Sync()
 	}
+	srcCloseErr := src.Close()
 	closeErr := dst.Close()
 	if copyErr != nil {
 		return copyErr
 	}
+	if srcCloseErr != nil {
+		return srcCloseErr
+	}
 	if closeErr != nil {
 		return closeErr
 	}
-	reporter.complete(info.Size())
+	reporter.complete(imageSize)
 	return nil
+}
+
+func openPartitionImage(path string) (io.ReadCloser, int64, error) {
+	if isTarGzImagePath(path) {
+		return openTarGzPartitionImage(path)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	src, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	return src, info.Size(), nil
+}
+
+func isTarGzImagePath(path string) bool {
+	return strings.HasSuffix(strings.ToLower(path), ".tar.gz")
+}
+
+func openTarGzPartitionImage(path string) (io.ReadCloser, int64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	gz, err := gzip.NewReader(file)
+	if err != nil {
+		_ = file.Close()
+		return nil, 0, fmt.Errorf("open gzip image %s: %w", path, err)
+	}
+	tr := tar.NewReader(gz)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			_ = gz.Close()
+			_ = file.Close()
+			return nil, 0, fmt.Errorf("tar.gz image %s contains no .img file", path)
+		}
+		if err != nil {
+			_ = gz.Close()
+			_ = file.Close()
+			return nil, 0, fmt.Errorf("read tar.gz image %s: %w", path, err)
+		}
+		if header.FileInfo().IsDir() {
+			continue
+		}
+		if header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeRegA {
+			_ = gz.Close()
+			_ = file.Close()
+			return nil, 0, fmt.Errorf("tar.gz image %s contains unsupported entry %q", path, header.Name)
+		}
+		if !strings.HasSuffix(strings.ToLower(filepath.Base(header.Name)), ".img") {
+			_ = gz.Close()
+			_ = file.Close()
+			return nil, 0, fmt.Errorf("tar.gz image %s entry %q is not an .img file", path, header.Name)
+		}
+		return &tarGzImageReader{path: path, file: file, gz: gz, tar: tr}, header.Size, nil
+	}
+}
+
+type tarGzImageReader struct {
+	path       string
+	file       *os.File
+	gz         *gzip.Reader
+	tar        *tar.Reader
+	done       bool
+	pendingErr error
+}
+
+func (r *tarGzImageReader) Read(p []byte) (int, error) {
+	if r.pendingErr != nil {
+		err := r.pendingErr
+		r.pendingErr = nil
+		return 0, err
+	}
+	if r.done {
+		return 0, io.EOF
+	}
+	n, err := r.tar.Read(p)
+	if err != io.EOF {
+		return n, err
+	}
+	r.done = true
+	if tailErr := r.ensureNoExtraRegularFiles(); tailErr != nil {
+		if n > 0 {
+			r.pendingErr = tailErr
+			return n, nil
+		}
+		return 0, tailErr
+	}
+	if n > 0 {
+		return n, nil
+	}
+	return 0, io.EOF
+}
+
+func (r *tarGzImageReader) Close() error {
+	gzipErr := r.gz.Close()
+	fileErr := r.file.Close()
+	if gzipErr != nil {
+		return gzipErr
+	}
+	return fileErr
+}
+
+func (r *tarGzImageReader) ensureNoExtraRegularFiles() error {
+	for {
+		header, err := r.tar.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read tar.gz image %s: %w", r.path, err)
+		}
+		if header.FileInfo().IsDir() {
+			continue
+		}
+		if header.Typeflag == tar.TypeReg || header.Typeflag == tar.TypeRegA {
+			return fmt.Errorf("tar.gz image %s contains multiple image files", r.path)
+		}
+		return fmt.Errorf("tar.gz image %s contains unsupported entry %q", r.path, header.Name)
+	}
 }
 
 func (w PartitionWriter) partitionSizes() map[string]int64 {

--- a/src/agent/internal/ota/writer.go
+++ b/src/agent/internal/ota/writer.go
@@ -77,8 +77,13 @@ func (w PartitionWriter) WritePartWithProgress(part string, targetSlot Slot, ima
 		reader: src,
 		onRead: reporter.maybeReport,
 	}
-	if _, copyErr = io.Copy(dst, reader); copyErr == nil {
-		copyErr = dst.Sync()
+	var written int64
+	if written, copyErr = io.Copy(dst, reader); copyErr == nil {
+		if written != imageSize {
+			copyErr = fmt.Errorf("written bytes %d do not match expected image size %d for %s", written, imageSize, imagePath)
+		} else {
+			copyErr = dst.Sync()
+		}
 	}
 	srcCloseErr := src.Close()
 	closeErr := dst.Close()
@@ -91,7 +96,7 @@ func (w PartitionWriter) WritePartWithProgress(part string, targetSlot Slot, ima
 	if closeErr != nil {
 		return closeErr
 	}
-	reporter.complete(imageSize)
+	reporter.complete(written)
 	return nil
 }
 
@@ -99,12 +104,13 @@ func openPartitionImage(path string) (io.ReadCloser, int64, error) {
 	if isTarGzImagePath(path) {
 		return openTarGzPartitionImage(path)
 	}
-	info, err := os.Stat(path)
+	src, err := os.Open(path)
 	if err != nil {
 		return nil, 0, err
 	}
-	src, err := os.Open(path)
+	info, err := src.Stat()
 	if err != nil {
+		_ = src.Close()
 		return nil, 0, err
 	}
 	return src, info.Size(), nil
@@ -123,6 +129,15 @@ func openTarGzPartitionImage(path string) (io.ReadCloser, int64, error) {
 	if !strings.HasSuffix(strings.ToLower(expectedImageName), ".img") {
 		_ = file.Close()
 		return nil, 0, fmt.Errorf("tar.gz image %s does not name an .img file", path)
+	}
+	imageSize, err := validateTarGzPartitionImage(file, path, expectedImageName)
+	if err != nil {
+		_ = file.Close()
+		return nil, 0, err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		_ = file.Close()
+		return nil, 0, fmt.Errorf("seek tar.gz image %s: %w", path, err)
 	}
 	gz, err := gzip.NewReader(file)
 	if err != nil {
@@ -155,7 +170,55 @@ func openTarGzPartitionImage(path string) (io.ReadCloser, int64, error) {
 			_ = file.Close()
 			return nil, 0, fmt.Errorf("tar.gz image %s entry %q, want %s", path, header.Name, expectedImageName)
 		}
-		return &tarGzImageReader{path: path, file: file, gz: gz, tar: tr}, header.Size, nil
+		return &tarGzImageReader{path: path, file: file, gz: gz, tar: tr}, imageSize, nil
+	}
+}
+
+func validateTarGzPartitionImage(file *os.File, path string, expectedImageName string) (int64, error) {
+	gz, err := gzip.NewReader(file)
+	if err != nil {
+		return 0, fmt.Errorf("open gzip image %s: %w", path, err)
+	}
+	tr := tar.NewReader(gz)
+	imageSize, scanErr := scanTarGzPartitionImage(tr, path, expectedImageName)
+	closeErr := gz.Close()
+	if scanErr != nil {
+		return 0, scanErr
+	}
+	if closeErr != nil {
+		return 0, closeErr
+	}
+	return imageSize, nil
+}
+
+func scanTarGzPartitionImage(tr *tar.Reader, path string, expectedImageName string) (int64, error) {
+	foundImage := false
+	var imageSize int64
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			if !foundImage {
+				return 0, fmt.Errorf("tar.gz image %s contains no .img file", path)
+			}
+			return imageSize, nil
+		}
+		if err != nil {
+			return 0, fmt.Errorf("read tar.gz image %s: %w", path, err)
+		}
+		if header.FileInfo().IsDir() {
+			continue
+		}
+		if header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeRegA {
+			return 0, fmt.Errorf("tar.gz image %s contains unsupported entry %q", path, header.Name)
+		}
+		if foundImage {
+			return 0, fmt.Errorf("tar.gz image %s contains multiple image files", path)
+		}
+		if filepath.Base(header.Name) != expectedImageName {
+			return 0, fmt.Errorf("tar.gz image %s entry %q, want %s", path, header.Name, expectedImageName)
+		}
+		foundImage = true
+		imageSize = header.Size
 	}
 }
 

--- a/src/agent/internal/ota/writer_test.go
+++ b/src/agent/internal/ota/writer_test.go
@@ -88,6 +88,28 @@ func TestWriterRejectsOversizedTarGzImageByExtractedSize(t *testing.T) {
 	}
 }
 
+func TestWriterRejectsTarGzImageNameMismatch(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "boot_b"), []byte("old boot"), 0o644); err != nil {
+		t.Fatalf("WriteFile(block) error = %v", err)
+	}
+	src := filepath.Join(dir, "boot_b.img.tar.gz")
+	if err := os.WriteFile(src, testTarGzImage(t, "boot_a.img", []byte("boot image")), 0o644); err != nil {
+		t.Fatalf("WriteFile(src) error = %v", err)
+	}
+	w := PartitionWriter{BlockDir: dir, ActiveSlot: SlotA, PartitionSizes: map[string]int64{"boot_b": 100}}
+	if err := w.WritePart("boot", SlotB, src); err == nil || !strings.Contains(err.Error(), "want boot_b.img") {
+		t.Fatalf("WritePart() error = %v, want image name mismatch", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "boot_b"))
+	if err != nil {
+		t.Fatalf("ReadFile(block) error = %v", err)
+	}
+	if string(got) != "old boot" {
+		t.Fatalf("block content = %q, want unchanged", got)
+	}
+}
+
 func TestWriterReportsProgressAndCompletion(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "boot_b"), []byte{}, 0o644); err != nil {

--- a/src/agent/internal/ota/writer_test.go
+++ b/src/agent/internal/ota/writer_test.go
@@ -44,6 +44,50 @@ func TestWriterWritesOnlyInactiveCanonicalPartitions(t *testing.T) {
 	}
 }
 
+func TestWriterExtractsTarGzImageBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "rootfs_b"), []byte{}, 0o644); err != nil {
+		t.Fatalf("WriteFile(block) error = %v", err)
+	}
+	src := filepath.Join(dir, "rootfs.img.tar.gz")
+	if err := os.WriteFile(src, testTarGzImage(t, "rootfs.img", []byte("rootfs image")), 0o644); err != nil {
+		t.Fatalf("WriteFile(src) error = %v", err)
+	}
+	w := PartitionWriter{BlockDir: dir, ActiveSlot: SlotA, PartitionSizes: map[string]int64{"rootfs_b": 100}}
+	if err := w.WritePart("rootfs", SlotB, src); err != nil {
+		t.Fatalf("WritePart() error = %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "rootfs_b"))
+	if err != nil {
+		t.Fatalf("ReadFile(block) error = %v", err)
+	}
+	if string(got) != "rootfs image" {
+		t.Fatalf("block content = %q", got)
+	}
+}
+
+func TestWriterRejectsOversizedTarGzImageByExtractedSize(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "boot_b"), []byte("old boot"), 0o644); err != nil {
+		t.Fatalf("WriteFile(block) error = %v", err)
+	}
+	src := filepath.Join(dir, "boot_b.img.tar.gz")
+	if err := os.WriteFile(src, testTarGzImage(t, "boot_b.img", []byte("12345")), 0o644); err != nil {
+		t.Fatalf("WriteFile(src) error = %v", err)
+	}
+	w := PartitionWriter{BlockDir: dir, ActiveSlot: SlotA, PartitionSizes: map[string]int64{"boot_b": 4}}
+	if err := w.WritePart("boot", SlotB, src); err == nil || !strings.Contains(err.Error(), "larger than partition") {
+		t.Fatalf("WritePart() error = %v, want extracted size rejection", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "boot_b"))
+	if err != nil {
+		t.Fatalf("ReadFile(block) error = %v", err)
+	}
+	if string(got) != "old boot" {
+		t.Fatalf("block content = %q, want unchanged", got)
+	}
+}
+
 func TestWriterReportsProgressAndCompletion(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "boot_b"), []byte{}, 0o644); err != nil {

--- a/src/agent/internal/ota/writer_test.go
+++ b/src/agent/internal/ota/writer_test.go
@@ -1,6 +1,9 @@
 package ota
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -110,6 +113,65 @@ func TestWriterRejectsTarGzImageNameMismatch(t *testing.T) {
 	}
 }
 
+func TestWriterRejectsMultiEntryTarGzBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "rootfs_b"), []byte("old rootfs"), 0o644); err != nil {
+		t.Fatalf("WriteFile(block) error = %v", err)
+	}
+	src := filepath.Join(dir, "rootfs.img.tar.gz")
+	archive := testTarGzWithEntries(t, []testTarEntry{
+		{name: "rootfs.img", body: []byte("rootfs image")},
+		{name: "extra.img", body: []byte("extra image")},
+	})
+	if err := os.WriteFile(src, archive, 0o644); err != nil {
+		t.Fatalf("WriteFile(src) error = %v", err)
+	}
+	w := PartitionWriter{BlockDir: dir, ActiveSlot: SlotA, PartitionSizes: map[string]int64{"rootfs_b": 100}}
+	if err := w.WritePart("rootfs", SlotB, src); err == nil || !strings.Contains(err.Error(), "multiple image files") {
+		t.Fatalf("WritePart() error = %v, want multiple image rejection", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "rootfs_b"))
+	if err != nil {
+		t.Fatalf("ReadFile(block) error = %v", err)
+	}
+	if string(got) != "old rootfs" {
+		t.Fatalf("block content = %q, want unchanged", got)
+	}
+}
+
+func TestWriterRejectsShortRawImageRead(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "boot_b"), []byte{}, 0o644); err != nil {
+		t.Fatalf("WriteFile(block) error = %v", err)
+	}
+	src := filepath.Join(dir, "boot_b.img")
+	image := bytes.Repeat([]byte("x"), 100*1024)
+	if err := os.WriteFile(src, image, 0o644); err != nil {
+		t.Fatalf("WriteFile(src) error = %v", err)
+	}
+	w := PartitionWriter{BlockDir: dir, ActiveSlot: SlotA, PartitionSizes: map[string]int64{"boot_b": int64(len(image))}}
+	truncated := false
+	var reports []WriteProgress
+	err := w.WritePartWithProgress("boot", SlotB, src, func(progress WriteProgress) {
+		reports = append(reports, progress)
+		if progress.Complete || truncated {
+			return
+		}
+		truncated = true
+		if truncateErr := os.Truncate(src, progress.Bytes); truncateErr != nil {
+			t.Fatalf("Truncate(src) error = %v", truncateErr)
+		}
+	})
+	if err == nil || !strings.Contains(err.Error(), "written bytes") {
+		t.Fatalf("WritePartWithProgress() error = %v, want written byte mismatch", err)
+	}
+	for _, report := range reports {
+		if report.Complete {
+			t.Fatalf("progress report = %+v, want no completion on short read", report)
+		}
+	}
+}
+
 func TestWriterReportsProgressAndCompletion(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "boot_b"), []byte{}, 0o644); err != nil {
@@ -210,4 +272,31 @@ func TestWriterPreservesDefaultLimitsWithPartialOverrides(t *testing.T) {
 	if err := w.WritePart("boot", SlotB, src); err == nil || !strings.Contains(err.Error(), "larger than partition") {
 		t.Fatalf("partial override oversize error = %v", err)
 	}
+}
+
+type testTarEntry struct {
+	name string
+	body []byte
+}
+
+func testTarGzWithEntries(t *testing.T, entries []testTarEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, entry := range entries {
+		if err := tw.WriteHeader(&tar.Header{Name: entry.name, Mode: 0o644, Size: int64(len(entry.body))}); err != nil {
+			t.Fatalf("WriteHeader(%s) error = %v", entry.name, err)
+		}
+		if _, err := tw.Write(entry.body); err != nil {
+			t.Fatalf("Write(%s) error = %v", entry.name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Close(tar) error = %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("Close(gzip) error = %v", err)
+	}
+	return buf.Bytes()
 }


### PR DESCRIPTION
Summary:
- Limit GitHub release uploads to boot_a.img, boot_b.img, oem.img, rootfs.img, update.img, and manifest.json.
- Allow OTA manifests to reference .img.tar.gz assets and stream-decompress them before partition writes.
- Validate compressed downloads by archive size/hash and partition writes by extracted image size.

Tests:
- sh scripts/test_release_ci_scripts.sh
- bash scripts/test_github_release_upload.sh
- bash scripts/test_github_actions_self_hosted_safety.sh
- go test ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for compressed (.tar.gz) OTA image files alongside raw image formats.

* **Chores**
  * Refined GitHub release asset configuration to include only essential OTA components and manifest files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->