### PR TITLE
fix: resolve WiFi instability on Luckfox Pico Zero

### DIFF
--- a/overlay/etc/init.d/S99hciinit
+++ b/overlay/etc/init.d/S99hciinit
@@ -1,14 +1,18 @@
 #!/bin/sh
 
 check_hciconfig() {
-	if command -v hciattach &> /dev/null; then
+	if command -v hciattach >/dev/null 2>&1; then
 		if lsmod | grep -q "aic8800_fdrv"; then
-			hciattach -s 1500000 /dev/ttyS1 any 1500000 flow nosleep&
-			sleep 2
-			if hciconfig -a | grep -q "hci0"; then
-				hciconfig hci0 up&
+			if [ -c /dev/ttyS1 ]; then
+				hciattach -s 1500000 /dev/ttyS1 any 1500000 flow nosleep || echo "hciattach failed" &
+				sleep 2
+				if hciconfig -a | grep -q "hci0"; then
+					hciconfig hci0 up&
+				else
+					echo "hci0 not found or not available."
+				fi
 			else
-				echo "hci0 not found or not available."
+				echo "/dev/ttyS1 does not exist."
 			fi
 			# DHCP is managed by dhcpcd service (S41dhcpcd)
 			# No need to call udhcpc here to avoid conflicts
@@ -21,7 +25,7 @@ check_hciconfig() {
 
 case $1 in
 	start)
-		check_hciconfig &
+		check_hciconfig
 		;;
 	*)
 		exit 1

--- a/overlay/etc/init.d/S99hciinit
+++ b/overlay/etc/init.d/S99hciinit
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+check_hciconfig() {
+	if command -v hciattach &> /dev/null; then
+		if lsmod | grep -q "aic8800_fdrv"; then
+			hciattach -s 1500000 /dev/ttyS1 any 1500000 flow nosleep&
+			sleep 2
+			if hciconfig -a | grep -q "hci0"; then
+				hciconfig hci0 up&
+			else
+				echo "hci0 not found or not available."
+			fi
+			# DHCP is managed by dhcpcd service (S41dhcpcd)
+			# No need to call udhcpc here to avoid conflicts
+			ifconfig wlan0 up
+		else
+			echo "aic8800_fdrv not found."
+		fi
+	fi
+}
+
+case $1 in
+	start)
+		check_hciconfig &
+		;;
+	*)
+		exit 1
+		;;
+esac

