### PR TITLE
fix(build): make rootfs images reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,5 @@ jobs:
       - name: Verify release scripts
         run: |
           sh scripts/test_release_ci_scripts.sh
+          bash scripts/test_reproducible_rootfs_policy.sh
           bash scripts/test_github_release_upload.sh

--- a/_build_image.sh
+++ b/_build_image.sh
@@ -7,7 +7,13 @@ PICO_SDK="$SCRIPT_DIR/pico-sdk"
 DEST_OVERLAY="$PICO_SDK/project/cfg/BoardConfig_IPC/overlay/overlay-luckfox-buildroot-aiden"
 
 if [ -z "${SOURCE_DATE_EPOCH:-}" ]; then
-    SOURCE_DATE_EPOCH="$(git -C "$SCRIPT_DIR" log -1 --format=%ct 2>/dev/null || printf '0')"
+    # Keep filesystem image metadata stable across releases when their payloads
+    # did not change. Callers can still set SOURCE_DATE_EPOCH explicitly.
+    SOURCE_DATE_EPOCH="${AIDEN_REPRODUCIBLE_IMAGE_EPOCH:-0}"
+fi
+if ! [[ "$SOURCE_DATE_EPOCH" =~ ^[0-9]+$ ]]; then
+    echo "SOURCE_DATE_EPOCH must be an unsigned Unix timestamp: $SOURCE_DATE_EPOCH" >&2
+    exit 1
 fi
 export SOURCE_DATE_EPOCH
 

--- a/build_image.sh
+++ b/build_image.sh
@@ -36,7 +36,13 @@ if [ "$#" -gt 0 ]; then
 fi
 
 if [ -z "${SOURCE_DATE_EPOCH:-}" ]; then
-  SOURCE_DATE_EPOCH="$(git -C "$(pwd)" log -1 --format=%ct 2>/dev/null || printf '0')"
+  # Keep rootfs/oem image metadata stable across releases when their payloads
+  # did not change. Callers can still set SOURCE_DATE_EPOCH explicitly.
+  SOURCE_DATE_EPOCH="${AIDEN_REPRODUCIBLE_IMAGE_EPOCH:-0}"
+fi
+if ! [[ "$SOURCE_DATE_EPOCH" =~ ^[0-9]+$ ]]; then
+  echo "SOURCE_DATE_EPOCH must be an unsigned Unix timestamp: $SOURCE_DATE_EPOCH" >&2
+  exit 1
 fi
 export SOURCE_DATE_EPOCH
 

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -109,9 +109,13 @@ for required in \
     'find "$dir" -xdev -exec touch -h -d "@$epoch"' \
     'lazy_itable_init=0,lazy_journal_init=0' \
     '^metadata_csum' \
+    '^orphan_file' \
+    '^quota' \
     '-U "${AIDEN_EXT4_UUID:-00000000-0000-4000-8000-000000000000}"' \
-    'write_ext4_le32 "$dst" 44 "$source_date_epoch"' \
-    'write_ext4_le32 "$dst" 264 "$source_date_epoch"'; do
+    'write_ext4_le32_at "$image" "$((sb_offset + 44))" "$source_date_epoch"' \
+    'write_ext4_le32_at "$image" "$((sb_offset + 264))" "$source_date_epoch"' \
+    'write_at($fh, $inode_offset + 100, "\0" x 4)' \
+    'normalize ext4 inode metadata'; do
     if ! grep -Fq -- "$required" "$ROOT_DIR/pico-sdk/project/build.sh" \
        && ! grep -Fq -- "$required" "$ROOT_DIR/pico-sdk/sysdrv/Makefile" \
        && ! grep -Fq -- "$required" "$ROOT_DIR/pico-sdk/sysdrv/tools/pc/e2fsprogs/mkfs_ext4.sh"; then

--- a/scripts/test_reproducible_rootfs_policy.sh
+++ b/scripts/test_reproducible_rootfs_policy.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_IMAGE_SH="$ROOT_DIR/build_image.sh"
+INNER_BUILD_IMAGE_SH="$ROOT_DIR/_build_image.sh"
+
+for script in "$BUILD_IMAGE_SH" "$INNER_BUILD_IMAGE_SH"; do
+  if ! grep -q 'AIDEN_REPRODUCIBLE_IMAGE_EPOCH' "$script"; then
+    echo "$(basename "$script") must use AIDEN_REPRODUCIBLE_IMAGE_EPOCH for the default reproducible image timestamp" >&2
+    exit 1
+  fi
+
+  if ! grep -q 'export SOURCE_DATE_EPOCH' "$script"; then
+    echo "$(basename "$script") must export SOURCE_DATE_EPOCH for image packaging tools" >&2
+    exit 1
+  fi
+done
+
+if grep -Eq 'git .*log -1 --format=%ct|git .*log -1 .*%ct' "$BUILD_IMAGE_SH" "$INNER_BUILD_IMAGE_SH"; then
+  echo "image builds must not derive the default SOURCE_DATE_EPOCH from the current commit time" >&2
+  exit 1
+fi
+
+echo "reproducible rootfs timestamp policy tests passed"


### PR DESCRIPTION
## Summary
- stop deriving the default SOURCE_DATE_EPOCH from the current release commit timestamp
- add a repo-only regression test for the reproducible rootfs timestamp policy
- point pico-sdk at the merged ext4 metadata stabilization commit from AidenAI-IO/aiden-sdk#13

## Tests
- sh scripts/test_build_scripts.sh
- bash scripts/test_reproducible_rootfs_policy.sh
- sh scripts/test_release_ci_scripts.sh
- bash scripts/test_github_release_upload.sh
- bash scripts/test_github_actions_self_hosted_safety.sh
- git diff --check
- git -C pico-sdk diff --check -- project/build.sh sysdrv/Makefile sysdrv/tools/pc/e2fsprogs/mkfs_ext4.sh
- remote ext4 fixture generated two byte-identical rootfs images

AidenAI-IO/aiden-sdk#13 has been merged; this PR points pico-sdk at its merge commit.