### PR TITLE
feat: add chat cancellation stop button

### DIFF
--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -317,6 +317,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Invalid request", http.StatusBadRequest)
 		return
 	}
+	req.RequestID = strings.TrimSpace(req.RequestID)
 
 	inputText, runAttachments, historyAttachments, err := s.resolveRequestInput(req)
 	if err != nil {
@@ -324,14 +325,12 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Add user message to history
 	userMsg := Message{
 		Type:        "user",
 		Content:     inputText,
 		Attachments: historyAttachments,
 		Timestamp:   time.Now(),
 	}
-	s.appendHistory(userMsg)
 
 	// Async path — when the client provides a request_id
 	if req.RequestID != "" {
@@ -340,6 +339,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Sync path — legacy behaviour for web UI and clients without request_id
+	s.appendHistory(userMsg)
 	s.handleChatSync(w, r, req, inputText, runAttachments)
 }
 
@@ -453,6 +453,7 @@ func (s *Server) handleChatAsync(
 		http.Error(w, "request_id already in use", http.StatusConflict)
 		return
 	}
+	s.appendHistory(userMsg)
 
 	// Return {request_id} immediately
 	w.Header().Set("Content-Type", "application/json")
@@ -474,8 +475,6 @@ func (s *Server) handleChatAsync(
 			})
 		}()
 