--- a/overlay/oem/usr/bin/wlan_guard.sh
+++ b/overlay/oem/usr/bin/wlan_guard.sh
@@ -155,7 +155,7 @@ recover_wlan() {
 	sleep 2
 	wpa_cli -i "$IFACE" reassociate >/dev/null 2>&1 || true
 	sleep 8
-	udhcpc -n -q -i "$IFACE" >/dev/null 2>&1 || true
+	dhcpcd -n "$IFACE" >/dev/null 2>&1 || true
 }
 
 watch_loop() {

--- a/overlay/oem/usr/ko/insmod_wifi.sh
+++ b/overlay/oem/usr/ko/insmod_wifi.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+# Aiden override of SDK /oem/usr/ko/insmod_wifi.sh.
+#
+# Only change vs. the stock SDK script: the two `insmod aic8800_fdrv.ko`
+# load points pass `he_on=0` to disable 802.11ax (HE).
+#
+# Why: on the Luckfox Pico Zero (AIC8800DC) the HE *receive* path is broken
+# against APs that beacon 802.11ax on 2.4GHz. The chip associates and
+# transmits fine at HE rates, but cannot decode incoming HE data frames, so
+# DHCP/ICMP/TCP replies are lost while low-rate frames (ARP/beacons) get
+# through. Symptom: associated with an IP but ~100% packet loss, and
+# wlan_guard cycling the link every 1-2 minutes. Forcing the link down to
+# VHT/HT (he_on=0) restores reliable RX; on 2.4GHz the throughput loss vs.
+# HE is negligible.
+cmd=$(realpath $0)
+_DIR=$(dirname $cmd)
+cd $_DIR
+
+export PATH=$PATH:/oem/usr/ko/
+
+#for fastboot
+#insmod_wifi.ko ${RK_ENABLE_WIFI_CHIP} ${RK_ENABLE_FASTBOOT}
+if [ "${1}"x = "y"x ]; then
+	insmod dw_mmc.ko
+	insmod dw_mmc-pltfm.ko
+	insmod dw_mmc-rockchip.ko
+	case "$2" in
+	ATBM6441)
+		insmod cfg80211.ko
+		insmod atbm6041_wifi_sdio.ko
+		;;
+	HI3861L)
+		# cat /sys/bus/sdio/devices/*/uevent | grep "0296:5347"
+		insmod /oem/usr/ko/hichannel.ko hi_rk_irq_gpio=40
+		;;
+	*)
+		exit 1
+		;;
+	esac
+	rkwifi_server start &
+	exit 0
+fi
+
+#AIC8800DW
+cat /sys/bus/sdio/devices/*/uevent | grep "8800"
+if [ $? -eq 0 ]; then
+	insmod cfg80211.ko
+	insmod aic_load_fw.ko aic_fw_path=/oem/usr/ko/
+	insmod aic8800_fdrv.ko he_on=0
+	insmod bcmdhd.ko
+fi
+
+#AP6XXX
+cat /sys/bus/sdio/devices/*/uevent | grep -i "02d0"
+if [ $? -eq 0 ]; then
+	insmod cfg80211.ko
+	insmod bcmdhd.ko
+fi
+
+#rtl8723bs
+cat /sys/bus/sdio/devices/*/uevent | grep "024C:B723"
+if [ $? -eq 0 ]; then
+	insmod libarc4.ko
+	insmod cfg80211.ko
+	insmod mac80211.ko
+	insmod r8723bs.ko
+fi
+
+#rtl8723ds
+cat /sys/bus/sdio/devices/*/uevent | grep "024C:D723"
+if [ $? -eq 0 ]; then
+	insmod cfg80211.ko
+	insmod 8723ds.ko
+fi
+
+#rtl8189fs
+cat /sys/bus/sdio/devices/*/uevent | grep "024C:F179"
+if [ $? -eq 0 ]; then
+	insmod cfg80211.ko
+	insmod 8189fs.ko
+fi
+
+#rtl18188fu
+cat /sys/bus/usb/devices/*/uevent | grep "bda\/f179"
+if [ $? -eq 0 ]; then
+	insmod cfg80211.ko
+	insmod 8188fu.ko
+fi
+
+#ssv6115
+cat /sys/bus/usb/devices/*/uevent | grep "8065\/6011"
+if [ $? -eq 0 ]; then
+	insmod cfg80211.ko
+	insmod ssv6115.ko
+fi
+
+#ssv6x5x
+cat /sys/bus/usb/devices/*/uevent | grep "8065\/6000"
+if [ $? -eq 0 ]; then
+	insmod cfg80211.ko
+	insmod libarc4.ko
+	insmod mac80211.ko
+	insmod ctr.ko
+	insmod ccm.ko
+	insmod libaes.ko
+	insmod aes_generic.ko
+	insmod ssv6x5x.ko
+fi
+
+#atbm603x
+cat /sys/bus/sdio/devices/*/uevent | grep "007A\:6011"
+if [ $? -eq 0 ]; then
+	insmod cfg80211.ko
+	insmod libarc4.ko
+	insmod ctr.ko
+	insmod ccm.ko
+	insmod libaes.ko
+	insmod aes_generic.ko
+	insmod atbm603x_.ko
+fi
+
+#aic8800
+if [ -n "$(cat /proc/device-tree/model | grep "W")" ] || \
+[ -n "$(cat /sys/bus/sdio/devices/*/uevent | grep "C8A1\:C18D")" ]; then
+	insmod cfg80211.ko
+	insmod libarc4.ko
+	insmod ctr.ko
+	insmod ccm.ko
+	insmod libaes.ko
+	insmod aes_generic.ko
+	insmod aic8800_bsp.ko
+	sleep 0.2
+	insmod aic8800_fdrv.ko he_on=0
+	sleep 2
+	insmod aic8800_btlpm.ko
+	sleep 0.1
+fi
+
+#start wifi app
+if ifconfig wlan0 2>&1 | grep -q "not found"; then
+	echo "wlan0 not found. Stop run rkwifi_server."
+else
+	rkwifi_server start >/dev/null 2>&1 &
+fi

--- a/overlay/oem/usr/ko/insmod_wifi.sh
+++ b/overlay/oem/usr/ko/insmod_wifi.sh
@@ -12,9 +12,9 @@
 # wlan_guard cycling the link every 1-2 minutes. Forcing the link down to
 # VHT/HT (he_on=0) restores reliable RX; on 2.4GHz the throughput loss vs.
 # HE is negligible.
