### PR TITLE
ci(build): clean stale artifacts before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,11 @@ jobs:
         scripts/validate_ota_pubkey.sh "$public_key"
         echo "OTA_PUBLIC_KEY_PATH=/home/.ota-ci/ota_ed25519_public_key.pem" >> "$GITHUB_ENV"
 
+    - name: Clean previous build artifacts
+      run: |
+        rm -rf pico-sdk/output/image/*.img pico-sdk/output/image/*.img.tar.gz pico-sdk/output/image/manifest.json
+        rm -rf pico-sdk/output/out
+
     - name: Generate release name
       id: release_info
       env:


### PR DESCRIPTION
Remove old .img, .img.tar.gz, manifest.json, and output directories before each build to prevent uploading stale binaries from previous runs on self-hosted runners.

## Changes
- Added cleanup step before release name generation
- Removes , , 
- Removes  directory

## Why
On self-hosted runners, the workspace persists across builds. Without cleanup, stale artifacts from previous builds could be picked up by the asset glob pattern and uploaded to the wrong release.

## Impact
- No performance impact: only deletes final build artifacts, not compilation caches
- Ensures each release only contains freshly built binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build workflow to clean up stale build artifacts before generating new releases, ensuring a cleaner and more reliable build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->