### PR TITLE
ci: reuse unchanged rootfs release assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,9 +149,21 @@ jobs:
 
     - name: Run build script
       run: ./build_image.sh
+
+    - name: Resolve reusable rootfs release asset
+      id: rootfs_asset
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        scripts/resolve_reusable_rootfs_asset.sh \
+          --image-dir pico-sdk/output/image \
+          --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+          --output "$GITHUB_OUTPUT"
+
     - name: Generate OTA manifest
       env:
         OTA_ED25519_PRIVATE_KEY: ${{ secrets.OTA_ED25519_PRIVATE_KEY }}
+        ROOTFS_ASSET_METADATA: ${{ steps.rootfs_asset.outputs.rootfs_asset_metadata }}
       run: |
         if [ -z "${OTA_ED25519_PRIVATE_KEY}" ]; then
           echo "OTA_ED25519_PRIVATE_KEY secret is required for manifest signing" >&2
@@ -160,12 +172,17 @@ jobs:
         private_key="$RUNNER_TEMP/ota_ed25519_private_key.pem"
         printf '%s\n' "${OTA_ED25519_PRIVATE_KEY}" > "$private_key"
         chmod 600 "$private_key"
+        asset_metadata_args=()
+        if [ -n "${ROOTFS_ASSET_METADATA}" ]; then
+          asset_metadata_args=(--asset-metadata "rootfs.img=${ROOTFS_ASSET_METADATA}")
+        fi
         scripts/generate_ota_manifest.sh \
           --version "${{ steps.release_info.outputs.release_name }}" \
           --channel "${{ steps.release_info.outputs.channel }}" \
           --build-time "${{ steps.release_info.outputs.build_time }}" \
           --sign-key "$private_key" \
           --image-dir pico-sdk/output/image \
+          "${asset_metadata_args[@]}" \
           --output pico-sdk/output/image/manifest.json
 
     - name: Generate OTA device config
@@ -183,11 +200,13 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
         GH_DEBUG: api
+        RELEASE_UPLOAD_ASSETS: ${{ steps.rootfs_asset.outputs.upload_assets }}
       run: |
         PRERELEASE_FLAG=""
         if [ "${{ steps.release_info.outputs.channel }}" != "stable" ]; then
           PRERELEASE_FLAG="--prerelease"
         fi
+        upload_assets="${RELEASE_UPLOAD_ASSETS:-boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json}"
 
         bash scripts/create_github_release.sh \
           --release-name "${{ steps.release_info.outputs.release_name }}" \
@@ -195,7 +214,7 @@ jobs:
           --target-commitish "${{ github.sha }}" \
           --asset-glob 'pico-sdk/output/image/*' \
           --required-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
-          --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+          --upload-assets "$upload_assets" \
           --retry-count 5 \
           --retry-delay-seconds 30 \
           $PRERELEASE_FLAG

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,6 +157,7 @@ jobs:
       run: |
         scripts/resolve_reusable_rootfs_asset.sh \
           --image-dir pico-sdk/output/image \
+          --channel "${{ steps.release_info.outputs.channel }}" \
           --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
           --output "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,4 @@ jobs:
           sh scripts/test_release_ci_scripts.sh
           bash scripts/test_reproducible_rootfs_policy.sh
           bash scripts/test_github_release_upload.sh
+          bash scripts/test_reusable_rootfs_release_asset.sh

--- a/scripts/generate_ota_manifest.sh
+++ b/scripts/generate_ota_manifest.sh
@@ -19,6 +19,11 @@ Required options:
 Optional:
   --base-url      Base URL for direct asset downloads (e.g. https://example.com/firmware/v1.0.0)
                   If provided, full asset URLs will be embedded in the manifest
+  --asset-url     Exact asset download URL in FILE=URL form; may be repeated
+                  Takes precedence over --base-url for the named file
+  --asset-metadata
+                  Exact manifest asset JSON in FILE=JSON form; may be repeated
+                  Takes precedence over --asset-url and --base-url for the named file
 
 Required images:
   boot_a.img and boot_b.img are always required.
@@ -38,6 +43,10 @@ sign_key=""
 image_dir=""
 output=""
 base_url=""
+asset_url_files=()
+asset_url_values=()
+asset_metadata_files=()
+asset_metadata_values=()
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -80,6 +89,38 @@ while [ "$#" -gt 0 ]; do
       base_url="$2"
       [[ "$base_url" =~ ^https?:// ]] || die "--base-url must start with http:// or https://"
       [[ "$base_url" =~ [[:space:]] ]] && die "--base-url must not contain whitespace"
+      shift 2
+      ;;
+    --asset-url)
+      [ "$#" -ge 2 ] || die "--asset-url requires a value"
+      asset_url_pair="$2"
+      asset_url_file="${asset_url_pair%%=*}"
+      asset_url_value="${asset_url_pair#*=}"
+      [ "$asset_url_file" != "$asset_url_pair" ] || die "--asset-url must use FILE=URL"
+      [ -n "$asset_url_file" ] || die "--asset-url file must not be empty"
+      [ -n "$asset_url_value" ] || die "--asset-url URL must not be empty"
+      case "$asset_url_file" in
+        */*|*[[:space:]]*) die "--asset-url file must be a release asset name: $asset_url_file" ;;
+      esac
+      [[ "$asset_url_value" =~ ^https?:// ]] || die "--asset-url URL must start with http:// or https://"
+      [[ "$asset_url_value" =~ [[:space:]] ]] && die "--asset-url URL must not contain whitespace"
+      asset_url_files+=("$asset_url_file")
+      asset_url_values+=("$asset_url_value")
+      shift 2
+      ;;
+    --asset-metadata)
+      [ "$#" -ge 2 ] || die "--asset-metadata requires a value"
+      asset_metadata_pair="$2"
+      asset_metadata_file="${asset_metadata_pair%%=*}"
+      asset_metadata_value="${asset_metadata_pair#*=}"
+      [ "$asset_metadata_file" != "$asset_metadata_pair" ] || die "--asset-metadata must use FILE=JSON"
+      [ -n "$asset_metadata_file" ] || die "--asset-metadata file must not be empty"
+      [ -n "$asset_metadata_value" ] || die "--asset-metadata JSON must not be empty"
+      case "$asset_metadata_file" in
+        */*|*[[:space:]]*) die "--asset-metadata file must be a release asset name: $asset_metadata_file" ;;
+      esac
+      asset_metadata_files+=("$asset_metadata_file")
+      asset_metadata_values+=("$asset_metadata_value")
       shift 2
       ;;
     *)
