### PR TITLE
fix(agent): load bundled skills from OEM

### DIFF
--- a/_build_image.sh
+++ b/_build_image.sh
@@ -110,8 +110,8 @@ fi
 cp "$KEY_SOURCE" "$OVERLAY/oem/etc/ota_pubkey.pem"
 echo "  ✓ OTA public key copied to overlay/oem/etc/ota_pubkey.pem"
 
-# Step 3: 同步 etc 与内置 skills 到 buildroot overlay（rootfs）
-echo "[3/6] Syncing overlay (etc + bundled skills) to buildroot overlay..."
+# Step 3: Sync rootfs overlay assets.
+echo "[3/6] Syncing rootfs overlay assets..."
 if [ ! -d "$DEST_OVERLAY" ]; then
     echo "  ✗ Error: destination directory not found at $DEST_OVERLAY"
     exit 1
@@ -124,10 +124,10 @@ if [ -d "$OVERLAY/etc" ]; then
     echo "  ✓ etc directory synced"
 fi
 
-# Bundled agent skills: src/agent/config/skills/ 是单一源，固件里要落到
-# /usr/share/aiden/skills/ 才能被 agent 的 resolveBundledSkillsDir() 找到。
+# Bundled agent skills use src/agent/config/skills as the single source and
+# ship with the agent in the OEM partition.
 SKILLS_SRC="$SCRIPT_DIR/src/agent/config/skills"
-SKILLS_DEST="$DEST_OVERLAY/usr/share/aiden/skills"
+SKILLS_DEST="$OVERLAY/oem/usr/share/aiden/skills"
 if [ -d "$SKILLS_SRC" ]; then
     mkdir -p "$SKILLS_DEST"
     rsync -a --delete "$SKILLS_SRC/" "$SKILLS_DEST/"

--- a/_build_image.sh
+++ b/_build_image.sh
@@ -124,23 +124,6 @@ if [ -d "$OVERLAY/etc" ]; then
     echo "  ✓ etc directory synced"
 fi
 
-# Bundled agent skills use src/agent/config/skills as the single source and
-# ship with the agent in the OEM partition.
-SKILLS_SRC="$SCRIPT_DIR/src/agent/config/skills"
-SKILLS_DEST="$OVERLAY/oem/usr/share/aiden/skills"
-if [ -d "$SKILLS_SRC" ]; then
-    mkdir -p "$SKILLS_DEST"
-    rsync -a --delete "$SKILLS_SRC/" "$SKILLS_DEST/"
-    skill_count=$(find "$SKILLS_DEST" -mindepth 2 -maxdepth 2 -type f -name SKILL.md | wc -l | tr -d ' ')
-    if [ "$skill_count" -lt 1 ]; then
-        echo "  ✗ Error: no SKILL.md staged in $SKILLS_DEST" >&2
-        exit 1
-    fi
-    echo "  ✓ bundled skills synced ($skill_count skill(s))"
-else
-    echo "  ⚠ Warning: $SKILLS_SRC not found; skipping bundled skills" >&2
-fi
-
 # Bundled phone-bridge app mapping: src/agent/internal/agent/app_mapping.json 是
 # Go embed 的单一源，固件里同步落到 /usr/share/aiden/app_mapping.json，方便运维
 # 不重新 build 二进制就能更新映射（agent 启动时优先读 configDir，再读这里，最后
@@ -185,6 +168,23 @@ if [ -d "$OVERLAY/oem" ]; then
     mkdir -p "$RK_PROJECT_PACKAGE_OEM_DIR"
     rsync -a "$OVERLAY/oem/" "$RK_PROJECT_PACKAGE_OEM_DIR/"
     echo "  ✓ OEM content copied"
+fi
+
+# Bundled agent skills use src/agent/config/skills as the single source and
+# ship with the agent in the OEM partition.
+SKILLS_SRC="$SCRIPT_DIR/src/agent/config/skills"
+SKILLS_DEST="$RK_PROJECT_PACKAGE_OEM_DIR/usr/share/aiden/skills"
+if [ -d "$SKILLS_SRC" ]; then
+    mkdir -p "$SKILLS_DEST"
+    rsync -a --delete "$SKILLS_SRC/" "$SKILLS_DEST/"
+    skill_count=$(find "$SKILLS_DEST" -mindepth 2 -maxdepth 2 -type f -name SKILL.md | wc -l | tr -d ' ')
+    if [ "$skill_count" -lt 1 ]; then
+        echo "  ✗ Error: no SKILL.md staged in $SKILLS_DEST" >&2
+        exit 1
+    fi
+    echo "  ✓ bundled skills synced to OEM staging ($skill_count skill(s))"
+else
+    echo "  ⚠ Warning: $SKILLS_SRC not found; skipping bundled skills" >&2
 fi
 
 # VAD models live in /oem/usr/model so OTA updates can replace them with the

--- a/docs/04-agent/skills-merge-design.md
+++ b/docs/04-agent/skills-merge-design.md
@@ -107,7 +107,7 @@ configDir/skills/**/SKILL.md
 
 ```text
 开发环境：src/agent/config/skills/
-设备环境：/usr/share/aiden/skills/
+设备环境：/oem/usr/share/aiden/skills/
 ```
 
 启动或更新时同步到：
@@ -190,7 +190,7 @@ src/agent/config/skills/
 设备安装后可以放到：
 
 ```text
-/usr/share/aiden/skills/
+/oem/usr/share/aiden/skills/
 ├── planner/SKILL.md
 ├── research/SKILL.md
 └── ...
@@ -1150,7 +1150,7 @@ src/agent/config/skills
 设备安装环境：
 
 ```text
