### PR TITLE
fix(boot): sync time from DHCP lease events

### DIFF
--- a/docs/01-getting-started/deployment.md
+++ b/docs/01-getting-started/deployment.md
@@ -7,13 +7,14 @@
 ```text
 /oem/usr/bin/                  # 应用二进制
 /etc/init.d/S43wlan_guard      # WLAN connectivity guard
-/etc/init.d/S49ntp             # NTP startup after network readiness
+/etc/init.d/S49ntp             # ntpd daemon + udhcpc-driven step sync
 /etc/init.d/S49usbhid          # USB HID gadget 初始化
 /etc/init.d/S52frame_service   # Frame Service watchdog
 /etc/init.d/S53audio_service   # Audio Service watchdog
 /etc/init.d/S53agent           # Go Agent watchdog
 /etc/init.d/S56config_web      # 配置网页
 /etc/init.d/S99rtcinit         # RTC 默认时间校准
+/etc/udhcpc/aiden.script       # udhcpc hook：DHCP bound 后触发 NTP step
 /userdata/agent/agent.toml     # Agent 默认配置
 /userdata/wpa_supplicant.conf  # Wi-Fi 默认配置
 ```
@@ -36,7 +37,7 @@ scp build/bin/agent root@<device-ip>:/oem/usr/bin/
 随固件启动时，主要服务关系如下：
 
 1. `S43wlan_guard` monitors WLAN connectivity and recovers automatically;
-2. `S49ntp` waits for network readiness before launching `ntpd`;
+2. `S49ntp` 以 daemon 模式启动 `ntpd`，使用 IP 直连 NTP server（绕开 DNS 启动顺序）；DHCP bound/renew 时由 `/etc/udhcpc/aiden.script` 触发一次 `S49ntp step` 强制同步；
 3. `S49usbhid` / `S50usbdevice` 配置 USB gadget；
 4. `S52frame_service` 独占 `/dev/video0` 并提供截图/帧服务；
 5. `S53audio_service` 提供音频录放服务；

--- a/docs/01-getting-started/deployment.md
+++ b/docs/01-getting-started/deployment.md
@@ -42,9 +42,10 @@ scp build/bin/agent root@<device-ip>:/oem/usr/bin/
 4. `S52frame_service` 独占 `/dev/video0` 并提供截图/帧服务；
 5. `S53audio_service` 提供音频录放服务；
 6. `S53agent` 启动 Go Agent；
-7. `S56config_web` 提供配置页面；
-8. `S55aiden_usb_dhcp` / `S99usb0config` 配置 USB 网络相关能力；
+7. `S55aiden_usb_dhcp` 配置 USB 网络 DHCP / dnsmasq 相关能力；
+8. `S56config_web` 提供配置页面；
 9. `S99rtcinit` 覆盖 SDK 默认 RTC 脚本；RTC 异常时只在系统时间仍早于基线日期时写入默认时间，避免覆盖已经由 NTP 校准过的系统时间。
+10. `S99usb0config` 执行 USB 网络接口后置配置。
 
 ## 常用服务命令
 

--- a/docs/01-getting-started/deployment.md
+++ b/docs/01-getting-started/deployment.md
@@ -13,7 +13,7 @@
 /etc/init.d/S53audio_service   # Audio Service watchdog
 /etc/init.d/S53agent           # Go Agent watchdog
 /etc/init.d/S56config_web      # 配置网页
-/etc/init.d/S99rtcinit         # RTC 默认时间校准
+/etc/init.d/S99rtcinit         # RTC 默认时间校准，覆盖 SDK 默认脚本
 /etc/udhcpc/aiden.script       # udhcpc hook：DHCP bound 后触发 NTP step
 /userdata/agent/agent.toml     # Agent 默认配置
 /userdata/wpa_supplicant.conf  # Wi-Fi 默认配置
@@ -43,7 +43,8 @@ scp build/bin/agent root@<device-ip>:/oem/usr/bin/
 5. `S53audio_service` 提供音频录放服务；
 6. `S53agent` 启动 Go Agent；
 7. `S56config_web` 提供配置页面；
-8. `S55aiden_usb_dhcp` / `S99usb0config` 配置 USB 网络相关能力。
+8. `S55aiden_usb_dhcp` / `S99usb0config` 配置 USB 网络相关能力；
+9. `S99rtcinit` 覆盖 SDK 默认 RTC 脚本；RTC 异常时只在系统时间仍早于基线日期时写入默认时间，避免覆盖已经由 NTP 校准过的系统时间。
 
 ## 常用服务命令
 

--- a/docs/01-getting-started/deployment.md
+++ b/docs/01-getting-started/deployment.md
@@ -7,11 +7,13 @@
 ```text
 /oem/usr/bin/                  # 应用二进制
 /etc/init.d/S43wlan_guard      # WLAN connectivity guard
+/etc/init.d/S49ntp             # NTP startup after network readiness
 /etc/init.d/S49usbhid          # USB HID gadget 初始化
 /etc/init.d/S52frame_service   # Frame Service watchdog
 /etc/init.d/S53audio_service   # Audio Service watchdog
 /etc/init.d/S53agent           # Go Agent watchdog
 /etc/init.d/S56config_web      # 配置网页
+/etc/init.d/S99rtcinit         # RTC 默认时间校准
 /userdata/agent/agent.toml     # Agent 默认配置
 /userdata/wpa_supplicant.conf  # Wi-Fi 默认配置
 ```
@@ -34,12 +36,13 @@ scp build/bin/agent root@<device-ip>:/oem/usr/bin/
 随固件启动时，主要服务关系如下：
 
 1. `S43wlan_guard` monitors WLAN connectivity and recovers automatically;
-2. `S49usbhid` / `S50usbdevice` 配置 USB gadget；
-3. `S52frame_service` 独占 `/dev/video0` 并提供截图/帧服务；
-4. `S53audio_service` 提供音频录放服务；
-5. `S53agent` 启动 Go Agent；
-6. `S56config_web` 提供配置页面；
-7. `S55aiden_usb_dhcp` / `S99usb0config` 配置 USB 网络相关能力。
+2. `S49ntp` waits for network readiness before launching `ntpd`;
+3. `S49usbhid` / `S50usbdevice` 配置 USB gadget；
+4. `S52frame_service` 独占 `/dev/video0` 并提供截图/帧服务；
+5. `S53audio_service` 提供音频录放服务；
+6. `S53agent` 启动 Go Agent；
+7. `S56config_web` 提供配置页面；
+8. `S55aiden_usb_dhcp` / `S99usb0config` 配置 USB 网络相关能力。
 
 ## 常用服务命令
 

--- a/docs/02-architecture/boot-services.md
+++ b/docs/02-architecture/boot-services.md
@@ -8,7 +8,7 @@
 | --- | --- |
 | `S20oemslot` | 根据 `aiden.slot_suffix` 挂载 slot-specific `/oem` |
 | `S43wlan_guard` | WLAN connectivity guard |
-| `S49ntp` | 等待网络 ready 后启动 `ntpd` |
+| `S49ntp` | 启动 `ntpd` daemon；DHCP bound/renew 由 udhcpc hook 触发 `S49ntp step` 同步 |
 | `S49usbhid` | 初始化 USB HID gadget |
 | `S50usbdevice` | USB device 相关初始化 |
 | `S52frame_service` | 启动并守护 HDMI 帧服务 |

--- a/docs/02-architecture/boot-services.md
+++ b/docs/02-architecture/boot-services.md
@@ -17,7 +17,7 @@
 | `S54ota` | 启动并守护 OTA daemon |
 | `S55aiden_usb_dhcp` | USB 网络 DHCP / dnsmasq 相关服务 |
 | `S56config_web` | 启动配置网页 |
-| `S99rtcinit` | RTC 异常时写入默认基线日期 |
+| `S99rtcinit` | 覆盖 SDK 默认 RTC 脚本；RTC 异常且系统时间仍早于基线时写入默认日期 |
 | `S99usb0config` | USB 网络接口后置配置 |
 
 ## Frame Service

