### PR TITLE
ci: compress release images before upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,6 +240,6 @@ jobs:
           --asset-glob 'pico-sdk/output/image/*' \
           --required-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
           --upload-assets "$upload_assets" \
-          --retry-count 5 \
+          --retry-count 10 \
           --retry-delay-seconds 30 \
           $PRERELEASE_FLAG

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,19 @@ jobs:
           --upload-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
           --output "$GITHUB_OUTPUT"
 
+    - name: Compress OTA manifest images
+      env:
+        ROOTFS_ASSET_METADATA: ${{ steps.rootfs_asset.outputs.rootfs_asset_metadata }}
+      run: |
+        manifest_image_assets="boot_a.img boot_b.img oem.img"
+        if [ -z "${ROOTFS_ASSET_METADATA}" ]; then
+          manifest_image_assets="$manifest_image_assets rootfs.img"
+        fi
+
+        scripts/compress_release_images.sh \
+          --image-dir pico-sdk/output/image \
+          --assets "$manifest_image_assets"
+
     - name: Generate OTA manifest
       env:
         OTA_ED25519_PRIVATE_KEY: ${{ secrets.OTA_ED25519_PRIVATE_KEY }}
@@ -197,17 +210,28 @@ jobs:
     - name: Repack update image with OTA config
       run: ./build_image.sh bash ./scripts/repack_ota_update_image.sh
 
+    - name: Compress release upload images
+      id: release_upload_assets
+      env:
+        RELEASE_UPLOAD_ASSETS: ${{ steps.rootfs_asset.outputs.upload_assets }}
+      run: |
+        upload_assets="${RELEASE_UPLOAD_ASSETS:-boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json}"
+        scripts/compress_release_images.sh \
+          --image-dir pico-sdk/output/image \
+          --assets "$upload_assets" \
+          --output "$GITHUB_OUTPUT"
+
     - name: Create Release
       env:
         GH_TOKEN: ${{ github.token }}
         GH_DEBUG: api
-        RELEASE_UPLOAD_ASSETS: ${{ steps.rootfs_asset.outputs.upload_assets }}
+        RELEASE_UPLOAD_ASSETS: ${{ steps.release_upload_assets.outputs.upload_assets }}
       run: |
         PRERELEASE_FLAG=""
         if [ "${{ steps.release_info.outputs.channel }}" != "stable" ]; then
           PRERELEASE_FLAG="--prerelease"
         fi
-        upload_assets="${RELEASE_UPLOAD_ASSETS:-boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json}"
+        upload_assets="${RELEASE_UPLOAD_ASSETS:-boot_a.img.tar.gz boot_b.img.tar.gz oem.img.tar.gz rootfs.img.tar.gz update.img.tar.gz manifest.json}"
 
         bash scripts/create_github_release.sh \
           --release-name "${{ steps.release_info.outputs.release_name }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,7 @@ jobs:
         run: |
           sh scripts/test_release_ci_scripts.sh
           bash scripts/test_reproducible_rootfs_policy.sh
+          bash scripts/test_compress_release_images.sh
+          bash scripts/test_ota_manifest_generation.sh
           bash scripts/test_github_release_upload.sh
           bash scripts/test_reusable_rootfs_release_asset.sh

--- a/docs/09-ota/README.md
+++ b/docs/09-ota/README.md
@@ -5,7 +5,7 @@
 ## 适用范围
 
 - 目标硬件：Luckfox Pico Zero / RV1106 + eMMC。
-- 分发方式：GitHub Release，发布资产包含 `manifest.json`、`boot_a.img`、`boot_b.img`、`oem.img`、`rootfs.img`、`userdata.img` 和 `update.img`（自 PR #112 起使用中性资源，历史版本使用 `oem_a.img`、`oem_b.img`、`rootfs_a.img`、`rootfs_b.img`）。
+- Distribution: GitHub Releases. Published assets contain `manifest.json` plus compressed image archives: `boot_a.img.tar.gz`, `boot_b.img.tar.gz`, `oem.img.tar.gz`, `rootfs.img.tar.gz`, and `update.img.tar.gz`. The extracted images still use the slot-neutral `oem.img` and `rootfs.img` layout introduced in PR #112; older releases used `oem_a.img`, `oem_b.img`, `rootfs_a.img`, and `rootfs_b.img`.
 - 更新方式：设备端 `/oem/usr/bin/ota` 拉取 manifest、验签、校验 SHA256、写 inactive slot、切换 `misc` 并重启。
 - 回滚方式：Rockchip SPL A/B metadata 控制 boot tries；应用健康确认后才 mark successful。
 

--- a/docs/09-ota/device-acceptance.md
+++ b/docs/09-ota/device-acceptance.md
@@ -4,19 +4,20 @@
 
 ## 前置条件
 
-- 生产镜像使用生产 Ed25519 public key 构建。
-- GitHub Release 包含 `manifest.json`、`boot_a.img`、`boot_b.img`、`oem.img`、`rootfs.img`、`userdata.img` 和 `update.img`（自 PR #112 起使用中性资源）。
-- 发布版 `update.img` 已内置 `/userdata/ota/config.json`。
+- The production image is built with the production Ed25519 public key.
+- GitHub Release contains `manifest.json` plus compressed image archives: `boot_a.img.tar.gz`, `boot_b.img.tar.gz`, `oem.img.tar.gz`, `rootfs.img.tar.gz`, and `update.img.tar.gz`.
+- The `update.img` inside `update.img.tar.gz` has `/userdata/ota/config.json` embedded.
 - 有 UART 时建议同时记录 SPL rollback 日志。
 
 `ota` 在启动时必须先处理 `/userdata/ota/pending_boot.json` health，再做网络或 GitHub update check。不要在 pending health 处理前加入网络等待。
 
 ## 1. USB 首刷验收
 
