### PR TITLE
feat: persist playback volume

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(aiden STATIC
     src/frame_service_protocol.cpp
     src/frame_service_server.cpp
     src/audio_service_protocol.cpp
+    src/audio_volume_state.cpp
     src/audio_record_session.cpp
     src/audio_playback_session.cpp
     src/audio_session_manager.cpp

--- a/overlay/etc/aiden_audio_service.conf
+++ b/overlay/etc/aiden_audio_service.conf
@@ -4,6 +4,7 @@
 AUDIO_SERVICE_BIN=/oem/usr/bin/audio_service
 
 SOCKET_PATH=/run/audio_service/audio_service.sock
+VOLUME_STATE_PATH=/userdata/audio_service/playback_volume
 LOG_PATH=/var/log/audio_service/audio_service.log
 PID_FILE=/run/audio_service/audio_service.pid
 WATCHDOG_PID_FILE=/run/audio_service/audio_service_watchdog.pid

--- a/overlay/etc/init.d/S53audio_service
+++ b/overlay/etc/init.d/S53audio_service
@@ -10,6 +10,7 @@ BOOT_CONF=/etc/aiden_boot.conf
 AUDIO_SERVICE_BIN=/oem/usr/bin/audio_service
 ENV_RUN_BIN=${ENV_RUN_BIN:-/oem/usr/bin/aiden-env-run}
 SOCKET_PATH=/run/audio_service/audio_service.sock
+VOLUME_STATE_PATH=/userdata/audio_service/playback_volume
 LOG_PATH=/var/log/audio_service/audio_service.log
 PID_FILE=/run/audio_service/audio_service.pid
 WATCHDOG_PID_FILE=/run/audio_service/audio_service_watchdog.pid
@@ -21,6 +22,7 @@ if [ -f "$BOOT_CONF" ]; then
     . "$BOOT_CONF"
 fi
 : "${ENABLE_AUDIO_SERVICE:=1}"
+: "${VOLUME_STATE_PATH:=/userdata/audio_service/playback_volume}"
 
 is_running() {
     pid="$1"
@@ -100,8 +102,8 @@ start() {
                 continue
             fi
 
-            echo "[audio_service] starting $AUDIO_SERVICE_BIN --socket $SOCKET_PATH" >> "$LOG_PATH"
-            "$ENV_RUN_BIN" "$AUDIO_SERVICE_BIN" --socket "$SOCKET_PATH" >> "$LOG_PATH" 2>&1 &
+            echo "[audio_service] starting $AUDIO_SERVICE_BIN --socket $SOCKET_PATH --volume-state $VOLUME_STATE_PATH" >> "$LOG_PATH"
+            "$ENV_RUN_BIN" "$AUDIO_SERVICE_BIN" --socket "$SOCKET_PATH" --volume-state "$VOLUME_STATE_PATH" >> "$LOG_PATH" 2>&1 &
             child="$!"
             echo "$child" > "$PID_FILE"
             wait "$child"

--- a/src/audio_service_main.cpp
+++ b/src/audio_service_main.cpp
@@ -1,4 +1,5 @@
 #include "audio_service_server.h"
+#include "audio_volume_state.h"
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -17,10 +18,11 @@ void signal_handler(int) {
 
 struct Options {
     std::string socket_path = "/run/audio_service/audio_service.sock";
+    std::string volume_state_path = aiden::kDefaultAudioVolumeStatePath;
 };
 
 void usage(const char* program) {
-    fprintf(stderr, "Usage: %s [--socket PATH]\n", program);
+    fprintf(stderr, "Usage: %s [--socket PATH] [--volume-state PATH]\n", program);
 }
 
 bool parse_options(int argc, char** argv, Options* opts) {
@@ -28,11 +30,17 @@ bool parse_options(int argc, char** argv, Options* opts) {
     if (env_socket && env_socket[0] != '\0') {
         opts->socket_path = env_socket;
     }
+    const char* env_volume_state = getenv("AUDIO_SERVICE_VOLUME_STATE");
+    if (env_volume_state && env_volume_state[0] != '\0') {
+        opts->volume_state_path = env_volume_state;
+    }
 
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
         if (arg == "--socket" && i + 1 < argc) {
             opts->socket_path = argv[++i];
+        } else if (arg == "--volume-state" && i + 1 < argc) {
+            opts->volume_state_path = argv[++i];
         } else if (arg == "--help") {
             usage(argv[0]);
             exit(0);
@@ -57,7 +65,8 @@ int main(int argc, char** argv) {
     signal(SIGHUP,  SIG_IGN);
     signal(SIGPIPE, SIG_IGN);
 
-    aiden::AudioServiceServer server(opts.socket_path.c_str());
+    aiden::AudioServiceServer server(opts.socket_path.c_str(),
+                                     opts.volume_state_path.c_str());
     if (server.start() != aiden::AidenServiceStatus::OK) {
         fprintf(stderr, "[audio_service] Failed to start socket at %s\n",
                 opts.socket_path.c_str());

--- a/src/audio_service_server.cpp
+++ b/src/audio_service_server.cpp
@@ -34,10 +34,15 @@ static void send_response(int fd, AidenServiceStatus status,
 // -----------------------------------------------------------------------
 
 AudioServiceServer::AudioServiceServer(const char* socket_path)
+    : AudioServiceServer(socket_path, nullptr) {}
+
+AudioServiceServer::AudioServiceServer(const char* socket_path,
+                                       const char* volume_state_path)
     : uds_server_(new UdsServer(socket_path ? socket_path : "",
                                 [this](const UdsMessage& req, int fd) {
                                     handle_request(req, fd);
-                                })) {}
+                                })),
+      manager_(volume_state_path) {}
 
 AudioServiceServer::~AudioServiceServer() {
     stop();

--- a/src/audio_service_server.h
+++ b/src/audio_service_server.h
@@ -12,6 +12,7 @@ namespace aiden {
 class AudioServiceServer {
 public:
     explicit AudioServiceServer(const char* socket_path);
+    AudioServiceServer(const char* socket_path, const char* volume_state_path);
     ~AudioServiceServer();
 
     AidenServiceStatus start();

--- a/src/audio_session_manager.cpp
+++ b/src/audio_session_manager.cpp
@@ -1,4 +1,5 @@
 #include "audio_session_manager.h"
+#include "audio_volume_state.h"
 #include <chrono>
 #include <stdio.h>
 #include <vector>
@@ -6,10 +7,33 @@
 namespace aiden {
 
 AudioSessionManager::AudioSessionManager()
+    : AudioSessionManager(nullptr) {}
+
+AudioSessionManager::AudioSessionManager(const char* volume_state_path)
     : stop_reaper_(false),
       draining_playback_count_(std::make_shared<std::atomic<uint32_t>>(0)),
+      volume_state_path_(volume_state_path ? volume_state_path : ""),
       playback_volume_(100),
+      last_persisted_playback_volume_(-1),
       next_id_(1) {
+    if (!volume_state_path_.empty()) {
+        int persisted_volume = 100;
+        std::string error;
+        AudioVolumeStateLoadStatus load_status =
+            load_playback_volume_state(volume_state_path_.c_str(), &persisted_volume, &error);
+        if (load_status == AudioVolumeStateLoadStatus::LOADED) {
+            playback_volume_ = persisted_volume;
+            last_persisted_playback_volume_ = persisted_volume;
+            fprintf(stderr, "[audio_service] loaded playback volume %d from %s\n",
+                    playback_volume_, volume_state_path_.c_str());
+        } else if (load_status == AudioVolumeStateLoadStatus::MISSING) {
+            last_persisted_playback_volume_ = playback_volume_;
+        } else if (load_status == AudioVolumeStateLoadStatus::INVALID ||
+                   load_status == AudioVolumeStateLoadStatus::ERROR) {
+            fprintf(stderr, "[audio_service] ignoring playback volume state %s: %s\n",
+                    volume_state_path_.c_str(), error.c_str());
+        }
+    }
     reaper_thread_ = std::thread([this]() { reaper_loop(); });
 }
 
@@ -29,6 +53,21 @@ AudioSessionManager::~AudioSessionManager() {
 
 uint64_t AudioSessionManager::next_session_id() {
     return next_id_++;
+}
+
+void AudioSessionManager::persist_playback_volume_if_changed(int volume) {
+    if (volume_state_path_.empty() || volume == last_persisted_playback_volume_) {
+        return;
+    }
+
+    std::string error;
+    if (!save_playback_volume_state(volume_state_path_.c_str(), volume, &error)) {
+        fprintf(stderr, "[audio_service] failed to persist playback volume to %s: %s\n",
+                volume_state_path_.c_str(), error.c_str());
+        return;
+    }
+
+    last_persisted_playback_volume_ = volume;
 }
 
 // -----------------------------------------------------------------------
@@ -216,6 +255,7 @@ AidenServiceStatus AudioSessionManager::set_playback_volume(int volume) {
         return AidenServiceStatus::INTERNAL_ERROR;
     }
 
+    std::lock_guard<std::mutex> volume_lock(volume_set_mutex_);
     std::vector<std::shared_ptr<AudioPlaybackSession>> sessions;
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -230,6 +270,7 @@ AidenServiceStatus AudioSessionManager::set_playback_volume(int volume) {
             return AidenServiceStatus::INTERNAL_ERROR;
         }
     }
+    persist_playback_volume_if_changed(volume);
     fprintf(stderr, "[audio_service] playback volume set to %d\n", volume);
     return AidenServiceStatus::OK;
 }

--- a/src/audio_session_manager.cpp
+++ b/src/audio_session_manager.cpp
@@ -55,19 +55,20 @@ uint64_t AudioSessionManager::next_session_id() {
     return next_id_++;
 }
 
-void AudioSessionManager::persist_playback_volume_if_changed(int volume) {
+bool AudioSessionManager::persist_playback_volume_if_changed(int volume) {
     if (volume_state_path_.empty() || volume == last_persisted_playback_volume_) {
-        return;
+        return true;
     }
 
     std::string error;
     if (!save_playback_volume_state(volume_state_path_.c_str(), volume, &error)) {
         fprintf(stderr, "[audio_service] failed to persist playback volume to %s: %s\n",
                 volume_state_path_.c_str(), error.c_str());
-        return;
+        return false;
     }
 
     last_persisted_playback_volume_ = volume;
+    return true;
 }
 
 // -----------------------------------------------------------------------
@@ -270,7 +271,9 @@ AidenServiceStatus AudioSessionManager::set_playback_volume(int volume) {
             return AidenServiceStatus::INTERNAL_ERROR;
         }
     }
-    persist_playback_volume_if_changed(volume);
+    if (!persist_playback_volume_if_changed(volume)) {
+        return AidenServiceStatus::INTERNAL_ERROR;
+    }
     fprintf(stderr, "[audio_service] playback volume set to %d\n", volume);
     return AidenServiceStatus::OK;
 }

--- a/src/audio_session_manager.h
+++ b/src/audio_session_manager.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <unordered_map>
 
@@ -21,6 +22,7 @@ public:
     static const uint32_t kSessionTimeoutMs = 30000;
 
     AudioSessionManager();
+    explicit AudioSessionManager(const char* volume_state_path);
     ~AudioSessionManager();
 
     // --- Recording ---
@@ -63,6 +65,7 @@ private:
     using Clock = std::chrono::steady_clock;
 
     uint64_t next_session_id();
+    void persist_playback_volume_if_changed(int volume);
     void reaper_loop();
     void reap_idle_sessions();
 
@@ -70,7 +73,10 @@ private:
     std::atomic<bool> stop_reaper_;
     std::thread reaper_thread_;
     std::shared_ptr<std::atomic<uint32_t>> draining_playback_count_;
+    std::string volume_state_path_;
+    std::mutex volume_set_mutex_;
     int playback_volume_;
+    int last_persisted_playback_volume_;
     uint64_t next_id_;
     std::unordered_map<uint64_t, std::shared_ptr<AudioRecordSession>>   record_sessions_;
     std::unordered_map<uint64_t, std::shared_ptr<AudioPlaybackSession>> playback_sessions_;

--- a/src/audio_session_manager.h
+++ b/src/audio_session_manager.h
@@ -65,7 +65,7 @@ private:
     using Clock = std::chrono::steady_clock;
 
     uint64_t next_session_id();
-    void persist_playback_volume_if_changed(int volume);
+    bool persist_playback_volume_if_changed(int volume);
     void reaper_loop();
     void reap_idle_sessions();
 

--- a/src/audio_volume_state.cpp
+++ b/src/audio_volume_state.cpp
@@ -43,11 +43,15 @@ bool mkdir_p(const std::string& path, mode_t mode, std::string* error) {
         if (!part.empty()) {
             if (!current.empty() && current[current.size() - 1] != '/') current += "/";
             current += part;
-            if (::mkdir(current.c_str(), mode) != 0 && errno != EEXIST) {
-                set_error(error, "mkdir " + current + ": " + std::strerror(errno));
+            if (::mkdir(current.c_str(), mode) != 0) {
+                if (errno != EEXIST) {
+                    set_error(error, "mkdir " + current + ": " + std::strerror(errno));
+                    return false;
+                }
+            } else if (::chmod(current.c_str(), mode) != 0) {
+                set_error(error, "chmod " + current + ": " + std::strerror(errno));
                 return false;
             }
-            ::chmod(current.c_str(), mode);
         }
         if (next == std::string::npos) break;
         pos = next + 1;
@@ -192,6 +196,22 @@ bool save_playback_volume_state(const char* path,
     if (::rename(tmp.c_str(), state_path.c_str()) != 0) {
         set_error(error, "rename " + tmp + " -> " + state_path + ": " + std::strerror(errno));
         ::unlink(tmp.c_str());
+        return false;
+    }
+
+    std::string dir = parent_dir(state_path);
+    int dirfd = ::open(dir.c_str(), O_RDONLY | O_DIRECTORY);
+    if (dirfd < 0) {
+        set_error(error, "open dir " + dir + ": " + std::strerror(errno));
+        return false;
+    }
+    if (::fsync(dirfd) != 0) {
+        set_error(error, "fsync dir " + dir + ": " + std::strerror(errno));
+        ::close(dirfd);
+        return false;
+    }
+    if (::close(dirfd) != 0) {
+        set_error(error, "close dir " + dir + ": " + std::strerror(errno));
         return false;
     }
 

--- a/src/audio_volume_state.cpp
+++ b/src/audio_volume_state.cpp
@@ -1,0 +1,201 @@
+#include "audio_volume_state.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace aiden {
+
+namespace {
+
+void set_error(std::string* error, const std::string& msg) {
+    if (error) {
+        *error = msg;
+    }
+}
+
+std::string parent_dir(const std::string& path) {
+    size_t slash = path.find_last_of('/');
+    if (slash == std::string::npos) return ".";
+    if (slash == 0) return "/";
+    return path.substr(0, slash);
+}
+
+bool mkdir_p(const std::string& path, mode_t mode, std::string* error) {
+    if (path.empty() || path == ".") return true;
+    if (path == "/") return true;
+
+    std::string current;
+    size_t pos = 0;
+    if (path[0] == '/') {
+        current = "/";
+        pos = 1;
+    }
+
+    while (pos <= path.size()) {
+        size_t next = path.find('/', pos);
+        std::string part = path.substr(pos, next == std::string::npos ? std::string::npos : next - pos);
+        if (!part.empty()) {
+            if (!current.empty() && current[current.size() - 1] != '/') current += "/";
+            current += part;
+            if (::mkdir(current.c_str(), mode) != 0 && errno != EEXIST) {
+                set_error(error, "mkdir " + current + ": " + std::strerror(errno));
+                return false;
+            }
+            ::chmod(current.c_str(), mode);
+        }
+        if (next == std::string::npos) break;
+        pos = next + 1;
+    }
+    return true;
+}
+
+bool write_all(int fd, const char* data, size_t len) {
+    size_t off = 0;
+    while (off < len) {
+        ssize_t n = ::write(fd, data + off, len - off);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (n == 0) return false;
+        off += static_cast<size_t>(n);
+    }
+    return true;
+}
+
+}  // namespace
+
+AudioVolumeStateLoadStatus load_playback_volume_state(const char* path,
+                                                      int* volume,
+                                                      std::string* error) {
+    if (error) error->clear();
+    if (!path || path[0] == '\0') {
+        set_error(error, "volume state path is empty");
+        return AudioVolumeStateLoadStatus::ERROR;
+    }
+    if (!volume) {
+        set_error(error, "volume output is null");
+        return AudioVolumeStateLoadStatus::ERROR;
+    }
+
+    FILE* fp = std::fopen(path, "r");
+    if (!fp) {
+        if (errno == ENOENT) {
+            return AudioVolumeStateLoadStatus::MISSING;
+        }
+        set_error(error, std::string("open ") + path + ": " + std::strerror(errno));
+        return AudioVolumeStateLoadStatus::ERROR;
+    }
+
+    char buf[64] = {0};
+    errno = 0;
+    if (!std::fgets(buf, sizeof(buf), fp)) {
+        int saved_errno = errno;
+        std::fclose(fp);
+        if (saved_errno != 0) {
+            set_error(error, std::string("read ") + path + ": " + std::strerror(saved_errno));
+            return AudioVolumeStateLoadStatus::ERROR;
+        }
+        set_error(error, "volume state is empty");
+        return AudioVolumeStateLoadStatus::INVALID;
+    }
+
+    char extra[2] = {0};
+    bool too_long = std::fgets(extra, sizeof(extra), fp) != nullptr;
+    std::fclose(fp);
+    if (too_long) {
+        set_error(error, "volume state has trailing content");
+        return AudioVolumeStateLoadStatus::INVALID;
+    }
+
+    errno = 0;
+    char* end = nullptr;
+    long value = std::strtol(buf, &end, 10);
+    if (errno != 0 || end == buf) {
+        set_error(error, "volume state is not an integer");
+        return AudioVolumeStateLoadStatus::INVALID;
+    }
+    while (*end == ' ' || *end == '\t' || *end == '\r' || *end == '\n') {
+        ++end;
+    }
+    if (*end != '\0') {
+        set_error(error, "volume state has invalid trailing characters");
+        return AudioVolumeStateLoadStatus::INVALID;
+    }
+    if (value < 0 || value > 100) {
+        set_error(error, "volume state is out of range 0..100");
+        return AudioVolumeStateLoadStatus::INVALID;
+    }
+
+    *volume = static_cast<int>(value);
+    return AudioVolumeStateLoadStatus::LOADED;
+}
+
+bool save_playback_volume_state(const char* path,
+                                int volume,
+                                std::string* error) {
+    if (error) error->clear();
+    if (!path || path[0] == '\0') {
+        set_error(error, "volume state path is empty");
+        return false;
+    }
+    if (volume < 0 || volume > 100) {
+        set_error(error, "volume must be in range 0..100");
+        return false;
+    }
+
+    std::string state_path(path);
+    if (!mkdir_p(parent_dir(state_path), 0755, error)) {
+        return false;
+    }
+
+    std::string tmp = state_path + ".tmp";
+    int fd = ::open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        set_error(error, "open " + tmp + ": " + std::strerror(errno));
+        return false;
+    }
+    if (::fchmod(fd, 0644) != 0) {
+        set_error(error, "chmod " + tmp + ": " + std::strerror(errno));
+        ::close(fd);
+        ::unlink(tmp.c_str());
+        return false;
+    }
+
+    char buf[16];
+    int len = std::snprintf(buf, sizeof(buf), "%d\n", volume);
+    if (len <= 0 || static_cast<size_t>(len) >= sizeof(buf) ||
+        !write_all(fd, buf, static_cast<size_t>(len))) {
+        set_error(error, "write " + tmp + ": " + std::strerror(errno));
+        ::close(fd);
+        ::unlink(tmp.c_str());
+        return false;
+    }
+
+    if (::fsync(fd) != 0) {
+        set_error(error, "fsync " + tmp + ": " + std::strerror(errno));
+        ::close(fd);
+        ::unlink(tmp.c_str());
+        return false;
+    }
+    if (::close(fd) != 0) {
+        set_error(error, "close " + tmp + ": " + std::strerror(errno));
+        ::unlink(tmp.c_str());
+        return false;
+    }
+    if (::rename(tmp.c_str(), state_path.c_str()) != 0) {
+        set_error(error, "rename " + tmp + " -> " + state_path + ": " + std::strerror(errno));
+        ::unlink(tmp.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+}  // namespace aiden

--- a/src/audio_volume_state.h
+++ b/src/audio_volume_state.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+
+namespace aiden {
+
+static const char kDefaultAudioVolumeStatePath[] =
+    "/userdata/audio_service/playback_volume";
+
+enum class AudioVolumeStateLoadStatus {
+    LOADED,
+    MISSING,
+    INVALID,
+    ERROR,
+};
+
+AudioVolumeStateLoadStatus load_playback_volume_state(const char* path,
+                                                      int* volume,
+                                                      std::string* error = nullptr);
+
+bool save_playback_volume_state(const char* path,
+                                int volume,
+                                std::string* error = nullptr);
+
+}  // namespace aiden

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(AIDEN_TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/src/frame_service_server.cpp
     ${CMAKE_SOURCE_DIR}/src/audio_service_protocol.cpp
     ${CMAKE_SOURCE_DIR}/src/audio_service_client.cpp
+    ${CMAKE_SOURCE_DIR}/src/audio_volume_state.cpp
     ${CMAKE_SOURCE_DIR}/src/cJSON/cJSON.c
 )
 
@@ -111,6 +112,7 @@ add_executable(aiden_tests
     audio_service_protocol_test.cpp
     audio_service_client_test.cpp
     audio_playback_session_test.cpp
+    audio_volume_state_test.cpp
     ${CMAKE_SOURCE_DIR}/src/system_env_parser.cpp
     ${AIDEN_IMAGE_TEST_SOURCES}
     ${AIDEN_TEST_SOURCES}

--- a/tests/audio_volume_state_test.cpp
+++ b/tests/audio_volume_state_test.cpp
@@ -1,0 +1,99 @@
+#include "doctest.h"
+#include "audio_volume_state.h"
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <cstdlib>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace {
+
+struct TempDir {
+    std::string path;
+
+    TempDir() {
+        char tmpl[] = "/tmp/aiden_audio_volume_state_XXXXXX";
+        char* p = ::mkdtemp(tmpl);
+        REQUIRE(p != nullptr);
+        path = p;
+    }
+
+    ~TempDir() {
+        if (!path.empty()) {
+            std::string cmd = "rm -rf '" + path + "'";
+            (void)std::system(cmd.c_str());
+        }
+    }
+};
+
+std::string read_file(const std::string& path) {
+    std::ifstream in(path);
+    std::ostringstream out;
+    out << in.rdbuf();
+    return out.str();
+}
+
+void write_file(const std::string& path, const std::string& text) {
+    std::ofstream out(path);
+    REQUIRE(out.good());
+    out << text;
+}
+
+}  // namespace
+
+TEST_CASE("load_playback_volume_state reports missing file") {
+    TempDir dir;
+    std::string path = dir.path + "/audio_service/playback_volume";
+
+    int volume = 7;
+    std::string error = "unchanged";
+    CHECK(aiden::load_playback_volume_state(path.c_str(), &volume, &error) ==
+          aiden::AudioVolumeStateLoadStatus::MISSING);
+    CHECK(volume == 7);
+}
+
+TEST_CASE("save_playback_volume_state writes integer newline and creates parent directory") {
+    TempDir dir;
+    std::string path = dir.path + "/audio_service/playback_volume";
+
+    std::string error;
+    REQUIRE(aiden::save_playback_volume_state(path.c_str(), 70, &error));
+    CHECK(read_file(path) == "70\n");
+
+    struct stat st;
+    REQUIRE(::stat(path.c_str(), &st) == 0);
+    CHECK((st.st_mode & 0777) == 0644);
+
+    int loaded = 0;
+    CHECK(aiden::load_playback_volume_state(path.c_str(), &loaded, &error) ==
+          aiden::AudioVolumeStateLoadStatus::LOADED);
+    CHECK(loaded == 70);
+}
+
+TEST_CASE("load_playback_volume_state rejects malformed or out-of-range values") {
+    TempDir dir;
+    std::string path = dir.path + "/playback_volume";
+
+    const char* invalid_values[] = {"", "loud\n", "-1\n", "101\n", "70x\n", "70\nx\n"};
+    for (size_t i = 0; i < sizeof(invalid_values) / sizeof(invalid_values[0]); ++i) {
+        write_file(path, invalid_values[i]);
+        int volume = 42;
+        std::string error;
+        CHECK(aiden::load_playback_volume_state(path.c_str(), &volume, &error) ==
+              aiden::AudioVolumeStateLoadStatus::INVALID);
+        CHECK(volume == 42);
+        CHECK_FALSE(error.empty());
+    }
+}
+
+TEST_CASE("save_playback_volume_state rejects out-of-range values") {
+    TempDir dir;
+    std::string path = dir.path + "/playback_volume";
+
+    std::string error;
+    CHECK_FALSE(aiden::save_playback_volume_state(path.c_str(), 101, &error));
+    CHECK_FALSE(error.empty());
+    CHECK(::access(path.c_str(), F_OK) != 0);
+}

--- a/tests/audio_volume_state_test.cpp
+++ b/tests/audio_volume_state_test.cpp
@@ -72,6 +72,20 @@ TEST_CASE("save_playback_volume_state writes integer newline and creates parent 
     CHECK(loaded == 70);
 }
 
+TEST_CASE("save_playback_volume_state does not chmod existing parent directories") {
+    TempDir dir;
+    std::string parent = dir.path + "/audio_service";
+    REQUIRE(::mkdir(parent.c_str(), 0700) == 0);
+    REQUIRE(::chmod(parent.c_str(), 0700) == 0);
+
+    std::string error;
+    REQUIRE(aiden::save_playback_volume_state((parent + "/playback_volume").c_str(), 33, &error));
+
+    struct stat st;
+    REQUIRE(::stat(parent.c_str(), &st) == 0);
+    CHECK((st.st_mode & 0777) == 0700);
+}
+
 TEST_CASE("load_playback_volume_state rejects malformed or out-of-range values") {
     TempDir dir;
     std::string path = dir.path + "/playback_volume";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playback volume is persisted across service restarts, preserving user volume settings.
  * Configurable storage path for saved volume state with a sensible default.
  * Service loads and applies saved volume state on startup.

* **Tests**
  * Added comprehensive tests for volume persistence, validation, permissions, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->