### PR TITLE
fix(agent/memory): seed lastPromptTokens from hot window on cold start

### DIFF
--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -391,7 +391,7 @@ func (m *MemoryManager) loadPersistedMessages(history *langmemory.ChatMessageHis
 	if m.storageDir == "" {
 		return nil
 	}
-	if records, ok, err := m.loadSessionMessageRecords(agentName); err != nil {
+	if records, hotWindowTokens, ok, err := m.loadSessionMessageRecords(agentName); err != nil {
 		return err
 	} else if ok {
 		// Hot-window boundary markers are NOT stored here. They are synthetic
@@ -409,6 +409,17 @@ func (m *MemoryManager) loadPersistedMessages(history *langmemory.ChatMessageHis
 			return fmt.Errorf("restore session events for %q: %w", agentName, err)
 		}
 		m.eventCount[agentName] = len(records)
+		// Cold-start seeding: a fresh process has lastPromptTokens == 0, which
+		// makes the first shouldCompress skip the token-driven branch and fall
+		// back to the coarse event-count heuristic. Seed it from the estimated
+		// size of the hot window just read off disk so token-driven compaction
+		// stays accurate on the very first turn after a restart. Only seed when
+		// no live prompt token count has been recorded yet, so we never clobber
+		// a value set by an in-flight turn. Caller holds m.mu, so assign the
+		// field directly rather than via SetLastPromptTokens (non-reentrant).
+		if m.lastPromptTokens == 0 {
+			m.lastPromptTokens = hotWindowTokens
+		}
 		return nil
 	}
 
@@ -442,23 +453,24 @@ func (m *MemoryManager) loadPersistedMessages(history *langmemory.ChatMessageHis
 	return nil
 }
 
-func (m *MemoryManager) loadSessionMessageRecords(agentName string) ([]MessageRecord, bool, error) {
+func (m *MemoryManager) loadSessionMessageRecords(agentName string) ([]MessageRecord, int, bool, error) {
 	fl := NewFileLock(m.storageDir)
 	if err := fl.Lock(m.lockTimeout); err != nil {
-		return nil, false, fmt.Errorf("lock for loading session events %q: %w", agentName, err)
+		return nil, 0, false, fmt.Errorf("lock for loading session events %q: %w", agentName, err)
 	}
 	defer fl.Unlock()
 
 	file, err := os.Open(m.sessionEventsPath())
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, false, nil
+			return nil, 0, false, nil
 		}
-		return nil, false, fmt.Errorf("read session events for %q: %w", agentName, err)
+		return nil, 0, false, fmt.Errorf("read session events for %q: %w", agentName, err)
 	}
 	defer file.Close()
 
 	var records []MessageRecord
+	hotWindowTokens := 0
 	validData := make([]byte, 0)
 	repairedTruncatedTail := false
 	scanner := bufio.NewScanner(file)
@@ -474,17 +486,21 @@ func (m *MemoryManager) loadSessionMessageRecords(agentName string) ([]MessageRe
 				repairedTruncatedTail = true
 				break
 			}
-			return nil, false, fmt.Errorf("decode session event for %q: %w", agentName, err)
+			return nil, 0, false, fmt.Errorf("decode session event for %q: %w", agentName, err)
 		}
 		validData = append(validData, line...)
 		validData = append(validData, '\n')
+		// Accumulate the token estimate over every persisted event (not just
+		// those that become message records) so the seeded value matches
+		// sumSessionEventTokens over the same on-disk hot window.
+		hotWindowTokens += estimateSessionEventTokens(event)
 		record, ok := messageRecordFromSessionEvent(event)
 		if ok {
 			records = append(records, record)
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, false, fmt.Errorf("scan session events for %q: %w", agentName, err)
+		return nil, 0, false, fmt.Errorf("scan session events for %q: %w", agentName, err)
 	}
 	if repairedTruncatedTail {
 		if err := writeFileAtomic(m.sessionEventsPath(), validData, 0o644); err != nil {
@@ -495,7 +511,7 @@ func (m *MemoryManager) loadSessionMessageRecords(agentName string) ([]MessageRe
 			m.logger.Warn("[memory] repaired truncated session events for %q", agentName)
 		}
 	}
-	return records, true, nil
+	return records, hotWindowTokens, true, nil
 }
 
 func (m *MemoryManager) persistSnapshot(agentName string, records []MessageRecord) error {
@@ -1008,8 +1024,18 @@ func (m *MemoryManager) shouldCompress(eventCount int) bool {
 		// Token data available but thresholds not reached - don't compress
 		return false
 	}
-	// Event count fallback: only used when token data unavailable (cold start,
-	// unknown model, or before first LLM call).
+	// Event-count fallback. This is a DEFENSIVE backstop, not a normal path:
+	// effectiveContextWindow always returns >= 32000 (normalizeMemoryExtractionConfig
+	// and DefaultMemoryExtractionConfig both floor it), and runtime sets
+	// lastPromptTokens via SetLastPromptTokens before requesting maintenance, so
+	// the token branch above governs every steady-state decision. Cold starts are
+	// seeded from the on-disk hot window in loadPersistedMessages, keeping them on
+	// the token branch too. This line only fires if lastPromptTokens is still 0
+	// when maintenance runs (e.g. maintenance racing ahead of the first LLM call,
+	// or a hot window that estimates to 0 tokens). It is kept as the only safety
+	// net that does not depend on any external timing contract: it counts the
+	// events in hand and guarantees the stream cannot grow without bound even if
+	// token bookkeeping is unavailable.
 	return eventCount > m.countCompressAfterEvents()
 }
 

--- a/src/agent/internal/agent/memory_context_window_test.go
+++ b/src/agent/internal/agent/memory_context_window_test.go
@@ -267,3 +267,65 @@ func TestMaintainFilesystemMemoryUpdatesLastPromptTokens(t *testing.T) {
 		t.Fatalf("second maintainFilesystemMemory created new chunks (spurious re-compression); before=%d, after=%d", len(chunksBefore), len(chunksAfter))
 	}
 }