-按正常 USB recovery 流程刷入发布版 `update.img`：
+Download the release `update.img.tar.gz`, extract `update.img`, then flash it with the normal USB recovery flow:
 
 ```bash
-./upgrade_tool/upgrade_tool uf pico-sdk/output/image/update.img
+tar -xzf update.img.tar.gz update.img
+./upgrade_tool/upgrade_tool uf ./update.img
 ```
 
 设备启动后检查：

--- a/docs/09-ota/key-management.md
+++ b/docs/09-ota/key-management.md
@@ -68,7 +68,7 @@ scripts/generate_ota_manifest.sh \
   --output pico-sdk/output/image/manifest.json
 ```
 
-脚本要求存在 `boot_a.img`、`boot_b.img`，以及 slot-specific 或 slot-neutral 的 `oem` 和 `rootfs` images。CI 上传 `pico-sdk/output/image/*`，包括 `manifest.json` 和 USB 首刷用 `update.img`。
+The script requires `boot_a.img`, `boot_b.img`, and either slot-specific or slot-neutral `oem` and `rootfs` images in `pico-sdk/output/image`. CI publishes `manifest.json` unchanged and uploads image assets as `.img.tar.gz` archives, including `update.img.tar.gz` for USB factory flashing after extraction.
 
 ## 密钥轮换
 

--- a/scripts/compress_release_images.sh
+++ b/scripts/compress_release_images.sh
@@ -136,7 +136,14 @@ archive_matches_source() {
   local source="$1"
   local archive="$2"
   local entry_name="$3"
-  local source_sha archive_sha
+  local source_sha archive_sha entries
+
+  if ! entries="$(tar -tzf "$archive" 2>/dev/null)"; then
+    return 1
+  fi
+  if [ "$entries" != "$entry_name" ]; then
+    return 1
+  fi
 
   source_sha="$(sha256_file "$source")" || return 1
   if ! archive_sha="$(tar -xOzf "$archive" "$entry_name" 2>/dev/null | sha256_stream)"; then

--- a/scripts/compress_release_images.sh
+++ b/scripts/compress_release_images.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  compress_release_images.sh \
+    --image-dir DIR \
+    --assets 'FILE ...' \
+    [--output FILE]
+
+Compress .img release assets into .img.tar.gz archives.
+
+Outputs:
+  upload_assets='FILE ...'
+USAGE
+}
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+die() {
+  log "compress_release_images.sh: $*"
+  exit 1
+}
+
+image_dir=""
+assets=""
+output="${GITHUB_OUTPUT:-}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --image-dir)
+      image_dir="${2:-}"
+      shift 2
+      ;;
+    --assets)
+      assets="${2:-}"
+      shift 2
+      ;;
+    --output)
+      output="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "$image_dir" ] || die "missing --image-dir"
+[ -n "$assets" ] || die "missing --assets"
+[ -d "$image_dir" ] || die "missing image directory: $image_dir"
+command -v tar >/dev/null 2>&1 || die "tar is required"
+if ! command -v python3 >/dev/null 2>&1 && ! command -v gzip >/dev/null 2>&1; then
+  die "python3 or gzip is required"
+fi
+
+emit_output() {
+  local key="$1"
+  local value="$2"
+
+  if [ -n "$output" ]; then
+    printf '%s=%s\n' "$key" "$value" >> "$output"
+  else
+    printf '%s=%s\n' "$key" "$value"
+  fi
+}
+
+create_tar_gz() {
+  local source="$1"
+  local archive="$2"
+  local entry_name="$3"
+  local mtime="${SOURCE_DATE_EPOCH:-0}"
+  local tmp_archive="${archive}.tmp.$$"
+
+  rm -f "$tmp_archive"
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$source" "$tmp_archive" "$entry_name" "$mtime" <<'PY'
+import gzip
+import os
+import sys
+import tarfile
+
+source, archive, entry_name, raw_mtime = sys.argv[1:]
+try:
+    mtime = int(raw_mtime)
+except ValueError:
+    mtime = 0
+
+size = os.path.getsize(source)
+info = tarfile.TarInfo(entry_name)
+info.size = size
+info.mtime = mtime
+info.mode = 0o644
+info.uid = 0
+info.gid = 0
+info.uname = ""
+info.gname = ""
+
+with open(source, "rb") as source_file, open(archive, "wb") as raw_file:
+    with gzip.GzipFile(filename="", mode="wb", fileobj=raw_file, compresslevel=9, mtime=mtime) as gzip_file:
+        with tarfile.TarFile(fileobj=gzip_file, mode="w", format=tarfile.USTAR_FORMAT) as tar_file:
+            tar_file.addfile(info, source_file)
+PY
+  else
+    tar -cf - -C "$(dirname "$source")" "$entry_name" | gzip -n -9 > "$tmp_archive"
+  fi
+
+  mv "$tmp_archive" "$archive"
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+sha256_stream() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+archive_matches_source() {
+  local source="$1"
+  local archive="$2"
+  local entry_name="$3"
+  local source_sha archive_sha
+
+  source_sha="$(sha256_file "$source")" || return 1
+  if ! archive_sha="$(tar -xOzf "$archive" "$entry_name" 2>/dev/null | sha256_stream)"; then
+    return 1
+  fi
+
+  [ "$source_sha" = "$archive_sha" ]
+}
+
+compressed_assets=()
+for asset in $assets; do
+  case "$asset" in
+    ''|*/*)
+      die "asset names must be release asset basenames: $asset"
+      ;;
+  esac
+
+  case "$asset" in
+    *.img)
+      source_path="$image_dir/$asset"
+      archive_name="$asset.tar.gz"
+      archive_path="$image_dir/$archive_name"
+      [ -f "$source_path" ] || die "missing image asset: $source_path"
+
+      if [ -f "$archive_path" ] && archive_matches_source "$source_path" "$archive_path" "$asset"; then
+        log "Compressed image is up to date: $archive_name"
+      else
+        log "Compressing release image: $asset -> $archive_name"
+        create_tar_gz "$source_path" "$archive_path" "$asset"
+      fi
+
+      compressed_assets+=("$archive_name")
+      ;;
+    *.img.tar.gz)
+      [ -f "$image_dir/$asset" ] || die "missing compressed image asset: $image_dir/$asset"
+      compressed_assets+=("$asset")
+      ;;
+    *)
+      [ -f "$image_dir/$asset" ] || die "missing release asset: $image_dir/$asset"
+      compressed_assets+=("$asset")
+      ;;
+  esac
+done
+
+IFS=' '
+emit_output "upload_assets" "${compressed_assets[*]}"