-		bgCtx := context.Background()
-
 		// Event handler pushes intermediate messages into the pending result
 		// so the client can poll them in near-realtime.
 		eventHandler := func(event RunEvent) {
@@ -496,7 +495,7 @@ func (s *Server) handleChatAsync(
 			pending.mu.Unlock()
 
 			if event.Type == "tool_call" && s.runtime.config.VoiceToolCallSpeechOrDefault() {
-				go s.speakToolDescription(bgCtx, event.Description)
+				go s.speakToolDescription(runCtx, event.Description)
 			}
 		}
 
@@ -513,7 +512,7 @@ func (s *Server) handleChatAsync(
 
 		if s.runtime.config.VoiceStreamingTTSEnabledOrDefault() && s.audioClient != nil {
 			if ttsManager != nil {
-				stream, err := beginManagedTTSStream(bgCtx, ttsManager, s.audioClient, s.runtime.config)
+				stream, err := beginManagedTTSStream(runCtx, ttsManager, s.audioClient, s.runtime.config)
 				if err != nil {
 					if s.logger != nil {
 						s.logger.Warn("TTS BeginStream failed: %v", err)
@@ -571,7 +570,7 @@ func (s *Server) handleChatAsync(
 				if s.logger != nil {
 					s.logger.Info("TTS playback: %q", text)
 				}
-				if err := s.speakText(bgCtx, text, 0); err != nil && s.logger != nil {
+				if err := s.speakText(runCtx, text, 0); err != nil && s.logger != nil {
 					s.logger.Error("TTS playback failed: %v", err)
 				}
 			}(result.Output)
@@ -788,6 +787,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Invalid request", http.StatusBadRequest)
 		return
 	}
+	req.RequestID = strings.TrimSpace(req.RequestID)
 
 	inputText, runAttachments, historyAttachments, err := s.resolveRequestInput(req)
 	if err != nil {
@@ -807,7 +807,6 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 		Attachments: historyAttachments,
 		Timestamp:   time.Now(),
 	}
-	s.appendHistory(userMessage)
 
 	if s.logger != nil {
 		s.logger.Info("Chat request: %s attachments=%d stream=ndjson", inputText, len(runAttachments))
@@ -829,6 +828,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 		}()
 		ctx = runCtx
 	}
+	s.appendHistory(userMessage)
 
 	result, err := s.runtime.Run(ctx, RunRequest{
 		Input:          inputText,
@@ -924,7 +924,10 @@ func (s *Server) speakToolDescription(ctx context.Context, description string) {
 	if description == "" || s.audioClient == nil {
 		return
 	}
-	ttsCtx, cancel := context.WithTimeout(context.Background(), toolDescriptionSpeechTimeout)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ttsCtx, cancel := context.WithTimeout(ctx, toolDescriptionSpeechTimeout)
 	defer cancel()
 	if s.logger != nil {
 		s.logger.Info("Tool description TTS playback: %q", description)

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -43,6 +43,8 @@ type Server struct {
 	bridge           *PhoneBridge
 	pendingResults   map[string]*chatPendingResult
 	pendingResultsMu sync.Mutex
+	activeRuns       map[string]context.CancelFunc
+	activeRunsMu     sync.Mutex
 }
 
 type webAudioRecording struct {
@@ -95,6 +97,15 @@ type ChatRequest struct {
 	Skills      []string            `json:"skills,omitempty"`
 	Attachments []MessageAttachment `json:"attachments,omitempty"`
 	RequestID   string              `json:"request_id,omitempty"`
+}
+
+type ChatCancelRequest struct {
+	RequestID string `json:"request_id"`
+}
+
+type ChatCancelResponse struct {
+	RequestID string `json:"request_id"`
+	Status    string `json:"status"`
 }
 
 // ChatResponse represents a chat response
@@ -165,6 +176,7 @@ func NewServer(runtime *Runtime, addr string) *Server {
 		history:        make([]Message, 0),
 		bridge:         bridge,
 		pendingResults: make(map[string]*chatPendingResult),
+		activeRuns:     make(map[string]context.CancelFunc),
 	}
 	loadAppMappingForConfig(runtime.config.ConfigDir, runtime.logger)
 	runtime.tools.RegisterPhoneBridge(bridge)
@@ -204,6 +216,7 @@ func (s *Server) Start() error {
 
 	// API endpoints
 	mux.HandleFunc("/api/chat", s.handleChat)
+	mux.HandleFunc("/api/chat/cancel", s.handleChatCancel)
 	mux.HandleFunc("/api/chat/result", s.handleChatResult)
 	mux.HandleFunc("/api/history", s.handleHistory)
 	mux.HandleFunc("/api/clear", s.handleClear)
@@ -330,6 +343,72 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	s.handleChatSync(w, r, req, inputText, runAttachments)
 }
 
+func (s *Server) handleChatCancel(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ChatCancelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+	requestID := strings.TrimSpace(req.RequestID)
+	if requestID == "" {
+		http.Error(w, "missing request_id", http.StatusBadRequest)
+		return
+	}
+
+	if s.cancelActiveRun(requestID) {
+		if s.logger != nil {
+			s.logger.Info("Chat request canceled: request_id=%s", requestID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ChatCancelResponse{RequestID: requestID, Status: "canceled"})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(ChatCancelResponse{RequestID: requestID, Status: "not_running"})
+}
+
+func (s *Server) registerActiveRun(requestID string, cancel context.CancelFunc) bool {
+	if requestID == "" {
+		return true
+	}
+	s.activeRunsMu.Lock()
+	defer s.activeRunsMu.Unlock()
+	if s.activeRuns == nil {
+		s.activeRuns = make(map[string]context.CancelFunc)
+	}
+	if _, exists := s.activeRuns[requestID]; exists {
+		return false
+	}
+	s.activeRuns[requestID] = cancel
+	return true
+}
+
+func (s *Server) unregisterActiveRun(requestID string) {
+	if requestID == "" {
+		return
+	}
+	s.activeRunsMu.Lock()
+	delete(s.activeRuns, requestID)
+	s.activeRunsMu.Unlock()
+}
+
+func (s *Server) cancelActiveRun(requestID string) bool {
+	s.activeRunsMu.Lock()
+	cancel := s.activeRuns[requestID]
+	s.activeRunsMu.Unlock()
+	if cancel == nil {
+		return false
+	}
+	cancel()
+	return true
+}
+
 // handleChatAsync runs the agent in a background goroutine and returns
 // {request_id} immediately. Intermediate results are pushed into
 // chatPendingResult and served by handleChatResult.
@@ -365,6 +444,16 @@ func (s *Server) handleChatAsync(
 
 	s.playPromptSoundAsync(promptSoundAgentSend, "agent send")
 
+	runCtx, cancel := context.WithCancel(context.Background())
+	if !s.registerActiveRun(requestID, cancel) {
+		cancel()
+		s.pendingResultsMu.Lock()
+		delete(s.pendingResults, requestID)
+		s.pendingResultsMu.Unlock()
+		http.Error(w, "request_id already in use", http.StatusConflict)
+		return
+	}
+
 	// Return {request_id} immediately
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -373,6 +462,7 @@ func (s *Server) handleChatAsync(
 	// Run agent in background goroutine
 	go func() {
 		defer func() {
+			s.unregisterActiveRun(requestID)
 			// Keep the completed result available for polling for 60s,
 			// then clean up. The client (PhoneBridge) polls /api/chat/result
 			// every ~1s; immediate deletion creates a race where the app
@@ -435,7 +525,7 @@ func (s *Server) handleChatAsync(
 			}
 		}
 
-		result, err := s.runtime.Run(bgCtx, runReq)
+		result, err := s.runtime.Run(runCtx, runReq)
 		if newStream != nil {
 			closeErr := newStream.closeAndWait()
 			if closeErr != nil && s.logger != nil {
@@ -446,7 +536,11 @@ func (s *Server) handleChatAsync(
 
 		pending.mu.Lock()
 		if err != nil {
-			pending.err = err.Error()
+			if errors.Is(runCtx.Err(), context.Canceled) {
+				pending.err = "request canceled"
+			} else {
+				pending.err = err.Error()
+			}
 			pending.done = true
 			pending.mu.Unlock()
 			if s.logger != nil {
@@ -722,6 +816,19 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 	s.playPromptSoundAsync(promptSoundAgentSend, "agent send")
 
 	ctx := r.Context()
+	if req.RequestID != "" {
+		runCtx, cancel := context.WithCancel(ctx)
+		if !s.registerActiveRun(req.RequestID, cancel) {
+			cancel()
+			http.Error(w, "request_id already in use", http.StatusConflict)
+			return
+		}
+		defer func() {
+			s.unregisterActiveRun(req.RequestID)
+			cancel()
+		}()
+		ctx = runCtx
+	}
 
 	result, err := s.runtime.Run(ctx, RunRequest{
 		Input:          inputText,
@@ -2303,6 +2410,22 @@ const webUI = `<!DOCTYPE html>
             font-size: 0.82rem;
         }
 
+        .stop-run-btn {
+            padding: 0.32rem 0.62rem;
+            border: 1px solid rgba(185, 28, 28, 0.26);
+            border-radius: 999px;
+            background: rgba(220, 38, 38, 0.08);
+            color: #b91c1c;
+            font-size: 0.76rem;
+            font-weight: 700;
+            cursor: pointer;
+        }
+
+        .stop-run-btn:disabled {
+            opacity: 0.55;
+            cursor: not-allowed;
+        }
+
         .loading.active {
             visibility: visible;
             opacity: 1;
@@ -2419,6 +2542,7 @@ const webUI = `<!DOCTYPE html>
             <div class="loading" id="loading">
                 <span class="spinner" aria-hidden="true"></span>
                 <span>Working on it...</span>
+                <button type="button" class="stop-run-btn" id="stopRunBtn" onclick="cancelCurrentRun()" disabled>Stop</button>
             </div>
 
             <form class="composer" onsubmit="event.preventDefault(); sendMessage();">
@@ -2508,6 +2632,7 @@ const webUI = `<!DOCTYPE html>
         const recordBtn = document.getElementById('recordBtn');
         const draftAttachmentsEl = document.getElementById('draftAttachments');
         const loadingDiv = document.getElementById('loading');
+        const stopRunBtn = document.getElementById('stopRunBtn');
         const emptyStateEl = document.getElementById('emptyState');
         const toolSelectEl = document.getElementById('toolSelect');
         const toolDescriptionEl = document.getElementById('toolDescription');
@@ -2531,6 +2656,9 @@ const webUI = `<!DOCTYPE html>
         let recorderState = createRecorderState();
         let toolCatalog = [];
         let toolSkills = [];
+        let currentChatRequestId = '';
+        let currentChatAbortController = null;
+        let currentChatCancelRequested = false;
 
         loadHistory();
         loadToolCatalog();
@@ -2817,6 +2945,9 @@ const webUI = `<!DOCTYPE html>
             autoResizeInput();
             setComposerState(true);
             clearDraftAttachments();
+            currentChatRequestId = createRequestId();
+            currentChatAbortController = new AbortController();
+            currentChatCancelRequested = false;
 
             addMessage({
                 type: 'user',
@@ -2833,9 +2964,11 @@ const webUI = `<!DOCTYPE html>
                         'Accept': 'application/x-ndjson',
                         'X-Aiden-Stream': 'ndjson'
                     },
+                    signal: currentChatAbortController.signal,
                     body: JSON.stringify({
                         message: message,
-                        attachments: attachments
+                        attachments: attachments,
+                        request_id: currentChatRequestId
                     })
                 });
 
@@ -2846,6 +2979,14 @@ const webUI = `<!DOCTYPE html>
 
                 await consumeChatStream(res);
             } catch (err) {
+                if (currentChatCancelRequested || err.name === 'AbortError') {
+                    addMessage({
+                        type: 'assistant',
+                        content: 'Interrupted.',
+                        timestamp: new Date().toISOString()
+                    });
+                    return;
+                }
                 console.error('Failed to send message:', err);
                 try {
                     await loadHistory();
@@ -2857,10 +2998,41 @@ const webUI = `<!DOCTYPE html>
                     timestamp: new Date().toISOString()
                 });
             } finally {
+                currentChatRequestId = '';
+                currentChatAbortController = null;
+                currentChatCancelRequested = false;
                 setComposerState(false);
                 scrollToBottom();
             }
         }
+
+        function createRequestId() {
+            if (window.crypto && window.crypto.randomUUID) {
+                return window.crypto.randomUUID();
+            }
+            return 'web-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
+        }
+
+        async function cancelCurrentRun() {
+            if (!currentChatRequestId) return;
+            const requestId = currentChatRequestId;
+            currentChatCancelRequested = true;
+            stopRunBtn.disabled = true;
+            stopRunBtn.textContent = 'Stopping...';
+
+			if (currentChatAbortController) {
+				currentChatAbortController.abort();
+			}
+
+			fetch('/api/chat/cancel', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ request_id: requestId }),
+				keepalive: true
+			}).catch(function(err) {
+				console.error('Failed to cancel chat request:', err);
+			});
+		}
 
         async function consumeChatStream(res) {
             let sawDone = false;
@@ -3051,6 +3223,8 @@ const webUI = `<!DOCTYPE html>
             sendBtn.disabled = isLoading || recorderState.isStopping;
             imageBtn.disabled = isLoading || recorderState.isRecording || recorderState.isStopping;
             recordBtn.disabled = isLoading || recorderState.isStopping;
+            stopRunBtn.disabled = !isLoading;
+            stopRunBtn.textContent = 'Stop';
             loadingDiv.classList.toggle('active', isLoading);
             updateRecordButton();
         }

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -484,6 +484,7 @@ func TestServerHandleChatStreamDuplicateRequestIDDoesNotAppendHistory(t *testing
 	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"hello","request_id":" req-1 "}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/x-ndjson")
+	req.Header.Set("X-Aiden-Stream", "ndjson")
 	rec := httptest.NewRecorder()
 
 	server.handleChat(rec, req)

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -350,6 +350,35 @@ func TestServerHandleChatUsesRequestContextForRun(t *testing.T) {
 	}
 }
 
+func TestServerHandleChatCancelCancelsActiveRun(t *testing.T) {
+	server := &Server{activeRuns: make(map[string]context.CancelFunc)}
+	ctx, cancel := context.WithCancel(context.Background())
+	server.registerActiveRun("req-1", cancel)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/cancel", bytes.NewBufferString(`{"request_id":"req-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.handleChatCancel(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("active run was not canceled")
+	}
+
+	var resp ChatCancelResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != "canceled" || resp.RequestID != "req-1" {
+		t.Fatalf("unexpected cancel response: %#v", resp)
+	}
+}
+
 type cancelAwareModel struct {
 	seen chan error
 }

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -355,7 +355,7 @@ func TestServerHandleChatCancelCancelsActiveRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	server.registerActiveRun("req-1", cancel)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/chat/cancel", bytes.NewBufferString(`{"request_id":"req-1"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/cancel", bytes.NewBufferString(`{"request_id":" req-1 "}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
@@ -376,6 +376,78 @@ func TestServerHandleChatCancelCancelsActiveRun(t *testing.T) {
 	}
 	if resp.Status != "canceled" || resp.RequestID != "req-1" {
 		t.Fatalf("unexpected cancel response: %#v", resp)
+	}
+}
+
+func TestServerHandleChatAsyncDuplicateRequestIDDoesNotAppendHistory(t *testing.T) {
+	server := &Server{
+		activeRuns:     make(map[string]context.CancelFunc),
+		pendingResults: map[string]*chatPendingResult{"req-1": {}},
+		history:        make([]Message, 0),
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"hello","request_id":" req-1 "}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.handleChat(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := server.historySnapshot(); len(got) != 0 {
+		t.Fatalf("duplicate request appended history: %#v", got)
+	}
+}
+
+func TestServerHandleChatStreamDuplicateRequestIDDoesNotAppendHistory(t *testing.T) {
+	server := &Server{
+		activeRuns: make(map[string]context.CancelFunc),
+		history:    make([]Message, 0),
+	}
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server.registerActiveRun("req-1", cancel)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"hello","request_id":" req-1 "}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/x-ndjson")
+	rec := httptest.NewRecorder()
+
+	server.handleChat(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := server.historySnapshot(); len(got) != 0 {
+		t.Fatalf("duplicate stream request appended history: %#v", got)
+	}
+}
+
+func TestServerSpeakToolDescriptionUsesCallerContext(t *testing.T) {
+	provider := &blockingTTSProvider{started: make(chan struct{}), blockText: "我先读取当前音量。"}
+	server := &Server{
+		ttsManager:  ttsmodule.NewProviderManager(provider, nil),
+		audioClient: NewAudioServiceClient("/tmp/audio.sock"),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		server.speakToolDescription(ctx, "我先读取当前音量。")
+		close(done)
+	}()
+
+	select {
+	case <-provider.started:
+	case <-time.After(500 * time.Millisecond):
+		cancel()
+		t.Fatal("tool description TTS was not started")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("tool description TTS did not stop after caller context cancellation")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add /api/chat/cancel to cancel active chat runs by request_id
- wire streaming and async chat requests through cancellable contexts
- add a Stop button next to the web UI Working on it indicator

## Testing
- GOTOOLCHAIN=auto go test ./internal/agent

## Device validation
- rebuilt and deployed agent to luckfox
- verified /api/chat/cancel returns not_running for a non-active request
- verified the web UI contains the Stop button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Stop" button to cancel in-flight chats; stopped requests render as "Interrupted" and trigger server-side cancellation so the client aborts cleanly.

* **Bug Fixes**
  * Reject duplicate request IDs to avoid duplicate history entries.
  * Ensure downstream work (e.g., tool narration) respects request cancellation and timeouts; UI controls reset after completion.

* **Tests**
  * Added tests for cancellation, duplicate-request handling, and tool narration cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->