### PR TITLE
feat: explicitly set port 80 for config_web service

### DIFF
--- a/overlay/etc/init.d/S56config_web
+++ b/overlay/etc/init.d/S56config_web
@@ -48,7 +48,7 @@ start() {
 
     mkdir -p "$(dirname "$CONFIG_PATH")" "$(dirname "$SYSTEM_ENV_PATH")"
 
-    "$ENV_RUN_BIN" "$BIN" --bind=0.0.0.0 --config="$CONFIG_PATH" --wifi-config="$WIFI_CONFIG_PATH" --system-env="$SYSTEM_ENV_PATH" &
+    "$ENV_RUN_BIN" "$BIN" --bind=0.0.0.0 --port=80 --config="$CONFIG_PATH" --wifi-config="$WIFI_CONFIG_PATH" --system-env="$SYSTEM_ENV_PATH" &
     child_pid=$!
     echo "$child_pid" > "$PID_FILE"
     sleep 1


### PR DESCRIPTION
## 变更说明

为 config_web 服务启动脚本添加显式的 `--port=80` 参数，使端口配置更加明确。

## 修改内容

- 在 `overlay/etc/init.d/S56config_web` 启动脚本中添加 `--port=80` 参数
- config_web 服务现在明确绑定到 `0.0.0.0:80`，可从所有网络接口访问

## 服务端口配置

修改后，两个服务都可以全网访问：
- **agent 服务**: `0.0.0.0:8080` - Web UI 和 HTTP API
- **config_web 服务**: `0.0.0.0:80` - 设备配置界面

## 测试

已在设备 192.168.42.1 上测试部署，服务成功重启并监听 80 端口。

## 部署说明

- 快速部署到现有设备：使用 `deploy_port_config.sh` 脚本
- 完整固件部署：重新构建镜像后刷入设备