--- a/scripts/create_github_release.sh
+++ b/scripts/create_github_release.sh
@@ -35,7 +35,7 @@ asset_glob=""
 required_assets=""
 upload_assets=""
 prerelease="false"
-retry_count=5
+retry_count=10
 retry_delay_seconds=20
 
 while [ "$#" -gt 0 ]; do
@@ -262,6 +262,83 @@ run_with_retry() {
   done
 }
 
+contains_line() {
+  local needle="$1"
+  local haystack="$2"
+  local line
+
+  while IFS= read -r line; do
+    if [ "$line" = "$needle" ]; then
+      return 0
+    fi
+  done <<< "$haystack"
+
+  return 1
+}
+
+verify_uploaded_assets() {
+  local attempt=1
+  local status=0
+  local tmp_base="${RUNNER_TEMP:-/tmp}"
+  local err_file
+  local retry_wait_seconds
+  local release_asset_names
+  local asset
+  local asset_name
+  local missing_files
+  local missing_names
+
+  while true; do
+    err_file="$(mktemp "$tmp_base/github-release.XXXXXX")"
+    log "release asset verification $tag_name attempt $attempt/$retry_count"
+
+    if release_asset_names="$(gh release view "$tag_name" --json assets --jq '.assets[].name' 2> >(tee "$err_file" >&2))"; then
+      rm -f "$err_file"
+      missing_files=()
+      missing_names=()
+
+      for asset in "${upload_files[@]}"; do
+        asset_name="$(basename "$asset")"
+        if ! contains_line "$asset_name" "$release_asset_names"; then
+          missing_files+=("$asset")
+          missing_names+=("$asset_name")
+        fi
+      done
+
+      if [ "${#missing_files[@]}" -eq 0 ]; then
+        log "Release asset verification succeeded for $tag_name"
+        return 0
+      fi
+
+      log "Release asset verification found missing assets: ${missing_names[*]}"
+      if [ "$attempt" -ge "$retry_count" ]; then
+        log "release asset verification $tag_name failed after $attempt attempt(s)"
+        return 1
+      fi
+
+      for asset in "${missing_files[@]}"; do
+        run_with_retry \
+          "release missing asset re-upload $(basename "$asset")" \
+          gh release upload "$tag_name" "$asset" --clobber
+      done
+    else
+      status=$?
+      rm -f "$err_file"
+      if [ "$attempt" -ge "$retry_count" ]; then
+        log "release asset verification $tag_name failed after $attempt attempt(s)"
+        return "$status"
+      fi
+    fi
+
+    retry_wait_seconds=$((retry_delay_seconds * attempt))
+    log "Retrying release asset verification $tag_name; waiting ${retry_wait_seconds}s before attempt $((attempt + 1))/$retry_count"
+    if [ "$retry_wait_seconds" -gt 0 ]; then
+      sleep "$retry_wait_seconds"
+    fi
+    attempt=$((attempt + 1))
+  done
+}
+
 ensure_release() {
   if gh release view "$tag_name" >/dev/null 2>&1; then
     log "Release already exists for tag $tag_name; assets will be uploaded with --clobber"
@@ -325,6 +402,8 @@ for asset in "${upload_files[@]}"; do
     "release asset upload $(basename "$asset")" \
     gh release upload "$tag_name" "$asset" --clobber
 done
+
+verify_uploaded_assets
 
 if [ "$prerelease" = "true" ]; then
   run_with_retry \

--- a/scripts/create_github_release.sh
+++ b/scripts/create_github_release.sh
@@ -262,18 +262,24 @@ run_with_retry() {
   done
 }
 
-contains_line() {
+asset_size_for_name() {
   local needle="$1"
-  local haystack="$2"
-  local line
+  local records="$2"
+  local name
+  local size
 
-  while IFS= read -r line; do
-    if [ "$line" = "$needle" ]; then
+  while IFS=$'\t' read -r name size _; do
+    if [ "$name" = "$needle" ]; then
+      printf '%s' "$size"
       return 0
     fi
-  done <<< "$haystack"
+  done <<< "$records"
 
   return 1
+}
+
+file_size_bytes() {
+  wc -c < "$1" | tr -d '[:space:]'
 }
 
 verify_uploaded_assets() {
@@ -282,45 +288,77 @@ verify_uploaded_assets() {
   local tmp_base="${RUNNER_TEMP:-/tmp}"
   local err_file
   local retry_wait_seconds
-  local release_asset_names
+  local release_asset_records
   local asset
   local asset_name
+  local local_size
+  local remote_size
   local missing_files
   local missing_names
+  local missing_count
+  local mismatched_files
+  local mismatched_names
+  local mismatched_count
 
   while true; do
     err_file="$(mktemp "$tmp_base/github-release.XXXXXX")"
     log "release asset verification $tag_name attempt $attempt/$retry_count"
 
-    if release_asset_names="$(gh release view "$tag_name" --json assets --jq '.assets[].name' 2> >(tee "$err_file" >&2))"; then
+    if release_asset_records="$(gh release view "$tag_name" --json assets --jq '.assets[] | [.name, (.size | tostring)] | @tsv' 2> >(tee "$err_file" >&2))"; then
       rm -f "$err_file"
       missing_files=()
       missing_names=()
+      missing_count=0
+      mismatched_files=()
+      mismatched_names=()
+      mismatched_count=0
 
       for asset in "${upload_files[@]}"; do
         asset_name="$(basename "$asset")"
-        if ! contains_line "$asset_name" "$release_asset_names"; then
+        if ! remote_size="$(asset_size_for_name "$asset_name" "$release_asset_records")"; then
           missing_files+=("$asset")
           missing_names+=("$asset_name")
+          missing_count=$((missing_count + 1))
+          continue
+        fi
+        local_size="$(file_size_bytes "$asset")"
+        if [ "$remote_size" != "$local_size" ]; then
+          mismatched_files+=("$asset")
+          mismatched_names+=("$asset_name")
+          mismatched_count=$((mismatched_count + 1))
         fi
       done
 
-      if [ "${#missing_files[@]}" -eq 0 ]; then
+      if [ "$missing_count" -eq 0 ] && [ "$mismatched_count" -eq 0 ]; then
         log "Release asset verification succeeded for $tag_name"
         return 0
       fi
 
-      log "Release asset verification found missing assets: ${missing_names[*]}"
+      if [ "$missing_count" -gt 0 ]; then
+        log "Release asset verification found missing assets: ${missing_names[*]}"
+      fi
+      if [ "$mismatched_count" -gt 0 ]; then
+        log "Release asset verification found size mismatches: ${mismatched_names[*]}"
+      fi
       if [ "$attempt" -ge "$retry_count" ]; then
         log "release asset verification $tag_name failed after $attempt attempt(s)"
         return 1
       fi
 
-      for asset in "${missing_files[@]}"; do
-        run_with_retry \
-          "release missing asset re-upload $(basename "$asset")" \
-          gh release upload "$tag_name" "$asset" --clobber
-      done
+      if [ "$missing_count" -gt 0 ]; then
+        for asset in "${missing_files[@]}"; do
+          run_with_retry \
+            "release missing asset re-upload $(basename "$asset")" \
+            gh release upload "$tag_name" "$asset" --clobber
+        done
+      fi
+      if [ "$mismatched_count" -gt 0 ]; then
+        for asset in "${mismatched_files[@]}"; do
+          run_with_retry \
+            "release size-mismatched asset re-upload $(basename "$asset")" \
+            gh release upload "$tag_name" "$asset" --clobber
+        done
+      fi
     else
       status=$?
       rm -f "$err_file"

--- a/scripts/generate_ota_manifest.sh
+++ b/scripts/generate_ota_manifest.sh
@@ -248,9 +248,40 @@ asset_json() {
   local file="$1"
   local path="$image_dir/$file"
   [ -f "$path" ] || die "missing required image: $path"
-  local size sha256 url metadata
+  local size sha256 image_sha256 url metadata compressed_file compressed_path
   if metadata="$(asset_metadata_for_file "$file")"; then
     asset_metadata_json "$file" "$metadata"
+    return
+  fi
+
+  compressed_file="${file}.tar.gz"
+  compressed_path="$image_dir/$compressed_file"
+  if [ -f "$compressed_path" ]; then
+    size="$(file_size "$compressed_path")"
+    sha256="$(file_sha256 "$compressed_path")"
+    image_sha256="$(file_sha256 "$path")"
+    if ! url="$(asset_url_for_file "$compressed_file")"; then
+      url=""
+    fi
+    if [ -z "$url" ] && [ -n "$base_url" ]; then
+      url="${base_url%/}/$compressed_file"
+    fi
+    if [ -n "$url" ]; then
+      jq -n \
+        --arg name "$compressed_file" \
+        --arg url "$url" \
+        --argjson size "$size" \
+        --arg sha256 "$sha256" \
+        --arg image_sha256 "$image_sha256" \
+        '{name:$name,url:$url,size:$size,sha256:$sha256,image_sha256:$image_sha256}'
+    else
+      jq -n \
+        --arg name "$compressed_file" \
+        --argjson size "$size" \
+        --arg sha256 "$sha256" \
+        --arg image_sha256 "$image_sha256" \
+        '{name:$name,size:$size,sha256:$sha256,image_sha256:$image_sha256}'
+    fi
     return
   fi
 

--- a/scripts/test_compress_release_images.sh
+++ b/scripts/test_compress_release_images.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+compress_script="$repo_root/scripts/compress_release_images.sh"
+if [ ! -x "$compress_script" ]; then
+  echo "compress_release_images.sh is missing or not executable: $compress_script" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+image_dir="$tmp_dir/images"
+mkdir -p "$image_dir"
+
+printf 'boot a image\n' > "$image_dir/boot_a.img"
+printf 'boot b image\n' > "$image_dir/boot_b.img"
+printf 'rootfs image\n' > "$image_dir/rootfs.img"
+printf 'update image\n' > "$image_dir/update.img"
+printf '{"version":"test"}\n' > "$image_dir/manifest.json"
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+output_value() {
+  local key="$1"
+  local file="$2"
+  awk -v key="$key" '
+    index($0, key "=") == 1 {
+      sub("^[^=]*=", "")
+      print
+    }
+  ' "$file" | tail -n 1
+}
+
+outputs_file="$tmp_dir/compress.outputs"
+SOURCE_DATE_EPOCH=0 "$compress_script" \
+  --image-dir "$image_dir" \
+  --assets 'boot_a.img boot_b.img rootfs.img update.img manifest.json' \
+  --output "$outputs_file"
+
+upload_assets="$(output_value upload_assets "$outputs_file")"
+if [ "$upload_assets" != "boot_a.img.tar.gz boot_b.img.tar.gz rootfs.img.tar.gz update.img.tar.gz manifest.json" ]; then
+  echo "compressed upload list is wrong: $upload_assets" >&2
+  exit 1
+fi
+
+for image in boot_a.img boot_b.img rootfs.img update.img; do
+  archive="$image_dir/$image.tar.gz"
+  if [ ! -f "$archive" ]; then
+    echo "missing compressed archive: $archive" >&2
+    exit 1
+  fi
+
+  if [ "$(tar -tzf "$archive")" != "$image" ]; then
+    echo "archive $archive must contain exactly $image" >&2
+    tar -tzf "$archive" >&2
+    exit 1
+  fi
+
+  extracted="$tmp_dir/$image.extracted"
+  tar -xOzf "$archive" "$image" > "$extracted"
+  if [ "$(sha256_of "$extracted")" != "$(sha256_of "$image_dir/$image")" ]; then
+    echo "archive $archive must preserve the original image bytes" >&2
+    exit 1
+  fi
+done
+
+if [ -f "$image_dir/manifest.json.tar.gz" ]; then
+  echo "manifest.json must not be compressed as an image" >&2
+  exit 1
+fi
+
+printf 'updated rootfs image\n' > "$image_dir/rootfs.img"
+SOURCE_DATE_EPOCH=0 "$compress_script" \
+  --image-dir "$image_dir" \
+  --assets 'rootfs.img' \
+  --output "$outputs_file"
+
+tar -xOzf "$image_dir/rootfs.img.tar.gz" rootfs.img > "$tmp_dir/rootfs.updated.extracted"
+if [ "$(sha256_of "$tmp_dir/rootfs.updated.extracted")" != "$(sha256_of "$image_dir/rootfs.img")" ]; then
+  echo "compression script must refresh stale image archives" >&2
+  exit 1
+fi
+
+echo "release image compression test passed"

--- a/scripts/test_compress_release_images.sh
+++ b/scripts/test_compress_release_images.sh
@@ -77,6 +77,19 @@ if [ -f "$image_dir/manifest.json.tar.gz" ]; then
   exit 1
 fi
 
+printf 'extra file\n' > "$image_dir/extra.txt"
+tar -czf "$image_dir/boot_a.img.tar.gz" -C "$image_dir" boot_a.img extra.txt
+SOURCE_DATE_EPOCH=0 "$compress_script" \
+  --image-dir "$image_dir" \
+  --assets 'boot_a.img' \
+  --output "$outputs_file"
+
+if [ "$(tar -tzf "$image_dir/boot_a.img.tar.gz")" != "boot_a.img" ]; then
+  echo "compression script must refresh archives with extra entries" >&2
+  tar -tzf "$image_dir/boot_a.img.tar.gz" >&2
+  exit 1
+fi
+
 printf 'updated rootfs image\n' > "$image_dir/rootfs.img"
 SOURCE_DATE_EPOCH=0 "$compress_script" \
   --image-dir "$image_dir" \

--- a/scripts/test_github_release_upload.sh
+++ b/scripts/test_github_release_upload.sh
@@ -16,6 +16,9 @@ printf '{"version":"v-test"}\n' > "$assets_dir/manifest.json"
 for image in boot_a.img boot_b.img oem.img rootfs.img userdata.img; do
   printf '%s\n' "$image" > "$assets_dir/$image"
 done
+for image in boot_a.img boot_b.img oem.img rootfs.img update.img; do
+  printf 'compressed %s\n' "$image" > "$assets_dir/$image.tar.gz"
+done
 printf 'extra debug asset\n' > "$assets_dir/debug.log"
 # Note: symlinks oem_a/oem_b/rootfs_a/rootfs_b should NOT exist
 # (they're cleaned up after update.img packaging in build.sh)
@@ -40,6 +43,14 @@ fi
 case "${2:-}" in
   view)
     if [ -f "$state_dir/release-exists" ]; then
+      case " $* " in
+        *" --json assets "*)
+          if [ -f "$state_dir/remote-assets" ]; then
+            cat "$state_dir/remote-assets"
+          fi
+          exit 0
+          ;;
+      esac
       echo "release exists"
       exit 0
     fi
@@ -97,6 +108,17 @@ case "${2:-}" in
       echo "write EPIPE" >&2
       exit 1
     fi
+    if [ "${FAKE_GH_DROP_ONCE_ASSET:-}" = "$name" ] && [ ! -f "$state_dir/dropped-$name" ]; then
+      touch "$state_dir/dropped-$name"
+      exit 0
+    fi
+    {
+      if [ -f "$state_dir/remote-assets" ]; then
+        cat "$state_dir/remote-assets"
+      fi
+      printf '%s\n' "$name"
+    } | sort -u > "$state_dir/remote-assets.tmp"
+    mv "$state_dir/remote-assets.tmp" "$state_dir/remote-assets"
     exit 0
     ;;
   *)
@@ -239,7 +261,46 @@ if ! grep -q '^publish:v-test$' "$state_dir/events"; then
   exit 1
 fi
 
-rm -f "$assets_dir/oem.img" "$state_dir/events" "$state_dir/calls" "$state_dir/release-exists" "$state_dir"/upload-* "$state_dir/create-count"
+rm -f "$state_dir/events" "$state_dir/calls" "$state_dir/sleeps" "$state_dir/release-exists" "$state_dir"/upload-* "$state_dir/create-count" "$state_dir/remote-assets" "$state_dir"/dropped-*
+if ! PATH="$fake_bin:$PATH" \
+  FAKE_GH_STATE_DIR="$state_dir" \
+  FAKE_GH_DROP_ONCE_ASSET=boot_b.img.tar.gz \
+  GH_TOKEN="test-token" \
+  GITHUB_REPOSITORY="owner/repo" \
+    "$repo_root/scripts/create_github_release.sh" \
+      --tag-name v-test \
+      --release-name "Test Release" \
+      --target-commitish abc123 \
+      --asset-glob "$assets_dir/*" \
+      --required-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+      --upload-assets 'boot_a.img.tar.gz boot_b.img.tar.gz oem.img.tar.gz rootfs.img.tar.gz update.img.tar.gz manifest.json' \
+      --retry-count 3 \
+      --retry-delay-seconds 0 \
+      >"$log_file" 2>&1; then
+  cat "$log_file" >&2
+  exit 1
+fi
+
+if [ "$(grep -c '^upload:boot_b.img.tar.gz:' "$state_dir/events")" -ne 2 ]; then
+  echo "release script must re-upload assets that are missing from the release asset list" >&2
+  cat "$state_dir/events" >&2
+  exit 1
+fi
+
+if ! grep -q 'Release asset verification found missing assets: boot_b.img.tar.gz' "$log_file"; then
+  echo "release script must log missing assets discovered by post-upload verification" >&2
+  cat "$log_file" >&2
+  exit 1
+fi
+
+last_boot_b_upload_line="$(grep -n '^upload:boot_b.img.tar.gz:' "$state_dir/events" | tail -n 1 | cut -d: -f1)"
+publish_line="$(grep -n '^publish:v-test$' "$state_dir/events" | cut -d: -f1)"
+if [ "$publish_line" -le "$last_boot_b_upload_line" ]; then
+  echo "release script must publish only after missing assets are re-uploaded" >&2
+  exit 1
+fi
+
+rm -f "$assets_dir/oem.img" "$state_dir/events" "$state_dir/calls" "$state_dir/sleeps" "$state_dir/release-exists" "$state_dir"/upload-* "$state_dir/create-count" "$state_dir/remote-assets" "$state_dir"/dropped-*
 if PATH="$fake_bin:$PATH" \
   FAKE_GH_STATE_DIR="$state_dir" \
   GH_TOKEN="test-token" \

--- a/scripts/test_github_release_upload.sh
+++ b/scripts/test_github_release_upload.sh
@@ -46,7 +46,23 @@ case "${2:-}" in
       case " $* " in
         *" --json assets "*)
           if [ -f "$state_dir/remote-assets" ]; then
-            cat "$state_dir/remote-assets"
+            jq_expr=""
+            previous=""
+            for arg in "$@"; do
+              if [ "$previous" = "--jq" ]; then
+                jq_expr="$arg"
+                break
+              fi
+              previous="$arg"
+            done
+            case "$jq_expr" in
+              '.assets[].name')
+                cut -f1 "$state_dir/remote-assets"
+                ;;
+              *)
+                cat "$state_dir/remote-assets"
+                ;;
+            esac
           fi
           exit 0
           ;;