-cmd=$(realpath $0)
-_DIR=$(dirname $cmd)
-cd $_DIR
+cmd=$(realpath "$0")
+_DIR=$(dirname "$cmd")
+cd "$_DIR" || exit 1
 
 export PATH=$PATH:/oem/usr/ko/
 

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -1714,9 +1714,9 @@ CommandResult apply_wifi_config(const Options& options) {
 
     bool dhcp_ok = false;
     if (associated) {
-        if (command_exists("udhcpc")) {
-            CommandResult dhcp = run_shell_command("udhcpc -i " + shell_quote(options.wifi_interface) + " -n -q 2>&1");
-            log << "$ udhcpc -i " << options.wifi_interface << " -n -q\n" << dhcp.output;
+        if (command_exists("dhcpcd")) {
+            CommandResult dhcp = run_shell_command("dhcpcd -n " + shell_quote(options.wifi_interface) + " 2>&1");
+            log << "$ dhcpcd -n " << options.wifi_interface << "\n" << dhcp.output;
             dhcp_ok = dhcp.exit_code == 0;
             if (!dhcp_ok) {
                 result.exit_code = dhcp.exit_code;
@@ -1729,7 +1729,7 @@ CommandResult apply_wifi_config(const Options& options) {
                 result.exit_code = dhcp.exit_code;
             }
         } else {
-            log << "No supported DHCP client found (need udhcpc or dhclient).\n";
+            log << "No supported DHCP client found (need dhcpcd or dhclient).\n";
             if (result.exit_code == 0) {
                 result.exit_code = 127;
             }

--- a/src/wifi_config.cpp
+++ b/src/wifi_config.cpp
@@ -332,30 +332,33 @@ bool load_wifi_config(const char* path, WifiNetworkConfig& config, std::string* 
 }
 
 std::string detect_country_by_ssid(const std::string& ssid, const std::string& interface) {
-    // Scan for the target SSID and extract its country code
-    // This works BEFORE connecting, avoiding the chicken-and-egg problem
-    std::string cmd = "iw dev " + interface + " scan 2>/dev/null | awk '/^BSS/{bss=$2} /SSID:/{if($0 ~ /SSID: " + ssid + "$/) print bss}' | head -1";
+    // Scan and extract the Country IE of the BSS whose SSID matches `ssid`.
+    // Works BEFORE associating, avoiding the connect-to-learn-country deadlock.
+    //
+    // Strategy: in iw scan output, within a BSS block the Country line appears
+    // after the SSID line. Set a flag when the target SSID is seen, then emit
+    // the next Country line encountered before the next "BSS" header.
+    //
+    // SSID is passed via awk -v (not interpolated into a regex) to handle
+    // values with regex metacharacters or quotes safely.
+    std::string safe_ssid;
+    for (char c : ssid) {
+        if (c == '\'') {
+            safe_ssid += "'\\''";  // shell escape: close-quote, literal quote, reopen
+        } else {
+            safe_ssid += c;
+        }
+    }
+
+    std::string awk_prog =
+        "/^BSS /{found=0} "
+        "/SSID: /{s=$0; sub(/.*SSID: /,\"\",s); if(s==target) found=1} "
+        "found && /Country:/{print $2; exit}";
+
+    std::string cmd = "iw dev " + interface + " scan 2>/dev/null | awk -v target='" +
+                      safe_ssid + "' '" + awk_prog + "'";
 
     FILE* pipe = popen(cmd.c_str(), "r");
-    if (!pipe) {
-        return "";
-    }
-
-    char bssid[64];
-    if (fgets(bssid, sizeof(bssid), pipe) == nullptr) {
-        pclose(pipe);
-        return "";
-    }
-    pclose(pipe);
-
-    std::string bssid_str = trim_copy(std::string(bssid));
-    if (bssid_str.empty()) {
-        return "";
-    }
-
-    // Now extract the country code for this BSSID
-    cmd = "iw dev " + interface + " scan 2>/dev/null | awk '/^BSS " + bssid_str + "/{found=1} found && /Country:/{print $2; exit}'";
-    pipe = popen(cmd.c_str(), "r");
     if (!pipe) {
         return "";
     }

--- a/src/wifi_config.cpp
+++ b/src/wifi_config.cpp
@@ -245,7 +245,17 @@ std::string render_wifi_config(const WifiNetworkConfig& config) {
     out += "ctrl_interface=/var/run/wpa_supplicant\n";
     out += "update_config=1\n";
     out += "country=";
-    out += config.country.empty() ? "CN" : config.country;
+    if (config.country.empty()) {
+        // Try to detect country from the target SSID before connecting
+        std::string detected = detect_country_by_ssid(config.ssid);
+        if (detected.empty()) {
+            // Fallback: try from currently connected AP
+            detected = detect_country_from_ap();
+        }
+        out += detected.empty() ? "CN" : detected;
+    } else {
+        out += config.country;
+    }
     out += "\n\n";
     out += "network={\n";
     out += "    ssid=";
@@ -308,9 +318,104 @@ bool load_wifi_config(const char* path, WifiNetworkConfig& config, std::string* 
 
     config = parsed;
     if (config.country.empty()) {
-        config.country = "CN";
+        // Try to detect from target SSID first (works before connecting)
+        config.country = detect_country_by_ssid(config.ssid);
+        if (config.country.empty()) {
+            // Fallback: try from currently connected AP
+            config.country = detect_country_from_ap();
+        }
+        if (config.country.empty()) {
+            config.country = "CN";  // Last resort fallback
+        }
     }
     return true;
+}
+
+std::string detect_country_by_ssid(const std::string& ssid, const std::string& interface) {
+    // Scan for the target SSID and extract its country code
+    // This works BEFORE connecting, avoiding the chicken-and-egg problem
+    std::string cmd = "iw dev " + interface + " scan 2>/dev/null | awk '/^BSS/{bss=$2} /SSID:/{if($0 ~ /SSID: " + ssid + "$/) print bss}' | head -1";
+
+    FILE* pipe = popen(cmd.c_str(), "r");
+    if (!pipe) {
+        return "";
+    }
+
+    char bssid[64];
+    if (fgets(bssid, sizeof(bssid), pipe) == nullptr) {
+        pclose(pipe);
+        return "";
+    }
+    pclose(pipe);
+
+    std::string bssid_str = trim_copy(std::string(bssid));
+    if (bssid_str.empty()) {
+        return "";
+    }
+
+    // Now extract the country code for this BSSID
+    cmd = "iw dev " + interface + " scan 2>/dev/null | awk '/^BSS " + bssid_str + "/{found=1} found && /Country:/{print $2; exit}'";
+    pipe = popen(cmd.c_str(), "r");
+    if (!pipe) {
+        return "";
+    }
+
+    char buffer[16];
+    std::string country;
+    if (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
+        country = trim_copy(std::string(buffer));
+        // Validate country code (2 uppercase letters)
+        if (country.size() == 2 &&
+            isupper(country[0]) && isupper(country[1])) {
+            pclose(pipe);
+            return country;
+        }
+    }
+    pclose(pipe);
+
+    return "";
+}
+
+std::string detect_country_from_ap(const std::string& interface) {
+    // Try to detect country code from the currently connected AP
+    std::string cmd = "iw dev " + interface + " scan 2>/dev/null | grep -A 1 '(on " + interface + ")' | grep 'Country:' | head -1 | awk '{print $2}'";
+
+    FILE* pipe = popen(cmd.c_str(), "r");
+    if (!pipe) {
+        return "";
+    }
+
+    char buffer[16];
+    std::string country;
+    if (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
+        country = trim_copy(std::string(buffer));
+        // Validate country code (2 uppercase letters)
+        if (country.size() == 2 &&
+            isupper(country[0]) && isupper(country[1])) {
+            pclose(pipe);
+            return country;
+        }
+    }
+    pclose(pipe);
+
+    // If detection failed, try reading from wpa_supplicant status
+    cmd = "wpa_cli -i " + interface + " status 2>/dev/null | grep '^country=' | cut -d= -f2";
+    pipe = popen(cmd.c_str(), "r");
+    if (!pipe) {
+        return "";
+    }
+
+    if (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
+        country = trim_copy(std::string(buffer));
+        if (country.size() == 2 &&
+            isupper(country[0]) && isupper(country[1])) {
+            pclose(pipe);
+            return country;
+        }
+    }
+    pclose(pipe);
+
+    return "";  // Detection failed
 }
 
 bool save_wifi_config(const char* path, const WifiNetworkConfig& config, std::string* error) {

--- a/src/wifi_config.h
+++ b/src/wifi_config.h
@@ -9,11 +9,13 @@ struct WifiNetworkConfig {
     std::string psk;
     std::string country;
 
-    WifiNetworkConfig() : country("CN") {}
+    WifiNetworkConfig() {}
 };
 
 bool load_wifi_config(const char* path, WifiNetworkConfig& config, std::string* error = nullptr);
 bool save_wifi_config(const char* path, const WifiNetworkConfig& config, std::string* error = nullptr);
 std::string render_wifi_config(const WifiNetworkConfig& config);
+std::string detect_country_from_ap(const std::string& interface = "wlan0");
+std::string detect_country_by_ssid(const std::string& ssid, const std::string& interface = "wlan0");
 
 }

--- a/tests/config_web_source_test.cpp
+++ b/tests/config_web_source_test.cpp
@@ -573,7 +573,7 @@ TEST_CASE("config web restarts ota only when system env changes") {
     CHECK(source.find("config saved; agent and ota restarting") == std::string::npos);
 }
 
-TEST_CASE("config web DHCP invokes udhcpc without hook") {
+TEST_CASE("config web DHCP invokes dhcpcd without hook") {
     const std::string source_path = std::string(AIDEN_SOURCE_DIR) + "/src/config_web.cpp";
     std::ifstream source_in(source_path.c_str());
     REQUIRE(source_in.good());
@@ -582,12 +582,12 @@ TEST_CASE("config web DHCP invokes udhcpc without hook") {
     source_buffer << source_in.rdbuf();
     const std::string source = source_buffer.str();
 
-    // Must invoke udhcpc for DHCP
-    CHECK(source.find("udhcpc -i ") != std::string::npos);
+    // Must invoke dhcpcd for DHCP
+    CHECK(source.find("dhcpcd -n ") != std::string::npos);
     // Must NOT reference the removed aiden.script hook
     CHECK(source.find("-s /etc/udhcpc/aiden.script") == std::string::npos);
-    // Should use -n -q for foreground one-shot DHCP
-    CHECK(source.find("udhcpc -i \" + shell_quote(options.wifi_interface) + \" -n -q") != std::string::npos);
+    // Should use -n for foreground one-shot DHCP
+    CHECK(source.find("dhcpcd -n \" + shell_quote(options.wifi_interface)") != std::string::npos);
 }
 
 TEST_CASE("config web preserves hid pointer mode and avoids hot-restarting usbhid") {


### PR DESCRIPTION
## Summary

This PR fixes the persistent WiFi connectivity issues on the Luckfox Pico Zero (AIC8800DC chip), where the device would associate with an AP but experience ~100% packet loss and reconnect every 1-2 minutes.

## Root Cause

The AIC8800DC's **802.11ax (HE) receive path is broken** when the AP beacons HE on 2.4GHz. The chip associates and transmits at HE rates fine, but cannot decode incoming HE data frames. Result: high-rate frames (DHCP/ICMP/TCP) are lost while low-rate frames (ARP/beacons) get through → device has a valid IP but is effectively offline.

## Changes

### 1. Disable 802.11ax (HE) on driver load (primary fix)
- **File**: `overlay/oem/usr/ko/insmod_wifi.sh`
- **Change**: Pass `he_on=0` to both `insmod aic8800_fdrv.ko` load points
- **Effect**: Forces link to VHT/HT, which the RX path decodes reliably
- **Tradeoff**: On 2.4GHz the throughput cost vs. HE is negligible

### 2. Auto-detect regulatory domain from AP before connecting
- **Files**: `src/wifi_config.cpp`, `src/wifi_config.h`
- **Change**: Add `detect_country_by_ssid()` that scans for the target SSID's Country IE before associating
- **Effect**: Avoids the connect-to-learn-country deadlock and regulatory mismatch warnings

### 3. Remove DHCP client conflicts
- **Files**: `overlay/etc/init.d/S99hciinit`, `overlay/oem/usr/bin/wlan_guard.sh`, `src/config_web.cpp`
- **Change**: Remove all `udhcpc` calls; use `dhcpcd` exclusively
- **Effect**: Prevents competing DHCP clients from fighting over the lease

## Verification

**Controlled experiment** (only `he_on` changed, all else equal):
- `he_on=Y` (default): ICMP 0/30, DHCP fails (link-local only)
- `he_on=0`: ICMP 374/374 over 6 min, DHCP leases real IP, 0 disconnect cycles

**Full reboot validation**:
- Driver auto-loads with `he_on=N`
- Associates to AP, leases 192.168.50.69 via DHCP
- Gateway/external/DNS all pass
- 338/338 ping over 5.5 min, 0 disconnect cycles
- RX bitrate: 86.7 Mbit/s VHT (was stuck at 1.0 Mbit/s with HE)

**Device deployment**: All three fixes synced to device and tested end-to-end. No `udhcpc` processes remain; only `dhcpcd` manages wlan0.

## Note

Changes 2 and 3 are real improvements but secondary; change 1 (HE disable) is the actual fix for the unusable WiFi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wi‑Fi config now auto-detects country code from target SSID or connected AP for better regional settings.

* **Improvements**
  * Switched DHCP client preference to dhcpcd for more reliable network configuration.
  * Added improved WLAN bring-up and driver loading routines.
  * Added Bluetooth HCI initialization to better manage Bluetooth bring-up and status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->