+
+// TestColdStartSeedsLastPromptTokensFromHotWindow verifies that loading a
+// persisted session on a fresh MemoryManager (process restart) seeds
+// lastPromptTokens from the estimated size of the hot window read off disk.
+//
+// Without this, the first shouldCompress after a restart sees
+// lastPromptTokens == 0, skips the token-driven branch entirely, and falls
+// back to the coarse event-count heuristic — which treats a hot window of
+// large events the same as one of tiny events. Seeding restores token-driven
+// compaction precision on the very first turn after a cold start.
+func TestColdStartSeedsLastPromptTokensFromHotWindow(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+
+	cfg := DefaultMemoryExtractionConfig()
+	cfg.ContextWindow = 10_000
+
+	// Phase 1: a prior session writes events to disk, then "shuts down".
+	sessionDir := filepath.Join(storageDir, "session")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session: %v", err)
+	}
+	session := NewSessionMemoryStore(sessionDir)
+	now := time.Now().UTC()
+	for i := 0; i < 6; i++ {
+		if _, err := session.AppendEvent(ctx, SessionEvent{
+			EventID: fmt.Sprintf("evt_%d", i),
+			Ts:      now.Format(time.RFC3339Nano),
+			Type:    "user_input",
+			Role:    "user",
+			Content: tokenSizedContent(50), // ~50 tokens each
+		}); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+
+	events, err := session.readEvents(session.eventsPath())
+	if err != nil {
+		t.Fatalf("readEvents: %v", err)
+	}
+	wantTokens := sumSessionEventTokens(events)
+	if wantTokens <= 0 {
+		t.Fatalf("test setup: expected positive token estimate, got %d", wantTokens)
+	}
+
+	// Phase 2: cold start — a brand new manager loads the persisted session.
+	mgr := NewMemoryManager(storageDir,
+		WithExtractionConfig(cfg),
+		WithContextWindowFn(func() int { return 10_000 }),
+	)
+	if got := mgr.LastPromptTokens(); got != 0 {
+		t.Fatalf("precondition: fresh manager should start at 0 tokens, got %d", got)
+	}
+
+	if _, err := mgr.Get("default", MemoryConfig{Type: "window", WindowSize: 10}); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got := mgr.LastPromptTokens(); got != wantTokens {
+		t.Fatalf("cold start should seed lastPromptTokens from hot window estimate; got %d, want %d", got, wantTokens)
+	}
+}


### PR DESCRIPTION
## Summary

Restores token-driven compaction precision on the first turn after a process restart.

A fresh `MemoryManager` starts with `lastPromptTokens == 0`, which made the first `shouldCompress` after a restart skip the token branch entirely (the guard is `lastPromptTokens > 0 && contextWindow > 0`) and fall back to the count-only heuristic. With a hot window of large events — e.g. heavy tool results that survived the previous session's last compaction — this could let the first prompt run close to the context window without compacting, or leave compaction precision degraded until `runtime.go` records the first real `metrics.LastPromptTokens` after the next LLM call.

## Approach

Seed `lastPromptTokens` during `loadPersistedMessages` by accumulating `estimateSessionEventTokens` over every parsed `SessionEvent` in the existing scan loop. This piggybacks on the JSON decode that already happens — no extra I/O, no extra unmarshal — and produces the same value `sumSessionEventTokens` would compute over the same hot window, keeping the cold-start seed consistent with the post-compaction assignment in `maintainFilesystemMemory` (`SetLastPromptTokens(cutMeta.KeptTokensEstimate)`).

Why re-estimate instead of persisting the old value: it avoids introducing a new piece of state that could desync from `events.jsonl`, and it stays accurate even if the file was modified between sessions.

The seed only applies when `lastPromptTokens == 0`, so an in-flight turn that already wrote a live value cannot be clobbered. The assignment runs under the `m.mu` the caller already holds, so it writes the field directly rather than going through the non-reentrant `SetLastPromptTokens`.

## Tested

- New unit test `TestColdStartSeedsLastPromptTokensFromHotWindow` writes events via `SessionMemoryStore.AppendEvent`, then loads them with a fresh `MemoryManager` and asserts `LastPromptTokens()` equals `sumSessionEventTokens(events)`.
- `go test ./internal/agent/ -count=1` — full agent package green (~31s).
- `go vet ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token count initialization from persisted session data on application startup, enabling proper token-based logic for message management immediately upon launch.

* **Tests**
  * Added test validating token count initialization during cold-start scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->