@@ -96,6 +112,7 @@ case "${2:-}" in
   upload)
     asset="${4:-}"
     name="${asset##*/}"
+    size="$(wc -c < "$asset" | tr -d '[:space:]')"
     count_file="$state_dir/upload-$name"
     count=0
     if [ -f "$count_file" ]; then
@@ -112,11 +129,15 @@ case "${2:-}" in
       touch "$state_dir/dropped-$name"
       exit 0
     fi
+    if [ "${FAKE_GH_KEEP_STALE_ONCE_ASSET:-}" = "$name" ] && [ ! -f "$state_dir/stale-kept-$name" ]; then
+      touch "$state_dir/stale-kept-$name"
+      exit 0
+    fi
     {
       if [ -f "$state_dir/remote-assets" ]; then
-        cat "$state_dir/remote-assets"
+        awk -F '\t' -v name="$name" '$1 != name' "$state_dir/remote-assets"
       fi
-      printf '%s\n' "$name"
+      printf '%s\t%s\n' "$name" "$size"
     } | sort -u > "$state_dir/remote-assets.tmp"
     mv "$state_dir/remote-assets.tmp" "$state_dir/remote-assets"
     exit 0
@@ -261,7 +282,7 @@ if ! grep -q '^publish:v-test$' "$state_dir/events"; then
   exit 1
 fi
 
