### PR TITLE
feat(phone-bridge): surface companion app environment

### DIFF
--- a/docs/04-agent/phone-bridge-protocol.md
+++ b/docs/04-agent/phone-bridge-protocol.md
@@ -83,7 +83,6 @@ App 也可以主动发送事件消息。事件复用 `BridgeCommandResponse` 外
     "manufacturer": "Apple",
     "brand": "Apple",
     "model": "iPhone16,2",
-    "device_name": "Qing's iPhone",
     "screen": {
       "width": 393,
       "height": 852,
@@ -96,15 +95,25 @@ App 也可以主动发送事件消息。事件复用 `BridgeCommandResponse` 外
       "charging": true,
       "state": "charging"
     },
+    "system_apps": [
+      {"name": "Camera", "available": true, "category": "system", "availability_source": "builtin"},
+      {"name": "Contacts", "available": true, "category": "system", "availability_source": "builtin"}
+    ],
+    "third_party_apps": [
+      {"name": "WeChat", "available": true, "category": "third_party", "availability_source": "can_open_url", "ios_url": "weixin://"},
+      {"name": "Douyin", "available": false, "category": "third_party", "availability_source": "can_open_url", "ios_url": "snssdk1128://"}
+    ],
     "available_apps": [
-      {"name": "WeChat", "available": true, "ios_url": "weixin://"},
-      {"name": "Douyin", "available": false, "ios_url": "snssdk1128://"}
+      {"name": "WeChat", "available": true, "category": "third_party", "ios_url": "weixin://"},
+      {"name": "Douyin", "available": false, "category": "third_party", "ios_url": "snssdk1128://"}
     ]
   }
 }
 ```
 
-板子会把最新环境写入 `GET /api/phone-bridge/status` 的 `environment` 字段，并注入每轮 Agent runtime context。断开连接时清理环境，避免使用旧信息。
+板子会把最新完整环境写入 `GET /api/phone-bridge/status` 的 `environment` 字段。每轮 Agent runtime context 只注入精简摘要：连接状态、系统类型/版本、语言地区/时区、屏幕尺寸、已确认可打开的第三方候选 App。断开连接时清理环境，避免使用旧信息。
+
+`system_apps` 表示系统内置 App/能力，iOS 上不依赖 `canOpenURL` 判断是否存在；`third_party_apps` 表示第三方候选 App，iOS 通过 `canOpenURL`、Android 通过 package launchability 探测。`available_apps` 是兼容旧板子的第三方候选摘要，新实现应优先读取拆分后的字段。
 
 ## 命令类型
 
@@ -585,7 +594,7 @@ App 也可以主动发送事件消息。事件复用 `BridgeCommandResponse` 外
 
 ## 版本兼容
 
-当前协议版本 1.0，后续扩展新命令时:
+当前协议版本 1.1，后续扩展新命令时:
 - 新增字段向后兼容 (旧版 App 忽略未知字段)
 - 新增命令类型，旧版 App 返回 `ok: false, error: "Unknown command type"`
 - 修改已有字段语义需升级版本号

--- a/docs/04-agent/phone-bridge-protocol.md
+++ b/docs/04-agent/phone-bridge-protocol.md
@@ -1,7 +1,7 @@
 # Phone Bridge Protocol Contract
 
-**Version**: 1.0  
-**Date**: 2026-06-02
+**Version**: 1.1
+**Date**: 2026-06-10
 
 本文档定义硬件板子 (aiden-hardware-demo) 与手机 App (aiden-app) 之间的 WebSocket 命令协议。
 
@@ -50,6 +50,61 @@ App 应每隔 10-15 秒发送一次心跳消息 (id 为 `"heartbeat"` 或 `"ping
   data?: object;    // 返回数据 (可选，读类命令使用)
 }
 ```
+
+### AppEvent (App → 板子)
+
+App 也可以主动发送事件消息。事件复用 `BridgeCommandResponse` 外层字段，但 `id`/`method` 不对应任何板子下发的命令，板子不会把它当作 pending command 回执。
+
+当前事件:
+
+- `phone_environment`: App 在 WebSocket 连接成功、从后台回到前台时上报手机环境快照。
+
+示例:
+
+```json
+{
+  "id": "phone_environment",
+  "ok": true,
+  "method": "phone_environment",
+  "data": {
+    "captured_at": "2026-06-10T03:20:00Z",
+    "source": "aiden-app",
+    "platform": "ios",
+    "system_name": "iOS",
+    "system_version": "18.5",
+    "is_tablet": false,
+    "locale": "zh-Hans-CN",
+    "language": "zh",
+    "region": "CN",
+    "time_zone": "Asia/Shanghai",
+    "utc_offset_minutes": 480,
+    "utc_offset": "+08:00",
+    "uses_24_hour_clock": true,
+    "manufacturer": "Apple",
+    "brand": "Apple",
+    "model": "iPhone16,2",
+    "device_name": "Qing's iPhone",
+    "screen": {
+      "width": 393,
+      "height": 852,
+      "width_pixels": 1179,
+      "height_pixels": 2556,
+      "scale": 3
+    },
+    "battery": {
+      "level": 0.87,
+      "charging": true,
+      "state": "charging"
+    },
+    "available_apps": [
+      {"name": "WeChat", "available": true, "ios_url": "weixin://"},
+      {"name": "Douyin", "available": false, "ios_url": "snssdk1128://"}
+    ]
+  }
+}
+```
+
+板子会把最新环境写入 `GET /api/phone-bridge/status` 的 `environment` 字段，并注入每轮 Agent runtime context。断开连接时清理环境，避免使用旧信息。
 
 ## 命令类型
 

--- a/docs/04-agent/phone-bridge.md
+++ b/docs/04-agent/phone-bridge.md
@@ -160,7 +160,8 @@ WebSocket 的核心价值：
 1. 板子 agent 新增 `phone_bridge` WebSocket 通道。
 2. 中转 App 启动后自动连接 `ws://192.168.42.1:8080/api/phone-bridge`。
 3. App 定时发 heartbeat。