@@ -128,15 +169,100 @@ file_sha256() {
   fi
 }
 
+asset_url_for_file() {
+  local file="$1"
+  local index
+
+  for index in "${!asset_url_files[@]}"; do
+    if [ "${asset_url_files[$index]}" = "$file" ]; then
+      printf '%s' "${asset_url_values[$index]}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+asset_metadata_for_file() {
+  local file="$1"
+  local index
+
+  for index in "${!asset_metadata_files[@]}"; do
+    if [ "${asset_metadata_files[$index]}" = "$file" ]; then
+      printf '%s' "${asset_metadata_values[$index]}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+asset_metadata_json() {
+  local file="$1"
+  local path="$image_dir/$file"
+  local metadata="$2"
+  local image_sha256 compressed_name
+
+  image_sha256="$(file_sha256 "$path")"
+  compressed_name="${file}.tar.gz"
+
+  if ! printf '%s' "$metadata" | jq -e \
+    --arg file "$file" \
+    --arg compressed_name "$compressed_name" \
+    --arg image_sha256 "$image_sha256" \
+    '
+      type == "object" and
+      (.name == $file or .name == $compressed_name) and
+      (.url | type == "string" and test("^https?://") and (test("[[:space:]]") | not)) and
+      (.size | type == "number" and . > 0) and
+      (.sha256 | type == "string" and test("^[A-Fa-f0-9]{64}$")) and
+      (
+        if .name == $compressed_name then
+          (.image_sha256 | type == "string" and test("^[A-Fa-f0-9]{64}$") and (ascii_downcase == ($image_sha256 | ascii_downcase)))
+        else
+          ((.image_sha256 // "") == "" and ((.sha256 | ascii_downcase) == ($image_sha256 | ascii_downcase)))
+        end
+      )
+    ' >/dev/null; then
+    die "invalid --asset-metadata for $file"
+  fi
+
+  printf '%s' "$metadata" | jq -c \
+    --arg compressed_name "$compressed_name" \
+    '
+      {
+        name: .name,
+        url: .url,
+        size: .size,
+        sha256: (.sha256 | ascii_downcase)
+      } +
+      if .name == $compressed_name then
+        {image_sha256: (.image_sha256 | ascii_downcase)}
+      else
+        {}
+      end
+    '
+}
+
 asset_json() {
   local file="$1"
   local path="$image_dir/$file"
   [ -f "$path" ] || die "missing required image: $path"
-  local size sha256
+  local size sha256 url metadata
+  if metadata="$(asset_metadata_for_file "$file")"; then
+    asset_metadata_json "$file" "$metadata"
+    return
+  fi
+
   size="$(file_size "$path")"
   sha256="$(file_sha256 "$path")"
-  if [ -n "$base_url" ]; then
-    local url="${base_url%/}/$file"
+  if ! url="$(asset_url_for_file "$file")"; then
+    url=""
+  fi
+  if [ -z "$url" ] && [ -n "$base_url" ]; then
+    url="${base_url%/}/$file"
+  fi
+  if [ -n "$url" ]; then
     jq -n \
       --arg name "$file" \
       --arg url "$url" \

--- a/scripts/resolve_reusable_rootfs_asset.sh
+++ b/scripts/resolve_reusable_rootfs_asset.sh
@@ -6,10 +6,11 @@ usage() {
 Usage:
   resolve_reusable_rootfs_asset.sh \
     --image-dir DIR \
+    [--channel CHANNEL] \
     --upload-assets 'FILE ...' \
     [--output FILE]
 
-Resolve whether rootfs.img can reuse the previous GitHub release asset.
+Resolve whether rootfs.img can reuse a previous same-channel GitHub release asset.
 
 Outputs:
   rootfs_reused=true|false
@@ -29,6 +30,7 @@ die() {
 }
 
 image_dir=""
+channel=""
 upload_assets=""
 output="${GITHUB_OUTPUT:-}"
 rootfs_asset_name="rootfs.img"
@@ -37,6 +39,10 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --image-dir)
       image_dir="${2:-}"
+      shift 2
+      ;;
+    --channel)
+      channel="${2:-}"
       shift 2
       ;;
     --upload-assets)
@@ -62,6 +68,9 @@ done
 [ -n "$upload_assets" ] || die "missing --upload-assets"
 [ -d "$image_dir" ] || die "missing image directory: $image_dir"
 [ -f "$image_dir/$rootfs_asset_name" ] || die "missing rootfs image: $image_dir/$rootfs_asset_name"
+case "$channel" in
+  *[!A-Za-z0-9._-]*) die "invalid --channel: $channel" ;;
+esac
 
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then
@@ -137,6 +146,31 @@ tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 err_file="$tmp_dir/gh.err"
 
+candidate_tag=""
+candidate_manifest_api_url=""
+candidate_manifest=""
+
+load_manifest_for_release() {
+  local release="$1"
+
+  candidate_tag="$(printf '%s' "$release" | jq -r '.tag_name // .tagName // "unknown"')"
+  candidate_manifest_api_url="$(printf '%s' "$release" | jq -r '.assets[]? | select(.name == "manifest.json") | .url // empty' | head -n 1)"
+  candidate_manifest=""
+
+  if [ -z "$candidate_manifest_api_url" ]; then
+    log "Rootfs reuse skipped: release $candidate_tag has no manifest.json asset"
+    return 1
+  fi
+
+  if ! candidate_manifest="$(gh api -H "Accept: application/octet-stream" "$candidate_manifest_api_url" 2>"$err_file")"; then
+    log "Rootfs reuse skipped: failed to download manifest.json from release $candidate_tag"
+    sed 's/^/  /' "$err_file" >&2 || true
+    return 1
+  fi
+
+  return 0
+}
+
 release_json=""
 if ! release_json="$(gh api "repos/$repo/releases?per_page=20" 2>"$err_file")"; then
   log "Rootfs reuse disabled: failed to query previous GitHub releases"