-rm -f "$state_dir/events" "$state_dir/calls" "$state_dir/sleeps" "$state_dir/release-exists" "$state_dir"/upload-* "$state_dir/create-count" "$state_dir/remote-assets" "$state_dir"/dropped-*
+rm -f "$state_dir/events" "$state_dir/calls" "$state_dir/sleeps" "$state_dir/release-exists" "$state_dir"/upload-* "$state_dir/create-count" "$state_dir/remote-assets" "$state_dir"/dropped-* "$state_dir"/stale-kept-*
 if ! PATH="$fake_bin:$PATH" \
   FAKE_GH_STATE_DIR="$state_dir" \
   FAKE_GH_DROP_ONCE_ASSET=boot_b.img.tar.gz \
@@ -300,7 +321,57 @@ if [ "$publish_line" -le "$last_boot_b_upload_line" ]; then
   exit 1
 fi
 
-rm -f "$assets_dir/oem.img" "$state_dir/events" "$state_dir/calls" "$state_dir/sleeps" "$state_dir/release-exists" "$state_dir"/upload-* "$state_dir/create-count" "$state_dir/remote-assets" "$state_dir"/dropped-*
+rm -f "$state_dir/events" "$state_dir/calls" "$state_dir/sleeps" "$state_dir/release-exists" "$state_dir"/upload-* "$state_dir/create-count" "$state_dir/remote-assets" "$state_dir"/dropped-* "$state_dir"/stale-kept-*
+touch "$state_dir/release-exists"
+wrong_boot_b_size=$(( $(wc -c < "$assets_dir/boot_b.img.tar.gz" | tr -d '[:space:]') + 1 ))
+printf '%s\t%s\n' \
+  "boot_a.img.tar.gz" "$(wc -c < "$assets_dir/boot_a.img.tar.gz" | tr -d '[:space:]')" \
+  "boot_b.img.tar.gz" "$wrong_boot_b_size" \
+  "oem.img.tar.gz" "$(wc -c < "$assets_dir/oem.img.tar.gz" | tr -d '[:space:]')" \
+  "rootfs.img.tar.gz" "$(wc -c < "$assets_dir/rootfs.img.tar.gz" | tr -d '[:space:]')" \
+  "update.img.tar.gz" "$(wc -c < "$assets_dir/update.img.tar.gz" | tr -d '[:space:]')" \
+  "manifest.json" "$(wc -c < "$assets_dir/manifest.json" | tr -d '[:space:]')" \
+  > "$state_dir/remote-assets"
+
+if ! PATH="$fake_bin:$PATH" \
+  FAKE_GH_STATE_DIR="$state_dir" \
+  FAKE_GH_KEEP_STALE_ONCE_ASSET=boot_b.img.tar.gz \
+  GH_TOKEN="test-token" \
+  GITHUB_REPOSITORY="owner/repo" \
+    "$repo_root/scripts/create_github_release.sh" \
+      --tag-name v-test \
+      --release-name "Test Release" \
+      --target-commitish abc123 \
+      --asset-glob "$assets_dir/*" \
+      --required-assets 'boot_a.img boot_b.img oem.img rootfs.img update.img manifest.json' \
+      --upload-assets 'boot_a.img.tar.gz boot_b.img.tar.gz oem.img.tar.gz rootfs.img.tar.gz update.img.tar.gz manifest.json' \
+      --retry-count 3 \
+      --retry-delay-seconds 0 \
+      >"$log_file" 2>&1; then
+  cat "$log_file" >&2
+  exit 1
+fi
+
+if [ "$(grep -c '^upload:boot_b.img.tar.gz:' "$state_dir/events")" -lt 1 ]; then
+  echo "release script must re-upload assets whose remote size does not match the local file" >&2
+  cat "$state_dir/events" >&2
+  exit 1
+fi
+
+if ! grep -q 'Release asset verification found size mismatches: boot_b.img.tar.gz' "$log_file"; then
+  echo "release script must log size mismatches discovered by post-upload verification" >&2
+  cat "$log_file" >&2
+  exit 1
+fi
+
+actual_boot_b_size="$(wc -c < "$assets_dir/boot_b.img.tar.gz" | tr -d '[:space:]')"
+if ! awk -F '\t' -v size="$actual_boot_b_size" '$1 == "boot_b.img.tar.gz" && $2 == size { found = 1 } END { exit found ? 0 : 1 }' "$state_dir/remote-assets"; then
+  echo "release script must replace the remote asset after size mismatch re-upload" >&2
+  cat "$state_dir/remote-assets" >&2
+  exit 1
+fi
+
+rm -f "$assets_dir/oem.img" "$state_dir/events" "$state_dir/calls" "$state_dir/sleeps" "$state_dir/release-exists" "$state_dir"/upload-* "$state_dir/create-count" "$state_dir/remote-assets" "$state_dir"/dropped-* "$state_dir"/stale-kept-*
 if PATH="$fake_bin:$PATH" \
   FAKE_GH_STATE_DIR="$state_dir" \
   GH_TOKEN="test-token" \