--- a/docs/02-architecture/boot-services.md
+++ b/docs/02-architecture/boot-services.md
@@ -8,6 +8,7 @@
 | --- | --- |
 | `S20oemslot` | 根据 `aiden.slot_suffix` 挂载 slot-specific `/oem` |
 | `S43wlan_guard` | WLAN connectivity guard |
+| `S49ntp` | 等待网络 ready 后启动 `ntpd` |
 | `S49usbhid` | 初始化 USB HID gadget |
 | `S50usbdevice` | USB device 相关初始化 |
 | `S52frame_service` | 启动并守护 HDMI 帧服务 |
@@ -16,6 +17,7 @@
 | `S54ota` | 启动并守护 OTA daemon |
 | `S55aiden_usb_dhcp` | USB 网络 DHCP / dnsmasq 相关服务 |
 | `S56config_web` | 启动配置网页 |
+| `S99rtcinit` | RTC 异常时写入默认基线日期 |
 | `S99usb0config` | USB 网络接口后置配置 |
 
 ## Frame Service

--- a/docs/08-reference/paths-and-artifacts.md
+++ b/docs/08-reference/paths-and-artifacts.md
@@ -54,7 +54,7 @@
 | `overlay/etc/init.d/S20oemslot` | Slot-aware `/oem` 挂载脚本 |
 | `overlay/etc/init.d/S49ntp` | ntpd daemon 启动 + `step` 一次性同步子命令 |
 | `overlay/etc/init.d/S54ota` | OTA daemon watchdog |
-| `overlay/etc/init.d/S99rtcinit` | RTC invalid-date calibration script |
+| `overlay/etc/init.d/S99rtcinit` | RTC invalid-date calibration script replacing the SDK default |
 | `overlay/etc/udhcpc/aiden.script` | udhcpc hook：委托默认脚本 + DHCP bound 后触发 NTP step |
 | `overlay/etc/profile.d/aiden-env.sh` | SSH/login shell environment loader snippet |
 | `overlay/oem/usr/bin/aiden-env-run` | Service environment launcher |

--- a/docs/08-reference/paths-and-artifacts.md
+++ b/docs/08-reference/paths-and-artifacts.md
@@ -52,9 +52,10 @@
 | `overlay/etc/aiden_frame_service.conf` | Frame Service init 配置模板 |
 | `overlay/etc/aiden_audio_service.conf` | Audio Service init 配置模板 |
 | `overlay/etc/init.d/S20oemslot` | Slot-aware `/oem` 挂载脚本 |
-| `overlay/etc/init.d/S49ntp` | Network-aware NTP startup script |
+| `overlay/etc/init.d/S49ntp` | ntpd daemon 启动 + `step` 一次性同步子命令 |
 | `overlay/etc/init.d/S54ota` | OTA daemon watchdog |
 | `overlay/etc/init.d/S99rtcinit` | RTC invalid-date calibration script |
+| `overlay/etc/udhcpc/aiden.script` | udhcpc hook：委托默认脚本 + DHCP bound 后触发 NTP step |
 | `overlay/etc/profile.d/aiden-env.sh` | SSH/login shell environment loader snippet |
 | `overlay/oem/usr/bin/aiden-env-run` | Service environment launcher |
 | `overlay/oem/usr/model/` | VAD 模型和 weights，随 OEM 分区更新 |

--- a/docs/08-reference/paths-and-artifacts.md
+++ b/docs/08-reference/paths-and-artifacts.md
@@ -52,7 +52,9 @@
 | `overlay/etc/aiden_frame_service.conf` | Frame Service init 配置模板 |
 | `overlay/etc/aiden_audio_service.conf` | Audio Service init 配置模板 |
 | `overlay/etc/init.d/S20oemslot` | Slot-aware `/oem` 挂载脚本 |
+| `overlay/etc/init.d/S49ntp` | Network-aware NTP startup script |
 | `overlay/etc/init.d/S54ota` | OTA daemon watchdog |
+| `overlay/etc/init.d/S99rtcinit` | RTC invalid-date calibration script |
 | `overlay/etc/profile.d/aiden-env.sh` | SSH/login shell environment loader snippet |
 | `overlay/oem/usr/bin/aiden-env-run` | Service environment launcher |
 | `overlay/oem/usr/model/` | VAD 模型和 weights，随 OEM 分区更新 |

--- a/overlay/etc/aiden_boot.conf
+++ b/overlay/etc/aiden_boot.conf
@@ -26,6 +26,13 @@ ENABLE_WIFIDRV=1
 ENABLE_WLAN_GUARD=1
 ENABLE_NTP=1
 
+# NTP starts after a default route, interface IPv4 address, and DNS are ready.
+# Set NTP_WAIT_DNS_HOST empty to skip the DNS probe.
+NTP_WAIT_NETWORK=1
+NTP_WAIT_TIMEOUT=60
+NTP_WAIT_INTERVAL=2
+NTP_WAIT_DNS_HOST=ntp.aliyun.com
+
 # System baseline service switches
 ENABLE_BLUETOOTHD=0
 ENABLE_TELNET=0

--- a/overlay/etc/aiden_boot.conf
+++ b/overlay/etc/aiden_boot.conf
@@ -26,11 +26,13 @@ ENABLE_WIFIDRV=1
 ENABLE_WLAN_GUARD=1
 ENABLE_NTP=1
 
-# NTP fallback server when /etc/ntp.conf is absent. Must be a numeric IPv4
-# address so ntpd does not depend on DNS being up at boot. The udhcpc hook
-# (/etc/udhcpc/aiden.script) re-runs `S49ntp step` on every DHCP bind so the
-# clock catches up the instant the network comes online.
-NTP_FALLBACK_SERVER=120.25.115.20
+# NTP fallback server, used only when /etc/ntp.conf is absent. Must be a
+# numeric IPv4 address so ntpd does not depend on DNS being up at boot.
+# The overlay normally ships /etc/ntp.conf so this is a defence-in-depth
+# default. The udhcpc hook (/etc/udhcpc/aiden.script) re-runs
+# `S49ntp step` on every DHCP bind so the clock catches up the instant
+# the network comes online.
+NTP_FALLBACK_SERVER=203.107.6.88
 
 # System baseline service switches
 ENABLE_BLUETOOTHD=0

--- a/overlay/etc/aiden_boot.conf
+++ b/overlay/etc/aiden_boot.conf
@@ -26,12 +26,11 @@ ENABLE_WIFIDRV=1
 ENABLE_WLAN_GUARD=1
 ENABLE_NTP=1
 
-# NTP starts after a default route, interface IPv4 address, and DNS are ready.
-# Set NTP_WAIT_DNS_HOST empty to skip the DNS probe.
-NTP_WAIT_NETWORK=1
-NTP_WAIT_TIMEOUT=60
-NTP_WAIT_INTERVAL=2
-NTP_WAIT_DNS_HOST=ntp.aliyun.com
+# NTP fallback server when /etc/ntp.conf is absent. Must be a numeric IPv4
+# address so ntpd does not depend on DNS being up at boot. The udhcpc hook
+# (/etc/udhcpc/aiden.script) re-runs `S49ntp step` on every DHCP bind so the
+# clock catches up the instant the network comes online.
+NTP_FALLBACK_SERVER=120.25.115.20
 
 # System baseline service switches
 ENABLE_BLUETOOTHD=0

