### PR TITLE
feat(ota): skip unchanged partition writes

### DIFF
--- a/src/agent/internal/ota/updater.go
+++ b/src/agent/internal/ota/updater.go
@@ -305,6 +305,11 @@ func (u *Updater) checkOnceLocked(ctx context.Context) (UpdateResult, error) {
 			u.recordError("asset", err)
 			return UpdateResult{}, err
 		}
+		selectedAssets[part.Name] = asset
+		if targetPartitionHashMatches(state, target, part.Name, asset) {
+			u.logf("ota partition: %s skipped; target slot %s hash matches manifest", part.Name, slotLogName(target))
+			continue
+		}
 		var assetURL string
 		var assetToken string
 		if asset.URL != "" {
@@ -340,7 +345,6 @@ func (u *Updater) checkOnceLocked(ctx context.Context) (UpdateResult, error) {
 				u.recordError("verify", err)
 				return UpdateResult{}, err
 			}
-			selectedAssets[part.Name] = asset
 			downloaded[part.Name] = dst
 			continue
 		}
@@ -362,7 +366,6 @@ func (u *Updater) checkOnceLocked(ctx context.Context) (UpdateResult, error) {
 			u.recordError("verify", err)
 			return UpdateResult{}, err
 		}
-		selectedAssets[part.Name] = asset
 		downloaded[part.Name] = dst
 	}
 	if u.config.DryRun {
@@ -488,6 +491,19 @@ func (u *Updater) cachedDownloadVerified(path string, asset ManifestAsset) bool 
 	}
 	u.logf("ota download: %s skipped; cached file verified dst=%s", asset.Name, path)
 	return true