--- a/scripts/test_ota_manifest_generation.sh
+++ b/scripts/test_ota_manifest_generation.sh
@@ -82,4 +82,33 @@ if ! jq -e '.signature.value' "$manifest_output" >/dev/null; then
   exit 1
 fi
 
+tar -czf "$image_dir/oem.img.tar.gz" -C "$image_dir" oem.img
+compressed_manifest_output="$tmp_dir/manifest-compressed.json"
+"$repo_root/scripts/generate_ota_manifest.sh" \
+  --version "test-version" \
+  --channel "test" \
+  --build-time "2026-01-01T00:00:00Z" \
+  --sign-key "$private_key" \
+  --image-dir "$image_dir" \
+  --output "$compressed_manifest_output"
+
+oem_image_sha="$(if command -v sha256sum >/dev/null 2>&1; then sha256sum "$image_dir/oem.img"; else shasum -a 256 "$image_dir/oem.img"; fi | awk '{print $1}')"
+oem_archive_sha="$(if command -v sha256sum >/dev/null 2>&1; then sha256sum "$image_dir/oem.img.tar.gz"; else shasum -a 256 "$image_dir/oem.img.tar.gz"; fi | awk '{print $1}')"
+oem_archive_size="$(if stat -c%s "$image_dir/oem.img.tar.gz" >/dev/null 2>&1; then stat -c%s "$image_dir/oem.img.tar.gz"; else stat -f%z "$image_dir/oem.img.tar.gz"; fi)"
+
+if ! jq -e \
+  --arg archive_sha "$oem_archive_sha" \
+  --arg image_sha "$oem_image_sha" \
+  --argjson archive_size "$oem_archive_size" \
+  '.parts[] | select(.name=="oem") | .asset |
+    .name == "oem.img.tar.gz" and
+    .size == $archive_size and
+    .sha256 == $archive_sha and
+    .image_sha256 == $image_sha' \
+  "$compressed_manifest_output" >/dev/null; then
+  echo "manifest must prefer local compressed image assets and include image_sha256" >&2
+  jq '.parts[] | select(.name=="oem") | .asset' "$compressed_manifest_output" >&2
+  exit 1
+fi
+
 echo "OTA manifest generation test passed (neutral resources correctly used)."

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -28,6 +28,16 @@ if ! grep -q -- '--retry-count' "$WORKFLOW" || ! grep -q -- '--retry-delay-secon
     exit 1
 fi
 