--- a/overlay/etc/init.d/S41dhcpcd
+++ b/overlay/etc/init.d/S41dhcpcd
@@ -15,8 +15,8 @@ start() {
 	fi
 
 	if [ -x /sbin/udhcpc ]; then
-		/sbin/udhcpc -b -i eth0 >/dev/null 2>&1 || true
-		/sbin/udhcpc -b -i wlan0 >/dev/null 2>&1 || true
+		/sbin/udhcpc -b -i eth0 -s /etc/udhcpc/aiden.script >/dev/null 2>&1 || true
+		/sbin/udhcpc -b -i wlan0 -s /etc/udhcpc/aiden.script >/dev/null 2>&1 || true
 		echo "Started udhcpc on eth0/wlan0"
 		return 0
 	fi

--- a/overlay/etc/init.d/S41dhcpcd
+++ b/overlay/etc/init.d/S41dhcpcd
@@ -15,8 +15,32 @@ start() {
 	fi
 
 	if [ -x /sbin/udhcpc ]; then
-		/sbin/udhcpc -b -i eth0 -s /etc/udhcpc/aiden.script >/dev/null 2>&1 || true
-		/sbin/udhcpc -b -i wlan0 -s /etc/udhcpc/aiden.script >/dev/null 2>&1 || true
+		if [ ! -x /etc/udhcpc/aiden.script ]; then
+			echo "udhcpc hook missing or not executable: /etc/udhcpc/aiden.script"
+			return 1
+		fi
+
+		failed=0
+		started=0
+		for iface in eth0 wlan0; do
+			if [ ! -d "/sys/class/net/$iface" ]; then
+				echo "Skipping udhcpc on missing interface $iface"
+				continue
+			fi
+			if /sbin/udhcpc -b -i "$iface" -s /etc/udhcpc/aiden.script >/dev/null 2>&1; then
+				started=1
+			else
+				echo "Failed to start udhcpc on $iface"
+				failed=1
+			fi
+		done
+		if [ "$failed" -ne 0 ]; then
+			return 1
+		fi
+		if [ "$started" -ne 1 ]; then
+			echo "No eth0/wlan0 interface available for udhcpc"
+			return 1
+		fi
 		echo "Started udhcpc on eth0/wlan0"
 		return 0
 	fi

--- a/overlay/etc/init.d/S49ntp
+++ b/overlay/etc/init.d/S49ntp
@@ -7,9 +7,83 @@ if [ -f "$BOOT_CONF" ]; then
 	. "$BOOT_CONF"
 fi
 : "${ENABLE_NTP:=1}"
+: "${NTP_WAIT_NETWORK:=1}"
+: "${NTP_WAIT_TIMEOUT:=60}"
+: "${NTP_WAIT_INTERVAL:=2}"
+: "${NTP_WAIT_DNS_HOST:=ntp.aliyun.com}"
+: "${NTP_FALLBACK_SERVER:=ntp.aliyun.com}"
 
 is_running() {
 	pidof ntpd >/dev/null 2>&1
+}
+
+sanitize_positive_int() {
+	value="$1"
+	default_value="$2"
+	case "$value" in
+		''|*[!0-9]*) echo "$default_value"; return ;;
+	esac
+	if [ "$value" -eq 0 ]; then
+		echo "$default_value"
+	else
+		echo "$value"
+	fi
+}
+
+default_route_iface() {
+	ip route show default 2>/dev/null | sed -n 's/^default .* dev \([^ ]*\).*/\1/p' | sed -n '1p'
+}
+
+iface_has_ipv4() {
+	iface="$1"
+	[ -n "$iface" ] || return 1
+	ip addr show "$iface" 2>/dev/null | grep -q ' inet '
+}
+
+dns_ready() {
+	[ -n "$NTP_WAIT_DNS_HOST" ] || return 0
+	if command -v nslookup >/dev/null 2>&1; then
+		RES_OPTIONS=attempts:1\ timeout:1 nslookup "$NTP_WAIT_DNS_HOST" >/dev/null 2>&1
+		return $?
+	fi
+	return 0
+}
+
+network_ready() {
+	if ! command -v ip >/dev/null 2>&1; then
+		return 0
+	fi
+	iface="$(default_route_iface)"
+	[ -n "$iface" ] || return 1
+	iface_has_ipv4 "$iface" || return 1
+	dns_ready || return 1
+}
+
+wait_for_network() {
+	if [ "$NTP_WAIT_NETWORK" != "1" ]; then
+		return 0
+	fi
+
+	timeout="$(sanitize_positive_int "$NTP_WAIT_TIMEOUT" 60)"
+	interval="$(sanitize_positive_int "$NTP_WAIT_INTERVAL" 2)"
+	elapsed=0
+
+	while [ "$elapsed" -lt "$timeout" ]; do
+		if network_ready; then
+			echo "NTP network ready after ${elapsed}s"
+			return 0
+		fi
+		sleep "$interval"
+		elapsed=$((elapsed + interval))
+	done
+
+	if network_ready; then
+		echo "NTP network ready after ${timeout}s"
+		return 0
+	fi
+
+	echo "NTP network not ready after ${timeout}s; starting ntpd anyway"
+	return 0
 }
 
 start() {
@@ -24,10 +98,11 @@ start() {
 	fi
 
 	if [ -x /usr/sbin/ntpd ]; then
+		wait_for_network
 		if [ -f /etc/ntp.conf ]; then
 			/usr/sbin/ntpd -g -c /etc/ntp.conf >/dev/null 2>&1
 		else
-			/usr/sbin/ntpd -g ntp.aliyun.com >/dev/null 2>&1
+			/usr/sbin/ntpd -g "$NTP_FALLBACK_SERVER" >/dev/null 2>&1
 		fi
 		rc="$?"
 		if [ "$rc" -ne 0 ]; then

--- a/overlay/etc/init.d/S49ntp
+++ b/overlay/etc/init.d/S49ntp
@@ -3,11 +3,15 @@
 #
 # ntpd is launched early in daemon mode so it can pick up the network as
 # soon as it appears. The first big step (RTC may be many years off) is
-# handled by passing -g, which busybox ntpd interprets as "allow the first
-# adjustment to be unrestricted". DHCP-driven re-sync is wired through the
-# udhcpc hook (/etc/udhcpc/aiden.script), which calls `S49ntp step` on
-# every bound/renew so the clock catches up the moment a lease lands —
+# handled with -g so the panic gate does not abort the first sample.
+# DHCP-driven re-sync is wired through the udhcpc hook
+# (/etc/udhcpc/aiden.script), which calls `S49ntp step` on every
+# bound/renew so the clock catches up the moment a lease lands —
 # no init-time polling, no DNS dependency.
+#
+# Important: the SDK ships ntp.org reference ntpd (not busybox). Servers
+# must be passed via the config file; -p is "pidfile" in this impl, NOT
+# "peer", so we never put a server name on the command line.
 
 BOOT_CONF=/etc/aiden_boot.conf
 
@@ -15,12 +19,32 @@ if [ -f "$BOOT_CONF" ]; then
 	. "$BOOT_CONF"
 fi
 : "${ENABLE_NTP:=1}"
-# Use a numeric IP so ntpd does not depend on DNS being up. 120.25.115.20
+# Use a numeric IP so ntpd does not depend on DNS being up. 203.107.6.88
 # is one of Alibaba Cloud's public NTP service addresses (ntp.aliyun.com).
-: "${NTP_FALLBACK_SERVER:=120.25.115.20}"
+: "${NTP_FALLBACK_SERVER:=203.107.6.88}"
+
+NTP_RUNTIME_CONF=/run/aiden/ntp.conf
 
 is_running() {
 	pidof ntpd >/dev/null 2>&1
+}
+
+# Pick the active config. If /etc/ntp.conf exists (the overlay ships an
+# IP-only one), use it. Otherwise synthesise a tiny conf in /run from
+# NTP_FALLBACK_SERVER so we never have to put the server on the cmdline.
+active_conf() {
+	if [ -f /etc/ntp.conf ]; then
+		echo /etc/ntp.conf
+		return 0
+	fi
+	mkdir -p /run/aiden
+	cat > "$NTP_RUNTIME_CONF" <<EOF
+server $NTP_FALLBACK_SERVER iburst
+restrict default nomodify nopeer noquery limited kod
+restrict 127.0.0.1
+restrict [::1]
+EOF
+	echo "$NTP_RUNTIME_CONF"
 }
 
 start() {
@@ -39,11 +63,9 @@ start() {
 		return 1
 	fi
 
-	if [ -f /etc/ntp.conf ]; then
-		/usr/sbin/ntpd -g -c /etc/ntp.conf >/dev/null 2>&1
-	else
-		/usr/sbin/ntpd -g -p "$NTP_FALLBACK_SERVER" >/dev/null 2>&1
-	fi
+	mkdir -p /run/aiden
+	conf="$(active_conf)"
+	/usr/sbin/ntpd -g -c "$conf" >/dev/null 2>&1
 	rc="$?"
 	if [ "$rc" -ne 0 ]; then
 		echo "Failed to start ntpd (exit=$rc)"
@@ -53,7 +75,7 @@ start() {
 		echo "Failed to start ntpd (not running after start)"
 		return 1
 	fi
-	echo "Started ntpd"
+	echo "Started ntpd (config=$conf)"
 	return 0
 }
 
@@ -75,10 +97,14 @@ restart() {
 	start
 }
 
-# Run a single foreground sync against the configured server, then exit.
-# Intended to be invoked from the udhcpc hook the moment a DHCP lease is
-# acquired so the system clock is corrected even when the daemon's poll
-# interval is long. Safe to run while the daemon is up.
+# Run a single foreground sync, then return. Intended to be invoked
+# from the udhcpc hook the moment a DHCP lease is acquired so the
+# system clock is corrected even when the daemon's poll interval is
+# long. The reference ntpd shipped on this SDK binds UDP/123 in any
+# mode (including -q), so we must stop the daemon, run a one-shot
+# step, and bring the daemon back up. The whole cycle is fast (~1-2s
+# on a healthy network) and is serialized via /run/aiden/ntp_step.lock
+# so concurrent DHCP renews don't pile up.
 step() {
 	if [ "$ENABLE_NTP" != "1" ]; then
 		return 0
@@ -86,11 +112,42 @@ step() {
 	if [ ! -x /usr/sbin/ntpd ]; then
 		return 0
 	fi
-	if [ -f /etc/ntp.conf ]; then
-		/usr/sbin/ntpd -nq -g -c /etc/ntp.conf >/dev/null 2>&1
-	else
-		/usr/sbin/ntpd -nq -g -p "$NTP_FALLBACK_SERVER" >/dev/null 2>&1
+	mkdir -p /run/aiden
+	# Best-effort lock — if another step is already running, skip.
+	# busybox sh has no `flock`, so we use a mkdir-based mutex.
+	if ! mkdir /run/aiden/ntp_step.lock 2>/dev/null; then
+		return 0
 	fi
+	trap 'rmdir /run/aiden/ntp_step.lock 2>/dev/null' EXIT INT TERM
+
+	conf="$(active_conf)"
+	was_running=0
+	if is_running; then
+		was_running=1
+		killall ntpd 2>/dev/null
+		# Wait up to ~3s for the daemon to release UDP/123.
+		i=0
+		while is_running && [ "$i" -lt 30 ]; do
+			sleep 0.1 2>/dev/null || sleep 1
+			i=$((i + 1))
+		done
+	fi
+
+	/usr/sbin/ntpd -gq -c "$conf" >/dev/null 2>&1
+	rc="$?"
+
+	if [ "$was_running" = "1" ] || [ "$rc" -eq 0 ]; then
+		# Always relaunch the daemon if it was running before, and also
+		# start it if step succeeded — that way a successful first step
+		# brings the daemon up even on a freshly-booted device.
+		if ! is_running; then
+			/usr/sbin/ntpd -g -c "$conf" >/dev/null 2>&1 || true
+		fi
+	fi
+
+	rmdir /run/aiden/ntp_step.lock 2>/dev/null
+	trap - EXIT INT TERM
+	return "$rc"
 }
 
 case "$1" in

--- a/overlay/etc/init.d/S49ntp
+++ b/overlay/etc/init.d/S49ntp
@@ -29,6 +29,18 @@ is_running() {
 	pidof ntpd >/dev/null 2>&1
 }
 
+wait_until_running() {
+	i=0
+	while [ "$i" -lt 3 ]; do
+		if is_running; then
+			return 0
+		fi
+		sleep 1
+		i=$((i + 1))
+	done
+	return 1
+}
+
 # Pick the active config. If /etc/ntp.conf exists (the overlay ships an
 # IP-only one), use it. Otherwise synthesise a tiny conf in /run from
 # NTP_FALLBACK_SERVER so we never have to put the server on the cmdline.
@@ -71,7 +83,7 @@ start() {
 		echo "Failed to start ntpd (exit=$rc)"
 		return "$rc"
 	fi
-	if ! is_running; then
+	if ! wait_until_running; then
 		echo "Failed to start ntpd (not running after start)"
 		return 1
 	fi

--- a/overlay/etc/init.d/S49ntp
+++ b/overlay/etc/init.d/S49ntp
@@ -1,5 +1,13 @@
 #!/bin/sh
 # Aiden override: optional NTP sync service startup.
+#
+# ntpd is launched early in daemon mode so it can pick up the network as
+# soon as it appears. The first big step (RTC may be many years off) is
+# handled by passing -g, which busybox ntpd interprets as "allow the first
+# adjustment to be unrestricted". DHCP-driven re-sync is wired through the
+# udhcpc hook (/etc/udhcpc/aiden.script), which calls `S49ntp step` on
+# every bound/renew so the clock catches up the moment a lease lands —
+# no init-time polling, no DNS dependency.
 
 BOOT_CONF=/etc/aiden_boot.conf
 
@@ -7,83 +15,12 @@ if [ -f "$BOOT_CONF" ]; then
 	. "$BOOT_CONF"
 fi
 : "${ENABLE_NTP:=1}"
-: "${NTP_WAIT_NETWORK:=1}"
-: "${NTP_WAIT_TIMEOUT:=60}"
-: "${NTP_WAIT_INTERVAL:=2}"
-: "${NTP_WAIT_DNS_HOST:=ntp.aliyun.com}"
-: "${NTP_FALLBACK_SERVER:=ntp.aliyun.com}"
+# Use a numeric IP so ntpd does not depend on DNS being up. 120.25.115.20
+# is one of Alibaba Cloud's public NTP service addresses (ntp.aliyun.com).
+: "${NTP_FALLBACK_SERVER:=120.25.115.20}"
 
 is_running() {
 	pidof ntpd >/dev/null 2>&1
-}
-
-sanitize_positive_int() {
-	value="$1"
-	default_value="$2"
-	case "$value" in
-		''|*[!0-9]*) echo "$default_value"; return ;;
-	esac
-	if [ "$value" -eq 0 ]; then
-		echo "$default_value"
-	else
-		echo "$value"
-	fi
-}
-
-default_route_iface() {
-	ip route show default 2>/dev/null | sed -n 's/^default .* dev \([^ ]*\).*/\1/p' | sed -n '1p'
-}
-
-iface_has_ipv4() {
-	iface="$1"
-	[ -n "$iface" ] || return 1
-	ip addr show "$iface" 2>/dev/null | grep -q ' inet '
-}
-
-dns_ready() {
-	[ -n "$NTP_WAIT_DNS_HOST" ] || return 0
-	if command -v nslookup >/dev/null 2>&1; then
-		RES_OPTIONS=attempts:1\ timeout:1 nslookup "$NTP_WAIT_DNS_HOST" >/dev/null 2>&1
-		return $?
-	fi
-	return 0
-}
-
-network_ready() {
-	if ! command -v ip >/dev/null 2>&1; then
-		return 0
-	fi
-	iface="$(default_route_iface)"
-	[ -n "$iface" ] || return 1
-	iface_has_ipv4 "$iface" || return 1
-	dns_ready || return 1
-}
-
-wait_for_network() {
-	if [ "$NTP_WAIT_NETWORK" != "1" ]; then
-		return 0
-	fi
-
-	timeout="$(sanitize_positive_int "$NTP_WAIT_TIMEOUT" 60)"
-	interval="$(sanitize_positive_int "$NTP_WAIT_INTERVAL" 2)"
-	elapsed=0
-
-	while [ "$elapsed" -lt "$timeout" ]; do
-		if network_ready; then
-			echo "NTP network ready after ${elapsed}s"
-			return 0
-		fi
-		sleep "$interval"
-		elapsed=$((elapsed + interval))
-	done
-
-	if network_ready; then
-		echo "NTP network ready after ${timeout}s"
-		return 0
-	fi
-
-	echo "NTP network not ready after ${timeout}s; starting ntpd anyway"
-	return 0
 }
 
 start() {
@@ -97,28 +34,27 @@ start() {
 		return 0
 	fi
 
-	if [ -x /usr/sbin/ntpd ]; then
-		wait_for_network
-		if [ -f /etc/ntp.conf ]; then
-			/usr/sbin/ntpd -g -c /etc/ntp.conf >/dev/null 2>&1
-		else
-			/usr/sbin/ntpd -g "$NTP_FALLBACK_SERVER" >/dev/null 2>&1
-		fi
-		rc="$?"
-		if [ "$rc" -ne 0 ]; then
-			echo "Failed to start ntpd (exit=$rc)"
-			return "$rc"
-		fi
-		if ! is_running; then
-			echo "Failed to start ntpd (not running after start)"
-			return 1
-		fi
-		echo "Started ntpd"
-		return 0
+	if [ ! -x /usr/sbin/ntpd ]; then
+		echo "ntpd binary not found"
+		return 1
 	fi
 
-	echo "ntpd binary not found"
-	return 1
+	if [ -f /etc/ntp.conf ]; then
+		/usr/sbin/ntpd -g -c /etc/ntp.conf >/dev/null 2>&1
+	else
+		/usr/sbin/ntpd -g -p "$NTP_FALLBACK_SERVER" >/dev/null 2>&1
+	fi
+	rc="$?"
+	if [ "$rc" -ne 0 ]; then
+		echo "Failed to start ntpd (exit=$rc)"
+		return "$rc"
+	fi
+	if ! is_running; then
+		echo "Failed to start ntpd (not running after start)"
+		return 1
+	fi
+	echo "Started ntpd"
+	return 0
 }
 
 stop() {
@@ -139,9 +75,28 @@ restart() {
 	start
 }
 
+# Run a single foreground sync against the configured server, then exit.
+# Intended to be invoked from the udhcpc hook the moment a DHCP lease is
+# acquired so the system clock is corrected even when the daemon's poll
+# interval is long. Safe to run while the daemon is up.
+step() {
+	if [ "$ENABLE_NTP" != "1" ]; then
+		return 0
+	fi
+	if [ ! -x /usr/sbin/ntpd ]; then
+		return 0
+	fi
+	if [ -f /etc/ntp.conf ]; then
+		/usr/sbin/ntpd -nq -g -c /etc/ntp.conf >/dev/null 2>&1
+	else
+		/usr/sbin/ntpd -nq -g -p "$NTP_FALLBACK_SERVER" >/dev/null 2>&1
+	fi
+}
+
 case "$1" in
 	start) start ;;
 	stop) stop ;;
 	restart|reload) restart ;;
-	*) echo "Usage: $0 {start|stop|restart}"; exit 1 ;;
+	step) step ;;
+	*) echo "Usage: $0 {start|stop|restart|step}"; exit 1 ;;
 esac

--- a/overlay/etc/init.d/S99rtcinit
+++ b/overlay/etc/init.d/S99rtcinit
@@ -1,7 +1,13 @@
 #!/bin/sh
-# Aiden override: seed invalid RTC values with a current baseline date.
+# Aiden override: replace the SDK S99rtcinit baseline with a current date.
 
 : "${RTC_DEFAULT_DATE:=2026-06-09}"
+
+system_date_before_default() {
+	current_date="$(date +%Y%m%d 2>/dev/null || echo 19700101)"
+	default_date="$(printf '%s' "$RTC_DEFAULT_DATE" | tr -d '-')"
+	[ "$current_date" -lt "$default_date" ] 2>/dev/null
+}
 
 start() {
 	if ! command -v hwclock >/dev/null 2>&1; then
@@ -12,8 +18,12 @@ start() {
 	rtc_time="$(hwclock 2>/dev/null || true)"
 	case "$rtc_time" in
 		*1969*|*1970*)
-			echo "RTC time calibration to $RTC_DEFAULT_DATE"
-			date -s "$RTC_DEFAULT_DATE" >/dev/null 2>&1 || return 1
+			if system_date_before_default; then
+				echo "RTC time calibration to $RTC_DEFAULT_DATE"
+				date -s "$RTC_DEFAULT_DATE" >/dev/null 2>&1 || return 1
+			else
+				echo "RTC invalid; preserving current system time"
+			fi
 			hwclock -w
 			;;
 		*)

--- a/overlay/etc/init.d/S99rtcinit
+++ b/overlay/etc/init.d/S99rtcinit
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Aiden override: seed invalid RTC values with a current baseline date.
+
+: "${RTC_DEFAULT_DATE:=2026-06-09}"
+
+start() {
+	if ! command -v hwclock >/dev/null 2>&1; then
+		echo "hwclock binary not found"
+		return 0
+	fi
+
+	rtc_time="$(hwclock 2>/dev/null || true)"
+	case "$rtc_time" in
+		*1969*|*1970*)
+			echo "RTC time calibration to $RTC_DEFAULT_DATE"
+			date -s "$RTC_DEFAULT_DATE" >/dev/null 2>&1 || return 1
+			hwclock -w
+			;;
+		*)
+			echo "RTC does not require time calibration"
+			;;
+	esac
+}
+
+case "$1" in
+	start) start ;;
+	stop) exit 0 ;;
+	restart|reload) start ;;
+	*) echo "Usage: $0 {start|stop|restart}"; exit 1 ;;
+esac

