### PR TITLE
fix(agent): improve skill manage recovery guidance

### DIFF
--- a/src/agent/config/skills/device-operator/SKILL.md
+++ b/src/agent/config/skills/device-operator/SKILL.md
@@ -3,7 +3,7 @@ name: device-operator
 description: Use when controlling a visible target device UI through screenshots, touch, mouse, or keyboard.
 metadata:
   preferred_model: primary
-  allowed_tools: [screenshot, touch_gesture, mouse_click, mouse_move, mouse_scroll, keyboard_tap, keyboard_text]
+  allowed_tools: [screenshot, touch_gesture, mouse_click, mouse_move, mouse_scroll, keyboard_tap, keyboard_text, shell]
 ---
 
 Use this skill when interacting with the connected device screen, app UI, keyboard, touch input, or mouse pointer.
@@ -19,6 +19,38 @@ Always operate through a visual feedback loop:
 5. Continue only after confirming what changed.
 
 Do not perform multiple blind UI actions in a row.
+
+## Screenshot Failure Recovery
+
+If `screenshot` fails, a post-action screenshot fails, or the tool output mentions `SERVICE_RECOVERING`, socket errors, empty image data, or invalid screenshot JSON, stop UI actions. Do not tap, type, swipe, or guess from stale visual state.
+
+Recovery sequence:
+
+1. Retry `screenshot` once if the error suggests transient recovery, such as `SERVICE_RECOVERING`.
+2. If the second screenshot fails, diagnose the frame service with `shell`:
+   ```bash
+   /etc/init.d/S52frame_service status
+   frame_service_cli --socket /run/frame_service/frame_service.sock health
+   ls -l /run/frame_service/frame_service.sock
+   ```
+3. If health reports a bad state or the service is recovering, request a capture-manager restart first:
+   ```bash
+   frame_service_cli --socket /run/frame_service/frame_service.sock restart
+   ```
+4. Verify recovery with `health`, then call `screenshot` again.
+5. If CLI restart fails, the socket is missing, or the service is not running, restart the init service:
+   ```bash
+   /etc/init.d/S52frame_service restart
+   ```
+6. After service restart, verify in order: `status`, `health`, then `screenshot`.
+
+If recovery still fails, inspect recent logs before asking the user to intervene:
+
+```bash
+tail -n 80 /var/log/frame_service/frame_service.log
+```
+
+When reporting a blocker, include the screenshot error, which recovery commands were tried, and the latest `health` or log signal. Do not claim the device UI task is complete without a fresh screenshot confirming the target screen.
 
 ## Action Choice
 

--- a/src/agent/internal/agent/skill_merge_test.go
+++ b/src/agent/internal/agent/skill_merge_test.go
@@ -792,6 +792,54 @@ func TestSkillToolDescriptionsMirrorHermesRoles(t *testing.T) {
 	}
 }
 
+func TestSkillManageToolDescriptionShowsPatchJSONExample(t *testing.T) {
+	desc := NewSkillManageTool(t.TempDir(), "").Description()
+	for _, want := range []string{
+		`{"action":"patch"`,
+		`"name":"device-operator"`,
+		`"old_string"`,
+		`"new_string"`,
+	} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("skill_manage description missing patch example fragment %q:\n%s", want, desc)
+		}
+	}
+}
+
+func TestSkillManageToolEmptyInputExplainsJSONContract(t *testing.T) {
+	_, err := NewSkillManageTool(t.TempDir(), "").Call(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected empty skill_manage input to fail")
+	}
+	for _, want := range []string{
+		"skill_manage input must be a JSON object",
+		`{"action":"patch"`,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("empty input error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestBundledDeviceOperatorSkillDocumentsScreenshotFailureRecovery(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "config", "skills", "device-operator", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"## Screenshot Failure Recovery",
+		"SERVICE_RECOVERING",
+		"frame_service_cli --socket /run/frame_service/frame_service.sock health",
+		"frame_service_cli --socket /run/frame_service/frame_service.sock restart",
+		"/etc/init.d/S52frame_service restart",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("device-operator skill missing screenshot recovery fragment %q", want)
+		}
+	}
+}
+
 func TestSkillManageTool_CreateAndPatch(t *testing.T) {
 	dir := t.TempDir()
 	tool := NewSkillManageTool(dir, "")

--- a/src/agent/internal/agent/skill_tools.go
+++ b/src/agent/internal/agent/skill_tools.go
@@ -379,8 +379,12 @@ func (t *SkillManageTool) Description() string {
 - content: full SKILL.md (for create/edit)
 - old_string, new_string: for patch
 - file_path, file_content: for write_file/remove_file under references/, templates/, scripts/, or assets/
-- reason: why this change is being made`
+- reason: why this change is being made
+Patch example: {"action":"patch","name":"device-operator","old_string":"old instructions","new_string":"new instructions","reason":"add recovery steps"}
+When using a function-call wrapper, put that JSON object as the __arg1 string and do not leave __arg1 empty.`
 }
+
+const skillManageInputExample = `{"action":"patch","name":"device-operator","old_string":"old instructions","new_string":"new instructions","reason":"add recovery steps"}`
 
 type skillManageInput struct {
 	Action      string `json:"action"`
@@ -394,9 +398,12 @@ type skillManageInput struct {
 }
 
 func (t *SkillManageTool) Call(_ context.Context, input string) (string, error) {
+	if strings.TrimSpace(input) == "" {
+		return "", fmt.Errorf("skill_manage input must be a JSON object, for example %s", skillManageInputExample)
+	}
 	var req skillManageInput
 	if err := json.Unmarshal([]byte(input), &req); err != nil {
-		return "", fmt.Errorf("invalid JSON input: %w", err)
+		return "", fmt.Errorf("skill_manage input must be a JSON object, for example %s: invalid JSON input: %w", skillManageInputExample, err)
 	}
 	if req.Name == "" {
 		return "", fmt.Errorf("name is required")


### PR DESCRIPTION
## Summary
- add screenshot failure troubleshooting and frame_service restart flow to device-operator skill
- make skill_manage empty or invalid JSON input errors actionable with a patch example
- add regression tests for skill_manage guidance and device-operator recovery docs

## Tests
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device-operator skill now supports running shell commands.
  * Added Screenshot Failure Recovery workflow with automatic retry logic, diagnostics, and fallback strategies.

* **Documentation**
  * Enhanced error messages for skill management operations with clearer input requirements and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->