-4. 板子维护 `bridge_connected`、`platform`、`last_heartbeat_at` 状态。
+4. App 在连接成功、从后台回到前台时主动上报 `phone_environment`，包括系统版本、语言地区、时区、屏幕/电池、候选 App 可用性等。
+5. 板子维护 `bridge_connected`、`platform`、`last_heartbeat_at`、`environment` 状态，并把最新手机环境注入 Agent runtime context。
 
 ### 命令协议
 
@@ -188,6 +189,30 @@ WebSocket 的核心价值：
   "data": { }      // 可选，返回的 JSON (读剪贴板内容、日历事件列表等)
 }
 ```
+
+**App 主动事件 (App → 板子)**:
+```json
+{
+  "id": "phone_environment",
+  "ok": true,
+  "method": "phone_environment",
+  "data": {
+    "platform": "ios",
+    "system_name": "iOS",
+    "system_version": "18.5",
+    "locale": "zh-Hans-CN",
+    "time_zone": "Asia/Shanghai",
+    "utc_offset": "+08:00",
+    "manufacturer": "Apple",
+    "model": "iPhone16,2",
+    "screen": {"width_pixels": 1179, "height_pixels": 2556, "scale": 3},
+    "battery": {"level": 0.87, "charging": true},
+    "available_apps": [{"name": "WeChat", "available": true}]
+  }
+}
+```
+
+`phone_environment` 不对应板子命令 ID，板子只更新 bridge status，不会把它当作工具调用回执。
 
 #### 命令类型
 

--- a/docs/04-agent/phone-bridge.md
+++ b/docs/04-agent/phone-bridge.md
@@ -160,8 +160,8 @@ WebSocket 的核心价值：
 1. 板子 agent 新增 `phone_bridge` WebSocket 通道。
 2. 中转 App 启动后自动连接 `ws://192.168.42.1:8080/api/phone-bridge`。
 3. App 定时发 heartbeat。
-4. App 在连接成功、从后台回到前台时主动上报 `phone_environment`，包括系统版本、语言地区、时区、屏幕/电池、候选 App 可用性等。
-5. 板子维护 `bridge_connected`、`platform`、`last_heartbeat_at`、`environment` 状态，并把最新手机环境注入 Agent runtime context。
+4. App 在连接成功、从后台回到前台时主动上报 `phone_environment`，包括系统版本、语言地区、时区、屏幕/电池、系统 App、第三方候选 App 可用性等。
+5. 板子维护 `bridge_connected`、`platform`、`last_heartbeat_at`、`environment` 状态。完整环境通过 status API 暴露；Agent runtime context 只注入系统类型/版本、语言地区/时区、屏幕尺寸、已确认可打开第三方候选 App 等摘要。
 
 ### 命令协议
 
@@ -207,12 +207,15 @@ WebSocket 的核心价值：
     "model": "iPhone16,2",
     "screen": {"width_pixels": 1179, "height_pixels": 2556, "scale": 3},
     "battery": {"level": 0.87, "charging": true},