--- a/overlay/etc/init.d/S99rtcinit
+++ b/overlay/etc/init.d/S99rtcinit
@@ -24,7 +24,10 @@ start() {
 			else
 				echo "RTC invalid; preserving current system time"
 			fi
-			hwclock -w
+			if ! hwclock -w >/dev/null 2>&1; then
+				echo "RTC write-back failed"
+				return 1
+			fi
 			;;
 		*)
 			echo "RTC does not require time calibration"

--- a/overlay/etc/ntp.conf
+++ b/overlay/etc/ntp.conf
@@ -1,0 +1,15 @@
+# Aiden override: NTP configuration with numeric server addresses so the
+# daemon does not depend on DNS being up at boot. udhcpc-driven
+# `S49ntp step` re-syncs as soon as a DHCP lease lands.
+#
+# Pool: Alibaba Cloud public NTP (resolved 2026-06-09).
+server 203.107.6.88 iburst
+server 223.4.249.80 iburst
+
+# Allow only time queries, at a limited rate, sending KoD when in excess.
+# Allow all local queries (IPv4, IPv6).
+restrict default nomodify nopeer noquery limited kod
+restrict 127.0.0.1
+restrict [::1]
+
+driftfile /run/aiden/ntp.drift

--- a/overlay/etc/udhcpc/aiden.script
+++ b/overlay/etc/udhcpc/aiden.script
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Aiden udhcpc hook: delegate IP/route/DNS configuration to busybox's
+# stock /usr/share/udhcpc/default.script, then trigger a one-shot NTP
+# sync the moment a lease is acquired or renewed. This replaces the
+# previous "wait at boot" loop in S49ntp — no polling, no DNS probe,
+# just an event-driven kick whenever the network actually comes up.
+#
+# Invoked by udhcpc as: aiden.script <event>
+#
+# Possible events: deconfig | bound | renew | nak | leasefail
+
+DEFAULT_SCRIPT=/usr/share/udhcpc/default.script
+
+# 1. Run the platform's stock hook first so the kernel ends up with the
+#    address, default route, and resolver configuration. We tolerate it
+#    being missing (some images ship udhcpc without one), in which case
+#    the caller is expected to have configured the interface manually.
+if [ -x "$DEFAULT_SCRIPT" ]; then
+	"$DEFAULT_SCRIPT" "$@" || true
+fi
+
+# 2. On lease acquisition/renew, kick a single NTP step so the system
+#    clock catches up immediately. The daemon stays running across
+#    events; `S49ntp step` is a foreground `ntpd -nq` that returns
+#    after one sync, regardless of whether the daemon is up.
+case "$1" in
+	bound|renew)
+		if [ -x /etc/init.d/S49ntp ]; then
+			/etc/init.d/S49ntp step >/dev/null 2>&1 &
+		fi
+		;;
+esac
+
+exit 0