@@ -145,26 +179,62 @@ if ! release_json="$(gh api "repos/$repo/releases?per_page=20" 2>"$err_file")"; 
   exit 0
 fi
 
-previous_release=""
-if ! previous_release="$(printf '%s' "$release_json" | jq -c 'map(select(.draft != true)) | .[0] // empty')"; then
+published_releases_file="$tmp_dir/published-releases.ndjson"
+if ! printf '%s' "$release_json" | jq -c 'if type == "array" then .[] | select(.draft != true) else error("expected releases array") end' > "$published_releases_file"; then
   disable_reuse "previous release JSON is invalid"
 fi
 
-if [ -z "$previous_release" ] || [ "$previous_release" = "null" ]; then
+if [ ! -s "$published_releases_file" ]; then
   disable_reuse "no previous published release found"
 fi
 
-previous_tag="$(printf '%s' "$previous_release" | jq -r '.tag_name // .tagName // "unknown"')"
-previous_manifest_api_url="$(printf '%s' "$previous_release" | jq -r '.assets[]? | select(.name == "manifest.json") | .url // empty' | head -n 1)"
+previous_release=""
+previous_tag=""
+previous_manifest_api_url=""
+previous_manifest=""
 
-if [ -z "$previous_manifest_api_url" ]; then
-  disable_reuse "previous release $previous_tag has no manifest.json asset"
+if [ -z "$channel" ]; then
+  previous_release="$(head -n 1 "$published_releases_file")"
+  if ! load_manifest_for_release "$previous_release"; then
+    log "Rootfs reuse disabled: no usable manifest.json found on latest published release"
+    finish
+    exit 0
+  fi
+  previous_tag="$candidate_tag"
+  previous_manifest_api_url="$candidate_manifest_api_url"
+  previous_manifest="$candidate_manifest"
+else
+  selected_previous_release="false"
+  while IFS= read -r candidate_release; do
+    if ! load_manifest_for_release "$candidate_release"; then
+      continue
+    fi
+
+    if ! candidate_channel="$(printf '%s' "$candidate_manifest" | jq -r '.channel // empty')"; then
+      log "Rootfs reuse skipped: release $candidate_tag manifest.json is invalid"
+      continue
+    fi
+
+    if [ "$candidate_channel" != "$channel" ]; then
+      log "Rootfs reuse skipped: release $candidate_tag channel ${candidate_channel:-<empty>} does not match current channel $channel"
+      continue
+    fi
+
+    previous_release="$candidate_release"
+    previous_tag="$candidate_tag"
+    previous_manifest_api_url="$candidate_manifest_api_url"
+    previous_manifest="$candidate_manifest"
+    selected_previous_release="true"
+    break
+  done < "$published_releases_file"
+
+  if [ "$selected_previous_release" != "true" ]; then
+    disable_reuse "no previous published release found for channel $channel"
+  fi
 fi
 
-previous_manifest=""
-if ! previous_manifest="$(gh api -H "Accept: application/octet-stream" "$previous_manifest_api_url" 2>"$err_file")"; then
-  log "Rootfs reuse disabled: failed to download previous manifest.json from release $previous_tag"
-  sed 's/^/  /' "$err_file" >&2 || true
+if [ -z "$previous_manifest_api_url" ] || [ -z "$previous_manifest" ]; then
+  log "Rootfs reuse disabled: no usable previous manifest.json found"
   finish
   exit 0
 fi

