### PR TITLE
fix(build): clean stale rootfs overlay staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Verify release scripts
         run: |
           sh scripts/test_release_ci_scripts.sh
+          bash scripts/test_clean_rootfs_overlay_staging.sh
           bash scripts/test_reproducible_rootfs_policy.sh
           bash scripts/test_compress_release_images.sh
           bash scripts/test_ota_manifest_generation.sh

--- a/_build_image.sh
+++ b/_build_image.sh
@@ -117,6 +117,8 @@ if [ ! -d "$DEST_OVERLAY" ]; then
     exit 1
 fi
 
+"$SCRIPT_DIR/scripts/clean_rootfs_overlay_staging.sh" --dest-overlay "$DEST_OVERLAY"
+
 # 只复制 etc 目录到 buildroot overlay
 if [ -d "$OVERLAY/etc" ]; then
     mkdir -p "$DEST_OVERLAY/etc"

--- a/scripts/clean_rootfs_overlay_staging.sh
+++ b/scripts/clean_rootfs_overlay_staging.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  clean_rootfs_overlay_staging.sh --dest-overlay DIR
+
+Remove stale generated files from the pico-sdk rootfs overlay staging tree.
+USAGE
+}
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+die() {
+  log "clean_rootfs_overlay_staging.sh: $*"
+  exit 1
+}
+
+dest_overlay=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dest-overlay)
+      dest_overlay="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "$dest_overlay" ] || die "missing --dest-overlay"
+[ -d "$dest_overlay" ] || die "missing destination rootfs overlay: $dest_overlay"
+
+remove_stale_path() {
+  local relative_path="$1"
+  local path="$dest_overlay/$relative_path"
+
+  case "$relative_path" in
+    ""|/*|*../*) die "invalid stale rootfs overlay path: $relative_path" ;;
+  esac
+
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    rm -rf -- "$path"
+    log "Removed stale rootfs overlay path: $relative_path"
+  fi
+}
+
+# Bundled skills moved from rootfs to OEM staging in 6abb8de. Old dev branches
+# can still leave this directory in the shared self-hosted runner workspace.
+remove_stale_path "usr/share/aiden/skills"

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -65,6 +65,16 @@ if ! grep -q './build.sh sysdrv' "$ROOT_DIR/_build_image.sh" || \
     exit 1
 fi
 
+if [ ! -x "$ROOT_DIR/scripts/clean_rootfs_overlay_staging.sh" ]; then
+    echo "rootfs overlay cleanup script must exist and be executable" >&2
+    exit 1
+fi
+
+if ! grep -Fq 'scripts/clean_rootfs_overlay_staging.sh" --dest-overlay "$DEST_OVERLAY"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must clean stale rootfs overlay staging before syncing current rootfs assets" >&2
+    exit 1
+fi
+
 if ! grep -Fq 'BENCHMARK_SRC="$SCRIPT_DIR/benchmark"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq 'BENCHMARK_DEST="$OVERLAY/userdata/agent/benchmark"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq -- "--exclude '__pycache__/'" "$ROOT_DIR/_build_image.sh" || \

--- a/scripts/test_clean_rootfs_overlay_staging.sh
+++ b/scripts/test_clean_rootfs_overlay_staging.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+CLEAN_SCRIPT="$ROOT_DIR/scripts/clean_rootfs_overlay_staging.sh"
+
+if [ ! -x "$CLEAN_SCRIPT" ]; then
+    echo "missing executable rootfs overlay cleanup script: $CLEAN_SCRIPT" >&2
+    exit 1
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+dest_overlay="$tmpdir/dest-overlay"
+mkdir -p "$dest_overlay/etc/init.d"
+mkdir -p "$dest_overlay/usr/share/aiden/skills/planner"
+mkdir -p "$dest_overlay/usr/share/aiden/skills/device-operator"
+mkdir -p "$dest_overlay/usr/share/aiden"
+
+printf 'service\n' > "$dest_overlay/etc/init.d/S53agent"
+printf 'mapping\n' > "$dest_overlay/usr/share/aiden/app_mapping.json"
+printf 'planner\n' > "$dest_overlay/usr/share/aiden/skills/planner/SKILL.md"
+printf 'operator\n' > "$dest_overlay/usr/share/aiden/skills/device-operator/SKILL.md"
+
+"$CLEAN_SCRIPT" --dest-overlay "$dest_overlay"
+
+if [ -e "$dest_overlay/usr/share/aiden/skills" ]; then
+    echo "cleanup script must remove legacy rootfs bundled skills staging" >&2
+    exit 1
+fi
+
+if [ "$(cat "$dest_overlay/usr/share/aiden/app_mapping.json")" != "mapping" ]; then
+    echo "cleanup script must preserve rootfs app mapping staging" >&2
+    exit 1
+fi
+
+if [ "$(cat "$dest_overlay/etc/init.d/S53agent")" != "service" ]; then
+    echo "cleanup script must preserve rootfs etc staging" >&2
+    exit 1
+fi
+
+if "$CLEAN_SCRIPT" --dest-overlay "$tmpdir/missing" 2>"$tmpdir/missing.err"; then
+    echo "cleanup script must fail for a missing destination overlay" >&2
+    exit 1
+fi
+if ! grep -q 'missing destination rootfs overlay' "$tmpdir/missing.err"; then
+    echo "cleanup script must explain missing destination overlay errors" >&2
+    exit 1
+fi
+
+echo "rootfs overlay cleanup tests passed"

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -113,6 +113,7 @@ if grep -q 'scripts/test_build_scripts.sh' "$CI_WORKFLOW"; then
 fi
 
 if ! grep -q 'scripts/test_release_ci_scripts.sh' "$CI_WORKFLOW" || \
+   ! grep -q 'scripts/test_clean_rootfs_overlay_staging.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_github_release_upload.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_compress_release_images.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_ota_manifest_generation.sh' "$CI_WORKFLOW" || \


### PR DESCRIPTION
## Summary
- add a rootfs overlay cleanup script for stale generated staging paths
- remove legacy `/usr/share/aiden/skills` rootfs staging before syncing current rootfs assets
- cover the cleanup script in CI release checks

## Tests
- `bash scripts/test_clean_rootfs_overlay_staging.sh`
- `sh scripts/test_release_ci_scripts.sh`
- `sh scripts/test_build_scripts.sh`
- `bash scripts/test_reproducible_rootfs_policy.sh`
- `bash scripts/test_compress_release_images.sh`
- `bash scripts/test_ota_manifest_generation.sh`
- `bash scripts/test_reusable_rootfs_release_asset.sh`
- `bash scripts/test_github_release_upload.sh`