--- a/overlay/oem/usr/bin/wlan_guard.sh
+++ b/overlay/oem/usr/bin/wlan_guard.sh
@@ -142,7 +142,7 @@ recover_wlan() {
 	sleep 2
 	wpa_cli -i "$IFACE" reassociate >/dev/null 2>&1 || true
 	sleep 8
-	udhcpc -n -q -i "$IFACE" >/dev/null 2>&1 || true
+	udhcpc -n -q -i "$IFACE" -s /etc/udhcpc/aiden.script >/dev/null 2>&1 || true
 }
 
 watch_loop() {

--- a/scripts/test_ntp_rtc_init.sh
+++ b/scripts/test_ntp_rtc_init.sh
@@ -4,9 +4,11 @@ set -eu
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 NTP_INIT="$ROOT_DIR/overlay/etc/init.d/S49ntp"
 RTC_INIT="$ROOT_DIR/overlay/etc/init.d/S99rtcinit"
+DHCPCD_INIT="$ROOT_DIR/overlay/etc/init.d/S41dhcpcd"
+UDHCPC_HOOK="$ROOT_DIR/overlay/etc/udhcpc/aiden.script"
 BOOT_CONF="$ROOT_DIR/overlay/etc/aiden_boot.conf"
 
-for script in "$NTP_INIT" "$RTC_INIT"; do
+for script in "$NTP_INIT" "$RTC_INIT" "$DHCPCD_INIT" "$UDHCPC_HOOK"; do
     if [ ! -x "$script" ]; then
         echo "missing executable $(basename "$script")" >&2
         exit 1
@@ -17,41 +19,62 @@ for script in "$NTP_INIT" "$RTC_INIT"; do
     fi
 done
 
-if ! grep -q 'wait_for_network' "$NTP_INIT"; then
-    echo "S49ntp must wait for network readiness before starting ntpd" >&2
+# S49ntp must NOT block on network readiness anymore — udhcpc hook handles
+# the post-DHCP step now. The script should also no longer rely on hostname
+# resolution: NTP_FALLBACK_SERVER defaults to a numeric IP.
+if grep -q 'wait_for_network' "$NTP_INIT"; then
+    echo "S49ntp must not poll for network readiness (use udhcpc hook instead)" >&2
     exit 1
 fi
 
-if ! grep -q 'ip route show default' "$NTP_INIT"; then
-    echo "S49ntp must check for a default route" >&2
+if ! grep -Eq '^: "\$\{NTP_FALLBACK_SERVER:=([0-9]{1,3}\.){3}[0-9]{1,3}\}"$' "$NTP_INIT"; then
+    echo "S49ntp NTP_FALLBACK_SERVER default must be an IPv4 literal" >&2
     exit 1
 fi
 
-if ! grep -q 'ip addr show "$iface"' "$NTP_INIT"; then
-    echo "S49ntp must check that the routed interface has IPv4" >&2
+if ! grep -Eq '^[[:space:]]*step\)' "$NTP_INIT"; then
+    echo "S49ntp must expose a 'step' subcommand for one-shot sync" >&2
     exit 1
 fi
 
-if ! grep -q 'nslookup "$NTP_WAIT_DNS_HOST"' "$NTP_INIT"; then
-    echo "S49ntp must check DNS readiness" >&2
+if ! grep -q 'ntpd -nq' "$NTP_INIT"; then
+    echo "S49ntp 'step' must invoke 'ntpd -nq' for query-and-exit sync" >&2
     exit 1
 fi
 
-wait_line=$(grep -n 'wait_for_network' "$NTP_INIT" | tail -1 | cut -d: -f1)
-start_line=$(grep -n '/usr/sbin/ntpd -g' "$NTP_INIT" | head -1 | cut -d: -f1)
-if [ "$wait_line" -ge "$start_line" ]; then
-    echo "S49ntp must wait before launching ntpd" >&2
+# udhcpc hook must delegate to the system default script (so DHCP-driven IP /
+# route / DNS configuration still happens) AND kick the NTP step on bound.
+if ! grep -q '/usr/share/udhcpc/default.script' "$UDHCPC_HOOK"; then
+    echo "udhcpc hook must delegate to /usr/share/udhcpc/default.script" >&2
     exit 1
 fi
 
-for setting in \
-    '^NTP_WAIT_NETWORK=1$' \
-    '^NTP_WAIT_TIMEOUT=60$' \
-    '^NTP_WAIT_INTERVAL=2$' \
-    '^NTP_WAIT_DNS_HOST=ntp.aliyun.com$'
-do
-    if ! grep -q "$setting" "$BOOT_CONF"; then
-        echo "aiden_boot.conf missing $setting" >&2
+if ! grep -q 'S49ntp step' "$UDHCPC_HOOK"; then
+    echo "udhcpc hook must call 'S49ntp step' on lease events" >&2
+    exit 1
+fi
+
+if ! grep -Eq 'bound\||\|bound|^[[:space:]]*bound\)' "$UDHCPC_HOOK"; then
+    echo "udhcpc hook must handle the 'bound' event" >&2
+    exit 1
+fi
+
+# S41dhcpcd must wire udhcpc to the aiden hook via -s.
+if ! grep -q 'udhcpc .*-s /etc/udhcpc/aiden.script' "$DHCPCD_INIT"; then
+    echo "S41dhcpcd must launch udhcpc with -s /etc/udhcpc/aiden.script" >&2
+    exit 1
+fi
+
+# Boot conf must carry the new IP-based default and must not carry the
+# obsolete NTP_WAIT_* knobs.
+if ! grep -Eq '^NTP_FALLBACK_SERVER=([0-9]{1,3}\.){3}[0-9]{1,3}$' "$BOOT_CONF"; then
+    echo "aiden_boot.conf must define NTP_FALLBACK_SERVER as an IPv4 literal" >&2
+    exit 1
+fi
+
+for stale in NTP_WAIT_NETWORK NTP_WAIT_TIMEOUT NTP_WAIT_INTERVAL NTP_WAIT_DNS_HOST; do
+    if grep -q "^${stale}=" "$BOOT_CONF"; then
+        echo "aiden_boot.conf still carries obsolete $stale setting" >&2
         exit 1
     fi
 done

--- a/scripts/test_ntp_rtc_init.sh
+++ b/scripts/test_ntp_rtc_init.sh
@@ -9,6 +9,8 @@ UDHCPC_HOOK="$ROOT_DIR/overlay/etc/udhcpc/aiden.script"
 BOOT_CONF="$ROOT_DIR/overlay/etc/aiden_boot.conf"
 NTP_CONF="$ROOT_DIR/overlay/etc/ntp.conf"
 CONFIG_WEB="$ROOT_DIR/src/config_web.cpp"
+IPV4_OCTET='(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])'
+IPV4_RE="${IPV4_OCTET}(\\.${IPV4_OCTET}){3}"
 
 for script in "$NTP_INIT" "$RTC_INIT" "$DHCPCD_INIT" "$UDHCPC_HOOK"; do
     if [ ! -x "$script" ]; then
@@ -26,6 +28,11 @@ if [ -e "$ROOT_DIR/overlay/etc/init.d/S39rtcinit" ]; then
     exit 1
 fi
 
+if [ ! -r "$BOOT_CONF" ]; then
+    echo "aiden_boot.conf not found or unreadable" >&2
+    exit 1
+fi
+
 # S49ntp must NOT block on network readiness anymore — udhcpc hook handles
 # the post-DHCP step now. The script should also no longer rely on hostname
 # resolution: NTP_FALLBACK_SERVER defaults to a numeric IP.
@@ -34,7 +41,7 @@ if grep -q 'wait_for_network' "$NTP_INIT"; then
     exit 1
 fi
 
-if ! grep -Eq '^: "\$\{NTP_FALLBACK_SERVER:=([0-9]{1,3}\.){3}[0-9]{1,3}\}"$' "$NTP_INIT"; then
+if ! grep -Eq "^: \"\\$\\{NTP_FALLBACK_SERVER:=${IPV4_RE}\\}\"$" "$NTP_INIT"; then
     echo "S49ntp NTP_FALLBACK_SERVER default must be an IPv4 literal" >&2
     exit 1
 fi
@@ -51,7 +58,7 @@ fi
 
 # Reference ntpd (4.2.x) is the implementation on this SDK: -p is "pidfile"
 # in that impl, so the server MUST come via -c <conf>, never on argv.
-if grep -Eq 'ntpd .* -p ' "$NTP_INIT"; then
+if sed 's/[[:space:]]*#.*//' "$NTP_INIT" | grep -Eq '^[[:space:]]*/usr/sbin/ntpd([[:space:]].*)?[[:space:]]-p([[:space:]]|$)'; then
     echo "S49ntp must not pass servers via -p (reference ntpd treats -p as pidfile)" >&2
     exit 1
 fi
@@ -79,6 +86,16 @@ if ! grep -q 'udhcpc .*-s /etc/udhcpc/aiden.script' "$DHCPCD_INIT"; then
     exit 1
 fi
 
+if ! grep -q 'udhcpc hook missing or not executable' "$DHCPCD_INIT"; then
+    echo "S41dhcpcd must fail clearly when the udhcpc hook is missing" >&2
+    exit 1
+fi
+
+if grep -Eq '^[[:space:]]*/sbin/udhcpc .*[|][|][[:space:]]*true' "$DHCPCD_INIT"; then
+    echo "S41dhcpcd must not hide udhcpc launch failures" >&2
+    exit 1
+fi
+
 if ! grep -q -- '-s /etc/udhcpc/aiden.script' "$CONFIG_WEB"; then
     echo "config_web DHCP path must use -s /etc/udhcpc/aiden.script" >&2
     exit 1
@@ -86,7 +103,7 @@ fi
 
 # Boot conf must carry the new IP-based default and must not carry the
 # obsolete NTP_WAIT_* knobs.
-if ! grep -Eq '^NTP_FALLBACK_SERVER=([0-9]{1,3}\.){3}[0-9]{1,3}$' "$BOOT_CONF"; then
+if ! grep -Eq "^NTP_FALLBACK_SERVER=${IPV4_RE}$" "$BOOT_CONF"; then
     echo "aiden_boot.conf must define NTP_FALLBACK_SERVER as an IPv4 literal" >&2
     exit 1
 fi
@@ -110,7 +127,7 @@ if grep -Eq '^[[:space:]]*server[[:space:]]+[a-zA-Z]' "$NTP_CONF"; then
     exit 1
 fi
 
-if ! grep -Eq '^[[:space:]]*server[[:space:]]+([0-9]{1,3}\.){3}[0-9]{1,3}\b' "$NTP_CONF"; then
+if ! grep -Eq "^[[:space:]]*server[[:space:]]+${IPV4_RE}([[:space:]]|$)" "$NTP_CONF"; then
     echo "overlay/etc/ntp.conf must list at least one IPv4 server line" >&2
     exit 1
 fi
@@ -132,6 +149,11 @@ fi
 
 if ! grep -q 'hwclock -w' "$RTC_INIT"; then
     echo "S99rtcinit must write the calibrated date back to RTC" >&2
+    exit 1
+fi
+
+if ! grep -q 'RTC write-back failed' "$RTC_INIT"; then
+    echo "S99rtcinit must fail clearly when RTC write-back fails" >&2
     exit 1
 fi
 

--- a/scripts/test_ntp_rtc_init.sh
+++ b/scripts/test_ntp_rtc_init.sh
@@ -7,6 +7,7 @@ RTC_INIT="$ROOT_DIR/overlay/etc/init.d/S99rtcinit"
 DHCPCD_INIT="$ROOT_DIR/overlay/etc/init.d/S41dhcpcd"
 UDHCPC_HOOK="$ROOT_DIR/overlay/etc/udhcpc/aiden.script"
 BOOT_CONF="$ROOT_DIR/overlay/etc/aiden_boot.conf"
+NTP_CONF="$ROOT_DIR/overlay/etc/ntp.conf"
 
 for script in "$NTP_INIT" "$RTC_INIT" "$DHCPCD_INIT" "$UDHCPC_HOOK"; do
     if [ ! -x "$script" ]; then
@@ -37,8 +38,15 @@ if ! grep -Eq '^[[:space:]]*step\)' "$NTP_INIT"; then
     exit 1
 fi
 
-if ! grep -q 'ntpd -nq' "$NTP_INIT"; then
-    echo "S49ntp 'step' must invoke 'ntpd -nq' for query-and-exit sync" >&2
+if ! grep -Eq 'ntpd -gq -c' "$NTP_INIT"; then
+    echo "S49ntp 'step' must invoke 'ntpd -gq -c <conf>' for query-and-exit sync" >&2
+    exit 1
+fi
+
+# Reference ntpd (4.2.x) is the implementation on this SDK: -p is "pidfile"
+# in that impl, so the server MUST come via -c <conf>, never on argv.
+if grep -Eq 'ntpd .* -p ' "$NTP_INIT"; then
+    echo "S49ntp must not pass servers via -p (reference ntpd treats -p as pidfile)" >&2
     exit 1
 fi
 
@@ -78,6 +86,23 @@ for stale in NTP_WAIT_NETWORK NTP_WAIT_TIMEOUT NTP_WAIT_INTERVAL NTP_WAIT_DNS_HO
         exit 1
     fi
 done
+
+# overlay must ship an IP-only /etc/ntp.conf to override the SDK's
+# pool.ntp.org default — DNS may not be up at the time ntpd starts.
+if [ ! -f "$NTP_CONF" ]; then
+    echo "overlay/etc/ntp.conf must exist (IP-based override of SDK default)" >&2
+    exit 1
+fi
+
+if grep -Eq '^[[:space:]]*server[[:space:]]+[a-zA-Z]' "$NTP_CONF"; then
+    echo "overlay/etc/ntp.conf must not reference servers by hostname" >&2
+    exit 1
+fi
+
+if ! grep -Eq '^[[:space:]]*server[[:space:]]+([0-9]{1,3}\.){3}[0-9]{1,3}\b' "$NTP_CONF"; then
+    echo "overlay/etc/ntp.conf must list at least one IPv4 server line" >&2
+    exit 1
+fi
 
 if ! grep -q 'RTC_DEFAULT_DATE:=2026-06-09' "$RTC_INIT"; then
     echo "S99rtcinit must default invalid RTC values to 2026-06-09" >&2

--- a/scripts/test_ntp_rtc_init.sh
+++ b/scripts/test_ntp_rtc_init.sh
@@ -8,6 +8,7 @@ DHCPCD_INIT="$ROOT_DIR/overlay/etc/init.d/S41dhcpcd"
 UDHCPC_HOOK="$ROOT_DIR/overlay/etc/udhcpc/aiden.script"
 BOOT_CONF="$ROOT_DIR/overlay/etc/aiden_boot.conf"
 NTP_CONF="$ROOT_DIR/overlay/etc/ntp.conf"
+CONFIG_WEB="$ROOT_DIR/src/config_web.cpp"
 
 for script in "$NTP_INIT" "$RTC_INIT" "$DHCPCD_INIT" "$UDHCPC_HOOK"; do
     if [ ! -x "$script" ]; then
@@ -19,6 +20,11 @@ for script in "$NTP_INIT" "$RTC_INIT" "$DHCPCD_INIT" "$UDHCPC_HOOK"; do
         exit 1
     fi
 done
+
+if [ -e "$ROOT_DIR/overlay/etc/init.d/S39rtcinit" ]; then
+    echo "rtc init must remain S99rtcinit so it overrides the SDK default script" >&2
+    exit 1
+fi
 
 # S49ntp must NOT block on network readiness anymore — udhcpc hook handles
 # the post-DHCP step now. The script should also no longer rely on hostname
@@ -73,6 +79,11 @@ if ! grep -q 'udhcpc .*-s /etc/udhcpc/aiden.script' "$DHCPCD_INIT"; then
     exit 1
 fi
 
+if ! grep -q -- '-s /etc/udhcpc/aiden.script' "$CONFIG_WEB"; then
+    echo "config_web DHCP path must use -s /etc/udhcpc/aiden.script" >&2
+    exit 1
+fi
+
 # Boot conf must carry the new IP-based default and must not carry the
 # obsolete NTP_WAIT_* knobs.
 if ! grep -Eq '^NTP_FALLBACK_SERVER=([0-9]{1,3}\.){3}[0-9]{1,3}$' "$BOOT_CONF"; then
@@ -106,6 +117,11 @@ fi
 
 if ! grep -q 'RTC_DEFAULT_DATE:=2026-06-09' "$RTC_INIT"; then
     echo "S99rtcinit must default invalid RTC values to 2026-06-09" >&2
+    exit 1
+fi
+
+if ! grep -q 'system_date_before_default' "$RTC_INIT"; then
+    echo "S99rtcinit must not clobber an already-sane system clock" >&2
     exit 1
 fi
 

--- a/scripts/test_ntp_rtc_init.sh
+++ b/scripts/test_ntp_rtc_init.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+NTP_INIT="$ROOT_DIR/overlay/etc/init.d/S49ntp"
+RTC_INIT="$ROOT_DIR/overlay/etc/init.d/S99rtcinit"
+BOOT_CONF="$ROOT_DIR/overlay/etc/aiden_boot.conf"
+
+for script in "$NTP_INIT" "$RTC_INIT"; do
+    if [ ! -x "$script" ]; then
+        echo "missing executable $(basename "$script")" >&2
+        exit 1
+    fi
+    if ! sh -n "$script"; then
+        echo "$(basename "$script") must be valid POSIX shell syntax" >&2
+        exit 1
+    fi
+done
+
+if ! grep -q 'wait_for_network' "$NTP_INIT"; then
+    echo "S49ntp must wait for network readiness before starting ntpd" >&2
+    exit 1
+fi
+
+if ! grep -q 'ip route show default' "$NTP_INIT"; then
+    echo "S49ntp must check for a default route" >&2
+    exit 1
+fi
+
+if ! grep -q 'ip addr show "$iface"' "$NTP_INIT"; then
+    echo "S49ntp must check that the routed interface has IPv4" >&2
+    exit 1
+fi
+
+if ! grep -q 'nslookup "$NTP_WAIT_DNS_HOST"' "$NTP_INIT"; then
+    echo "S49ntp must check DNS readiness" >&2
+    exit 1
+fi
+
+wait_line=$(grep -n 'wait_for_network' "$NTP_INIT" | tail -1 | cut -d: -f1)
+start_line=$(grep -n '/usr/sbin/ntpd -g' "$NTP_INIT" | head -1 | cut -d: -f1)
+if [ "$wait_line" -ge "$start_line" ]; then
+    echo "S49ntp must wait before launching ntpd" >&2
+    exit 1
+fi
+
+for setting in \
+    '^NTP_WAIT_NETWORK=1$' \
+    '^NTP_WAIT_TIMEOUT=60$' \
+    '^NTP_WAIT_INTERVAL=2$' \
+    '^NTP_WAIT_DNS_HOST=ntp.aliyun.com$'
+do
+    if ! grep -q "$setting" "$BOOT_CONF"; then
+        echo "aiden_boot.conf missing $setting" >&2
+        exit 1
+    fi
+done
+
+if ! grep -q 'RTC_DEFAULT_DATE:=2026-06-09' "$RTC_INIT"; then
+    echo "S99rtcinit must default invalid RTC values to 2026-06-09" >&2
+    exit 1
+fi
+
+if ! grep -q 'date -s "$RTC_DEFAULT_DATE"' "$RTC_INIT"; then
+    echo "S99rtcinit must set the system time from RTC_DEFAULT_DATE" >&2
+    exit 1
+fi
+
+if ! grep -q 'hwclock -w' "$RTC_INIT"; then
+    echo "S99rtcinit must write the calibrated date back to RTC" >&2
+    exit 1
+fi
+
+echo "ntp/rtc init tests passed"

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -1410,8 +1410,8 @@ CommandResult apply_wifi_config(const Options& options) {
     bool dhcp_ok = false;
     if (associated) {
         if (command_exists("udhcpc")) {
-            CommandResult dhcp = run_shell_command("udhcpc -i " + shell_quote(options.wifi_interface) + " -n -q 2>&1");
-            log << "$ udhcpc -i " << options.wifi_interface << " -n -q\n" << dhcp.output;
+            CommandResult dhcp = run_shell_command("udhcpc -i " + shell_quote(options.wifi_interface) + " -n -q -s /etc/udhcpc/aiden.script 2>&1");
+            log << "$ udhcpc -i " << options.wifi_interface << " -n -q -s /etc/udhcpc/aiden.script\n" << dhcp.output;
             dhcp_ok = dhcp.exit_code == 0;
             if (!dhcp_ok) {
                 result.exit_code = dhcp.exit_code;

--- a/tests/config_web_source_test.cpp
+++ b/tests/config_web_source_test.cpp
@@ -366,6 +366,20 @@ TEST_CASE("config web restarts ota only when system env changes") {
     CHECK(source.find("config saved; agent and ota restarting") == std::string::npos);
 }
 
+TEST_CASE("config web DHCP uses aiden udhcpc hook") {
+    const std::string source_path = std::string(AIDEN_SOURCE_DIR) + "/src/config_web.cpp";
+    std::ifstream source_in(source_path.c_str());
+    REQUIRE(source_in.good());
+
+    std::ostringstream source_buffer;
+    source_buffer << source_in.rdbuf();
+    const std::string source = source_buffer.str();
+
+    CHECK(source.find("udhcpc -i ") != std::string::npos);
+    CHECK(source.find("-s /etc/udhcpc/aiden.script") != std::string::npos);
+    CHECK(source.find("udhcpc -i \" + shell_quote(options.wifi_interface) + \" -n -q 2>&1") == std::string::npos);
+}
+
 TEST_CASE("config web custom benchmark suite import endpoints") {
     const std::string source_path = std::string(AIDEN_SOURCE_DIR) + "/src/config_web.cpp";
     std::ifstream source_in(source_path.c_str());


### PR DESCRIPTION
## Summary

Fixes the first-boot time sync race by making time correction DHCP-event driven instead of blocking init while waiting for networking. `ntpd` now starts with an IP-only config so boot does not depend on DNS, and DHCP `bound`/`renew` events trigger a serialized `S49ntp step` as soon as a lease lands.

`S99rtcinit` remains the overlay override for the SDK default script. It seeds an invalid 1969/1970 RTC only when system time is still before the 2026-06-09 baseline, preserves already NTP-synced time, and fails clearly if `hwclock -w` cannot persist the correction.

## Changes

- Start reference `ntpd` via config file with numeric NTP servers and a `/run` fallback config.
- Add `S49ntp step` for one-shot foreground sync, serialized with a mkdir lock, and relaunch the daemon after sync when appropriate.
- Add `/etc/udhcpc/aiden.script` to delegate normal DHCP setup and trigger `S49ntp step` on `bound`/`renew`.
- Wire boot DHCP, WLAN recovery, and config web Wi-Fi DHCP through the Aiden udhcpc hook.
- Keep `S99rtcinit` as the SDK override while preventing it from clobbering already-correct system time.
- Harden DHCP/NTP/RTC startup checks and update boot service documentation.

## Tests

- `sh scripts/test_ntp_rtc_init.sh`
- `sh scripts/test_wlan_guard.sh`
- `sh -n overlay/etc/init.d/S41dhcpcd overlay/etc/init.d/S49ntp overlay/etc/init.d/S99rtcinit scripts/test_ntp_rtc_init.sh`
- `git diff --check`
- `cmake --build /tmp/aiden-hardware-demo-tests --target aiden_tests`
- `ctest --test-dir /tmp/aiden-hardware-demo-tests --output-on-failure`

## Notes

- This branch no longer uses the earlier `wait_for_network` approach; DHCP lease events are the synchronization trigger.
- `RTC_DEFAULT_DATE=2026-06-09` is only a baseline for invalid RTC values. Real time is corrected by NTP.