--- a/scripts/resolve_reusable_rootfs_asset.sh
+++ b/scripts/resolve_reusable_rootfs_asset.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  resolve_reusable_rootfs_asset.sh \
+    --image-dir DIR \
+    --upload-assets 'FILE ...' \
+    [--output FILE]
+
+Resolve whether rootfs.img can reuse the previous GitHub release asset.
+
+Outputs:
+  rootfs_reused=true|false
+  rootfs_asset_url=URL
+  rootfs_asset_metadata=JSON
+  upload_assets='FILE ...'
+USAGE
+}
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+die() {
+  log "resolve_reusable_rootfs_asset.sh: $*"
+  exit 1
+}
+
+image_dir=""
+upload_assets=""
+output="${GITHUB_OUTPUT:-}"
+rootfs_asset_name="rootfs.img"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --image-dir)
+      image_dir="${2:-}"
+      shift 2
+      ;;
+    --upload-assets)
+      upload_assets="${2:-}"
+      shift 2
+      ;;
+    --output)
+      output="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "$image_dir" ] || die "missing --image-dir"
+[ -n "$upload_assets" ] || die "missing --upload-assets"
+[ -d "$image_dir" ] || die "missing image directory: $image_dir"
+[ -f "$image_dir/$rootfs_asset_name" ] || die "missing rootfs image: $image_dir/$rootfs_asset_name"
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+emit_output() {
+  local key="$1"
+  local value="$2"
+
+  if [ -n "$output" ]; then
+    printf '%s=%s\n' "$key" "$value" >> "$output"
+  else
+    printf '%s=%s\n' "$key" "$value"
+  fi
+}
+
+remove_upload_asset() {
+  local remove_name="$1"
+  local resolved=()
+  local asset
+
+  for asset in $upload_assets; do
+    if [ "$asset" = "$remove_name" ]; then
+      continue
+    fi
+    resolved+=("$asset")
+  done
+
+  local IFS=' '
+  printf '%s' "${resolved[*]}"
+}
+
+finish() {
+  emit_output "rootfs_reused" "$rootfs_reused"
+  emit_output "rootfs_asset_url" "$rootfs_asset_url"
+  emit_output "rootfs_asset_metadata" "$rootfs_asset_metadata"
+  emit_output "upload_assets" "$resolved_upload_assets"
+}
+
+disable_reuse() {
+  log "Rootfs reuse disabled: $*"
+  finish
+  exit 0
+}
+
+rootfs_reused="false"
+rootfs_asset_url=""
+rootfs_asset_metadata=""
+resolved_upload_assets="$upload_assets"
+
+command -v jq >/dev/null 2>&1 || disable_reuse "jq is unavailable"
+command -v gh >/dev/null 2>&1 || disable_reuse "gh CLI is unavailable"
+current_rootfs_sha="$(sha256_of "$image_dir/$rootfs_asset_name")" || disable_reuse "sha256 tool is unavailable"
+compressed_rootfs_asset_name="${rootfs_asset_name}.tar.gz"
+
+repo="${GITHUB_REPOSITORY:-}"
+case "$repo" in
+  */*) ;;
+  *) disable_reuse "GITHUB_REPOSITORY is not set to OWNER/REPO" ;;
+esac
+
+if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
+  disable_reuse "GH_TOKEN or GITHUB_TOKEN is not set"
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+err_file="$tmp_dir/gh.err"
+
+release_json=""
+if ! release_json="$(gh api "repos/$repo/releases?per_page=20" 2>"$err_file")"; then
+  log "Rootfs reuse disabled: failed to query previous GitHub releases"
+  sed 's/^/  /' "$err_file" >&2 || true
+  finish
+  exit 0
+fi
+
+previous_release=""
+if ! previous_release="$(printf '%s' "$release_json" | jq -c 'map(select(.draft != true)) | .[0] // empty')"; then
+  disable_reuse "previous release JSON is invalid"
+fi
+
+if [ -z "$previous_release" ] || [ "$previous_release" = "null" ]; then
+  disable_reuse "no previous published release found"
+fi
+
+previous_tag="$(printf '%s' "$previous_release" | jq -r '.tag_name // .tagName // "unknown"')"
+previous_manifest_api_url="$(printf '%s' "$previous_release" | jq -r '.assets[]? | select(.name == "manifest.json") | .url // empty' | head -n 1)"
+
+if [ -z "$previous_manifest_api_url" ]; then
+  disable_reuse "previous release $previous_tag has no manifest.json asset"
+fi
+
+previous_manifest=""
+if ! previous_manifest="$(gh api -H "Accept: application/octet-stream" "$previous_manifest_api_url" 2>"$err_file")"; then
+  log "Rootfs reuse disabled: failed to download previous manifest.json from release $previous_tag"
+  sed 's/^/  /' "$err_file" >&2 || true
+  finish
+  exit 0
+fi
+
+rootfs_query='
+  .parts[]?
+  | select(.name == "rootfs")
+  | .asset // empty
+  | select(.name == $name or .name == $compressed_name)
+  | {
+      name:(.name // ""),
+      url:(.url // ""),
+      size:(.size // 0),
+      sha256:(.sha256 // ""),
+      image_sha256:(.image_sha256 // "")
+    }
+'
+previous_rootfs_json=""
+if ! previous_rootfs_json="$(printf '%s' "$previous_manifest" | jq -c --arg name "$rootfs_asset_name" --arg compressed_name "$compressed_rootfs_asset_name" "$rootfs_query" | head -n 1)"; then
+  disable_reuse "previous manifest.json is invalid"
+fi
+
+if [ -z "$previous_rootfs_json" ]; then
+  disable_reuse "previous manifest.json has no reusable neutral rootfs asset"
+fi
+
+previous_rootfs_name="$(printf '%s' "$previous_rootfs_json" | jq -r '.name // empty')"
+previous_rootfs_size="$(printf '%s' "$previous_rootfs_json" | jq -r '.size // empty')"
+previous_rootfs_sha="$(printf '%s' "$previous_rootfs_json" | jq -r '.sha256 // empty' | tr '[:upper:]' '[:lower:]')"
+previous_rootfs_image_sha="$(printf '%s' "$previous_rootfs_json" | jq -r '.image_sha256 // empty' | tr '[:upper:]' '[:lower:]')"
+previous_manifest_rootfs_url="$(printf '%s' "$previous_rootfs_json" | jq -r '.url // empty')"
+previous_release_rootfs_url="$(printf '%s' "$previous_release" | jq -r --arg name "$previous_rootfs_name" '.assets[]? | select(.name == $name) | .browser_download_url // .browserDownloadUrl // empty' | head -n 1)"
+reuse_url="$previous_manifest_rootfs_url"
+if [ -z "$reuse_url" ]; then
+  reuse_url="$previous_release_rootfs_url"
+fi
+
+case "$previous_rootfs_size" in
+  ''|*[!0-9]*|0)
+    disable_reuse "previous manifest.json rootfs asset has invalid size: $previous_rootfs_size"
+    ;;
+esac
+
+if [ -z "$previous_rootfs_sha" ]; then
+  disable_reuse "previous manifest.json rootfs asset has no sha256"
+fi
+
+comparison_sha="$previous_rootfs_sha"
+comparison_field="sha256"
+if [ "$previous_rootfs_name" = "$compressed_rootfs_asset_name" ]; then
+  if [ -z "$previous_rootfs_image_sha" ]; then
+    disable_reuse "previous compressed rootfs asset has no image_sha256"
+  fi
+  comparison_sha="$previous_rootfs_image_sha"
+  comparison_field="image_sha256"
+elif [ "$previous_rootfs_name" != "$rootfs_asset_name" ]; then
+  disable_reuse "previous rootfs asset name is not reusable: $previous_rootfs_name"
+fi
+
+if [ "$current_rootfs_sha" != "$comparison_sha" ]; then
+  log "Rootfs reuse skipped: sha256 differs from previous release $previous_tag"
+  log "  current:  $current_rootfs_sha"
+  log "  previous $comparison_field: $comparison_sha"
+  finish
+  exit 0
+fi
+
+case "$reuse_url" in
+  http://*|https://*) ;;
+  "") disable_reuse "previous release $previous_tag has no reusable rootfs download URL" ;;
+  *) disable_reuse "previous rootfs download URL is not http(s): $reuse_url" ;;
+esac
+
+rootfs_reused="true"
+rootfs_asset_url="$reuse_url"
+rootfs_asset_metadata="$(printf '%s' "$previous_rootfs_json" | jq -c --arg url "$rootfs_asset_url" '.url = $url | if .image_sha256 == "" then del(.image_sha256) else . end')"
+resolved_upload_assets="$(remove_upload_asset "$rootfs_asset_name")"
+
+log "Rootfs reuse enabled: $previous_rootfs_name $comparison_field matches previous release $previous_tag"
+log "  url: $rootfs_asset_url"
+log "  upload_assets: $resolved_upload_assets"
+finish

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -59,6 +59,11 @@ if ! grep -q -- '--upload-assets "$upload_assets"' "$WORKFLOW"; then
     exit 1
 fi
 
+if ! grep -q -- '--channel "${{ steps.release_info.outputs.channel }}"' "$WORKFLOW"; then
+    echo "build workflow must pass the current release channel to the rootfs reuse resolver" >&2
+    exit 1
+fi
+
 if grep -q 'userdata.img' "$WORKFLOW"; then
     echo "build workflow must not upload userdata.img to GitHub releases" >&2
     exit 1

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -50,7 +50,12 @@ if ! grep -q -- '--upload-assets' "$WORKFLOW"; then
 fi
 
 if ! grep -q -- "--upload-assets '$release_assets'" "$WORKFLOW"; then
-    echo "build workflow must upload only allowlisted release assets" >&2
+    echo "build workflow must pass the full release asset allowlist to the rootfs reuse resolver" >&2
+    exit 1
+fi
+
+if ! grep -q -- '--upload-assets "$upload_assets"' "$WORKFLOW"; then
+    echo "build workflow must upload the resolver-adjusted release asset allowlist" >&2
     exit 1
 fi
 
@@ -93,8 +98,25 @@ if grep -q 'scripts/test_build_scripts.sh' "$CI_WORKFLOW"; then
 fi
 
 if ! grep -q 'scripts/test_release_ci_scripts.sh' "$CI_WORKFLOW" || \
-   ! grep -q 'scripts/test_github_release_upload.sh' "$CI_WORKFLOW"; then
+   ! grep -q 'scripts/test_github_release_upload.sh' "$CI_WORKFLOW" || \
+   ! grep -q 'scripts/test_reusable_rootfs_release_asset.sh' "$CI_WORKFLOW"; then
     echo "CI must run repo-only release workflow and upload script tests" >&2
+    exit 1
+fi
+
+if ! grep -q 'Resolve reusable rootfs release asset' "$WORKFLOW"; then
+    echo "build workflow must resolve reusable rootfs release assets before manifest generation" >&2
+    exit 1
+fi
+
+if ! grep -q 'rootfs_asset.outputs.upload_assets' "$WORKFLOW"; then
+    echo "build workflow must pass the resolved release upload asset list to the release script" >&2
+    exit 1
+fi
+
+if ! grep -q 'rootfs_asset.outputs.rootfs_asset_metadata' "$WORKFLOW" || \
+   ! grep -q -- '--asset-metadata' "$WORKFLOW"; then
+    echo "build workflow must pass full reused rootfs asset metadata into manifest generation" >&2
     exit 1
 fi
 

--- a/scripts/test_reusable_rootfs_release_asset.sh
+++ b/scripts/test_reusable_rootfs_release_asset.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+assets_dir="$tmp_dir/assets"
+fake_bin="$tmp_dir/bin"
+state_dir="$tmp_dir/state"
+mkdir -p "$assets_dir" "$fake_bin" "$state_dir"
+
+printf 'boot a\n' > "$assets_dir/boot_a.img"
+printf 'boot b\n' > "$assets_dir/boot_b.img"
+printf 'oem\n' > "$assets_dir/oem.img"
+printf 'same rootfs payload\n' > "$assets_dir/rootfs.img"
+printf 'update\n' > "$assets_dir/update.img"
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+output_value() {
+  local key="$1"
+  local file="$2"
+  awk -v key="$key" '
+    index($0, key "=") == 1 {
+      sub("^[^=]*=", "")
+      print
+    }
+  ' "$file" | tail -n 1
+}
+
+cat > "$fake_bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state_dir="${FAKE_GH_STATE_DIR:?}"
+printf '%s\n' "$*" >> "$state_dir/calls"
+
+if [ "${1:-}" = "--version" ]; then
+  echo "gh version 2.0.0"
+  exit 0
+fi
+
+if [ "${1:-}" = "api" ]; then
+  shift
+  endpoint=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -H)
+        shift 2
+        ;;
+      *)
+        endpoint="$1"
+        shift
+        ;;
+    esac
+  done
+
+  case "$endpoint" in
+    repos/owner/repo/releases\?per_page=20)
+      cat "$state_dir/releases.json"
+      ;;
+    https://api.github.com/repos/owner/repo/releases/assets/manifest)
+      cat "$state_dir/previous_manifest.json"
+      ;;
+    *)
+      echo "unexpected gh api endpoint: $endpoint" >&2
+      exit 2
+      ;;
+  esac
+  exit 0
+fi
+
+if [ "${1:-}" != "release" ]; then
+  echo "unexpected gh command: $*" >&2
+  exit 2
+fi
+
+case "${2:-}" in
+  view)
+    if [ -f "$state_dir/release-exists" ]; then
+      echo "release exists"
+      exit 0
+    fi
+    echo "release not found" >&2
+    exit 1
+    ;;
+  create)
+    touch "$state_dir/release-exists"
+    printf 'create:%s\n' "${3:-}" >> "$state_dir/events"
+    exit 0
+    ;;
+  edit)
+    printf 'publish:%s\n' "${3:-}" >> "$state_dir/events"
+    exit 0
+    ;;
+  upload)
+    asset="${4:-}"
+    printf 'upload:%s\n' "${asset##*/}" >> "$state_dir/events"
+    exit 0
+    ;;
+  *)
+    echo "unexpected gh release command: $*" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$fake_bin/gh"
+
+current_rootfs_sha="$(sha256_of "$assets_dir/rootfs.img")"
+previous_manifest_url="https://downloads.example.test/releases/v-prev/rootfs.img"
+previous_release_rootfs_url="https://github.example.test/owner/repo/releases/download/v-prev/rootfs.img"
+
+jq -n \
+  --arg manifest_api_url "https://api.github.com/repos/owner/repo/releases/assets/manifest" \
+  --arg rootfs_url "$previous_release_rootfs_url" \
+  '[{draft:false,tag_name:"v-prev",assets:[
+    {name:"manifest.json",url:$manifest_api_url,browser_download_url:"https://github.example.test/owner/repo/releases/download/v-prev/manifest.json"},
+    {name:"rootfs.img",url:"https://api.github.com/repos/owner/repo/releases/assets/rootfs",browser_download_url:$rootfs_url}
+  ]}]' > "$state_dir/releases.json"
+
+jq -n \
+  --arg sha "$current_rootfs_sha" \
+  --arg url "$previous_manifest_url" \
+  '{schema_version:1,parts:[{name:"rootfs",asset:{name:"rootfs.img",size:20,sha256:$sha,url:$url}}]}' \
+  > "$state_dir/previous_manifest.json"
+
+outputs_file="$tmp_dir/reuse.outputs"
+PATH="$fake_bin:$PATH" \
+  FAKE_GH_STATE_DIR="$state_dir" \
+  GH_TOKEN="test-token" \
+  GITHUB_REPOSITORY="owner/repo" \
+  "$repo_root/scripts/resolve_reusable_rootfs_asset.sh" \
+    --image-dir "$assets_dir" \
+    --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+    --output "$outputs_file"
+
+if [ "$(output_value rootfs_reused "$outputs_file")" != "true" ]; then
+  echo "rootfs asset resolver must reuse a previous release asset when sha256 matches" >&2
+  exit 1
+fi
+
+rootfs_asset_url="$(output_value rootfs_asset_url "$outputs_file")"
+if [ "$rootfs_asset_url" != "$previous_manifest_url" ]; then
+  echo "rootfs asset resolver must prefer the previous manifest download URL, got: $rootfs_asset_url" >&2
+  exit 1
+fi
+
+upload_assets="$(output_value upload_assets "$outputs_file")"
+if [ "$upload_assets" != "boot_a.img boot_b.img oem.img update.img manifest.json" ]; then
+  echo "rootfs asset resolver must remove rootfs.img from the upload list, got: $upload_assets" >&2
+  exit 1
+fi
+
+rootfs_asset_metadata="$(output_value rootfs_asset_metadata "$outputs_file")"
+if [ "$(printf '%s' "$rootfs_asset_metadata" | jq -r '.name')" != "rootfs.img" ] || \
+   [ "$(printf '%s' "$rootfs_asset_metadata" | jq -r '.url')" != "$previous_manifest_url" ] || \
+   [ "$(printf '%s' "$rootfs_asset_metadata" | jq -r '.sha256')" != "$current_rootfs_sha" ] || \
+   [ "$(printf '%s' "$rootfs_asset_metadata" | jq -r '.image_sha256 // ""')" != "" ]; then
+  echo "rootfs asset resolver must output full uncompressed rootfs asset metadata" >&2
+  printf '%s\n' "$rootfs_asset_metadata" >&2
+  exit 1
+fi
+
+private_key="$tmp_dir/test_key.pem"
+openssl genpkey -algorithm ED25519 -out "$private_key" 2>/dev/null
+manifest_output="$assets_dir/manifest.json"
+"$repo_root/scripts/generate_ota_manifest.sh" \
+  --version "test-version" \
+  --channel "test" \
+  --build-time "2026-01-01T00:00:00Z" \
+  --sign-key "$private_key" \
+  --image-dir "$assets_dir" \
+  --asset-metadata "rootfs.img=$rootfs_asset_metadata" \
+  --output "$manifest_output"
+
+if [ "$(jq -r '.parts[] | select(.name=="rootfs") | .asset.url' "$manifest_output")" != "$previous_manifest_url" ]; then
+  echo "manifest generation must embed the reused rootfs download URL" >&2
+  exit 1
+fi
+
+log_file="$tmp_dir/release.log"
+PATH="$fake_bin:$PATH" \
+  FAKE_GH_STATE_DIR="$state_dir" \
+  GH_TOKEN="test-token" \
+  GITHUB_REPOSITORY="owner/repo" \
+  "$repo_root/scripts/create_github_release.sh" \
+    --tag-name v-test \
+    --release-name "Test Release" \
+    --target-commitish "$(git -C "$repo_root" rev-parse HEAD)" \
+    --asset-glob "$assets_dir/*" \
+    --required-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+    --upload-assets "$upload_assets" \
+    --retry-count 1 \
+    --retry-delay-seconds 0 \
+    > "$log_file" 2>&1
+
+if grep -q '^upload:rootfs.img$' "$state_dir/events"; then
+  echo "release upload must skip rootfs.img when the previous asset is reused" >&2
+  exit 1
+fi
+
+if ! grep -q '^upload:manifest.json$' "$state_dir/events"; then
+  echo "release upload must still publish the rewritten manifest.json" >&2
+  exit 1
+fi
+
+rm -f "$outputs_file" "$state_dir/events"
+previous_compressed_url="https://downloads.example.test/releases/v-prev/rootfs.img.tar.gz"
+previous_compressed_sha="1111111111111111111111111111111111111111111111111111111111111111"
+previous_compressed_size=12345
+
+jq -n \
+  --arg manifest_api_url "https://api.github.com/repos/owner/repo/releases/assets/manifest" \
+  --arg rootfs_url "$previous_compressed_url" \
+  '[{draft:false,tag_name:"v-prev",assets:[
+    {name:"manifest.json",url:$manifest_api_url,browser_download_url:"https://github.example.test/owner/repo/releases/download/v-prev/manifest.json"},
+    {name:"rootfs.img.tar.gz",url:"https://api.github.com/repos/owner/repo/releases/assets/rootfs-archive",browser_download_url:$rootfs_url}
+  ]}]' > "$state_dir/releases.json"
+
+jq -n \
+  --arg archive_sha "$previous_compressed_sha" \
+  --arg image_sha "$current_rootfs_sha" \
+  --arg url "$previous_compressed_url" \
+  --argjson size "$previous_compressed_size" \
+  '{schema_version:1,parts:[{name:"rootfs",asset:{name:"rootfs.img.tar.gz",size:$size,sha256:$archive_sha,image_sha256:$image_sha,url:$url}}]}' \
+  > "$state_dir/previous_manifest.json"
+
+PATH="$fake_bin:$PATH" \
+  FAKE_GH_STATE_DIR="$state_dir" \
+  GH_TOKEN="test-token" \
+  GITHUB_REPOSITORY="owner/repo" \
+  "$repo_root/scripts/resolve_reusable_rootfs_asset.sh" \
+    --image-dir "$assets_dir" \
+    --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+    --output "$outputs_file"
+
+if [ "$(output_value rootfs_reused "$outputs_file")" != "true" ]; then
+  echo "rootfs asset resolver must reuse a previous compressed rootfs asset when image_sha256 matches" >&2
+  exit 1
+fi
+
+compressed_metadata="$(output_value rootfs_asset_metadata "$outputs_file")"
+if [ "$(printf '%s' "$compressed_metadata" | jq -r '.name')" != "rootfs.img.tar.gz" ] || \
+   [ "$(printf '%s' "$compressed_metadata" | jq -r '.url')" != "$previous_compressed_url" ] || \
+   [ "$(printf '%s' "$compressed_metadata" | jq -r '.sha256')" != "$previous_compressed_sha" ] || \
+   [ "$(printf '%s' "$compressed_metadata" | jq -r '.image_sha256')" != "$current_rootfs_sha" ] || \
+   [ "$(printf '%s' "$compressed_metadata" | jq -r '.size')" != "$previous_compressed_size" ]; then
+  echo "rootfs asset resolver must output full compressed rootfs asset metadata" >&2
+  printf '%s\n' "$compressed_metadata" >&2
+  exit 1
+fi
+
+compressed_upload_assets="$(output_value upload_assets "$outputs_file")"
+if [ "$compressed_upload_assets" != "boot_a.img boot_b.img oem.img update.img manifest.json" ]; then
+  echo "rootfs asset resolver must remove rootfs.img from the upload list when reusing a compressed asset, got: $compressed_upload_assets" >&2
+  exit 1
+fi
+
+"$repo_root/scripts/generate_ota_manifest.sh" \
+  --version "test-version" \
+  --channel "test" \
+  --build-time "2026-01-01T00:00:00Z" \
+  --sign-key "$private_key" \
+  --image-dir "$assets_dir" \
+  --asset-metadata "rootfs.img=$compressed_metadata" \
+  --output "$manifest_output"
+
+if ! jq -e \
+  --arg archive_sha "$previous_compressed_sha" \
+  --arg image_sha "$current_rootfs_sha" \
+  --arg url "$previous_compressed_url" \
+  --argjson size "$previous_compressed_size" \
+  '.parts[] | select(.name=="rootfs") | .asset |
+    .name == "rootfs.img.tar.gz" and
+    .url == $url and
+    .size == $size and
+    .sha256 == $archive_sha and
+    .image_sha256 == $image_sha' \
+  "$manifest_output" >/dev/null; then
+  echo "manifest generation must embed the complete reused compressed rootfs asset metadata" >&2
+  jq '.parts[] | select(.name=="rootfs") | .asset' "$manifest_output" >&2
+  exit 1
+fi
+
+rm -f "$outputs_file" "$state_dir/events"
+jq -n \
+  --arg archive_sha "$previous_compressed_sha" \
+  --arg url "$previous_compressed_url" \
+  --argjson size "$previous_compressed_size" \
+  '{schema_version:1,parts:[{name:"rootfs",asset:{name:"rootfs.img.tar.gz",size:$size,sha256:$archive_sha,image_sha256:"2222222222222222222222222222222222222222222222222222222222222222",url:$url}}]}' \
+  > "$state_dir/previous_manifest.json"
+
+PATH="$fake_bin:$PATH" \
+  FAKE_GH_STATE_DIR="$state_dir" \
+  GH_TOKEN="test-token" \
+  GITHUB_REPOSITORY="owner/repo" \
+  "$repo_root/scripts/resolve_reusable_rootfs_asset.sh" \
+    --image-dir "$assets_dir" \
+    --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+    --output "$outputs_file"
+
+if [ "$(output_value rootfs_reused "$outputs_file")" != "false" ]; then
+  echo "rootfs asset resolver must compare compressed rootfs assets by image_sha256" >&2
+  exit 1
+fi
+
+rm -f "$outputs_file" "$state_dir/events"
+jq -n \
+  --arg url "$previous_manifest_url" \
+  '{schema_version:1,parts:[{name:"rootfs",asset:{name:"rootfs.img",size:20,sha256:"0000000000000000000000000000000000000000000000000000000000000000",url:$url}}]}' \
+  > "$state_dir/previous_manifest.json"
+
+PATH="$fake_bin:$PATH" \
+  FAKE_GH_STATE_DIR="$state_dir" \
+  GH_TOKEN="test-token" \
+  GITHUB_REPOSITORY="owner/repo" \
+  "$repo_root/scripts/resolve_reusable_rootfs_asset.sh" \
+    --image-dir "$assets_dir" \
+    --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+    --output "$outputs_file"
+
+if [ "$(output_value rootfs_reused "$outputs_file")" != "false" ]; then
+  echo "rootfs asset resolver must not reuse a previous asset when sha256 differs" >&2
+  exit 1
+fi
+
+if [ "$(output_value rootfs_asset_url "$outputs_file")" != "" ]; then
+  echo "rootfs asset resolver must leave rootfs_asset_url empty when sha256 differs" >&2
+  exit 1
+fi
+
+if [ "$(output_value upload_assets "$outputs_file")" != "boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json" ]; then
+  echo "rootfs asset resolver must keep rootfs.img in the upload list when sha256 differs" >&2
+  exit 1
+fi
+
+echo "Reusable rootfs release asset test passed."