-/usr/share/aiden/skills
+/oem/usr/share/aiden/skills
 ```
 
 MVP 可以从 build-time 常量、配置项或相对路径解析。
@@ -1463,7 +1463,7 @@ configDir/skills/<name>/assets/**
 禁止修改：
 
 ```text
-/usr/share/aiden/skills/<name>/SKILL.md
+/oem/usr/share/aiden/skills/<name>/SKILL.md
 src/agent/config/skills/<name>/SKILL.md
 configDir/skill-state/.bundled_manifest.json
 configDir/skill-state/bases/<name>/SKILL.md

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -78,13 +78,22 @@ if ! grep -Fq 'BENCHMARK_SRC="$SCRIPT_DIR/benchmark"' "$ROOT_DIR/_build_image.sh
     exit 1
 fi
 
-if ! grep -Fq 'SKILLS_DEST="$OVERLAY/oem/usr/share/aiden/skills"' "$ROOT_DIR/_build_image.sh"; then
-    echo "_build_image.sh must stage bundled skills into the OEM partition" >&2
+if grep -Fq 'SKILLS_DEST="$OVERLAY/oem/usr/share/aiden/skills"' "$ROOT_DIR/_build_image.sh" || \
+   grep -Fq 'SKILLS_DEST="$DEST_OVERLAY/usr/share/aiden/skills"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must not stage bundled skills through repo overlay directories" >&2
     exit 1
 fi
 
-if grep -Fq 'SKILLS_DEST="$DEST_OVERLAY/usr/share/aiden/skills"' "$ROOT_DIR/_build_image.sh"; then
-    echo "_build_image.sh must not stage bundled skills into the rootfs overlay" >&2
+if ! grep -Fq 'SKILLS_DEST="$RK_PROJECT_PACKAGE_OEM_DIR/usr/share/aiden/skills"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'rsync -a --delete "$SKILLS_SRC/" "$SKILLS_DEST/"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must sync bundled skills directly into final OEM staging with delete semantics" >&2
+    exit 1
+fi
+
+oem_dir_line=$(grep -n 'RK_PROJECT_PACKAGE_OEM_DIR="${RK_PROJECT_OUTPUT}/oem"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
+skills_dest_line=$(grep -n 'SKILLS_DEST="$RK_PROJECT_PACKAGE_OEM_DIR/usr/share/aiden/skills"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
+if [ -z "$oem_dir_line" ] || [ -z "$skills_dest_line" ] || [ "$skills_dest_line" -le "$oem_dir_line" ]; then
+    echo "_build_image.sh must resolve final OEM staging before setting bundled skills destination" >&2
     exit 1
 fi
 

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -78,6 +78,16 @@ if ! grep -Fq 'BENCHMARK_SRC="$SCRIPT_DIR/benchmark"' "$ROOT_DIR/_build_image.sh
     exit 1
 fi
 
+if ! grep -Fq 'SKILLS_DEST="$OVERLAY/oem/usr/share/aiden/skills"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must stage bundled skills into the OEM partition" >&2
+    exit 1
+fi
+
+if grep -Fq 'SKILLS_DEST="$DEST_OVERLAY/usr/share/aiden/skills"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must not stage bundled skills into the rootfs overlay" >&2
+    exit 1
+fi
+
 if ! grep -q 'overlay/userdata' "$BUILD_IMAGE_SH"; then
     echo "build_image.sh must restore ownership of Docker-staged overlay userdata" >&2
     exit 1

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -356,15 +356,16 @@ func resolveBundledSkillsDir() string {
 	if v := os.Getenv("AIDEN_BUNDLED_SKILLS_DIR"); v != "" {
 		return v
 	}
-	candidates := []string{
-		"/usr/share/aiden/skills",
-	}
-	for _, c := range candidates {
-		if info, err := os.Stat(c); err == nil && info.IsDir() {
-			return c
+	for _, dir := range bundledSkillsDirCandidates() {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
 		}
 	}
 	return ""
+}
+
+func bundledSkillsDirCandidates() []string {
+	return []string{"/oem/usr/share/aiden/skills"}
 }
 
 func LoadConfig(path string) (Config, error) {

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,13 @@ func TestConfigValidateAcceptsAudioWakeup(t *testing.T) {
 	}
 	if got := cfg.TriggerModeOrDefault(); got != "wakeup" {
 		t.Fatalf("TriggerModeOrDefault() = %q, want wakeup", got)
+	}
+}
+
+func TestBundledSkillsDirCandidatesUseOEMOnly(t *testing.T) {
+	want := []string{"/oem/usr/share/aiden/skills"}
+	if got := bundledSkillsDirCandidates(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("bundledSkillsDirCandidates() = %#v, want %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- load bundled skills from /oem/usr/share/aiden/skills without rootfs fallback
- stage bundled skills into the OEM partition during image builds
- update build script checks and skills path documentation

## Tests
- go test ./internal/agent -run 'Test(BundledSkillsDirCandidatesUseOEMOnly|NewRuntimeLoadsBundledSkillsSeededOnFirstStartup|SyncBundledSkills)' -count=1
- go test ./internal/agent -run TestConfig -count=1
- scripts/test_build_scripts.sh
- git diff --check

## Notes
- Full go test ./internal/agent still has existing unrelated failures in TestServerHandleChatReturnsToolHistory and TestServerHandleChatWithAudioAttachmentUsesSTT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Relocated bundled agent skills to the OEM partition for improved package organization.
  * Enhanced build process messaging for rootfs overlay synchronization.

* **Documentation**
  * Updated device environment paths for bundled skills installation locations.

* **Tests**
  * Added validation checks to ensure bundled skills are staged to the correct partition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->