-    "available_apps": [{"name": "WeChat", "available": true}]
+    "system_apps": [{"name": "Camera", "available": true, "category": "system", "availability_source": "builtin"}],
+    "third_party_apps": [{"name": "WeChat", "available": true, "category": "third_party", "availability_source": "can_open_url"}],
+    "available_apps": [{"name": "WeChat", "available": true, "category": "third_party"}]
   }
 }
 ```
 
 `phone_environment` 不对应板子命令 ID，板子只更新 bridge status，不会把它当作工具调用回执。
+`system_apps` 是系统内置 App/能力清单，`third_party_apps` 才是安装/可打开性探测结果。`available_apps` 仅保留为旧板子兼容字段。
 
 #### 命令类型
 

--- a/src/agent/internal/agent/phone_bridge.go
+++ b/src/agent/internal/agent/phone_bridge.go
@@ -64,6 +64,8 @@ type PhoneEnvironment struct {
 	DeviceName       string             `json:"device_name,omitempty"`
 	Screen           PhoneScreenInfo    `json:"screen,omitempty"`
 	Battery          PhoneBatteryInfo   `json:"battery,omitempty"`
+	SystemApps       []AvailableAppInfo `json:"system_apps,omitempty"`
+	ThirdPartyApps   []AvailableAppInfo `json:"third_party_apps,omitempty"`
 	AvailableApps    []AvailableAppInfo `json:"available_apps,omitempty"`
 }
 
@@ -88,11 +90,14 @@ type PhoneBatteryInfo struct {
 }
 
 type AvailableAppInfo struct {
-	Name           string `json:"name"`
-	Available      bool   `json:"available"`
-	IOSURL         string `json:"ios_url,omitempty"`
-	AndroidPackage string `json:"android_package,omitempty"`
-	Error          string `json:"error,omitempty"`
+	Name               string `json:"name"`
+	Available          bool   `json:"available"`
+	Category           string `json:"category,omitempty"`
+	AvailabilitySource string `json:"availability_source,omitempty"`
+	IOSURL             string `json:"ios_url,omitempty"`
+	AndroidPackage     string `json:"android_package,omitempty"`
+	Note               string `json:"note,omitempty"`
+	Error              string `json:"error,omitempty"`
 }
 
 type PhoneBridgeStatus struct {
@@ -386,6 +391,12 @@ func (pb *PhoneBridge) Status() PhoneBridgeStatus {
 }
 
 func clonePhoneEnvironment(env PhoneEnvironment) PhoneEnvironment {
+	if len(env.SystemApps) > 0 {
+		env.SystemApps = append([]AvailableAppInfo(nil), env.SystemApps...)
+	}
+	if len(env.ThirdPartyApps) > 0 {
+		env.ThirdPartyApps = append([]AvailableAppInfo(nil), env.ThirdPartyApps...)
+	}
 	if len(env.AvailableApps) > 0 {
 		env.AvailableApps = append([]AvailableAppInfo(nil), env.AvailableApps...)
 	}
@@ -421,27 +432,16 @@ func phoneBridgeRuntimeContext(status PhoneBridgeStatus) string {
 }
 
 func appendPhoneEnvironmentContext(builder *strings.Builder, env PhoneEnvironment, updatedAt *time.Time) {
-	builder.WriteString("Phone environment:\n")
+	builder.WriteString("Phone environment summary:\n")
 	if updatedAt != nil {
 		builder.WriteString("- environment_updated_at: ")
 		builder.WriteString(updatedAt.UTC().Format(time.RFC3339))
-		builder.WriteByte('\n')
-	}
-	if text := strings.TrimSpace(env.CapturedAt); text != "" {
-		builder.WriteString("- captured_at: ")
-		builder.WriteString(text)
 		builder.WriteByte('\n')
 	}
 	appendNonEmptyLine(builder, "- system: ", joinNonEmpty(", ",
 		firstNonEmptyPhoneField(env.SystemName, env.Platform),
 		env.SystemVersion,
 		boolLabel("tablet", env.IsTablet),
-	))
-	appendNonEmptyLine(builder, "- device: ", joinNonEmpty(", ",
-		env.Manufacturer,
-		env.Brand,
-		env.Model,
-		env.DeviceName,
 	))
 	appendNonEmptyLine(builder, "- locale: ", joinNonEmpty(", ",
 		env.Locale,
@@ -452,11 +452,16 @@ func appendPhoneEnvironmentContext(builder *strings.Builder, env PhoneEnvironmen
 		boolLabel("24h_clock", env.Uses24HourClock),
 	))
 	appendNonEmptyLine(builder, "- screen: ", formatPhoneScreen(env.Screen))
-	appendNonEmptyLine(builder, "- battery: ", formatPhoneBattery(env.Battery))
-	if apps := availableAppNames(env.AvailableApps, 30); len(apps) > 0 {
-		builder.WriteString("- available_apps: ")
+	if apps := availableAppNames(env.ThirdPartyApps, 30); len(apps) > 0 {
+		builder.WriteString("- confirmed_launchable_third_party_apps: ")
 		builder.WriteString(strings.Join(apps, ", "))
 		builder.WriteByte('\n')
+		builder.WriteString("- App list is sampled from Aiden's prepared candidates; apps not listed may still be installed or openable. If the user asks for another app, try open_app by mapping/deeplink and verify with screenshot/HID if needed.\n")
+	} else if apps := availableAppNames(env.AvailableApps, 30); len(apps) > 0 {
+		builder.WriteString("- confirmed_launchable_third_party_apps: ")
+		builder.WriteString(strings.Join(apps, ", "))
+		builder.WriteByte('\n')
+		builder.WriteString("- App list is sampled from Aiden's prepared candidates; apps not listed may still be installed or openable. If the user asks for another app, try open_app by mapping/deeplink and verify with screenshot/HID if needed.\n")
 	}
 }
 

--- a/src/agent/internal/agent/phone_bridge.go
+++ b/src/agent/internal/agent/phone_bridge.go
@@ -22,11 +22,11 @@ const (
 )
 
 type BridgeCommand struct {
-	ID              string          `json:"id"`
-	Type            string          `json:"type"`
-	IOSURLs         []string        `json:"ios_urls,omitempty"`
-	AndroidPackages []string        `json:"android_packages,omitempty"`
-	TimeoutMs       int             `json:"timeout_ms,omitempty"`
+	ID              string   `json:"id"`
+	Type            string   `json:"type"`
+	IOSURLs         []string `json:"ios_urls,omitempty"`
+	AndroidPackages []string `json:"android_packages,omitempty"`
+	TimeoutMs       int      `json:"timeout_ms,omitempty"`
 	// Payload carries command-specific JSON (clipboard text, calendar event,
 	// query window, etc.). Older command types like open_app leave this empty
 	// because their parameters are top-level.
@@ -44,10 +44,63 @@ type BridgeCommandResponse struct {
 	Data json.RawMessage `json:"data,omitempty"`
 }
 
+type PhoneEnvironment struct {
+	CapturedAt       string             `json:"captured_at,omitempty"`
+	Source           string             `json:"source,omitempty"`
+	Platform         string             `json:"platform,omitempty"`
+	SystemName       string             `json:"system_name,omitempty"`
+	SystemVersion    string             `json:"system_version,omitempty"`
+	IsTablet         *bool              `json:"is_tablet,omitempty"`
+	Locale           string             `json:"locale,omitempty"`
+	Language         string             `json:"language,omitempty"`
+	Region           string             `json:"region,omitempty"`
+	TimeZone         string             `json:"time_zone,omitempty"`
+	UTCOffsetMinutes *int               `json:"utc_offset_minutes,omitempty"`
+	UTCOffset        string             `json:"utc_offset,omitempty"`
+	Uses24HourClock  *bool              `json:"uses_24_hour_clock,omitempty"`
+	Manufacturer     string             `json:"manufacturer,omitempty"`
+	Brand            string             `json:"brand,omitempty"`
+	Model            string             `json:"model,omitempty"`
+	DeviceName       string             `json:"device_name,omitempty"`
+	Screen           PhoneScreenInfo    `json:"screen,omitempty"`
+	Battery          PhoneBatteryInfo   `json:"battery,omitempty"`
+	AvailableApps    []AvailableAppInfo `json:"available_apps,omitempty"`
+}
+
+type PhoneScreenInfo struct {
+	Width              *float64 `json:"width,omitempty"`
+	Height             *float64 `json:"height,omitempty"`
+	WidthPixels        *int     `json:"width_pixels,omitempty"`
+	HeightPixels       *int     `json:"height_pixels,omitempty"`
+	NativeWidthPixels  *int     `json:"native_width_pixels,omitempty"`
+	NativeHeightPixels *int     `json:"native_height_pixels,omitempty"`
+	Scale              *float64 `json:"scale,omitempty"`
+	NativeScale        *float64 `json:"native_scale,omitempty"`
+	Density            *float64 `json:"density,omitempty"`
+	DensityDPI         *int     `json:"density_dpi,omitempty"`
+	ScaledDensity      *float64 `json:"scaled_density,omitempty"`
+}
+
+type PhoneBatteryInfo struct {
+	Level    *float64 `json:"level,omitempty"`
+	Charging *bool    `json:"charging,omitempty"`
+	State    string   `json:"state,omitempty"`
+}
+
+type AvailableAppInfo struct {
+	Name           string `json:"name"`
+	Available      bool   `json:"available"`
+	IOSURL         string `json:"ios_url,omitempty"`
+	AndroidPackage string `json:"android_package,omitempty"`
+	Error          string `json:"error,omitempty"`
+}
+
 type PhoneBridgeStatus struct {
-	Connected       bool       `json:"connected"`
-	Platform        string     `json:"platform,omitempty"`
-	LastHeartbeatAt *time.Time `json:"last_heartbeat_at,omitempty"`
+	Connected            bool              `json:"connected"`
+	Platform             string            `json:"platform,omitempty"`
+	LastHeartbeatAt      *time.Time        `json:"last_heartbeat_at,omitempty"`
+	Environment          *PhoneEnvironment `json:"environment,omitempty"`
+	EnvironmentUpdatedAt *time.Time        `json:"environment_updated_at,omitempty"`
 }
 
 type PhoneBridge struct {
@@ -56,6 +109,8 @@ type PhoneBridge struct {
 	connected       bool
 	platform        string
 	lastHeartbeatAt time.Time
+	environment     *PhoneEnvironment
+	environmentAt   time.Time
 	pendingCmds     map[string]chan BridgeCommandResponse
 	logger          *Logger
 	done            chan struct{}
@@ -97,6 +152,8 @@ func (pb *PhoneBridge) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	pb.connected = true
 	pb.platform = platform
 	pb.lastHeartbeatAt = time.Now()
+	pb.environment = nil
+	pb.environmentAt = time.Time{}
 	pb.done = make(chan struct{})
 	done := pb.done
 	pb.mu.Unlock()
@@ -142,6 +199,8 @@ func (pb *PhoneBridge) readLoop(conn *websocket.Conn, done chan struct{}) {
 		if pb.conn == conn {
 			pb.conn = nil
 			pb.connected = false
+			pb.environment = nil
+			pb.environmentAt = time.Time{}
 			for id, ch := range pb.pendingCmds {
 				close(ch)
 				delete(pb.pendingCmds, id)
@@ -172,6 +231,10 @@ func (pb *PhoneBridge) readLoop(conn *websocket.Conn, done chan struct{}) {
 			continue
 		}
 
+		if pb.handleAppEvent(resp) {
+			continue
+		}
+
 		// Echo heartbeat/ping back to the app so it can reset its missedPongs counter.
 		// Without this, the app forces a reconnect every HEARTBEAT_INTERVAL * MAX_MISSED_PONGS.
 		isHeartbeat := resp.ID == "heartbeat" || resp.ID == "ping"
@@ -195,6 +258,46 @@ func (pb *PhoneBridge) readLoop(conn *websocket.Conn, done chan struct{}) {
 		}
 		pb.mu.Unlock()
 	}
+}
+
+func (pb *PhoneBridge) handleAppEvent(resp BridgeCommandResponse) bool {
+	if resp.ID != "phone_environment" && resp.Method != "phone_environment" {
+		return false
+	}
+	if !resp.OK {
+		if pb.logger != nil {
+			pb.logger.Warn("phone-bridge: environment report failed: %s", resp.Error)
+		}
+		return true
+	}
+	if len(resp.Data) == 0 {
+		if pb.logger != nil {
+			pb.logger.Warn("phone-bridge: environment report missing data")
+		}
+		return true
+	}
+
+	var env PhoneEnvironment
+	if err := json.Unmarshal(resp.Data, &env); err != nil {
+		if pb.logger != nil {
+			pb.logger.Error("phone-bridge: decode environment report failed: %v", err)
+		}
+		return true
+	}
+
+	pb.mu.Lock()
+	if strings.TrimSpace(env.Platform) == "" {
+		env.Platform = pb.platform
+	}
+	pb.environment = &env
+	pb.environmentAt = time.Now()
+	pb.lastHeartbeatAt = pb.environmentAt
+	pb.mu.Unlock()
+
+	if pb.logger != nil {
+		pb.logger.Info("phone-bridge: environment updated (platform=%s)", env.Platform)
+	}
+	return true
 }
 
 func (pb *PhoneBridge) SendCommand(ctx context.Context, cmd BridgeCommand) (BridgeCommandResponse, error) {
@@ -271,7 +374,22 @@ func (pb *PhoneBridge) Status() PhoneBridgeStatus {
 		t := pb.lastHeartbeatAt
 		status.LastHeartbeatAt = &t
 	}
+	if pb.connected && pb.environment != nil {
+		env := clonePhoneEnvironment(*pb.environment)
+		status.Environment = &env
+		if !pb.environmentAt.IsZero() {
+			t := pb.environmentAt
+			status.EnvironmentUpdatedAt = &t
+		}
+	}
 	return status
+}
+
+func clonePhoneEnvironment(env PhoneEnvironment) PhoneEnvironment {
+	if len(env.AvailableApps) > 0 {
+		env.AvailableApps = append([]AvailableAppInfo(nil), env.AvailableApps...)
+	}
+	return env
 }
 
 func phoneBridgeRuntimeContext(status PhoneBridgeStatus) string {
@@ -289,6 +407,9 @@ func phoneBridgeRuntimeContext(status PhoneBridgeStatus) string {
 			builder.WriteString(status.LastHeartbeatAt.UTC().Format(time.RFC3339))
 			builder.WriteByte('\n')
 		}
+		if status.Environment != nil {
+			appendPhoneEnvironmentContext(&builder, *status.Environment, status.EnvironmentUpdatedAt)
+		}
 		builder.WriteString("- The phone companion app is connected. Use open_app as the primary path for opening apps, URLs, deeplinks, and phone dialer screens before falling back to screenshot/HID navigation.\n")
 		builder.WriteString("- clipboard, calendar, contacts, and notification tools are available through the companion app: prefer them over manual UI navigation for reading/writing the system clipboard, creating/querying/deleting system calendar events, managing contacts, or sending notifications.\n")
 		builder.WriteString("- If open_app returns {\"ok\":true}, treat the app launch as complete unless the user requested additional in-app actions.")
@@ -297,4 +418,143 @@ func phoneBridgeRuntimeContext(status PhoneBridgeStatus) string {
 	builder.WriteString("- connected: false\n")
 	builder.WriteString("- The phone companion app is not connected. Do not assume open_app, clipboard, calendar, contacts, or notification tools can control the phone; use screenshot plus HID/touch fallback for phone UI tasks, and tell the user when calendar/clipboard/contacts/notification actions cannot be completed without the companion app.")
 	return builder.String()
+}
+
+func appendPhoneEnvironmentContext(builder *strings.Builder, env PhoneEnvironment, updatedAt *time.Time) {
+	builder.WriteString("Phone environment:\n")
+	if updatedAt != nil {
+		builder.WriteString("- environment_updated_at: ")
+		builder.WriteString(updatedAt.UTC().Format(time.RFC3339))
+		builder.WriteByte('\n')
+	}
+	if text := strings.TrimSpace(env.CapturedAt); text != "" {
+		builder.WriteString("- captured_at: ")
+		builder.WriteString(text)
+		builder.WriteByte('\n')
+	}
+	appendNonEmptyLine(builder, "- system: ", joinNonEmpty(", ",
+		firstNonEmptyPhoneField(env.SystemName, env.Platform),
+		env.SystemVersion,
+		boolLabel("tablet", env.IsTablet),
+	))
+	appendNonEmptyLine(builder, "- device: ", joinNonEmpty(", ",
+		env.Manufacturer,
+		env.Brand,
+		env.Model,
+		env.DeviceName,
+	))
+	appendNonEmptyLine(builder, "- locale: ", joinNonEmpty(", ",
+		env.Locale,
+		fieldLabel("language", env.Language),
+		fieldLabel("region", env.Region),
+		fieldLabel("timezone", env.TimeZone),
+		fieldLabel("utc_offset", env.UTCOffset),
+		boolLabel("24h_clock", env.Uses24HourClock),
+	))
+	appendNonEmptyLine(builder, "- screen: ", formatPhoneScreen(env.Screen))
+	appendNonEmptyLine(builder, "- battery: ", formatPhoneBattery(env.Battery))
+	if apps := availableAppNames(env.AvailableApps, 30); len(apps) > 0 {
+		builder.WriteString("- available_apps: ")
+		builder.WriteString(strings.Join(apps, ", "))
+		builder.WriteByte('\n')
+	}
+}
+
+func appendNonEmptyLine(builder *strings.Builder, prefix, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	builder.WriteString(prefix)
+	builder.WriteString(value)
+	builder.WriteByte('\n')
+}
+
+func joinNonEmpty(sep string, values ...string) string {
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			parts = append(parts, trimmed)
+		}
+	}
+	return strings.Join(parts, sep)
+}
+
+func firstNonEmptyPhoneField(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func fieldLabel(label, value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	return label + "=" + value
+}
+
+func boolLabel(label string, value *bool) string {
+	if value == nil {
+		return ""
+	}
+	if *value {
+		return label + "=true"
+	}
+	return label + "=false"
+}
+
+func formatPhoneScreen(screen PhoneScreenInfo) string {
+	parts := make([]string, 0, 4)
+	if screen.WidthPixels != nil && screen.HeightPixels != nil {
+		parts = append(parts, fmt.Sprintf("%dx%d px", *screen.WidthPixels, *screen.HeightPixels))
+	}
+	if screen.Width != nil && screen.Height != nil {
+		parts = append(parts, fmt.Sprintf("%.0fx%.0f pt/dp", *screen.Width, *screen.Height))
+	}
+	if screen.Scale != nil {
+		parts = append(parts, fmt.Sprintf("scale=%.2f", *screen.Scale))
+	}
+	if screen.NativeScale != nil {
+		parts = append(parts, fmt.Sprintf("native_scale=%.2f", *screen.NativeScale))
+	}
+	if screen.DensityDPI != nil {
+		parts = append(parts, fmt.Sprintf("density_dpi=%d", *screen.DensityDPI))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatPhoneBattery(battery PhoneBatteryInfo) string {
+	parts := make([]string, 0, 3)
+	if battery.Level != nil {
+		parts = append(parts, fmt.Sprintf("level=%.0f%%", *battery.Level*100))
+	}
+	if battery.Charging != nil {
+		parts = append(parts, boolLabel("charging", battery.Charging))
+	}
+	if state := strings.TrimSpace(battery.State); state != "" {
+		parts = append(parts, "state="+state)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func availableAppNames(apps []AvailableAppInfo, limit int) []string {
+	names := make([]string, 0, len(apps))
+	for _, app := range apps {
+		if !app.Available {
+			continue
+		}
+		name := strings.TrimSpace(app.Name)
+		if name == "" {
+			continue
+		}
+		names = append(names, name)
+		if limit > 0 && len(names) >= limit {
+			break
+		}
+	}
+	return names
 }

--- a/src/agent/internal/agent/phone_bridge_test.go
+++ b/src/agent/internal/agent/phone_bridge_test.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPhoneBridgeHandlesEnvironmentEvent(t *testing.T) {
+	bridge := NewPhoneBridge(nil)
+	defer bridge.queue.Stop()
+
+	bridge.mu.Lock()
+	bridge.connected = true
+	bridge.platform = "ios"
+	bridge.pendingCmds["phone_environment"] = make(chan BridgeCommandResponse, 1)
+	bridge.mu.Unlock()
+
+	handled := bridge.handleAppEvent(BridgeCommandResponse{
+		ID:     "phone_environment",
+		OK:     true,
+		Method: "phone_environment",
+		Data: json.RawMessage(`{
+			"captured_at":"2026-06-01T02:03:05Z",
+			"system_name":"iOS",
+			"system_version":"18.5",
+			"locale":"zh-Hans-CN",
+			"available_apps":[
+				{"name":"WeChat","available":true},
+				{"name":"Douyin","available":false}
+			]
+		}`),
+	})
+	if !handled {
+		t.Fatal("environment event was not handled")
+	}
+
+	status := bridge.Status()
+	if status.Environment == nil {
+		t.Fatal("expected environment in status")
+	}
+	if status.Environment.Platform != "ios" {
+		t.Fatalf("environment platform = %q, want ios", status.Environment.Platform)
+	}
+	if status.Environment.SystemName != "iOS" {
+		t.Fatalf("environment system_name = %q, want iOS", status.Environment.SystemName)
+	}
+	if got := len(status.Environment.AvailableApps); got != 2 {
+		t.Fatalf("available app count = %d, want 2", got)
+	}
+	if status.EnvironmentUpdatedAt == nil {
+		t.Fatal("expected environment_updated_at")
+	}
+
+	bridge.mu.Lock()
+	_, pendingStillExists := bridge.pendingCmds["phone_environment"]
+	bridge.mu.Unlock()
+	if !pendingStillExists {
+		t.Fatal("environment event should not consume pending command responses")
+	}
+}

--- a/src/agent/internal/agent/phone_bridge_test.go
+++ b/src/agent/internal/agent/phone_bridge_test.go
@@ -24,6 +24,13 @@ func TestPhoneBridgeHandlesEnvironmentEvent(t *testing.T) {
 			"system_name":"iOS",
 			"system_version":"18.5",
 			"locale":"zh-Hans-CN",
+			"system_apps":[
+				{"name":"Camera","available":true,"category":"system","availability_source":"builtin"}
+			],
+			"third_party_apps":[
+				{"name":"WeChat","available":true,"category":"third_party","availability_source":"can_open_url"},
+				{"name":"Douyin","available":false,"category":"third_party","availability_source":"can_open_url"}
+			],
 			"available_apps":[
 				{"name":"WeChat","available":true},
 				{"name":"Douyin","available":false}
@@ -44,8 +51,11 @@ func TestPhoneBridgeHandlesEnvironmentEvent(t *testing.T) {
 	if status.Environment.SystemName != "iOS" {
 		t.Fatalf("environment system_name = %q, want iOS", status.Environment.SystemName)
 	}
-	if got := len(status.Environment.AvailableApps); got != 2 {
-		t.Fatalf("available app count = %d, want 2", got)
+	if got := len(status.Environment.SystemApps); got != 1 {
+		t.Fatalf("system app count = %d, want 1", got)
+	}
+	if got := len(status.Environment.ThirdPartyApps); got != 2 {
+		t.Fatalf("third-party app count = %d, want 2", got)
 	}
 	if status.EnvironmentUpdatedAt == nil {
 		t.Fatal("expected environment_updated_at")

--- a/src/agent/internal/agent/prompt_test.go
+++ b/src/agent/internal/agent/prompt_test.go
@@ -281,25 +281,35 @@ func TestPhoneBridgeRuntimeContextIncludesPhoneEnvironment(t *testing.T) {
 			Manufacturer:    "Apple",
 			Brand:           "Apple",
 			Model:           "iPhone16,2",
-			DeviceName:      "Qing's iPhone",
+			DeviceName:      "User device",
 			Screen:          PhoneScreenInfo{WidthPixels: testIntPtr(1179), HeightPixels: testIntPtr(2556), Scale: testFloatPtr(3)},
 			Battery:         PhoneBatteryInfo{Level: testFloatPtr(0.87), Charging: testBoolPtr(true), State: "charging"},
-			AvailableApps:   []AvailableAppInfo{{Name: "WeChat", Available: true}, {Name: "Douyin", Available: false}, {Name: "Alipay", Available: true}},
+			SystemApps:      []AvailableAppInfo{{Name: "Camera", Available: true}, {Name: "Contacts", Available: true}},
+			ThirdPartyApps:  []AvailableAppInfo{{Name: "WeChat", Available: true}, {Name: "Douyin", Available: false}, {Name: "Alipay", Available: true}},
 		},
 	})
 
 	for _, want := range []string{
-		"Phone environment:",
+		"Phone environment summary:",
 		"- environment_updated_at: 2026-06-01T02:03:05Z",
 		"- system: iOS, 18.5, tablet=false",
-		"- device: Apple, Apple, iPhone16,2, Qing's iPhone",
 		"- locale: zh-Hans-CN, language=zh, region=CN, timezone=Asia/Shanghai, utc_offset=+08:00, 24h_clock=true",
 		"- screen: 1179x2556 px, scale=3.00",
-		"- battery: level=87%, charging=true, state=charging",
-		"- available_apps: WeChat, Alipay",
+		"- confirmed_launchable_third_party_apps: WeChat, Alipay",
+		"apps not listed may still be installed or openable",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("runtime context missing %q:\n%s", want, got)
+		}
+	}
+	for _, notWant := range []string{
+		"User device",
+		"- device:",
+		"- battery:",
+		"- system_apps:",
+	} {
+		if strings.Contains(got, notWant) {
+			t.Fatalf("runtime context should not include %q:\n%s", notWant, got)
 		}
 	}
 }

--- a/src/agent/internal/agent/prompt_test.go
+++ b/src/agent/internal/agent/prompt_test.go
@@ -258,6 +258,52 @@ func TestPhoneBridgeRuntimeContextConnected(t *testing.T) {
 	}
 }
 
+func TestPhoneBridgeRuntimeContextIncludesPhoneEnvironment(t *testing.T) {
+	lastHeartbeat := time.Date(2026, 6, 1, 2, 3, 4, 0, time.UTC)
+	environmentUpdatedAt := time.Date(2026, 6, 1, 2, 3, 5, 0, time.UTC)
+	got := phoneBridgeRuntimeContext(PhoneBridgeStatus{
+		Connected:            true,
+		Platform:             "ios",
+		LastHeartbeatAt:      &lastHeartbeat,
+		EnvironmentUpdatedAt: &environmentUpdatedAt,
+		Environment: &PhoneEnvironment{
+			CapturedAt:      "2026-06-01T02:03:05Z",
+			Platform:        "ios",
+			SystemName:      "iOS",
+			SystemVersion:   "18.5",
+			IsTablet:        testBoolPtr(false),
+			Locale:          "zh-Hans-CN",
+			Language:        "zh",
+			Region:          "CN",
+			TimeZone:        "Asia/Shanghai",
+			UTCOffset:       "+08:00",
+			Uses24HourClock: testBoolPtr(true),
+			Manufacturer:    "Apple",
+			Brand:           "Apple",
+			Model:           "iPhone16,2",
+			DeviceName:      "Qing's iPhone",
+			Screen:          PhoneScreenInfo{WidthPixels: testIntPtr(1179), HeightPixels: testIntPtr(2556), Scale: testFloatPtr(3)},
+			Battery:         PhoneBatteryInfo{Level: testFloatPtr(0.87), Charging: testBoolPtr(true), State: "charging"},
+			AvailableApps:   []AvailableAppInfo{{Name: "WeChat", Available: true}, {Name: "Douyin", Available: false}, {Name: "Alipay", Available: true}},
+		},
+	})
+
+	for _, want := range []string{
+		"Phone environment:",
+		"- environment_updated_at: 2026-06-01T02:03:05Z",
+		"- system: iOS, 18.5, tablet=false",
+		"- device: Apple, Apple, iPhone16,2, Qing's iPhone",
+		"- locale: zh-Hans-CN, language=zh, region=CN, timezone=Asia/Shanghai, utc_offset=+08:00, 24h_clock=true",
+		"- screen: 1179x2556 px, scale=3.00",
+		"- battery: level=87%, charging=true, state=charging",
+		"- available_apps: WeChat, Alipay",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("runtime context missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestPhoneBridgeRuntimeContextDisconnected(t *testing.T) {
 	got := phoneBridgeRuntimeContext(PhoneBridgeStatus{})
 
@@ -272,3 +318,7 @@ func TestPhoneBridgeRuntimeContextDisconnected(t *testing.T) {
 		}
 	}
 }
+
+func testBoolPtr(v bool) *bool        { return &v }
+func testIntPtr(v int) *int           { return &v }
+func testFloatPtr(v float64) *float64 { return &v }


### PR DESCRIPTION
## Summary
- accept companion-app phone_environment events on the phone bridge
- expose the latest phone environment through bridge status and Agent runtime context
- document protocol v1.1 and add focused PhoneBridge/runtime-context tests

## Test Plan
- `go test ./internal/agent -run "TestPhoneBridge|TestFunctionAgentSystemMessageIncludesRuntimeContext" -count=1`
- `git diff --check`

Note: full `go test ./internal/agent` still fails existing server history count tests: `TestServerHandleChatReturnsToolHistory` and `TestServerHandleChatWithAudioAttachmentUsesSTT`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps can proactively report phone environment (OS, locale, timezone, screen, battery, available apps); the bridge captures this, injects a concise summary into agent runtime context each round, and exposes the latest snapshot in the bridge status.

* **Behavior**
  * App-originated environment events are treated as status updates (not command responses) and the environment is cleared on disconnect.

* **Documentation**
  * Protocol docs updated to v1.1 with phone-environment event details and examples.

* **Tests**
  * Added unit tests validating environment handling and runtime-context generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->