--- a/scripts/test_reusable_rootfs_release_asset.sh
+++ b/scripts/test_reusable_rootfs_release_asset.sh
@@ -2,6 +2,13 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+resolver_script="$repo_root/scripts/resolve_reusable_rootfs_asset.sh"
+if [ ! -x "$resolver_script" ]; then
+  echo "resolve_reusable_rootfs_asset.sh is missing or not executable: $resolver_script" >&2
+  echo "Check repo_root detection and script permissions." >&2
+  exit 1
+fi
+
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
@@ -136,7 +143,7 @@ PATH="$fake_bin:$PATH" \
   FAKE_GH_STATE_DIR="$state_dir" \
   GH_TOKEN="test-token" \
   GITHUB_REPOSITORY="owner/repo" \
-  "$repo_root/scripts/resolve_reusable_rootfs_asset.sh" \
+  "$resolver_script" \
     --image-dir "$assets_dir" \
     --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
     --output "$outputs_file"
@@ -236,7 +243,7 @@ PATH="$fake_bin:$PATH" \
   FAKE_GH_STATE_DIR="$state_dir" \
   GH_TOKEN="test-token" \
   GITHUB_REPOSITORY="owner/repo" \
-  "$repo_root/scripts/resolve_reusable_rootfs_asset.sh" \
+  "$resolver_script" \
     --image-dir "$assets_dir" \
     --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
     --output "$outputs_file"