+if ! grep -q -- '--retry-count 10' "$WORKFLOW"; then
+    echo "build workflow must use doubled release upload retry attempts" >&2
+    exit 1
+fi
+
+if ! grep -q '^retry_count=10$' "$ROOT_DIR/scripts/create_github_release.sh"; then
+    echo "release script default retry count must stay doubled" >&2
+    exit 1
+fi
+
 if ! grep -q -- '--retry-delay-seconds 30' "$WORKFLOW"; then
     echo "build workflow must use a longer release upload retry base delay" >&2
     exit 1

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -104,6 +104,8 @@ fi
 
 if ! grep -q 'scripts/test_release_ci_scripts.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_github_release_upload.sh' "$CI_WORKFLOW" || \
+   ! grep -q 'scripts/test_compress_release_images.sh' "$CI_WORKFLOW" || \
+   ! grep -q 'scripts/test_ota_manifest_generation.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_reusable_rootfs_release_asset.sh' "$CI_WORKFLOW"; then
     echo "CI must run repo-only release workflow and upload script tests" >&2
     exit 1
@@ -122,6 +124,22 @@ fi
 if ! grep -q 'rootfs_asset.outputs.rootfs_asset_metadata' "$WORKFLOW" || \
    ! grep -q -- '--asset-metadata' "$WORKFLOW"; then
     echo "build workflow must pass full reused rootfs asset metadata into manifest generation" >&2