+}
+
+func targetPartitionHashMatches(state State, target Slot, partName string, asset ManifestAsset) bool {
+	targetName, err := slotName(target)
+	if err != nil {
+		return false
+	}
+	slotState, ok := state.Slots[targetName]
+	if !ok {
+		return false
+	}
+	local, ok := slotState.Partitions[partName]
+	return ok && local.Version != "" && local.Hash == partitionSHA256ForAsset(asset)
 }
 
 func (u *Updater) verifyDownloadedImage(path string, asset ManifestAsset) error {

--- a/src/agent/internal/ota/updater_test.go
+++ b/src/agent/internal/ota/updater_test.go
@@ -355,6 +355,111 @@ func TestUpdaterSkipsAssetDownloadWhenCachedFileMatchesSHA256(t *testing.T) {
 	assertFileContent(t, filepath.Join(env.blockDir, "rootfs_b"), "rootfs-v2")
 }
 
+func TestUpdaterSkipsDownloadAndWriteWhenTargetPartitionHashMatches(t *testing.T) {
+	env := newUpdaterTestEnv(t)
+	assetBytes := map[string][]byte{
+		"boot_a.img": []byte("boot-a-v2"),
+		"boot_b.img": []byte("boot-b-v2"),
+		"oem_a.img":  []byte("oem-a-v2"),
+		"oem_b.img":  []byte("oem-b-v2"),
+		"rootfs.img": []byte("rootfs-v2"),
+	}
+	oemHash := testSHA256Hex(assetBytes["oem_b.img"])
+	env.state.Slots["b"] = SlotPartitionInfo{Partitions: map[string]PartitionVersion{
+		"boot":   {Version: "factory", Hash: testHashA},
+		"oem":    {Version: "previous", Hash: oemHash},
+		"rootfs": {Version: "factory", Hash: testHashA},
+	}}
+	env.saveState(t)
+	manifest := env.signedManifest(assetBytes, nil)
+
+	oemRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/repos/AidenAI-IO/aiden-hardware-demo/releases/latest") {
+			var release struct {
+				Assets []githubAsset `json:"assets"`
+			}
+			release.Assets = append(release.Assets, githubAsset{Name: "manifest.json", BrowserDownloadURL: "http://" + r.Host + "/assets/manifest.json"})
+			for _, name := range []string{"boot_b.img", "oem_b.img", "rootfs.img"} {
+				release.Assets = append(release.Assets, githubAsset{Name: name, BrowserDownloadURL: "http://" + r.Host + "/assets/" + name})
+			}
+			_ = json.NewEncoder(w).Encode(release)
+			return
+		}
+		if r.URL.Path == "/assets/manifest.json" {
+			_, _ = w.Write(manifest)
+			return
+		}
+		name := strings.TrimPrefix(r.URL.Path, "/assets/")
+		if name == "oem_b.img" {
+			oemRequests++
+			http.Error(w, "matching partition should not be downloaded", http.StatusInternalServerError)
+			return
+		}
+		if b, ok := assetBytes[name]; ok {
+			w.Header().Set("Content-Length", fmt.Sprint(len(b)))
+			_, _ = w.Write(b)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+	env.config.ReleaseURL = server.URL + "/repos/AidenAI-IO/aiden-hardware-demo/releases/latest"
+
+	result, err := env.updater().CheckOnce(context.Background())
+	if err != nil {
+		t.Fatalf("CheckOnce() error = %v", err)
+	}
+	if !result.Updated || result.TargetSlot != SlotB {
+		t.Fatalf("CheckOnce() = %+v", result)
+	}
+	if oemRequests != 0 {
+		t.Fatalf("oemRequests = %d, want 0", oemRequests)
+	}
+	if _, err := os.Stat(filepath.Join(env.downloadDir, "oem_b.img")); !os.IsNotExist(err) {
+		t.Fatalf("oem_b.img cache exists after partition skip: %v", err)
+	}
+	assertFileContent(t, filepath.Join(env.blockDir, "boot_b"), "boot-b-v2")
+	assertFileContent(t, filepath.Join(env.blockDir, "oem_b"), "old-oem-b")
+	assertFileContent(t, filepath.Join(env.blockDir, "rootfs_b"), "rootfs-v2")
+
+	state, err := LoadState(filepath.Join(env.stateDir, "state.json"))
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if got := state.DownloadedHashes["oem"]; got != oemHash {
+		t.Fatalf("DownloadedHashes[oem] = %s, want %s", got, oemHash)
+	}
+	pendingBytes, err := os.ReadFile(filepath.Join(env.stateDir, "pending_boot.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(pending_boot.json) error = %v", err)
+	}
+	var pending PendingBoot
+	if err := json.Unmarshal(pendingBytes, &pending); err != nil {
+		t.Fatalf("Unmarshal(PendingBoot) error = %v", err)
+	}
+	marker := HealthMarker{Slot: "b", Version: env.version, BuildTime: env.buildTime, Nonce: pending.Nonce, BootID: currentBootID()}
+	data, err := json.Marshal(marker)
+	if err != nil {
+		t.Fatalf("Marshal(HealthMarker) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(env.stateDir, "health.ok"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile(health.ok) error = %v", err)
+	}
+	updater := env.updater()
+	updater.currentSlot = func() (Slot, bool, error) { return SlotB, true, nil }
+	if err := updater.ProcessPendingHealth(context.Background()); err != nil {
+		t.Fatalf("ProcessPendingHealth() error = %v", err)
+	}
+	state, err = LoadState(filepath.Join(env.stateDir, "state.json"))
+	if err != nil {
+		t.Fatalf("LoadState(committed) error = %v", err)
+	}
+	if got := state.Slots["b"].Partitions["oem"]; got.Version != env.version || got.Hash != oemHash {
+		t.Fatalf("committed oem partition = %+v, want %s/%s", got, env.version, oemHash)
+	}
+}
+
 func TestUpdaterInitializesMissingStateFromFactoryConfig(t *testing.T) {
 	env := newUpdaterTestEnv(t)
 	statePath := filepath.Join(env.stateDir, "state.json")
@@ -585,7 +690,7 @@ func TestUpdaterRejectsBadSignature(t *testing.T) {
 func TestUpdaterRejectsHashMismatchBeforeWriting(t *testing.T) {
 	env := newUpdaterTestEnv(t)
 	assets := map[string][]byte{"boot_a.img": []byte("boot-a-v2"), "boot_b.img": []byte("boot-b-v2"), "oem_a.img": []byte("oem-a-v2"), "oem_b.img": []byte("oem-b-v2"), "rootfs.img": []byte("rootfs-v2")}
-	manifest := env.signedManifest(assets, func(m *Manifest) { m.Parts[0].AssetB.SHA256 = testHashA })
+	manifest := env.signedManifest(assets, func(m *Manifest) { m.Parts[0].AssetB.SHA256 = testHashC })
 	server := env.releaseServer(t, manifest, assets)
 	env.config.ReleaseURL = server.URL + "/repos/AidenAI-IO/aiden-hardware-demo/releases/latest"
 

--- a/src/agent/internal/ota/updater_test.go
+++ b/src/agent/internal/ota/updater_test.go
@@ -365,6 +365,9 @@ func TestUpdaterSkipsDownloadAndWriteWhenTargetPartitionHashMatches(t *testing.T
 		"rootfs.img": []byte("rootfs-v2"),
 	}
 	oemHash := testSHA256Hex(assetBytes["oem_b.img"])
+	if err := os.WriteFile(filepath.Join(env.blockDir, "oem_b"), assetBytes["oem_b.img"], 0o644); err != nil {
+		t.Fatalf("WriteFile(oem_b) error = %v", err)
+	}
 	env.state.Slots["b"] = SlotPartitionInfo{Partitions: map[string]PartitionVersion{
 		"boot":   {Version: "factory", Hash: testHashA},
 		"oem":    {Version: "previous", Hash: oemHash},
@@ -420,7 +423,7 @@ func TestUpdaterSkipsDownloadAndWriteWhenTargetPartitionHashMatches(t *testing.T
 		t.Fatalf("oem_b.img cache exists after partition skip: %v", err)
 	}
 	assertFileContent(t, filepath.Join(env.blockDir, "boot_b"), "boot-b-v2")
-	assertFileContent(t, filepath.Join(env.blockDir, "oem_b"), "old-oem-b")
+	assertFileContent(t, filepath.Join(env.blockDir, "oem_b"), "oem-b-v2")
 	assertFileContent(t, filepath.Join(env.blockDir, "rootfs_b"), "rootfs-v2")
 
 	state, err := LoadState(filepath.Join(env.stateDir, "state.json"))


### PR DESCRIPTION
## Summary
- skip OTA asset URL resolution, download, and partition writes when the target slot partition hash already matches the manifest image hash
- keep skipped partitions in the pending hash set so health commit records the new manifest version/hash
- add coverage for skipping without a local cache and preserving hash mismatch validation

## Tests
- go test ./internal/ota -count=1

## Notes
- go test ./... was also run; OTA passed, but existing internal/agent tests failed: TestServerHandleChatReturnsToolHistory and TestServerHandleChatWithAudioAttachmentUsesSTT expect different history entry counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OTA updates now skip unnecessary downloads and writes for partitions when their hash already matches the target state, improving update speed and reducing data transfer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->