@@ -301,7 +308,7 @@ PATH="$fake_bin:$PATH" \
   FAKE_GH_STATE_DIR="$state_dir" \
   GH_TOKEN="test-token" \
   GITHUB_REPOSITORY="owner/repo" \
-  "$repo_root/scripts/resolve_reusable_rootfs_asset.sh" \
+  "$resolver_script" \
     --image-dir "$assets_dir" \
     --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
     --output "$outputs_file"
@@ -321,7 +328,7 @@ PATH="$fake_bin:$PATH" \
   FAKE_GH_STATE_DIR="$state_dir" \
   GH_TOKEN="test-token" \
   GITHUB_REPOSITORY="owner/repo" \
-  "$repo_root/scripts/resolve_reusable_rootfs_asset.sh" \
+  "$resolver_script" \
     --image-dir "$assets_dir" \
     --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
     --output "$outputs_file"

--- a/scripts/test_reusable_rootfs_release_asset.sh
+++ b/scripts/test_reusable_rootfs_release_asset.sh
@@ -76,6 +76,12 @@ if [ "${1:-}" = "api" ]; then
     https://api.github.com/repos/owner/repo/releases/assets/manifest)
       cat "$state_dir/previous_manifest.json"
       ;;
+    https://api.github.com/repos/owner/repo/releases/assets/manifest-dev)
+      cat "$state_dir/previous_manifest_dev.json"
+      ;;
+    https://api.github.com/repos/owner/repo/releases/assets/manifest-stable)
+      cat "$state_dir/previous_manifest_stable.json"
+      ;;
     *)
       echo "unexpected gh api endpoint: $endpoint" >&2
       exit 2