+    exit 1
+fi
+
+if ! grep -q 'Compress OTA manifest images' "$WORKFLOW" || \
+   ! grep -q 'Compress release upload images' "$WORKFLOW"; then
+    echo "build workflow must compress OTA image assets before publishing releases" >&2
+    exit 1
+fi
+
+if ! grep -q 'release_upload_assets.outputs.upload_assets' "$WORKFLOW"; then
+    echo "build workflow must upload compressed release image assets" >&2
+    exit 1
+fi
+
+if ! grep -q 'scripts/compress_release_images.sh' "$WORKFLOW"; then
+    echo "build workflow must use the shared release image compression script" >&2
     exit 1
 fi
 

--- a/scripts/test_reusable_rootfs_release_asset.sh
+++ b/scripts/test_reusable_rootfs_release_asset.sh
@@ -98,6 +98,14 @@ fi
 case "${2:-}" in
   view)
     if [ -f "$state_dir/release-exists" ]; then
+      case " $* " in
+        *" --json assets "*)
+          if [ -f "$state_dir/remote-assets" ]; then
+            cat "$state_dir/remote-assets"
+          fi
+          exit 0
+          ;;
+      esac
       echo "release exists"
       exit 0
     fi
@@ -115,7 +123,15 @@ case "${2:-}" in
     ;;
   upload)
     asset="${4:-}"
-    printf 'upload:%s\n' "${asset##*/}" >> "$state_dir/events"
+    name="${asset##*/}"
+    printf 'upload:%s\n' "$name" >> "$state_dir/events"
+    {
+      if [ -f "$state_dir/remote-assets" ]; then
+        cat "$state_dir/remote-assets"
+      fi
+      printf '%s\n' "$name"
+    } | sort -u > "$state_dir/remote-assets.tmp"
+    mv "$state_dir/remote-assets.tmp" "$state_dir/remote-assets"
     exit 0
     ;;
   *)

--- a/scripts/test_reusable_rootfs_release_asset.sh
+++ b/scripts/test_reusable_rootfs_release_asset.sh
@@ -101,7 +101,23 @@ case "${2:-}" in
       case " $* " in
         *" --json assets "*)
           if [ -f "$state_dir/remote-assets" ]; then
-            cat "$state_dir/remote-assets"
+            jq_expr=""
+            previous=""
+            for arg in "$@"; do
+              if [ "$previous" = "--jq" ]; then
+                jq_expr="$arg"
+                break
+              fi
+              previous="$arg"
+            done
+            case "$jq_expr" in
+              '.assets[].name')
+                cut -f1 "$state_dir/remote-assets"
+                ;;
+              *)
+                cat "$state_dir/remote-assets"
+                ;;
+            esac
           fi
           exit 0
           ;;
@@ -124,12 +140,13 @@ case "${2:-}" in
   upload)
     asset="${4:-}"
     name="${asset##*/}"
+    size="$(wc -c < "$asset" | tr -d '[:space:]')"
     printf 'upload:%s\n' "$name" >> "$state_dir/events"
     {
       if [ -f "$state_dir/remote-assets" ]; then
-        cat "$state_dir/remote-assets"
+        awk -F '\t' -v name="$name" '$1 != name' "$state_dir/remote-assets"
       fi
-      printf '%s\n' "$name"
+      printf '%s\t%s\n' "$name" "$size"
     } | sort -u > "$state_dir/remote-assets.tmp"
     mv "$state_dir/remote-assets.tmp" "$state_dir/remote-assets"
     exit 0


### PR DESCRIPTION
## Summary
- compress release image assets into .img.tar.gz archives before upload
- make OTA manifest generation point to compressed image assets with image_sha256 metadata
- add CI coverage for release image compression and compressed manifest metadata

## Tests
- sh scripts/test_release_ci_scripts.sh
- bash scripts/test_reproducible_rootfs_policy.sh
- bash scripts/test_compress_release_images.sh
- bash scripts/test_ota_manifest_generation.sh
- bash scripts/test_github_release_upload.sh
- bash scripts/test_reusable_rootfs_release_asset.sh
- go test ./internal/ota

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release build process now automatically compresses OTA image assets into archives for distribution.
  * OTA manifest generation enhanced to track compressed artifact metadata and checksums.

* **Tests**
  * Added validation tests for release asset compression process.
  * Enhanced CI pipeline with additional release verification checks to ensure compression functionality works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->