@@ -345,6 +351,53 @@ fi
 
 if [ "$(output_value upload_assets "$outputs_file")" != "boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json" ]; then
   echo "rootfs asset resolver must keep rootfs.img in the upload list when sha256 differs" >&2
+  exit 1
+fi
+
+rm -f "$outputs_file" "$state_dir/events"
+dev_rootfs_url="https://downloads.example.test/releases/dev/rootfs.img"
+stable_rootfs_url="https://downloads.example.test/releases/stable/rootfs.img"
+
+jq -n \
+  '[{draft:false,prerelease:true,tag_name:"v-dev",assets:[
+    {name:"manifest.json",url:"https://api.github.com/repos/owner/repo/releases/assets/manifest-dev",browser_download_url:"https://github.example.test/owner/repo/releases/download/v-dev/manifest.json"},
+    {name:"rootfs.img",url:"https://api.github.com/repos/owner/repo/releases/assets/rootfs-dev",browser_download_url:"https://github.example.test/owner/repo/releases/download/v-dev/rootfs.img"}
+  ]},
+  {draft:false,prerelease:false,tag_name:"v-stable",assets:[
+    {name:"manifest.json",url:"https://api.github.com/repos/owner/repo/releases/assets/manifest-stable",browser_download_url:"https://github.example.test/owner/repo/releases/download/v-stable/manifest.json"},
+    {name:"rootfs.img",url:"https://api.github.com/repos/owner/repo/releases/assets/rootfs-stable",browser_download_url:"https://github.example.test/owner/repo/releases/download/v-stable/rootfs.img"}
+  ]}]' > "$state_dir/releases.json"
+
+jq -n \
+  --arg sha "$current_rootfs_sha" \
+  --arg url "$dev_rootfs_url" \
+  '{schema_version:1,channel:"dev-feature",parts:[{name:"rootfs",asset:{name:"rootfs.img",size:20,sha256:$sha,url:$url}}]}' \
+  > "$state_dir/previous_manifest_dev.json"
+
+jq -n \
+  --arg sha "$current_rootfs_sha" \
+  --arg url "$stable_rootfs_url" \
+  '{schema_version:1,channel:"stable",parts:[{name:"rootfs",asset:{name:"rootfs.img",size:20,sha256:$sha,url:$url}}]}' \
+  > "$state_dir/previous_manifest_stable.json"
+
+PATH="$fake_bin:$PATH" \
+  FAKE_GH_STATE_DIR="$state_dir" \
+  GH_TOKEN="test-token" \
+  GITHUB_REPOSITORY="owner/repo" \
+  "$resolver_script" \
+    --image-dir "$assets_dir" \
+    --channel stable \
+    --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+    --output "$outputs_file"
+
+if [ "$(output_value rootfs_reused "$outputs_file")" != "true" ]; then
+  echo "stable rootfs asset resolver must keep scanning after a newer dev prerelease" >&2
+  exit 1
+fi
+
+if [ "$(output_value rootfs_asset_url "$outputs_file")" != "$stable_rootfs_url" ]; then
+  echo "stable rootfs asset resolver must not reuse a dev prerelease asset" >&2
+  echo "got: $(output_value rootfs_asset_url "$outputs_file")" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Resolve reusable rootfs assets before generating the OTA manifest
- Reuse previous rootfs download metadata when the current rootfs image hash matches
- Preserve compressed rootfs metadata by comparing image_sha256 and carrying name, url, size, sha256, and image_sha256 into the new manifest
- Skip uploading rootfs.img when a previous release asset is reused

## Tests
- sh scripts/test_release_ci_scripts.sh
- bash scripts/test_reproducible_rootfs_policy.sh
- bash scripts/test_github_release_upload.sh
- bash scripts/test_reusable_rootfs_release_asset.sh
- bash scripts/test_ota_manifest_generation.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved build efficiency by enabling rootfs asset reuse from previous releases when unchanged, reducing build time and deployment overhead.
  * Enhanced CI/CD workflows to resolve, validate, and conditionally reuse rootfs assets with proper metadata tracking and versioning.
  * Updated release asset handling to support dynamic asset lists and per-asset metadata overrides.

* **Tests**
  * Added comprehensive integration tests for asset reuse detection and OTA manifest generation with asset metadata support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->