### PR TITLE
Allow non-1080p screenshots and document manual deployment

### DIFF
--- a/docs/01-getting-started/deployment.md
+++ b/docs/01-getting-started/deployment.md
@@ -21,16 +21,72 @@
 
 ## 手动复制二进制
 
-开发时可先交叉编译，再通过 `scp` 将 `build/bin/` 中的目标程序复制到设备：
+`./build.sh` 完成后，主要产物在 `build/bin/`。其中和设备常驻运行直接相关的是：
+
+- `build/bin/frame_service`
+- `build/bin/audio_service`
+- `build/bin/config_web`
+- `build/bin/agent`
+- `overlay/oem/usr/bin/aiden-env-run`
+
+如果目标设备已经刷过一版 Aiden 固件，通常 init 脚本和 `/etc/*.conf` 已经存在，此时最小部署集合就是上面 5 个文件：
 
 ```bash
 ./build.sh
+
 scp build/bin/frame_service root@<device-ip>:/oem/usr/bin/
 scp build/bin/audio_service root@<device-ip>:/oem/usr/bin/
+scp build/bin/config_web root@<device-ip>:/oem/usr/bin/
 scp build/bin/agent root@<device-ip>:/oem/usr/bin/
+scp overlay/oem/usr/bin/aiden-env-run root@<device-ip>:/oem/usr/bin/
 ```
 
-也可以复制到 `/root` 或 `/userdata` 做临时测试，但启动脚本默认从 `/oem/usr/bin/` 查找。
+如果还需要设备端排障/调试工具，可选再复制：
+
+```bash
+scp build/bin/frame_service_cli root@<device-ip>:/oem/usr/bin/
+scp build/bin/audio_service_cli root@<device-ip>:/oem/usr/bin/
+scp build/bin/ota root@<device-ip>:/oem/usr/bin/
+scp build/bin/abctl root@<device-ip>:/oem/usr/bin/
+```
+
+如果目标设备是更裸的系统，缺少 Aiden 的 init 脚本和配置文件，还需要一起复制这些运行时文件：
+
+```bash
+scp overlay/etc/init.d/S52frame_service root@<device-ip>:/etc/init.d/
+scp overlay/etc/init.d/S53audio_service root@<device-ip>:/etc/init.d/
+scp overlay/etc/init.d/S53agent root@<device-ip>:/etc/init.d/
+scp overlay/etc/init.d/S56config_web root@<device-ip>:/etc/init.d/
+
+scp overlay/etc/aiden_frame_service.conf root@<device-ip>:/etc/
+scp overlay/etc/aiden_audio_service.conf root@<device-ip>:/etc/
+```
+
+首次部署通常还要准备 `/userdata` 下的默认配置：
+
+```bash
+ssh root@<device-ip> "mkdir -p /userdata/agent /userdata/system"
+scp overlay/userdata/agent/agent.toml root@<device-ip>:/userdata/agent/
+scp overlay/userdata/system/env root@<device-ip>:/userdata/system/
+scp overlay/userdata/wpa_supplicant.conf root@<device-ip>:/userdata/
+```
+
+说明：
+
+- `config_web` 会调用 `/oem/usr/bin/agent` 的 `config-check` / `config-meta` 子命令，因此复制 `config_web` 时应同时复制 `agent`。
+- `S52frame_service`、`S53audio_service`、`S53agent`、`S56config_web` 默认都通过 `/oem/usr/bin/aiden-env-run` 启动实际二进制，因此这个 wrapper 也要在设备上。
+- 也可以把二进制先复制到 `/root` 或 `/userdata` 做临时测试，但现有 init 脚本默认查找 `/oem/usr/bin/`。
+- 如果只是更新二进制，复制完成后执行 `chmod +x /oem/usr/bin/*` 一次即可。
+
+复制完成后，常见重启命令：
+
+```bash
+ssh root@<device-ip> "chmod +x /oem/usr/bin/frame_service /oem/usr/bin/audio_service /oem/usr/bin/config_web /oem/usr/bin/agent /oem/usr/bin/aiden-env-run"
+ssh root@<device-ip> "/etc/init.d/S52frame_service restart"
+ssh root@<device-ip> "/etc/init.d/S53audio_service restart"
+ssh root@<device-ip> "/etc/init.d/S53agent restart"
+ssh root@<device-ip> "/etc/init.d/S56config_web restart"
+```
 
 ## 服务启动顺序
 

--- a/docs/03-services/frame-service.md
+++ b/docs/03-services/frame-service.md
@@ -42,19 +42,21 @@
 frame_service [--socket PATH] [--device PATH] [--width N] [--height N]
               [--pixel-format FMT] [--subdev PATH] [--edid PATH]
               [--ring-size N] [--fps N] [--no-hdmi-sync]
+              [--require-exact-resolution]
 ```
 
 | 参数 | 说明 |
 | --- | --- |
 | `--socket PATH` | UDS socket 路径 |
 | `--device PATH` | V4L2 capture device，默认 `/dev/video0` |
-| `--width N` / `--height N` | 期望分辨率，默认 1920x1080 |
+| `--width N` / `--height N` | HDMI sync 前的目标分辨率提示值，默认 1920x1080；默认接受实际协商到的输入分辨率 |
 | `--pixel-format FMT` | `nv12`、`nv16`、`uyvy`、`yuyv`，默认 `uyvy` |
 | `--subdev PATH` | HDMI bridge subdev，默认 `/dev/v4l-subdev2` |
 | `--edid PATH` | 自定义 EDID hex；为空时使用内置 1080p30-only CTA EDID |
 | `--ring-size N` | ring buffer 容量 |
 | `--fps N` | 采样 FPS；`0` 表示尽可能快 |
 | `--no-hdmi-sync` | 跳过 HDMI sync 辅助流程 |
+| `--require-exact-resolution` | 严格要求实际输入分辨率与 `--width/--height` 一致；默认关闭，便于 720p/竖屏等模式直接截图 |
 
 也可使用环境变量：
 

--- a/docs/05-sdk-and-tools/cpp-sdk.md
+++ b/docs/05-sdk-and-tools/cpp-sdk.md
@@ -42,7 +42,7 @@ struct CameraConfig {
     int capture_retries = 2;
     bool enable_hdmi_sync = true;
     bool force_trigger = false;
-    bool require_exact_resolution = true;
+    bool require_exact_resolution = false;
     bool reject_uniform_frames = true;
 };
 ```

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -63,6 +63,22 @@ func TestResolvePointerPositionPixelUsesActiveArea(t *testing.T) {
 	}
 }
 
+func TestResolvePointerPositionPixelUses720pActiveArea(t *testing.T) {
+	screen := &screenState{}
+	screen.UpdateActiveArea(1280, 720, screenActiveArea{X: 320, Y: 0, Width: 640, Height: 720, Valid: true})
+
+	x, y, err := resolvePointerPosition(screen, 640, 360, "pixel", coordinateSpaceAuto)
+	if err != nil {
+		t.Fatalf("resolvePointerPosition returned error: %v", err)
+	}
+	if x != 16409 {
+		t.Fatalf("x = %d, want 16409", x)
+	}
+	if y != 16406 {
+		t.Fatalf("y = %d, want 16406", y)
+	}
+}
+
 func TestResolvePointerPositionPixelRejectsBlackBar(t *testing.T) {
 	screen := &screenState{}
 	screen.UpdateActiveArea(1920, 1080, screenActiveArea{X: 656, Y: 0, Width: 608, Height: 1080, Valid: true})

--- a/src/agent/internal/agent/tools_mobilegym_test.go
+++ b/src/agent/internal/agent/tools_mobilegym_test.go
@@ -83,7 +83,7 @@ func TestMobileGymScreenshotToolCallsBridgeWithEpisodeAndToken(t *testing.T) {
 		}
 		gotEpisode = req.EpisodeID
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"width":1080,"height":2400,"format":"jpeg","size":4,"data":"/9j/"}`))
+		_, _ = w.Write([]byte(`{"width":720,"height":1280,"format":"jpeg","size":4,"data":"/9j/"}`))
 	}))
 	defer bridge.Close()
 
@@ -101,10 +101,10 @@ func TestMobileGymScreenshotToolCallsBridgeWithEpisodeAndToken(t *testing.T) {
 	if gotEpisode != "ep1" {
 		t.Fatalf("episode_id = %q", gotEpisode)
 	}
-	if !strings.Contains(out, `"width":1080`) || !strings.Contains(out, `"data":"/9j/"`) {
+	if !strings.Contains(out, `"width":720`) || !strings.Contains(out, `"height":1280`) || !strings.Contains(out, `"data":"/9j/"`) {
 		t.Fatalf("output = %s", out)
 	}
-	if width, height, ok := screen.Dimensions(); !ok || width != 1080 || height != 2400 {
+	if width, height, ok := screen.Dimensions(); !ok || width != 720 || height != 1280 {
 		t.Fatalf("screen dimensions = %dx%d ok=%v", width, height, ok)
 	}
 }

--- a/src/aiden_sdk.h
+++ b/src/aiden_sdk.h
@@ -38,7 +38,7 @@ struct CameraConfig {
     int capture_retries = 2;            // Full init/capture recovery retries
     bool enable_hdmi_sync = true;
     bool force_trigger = false;
-    bool require_exact_resolution = true;
+    bool require_exact_resolution = false;
     bool reject_uniform_frames = true;  // Reject known-bad all-same HDMI frames
 };
 

--- a/src/camera_frame_utils.h
+++ b/src/camera_frame_utils.h
@@ -27,7 +27,7 @@ inline void set_default_camera_config(aiden::CameraConfig* config) {
     config->capture_retries = 2;
     config->enable_hdmi_sync = true;
     config->force_trigger = false;
-    config->require_exact_resolution = true;
+    config->require_exact_resolution = false;
     config->reject_uniform_frames = true;
 }
 

--- a/src/example_camera_capture.cpp
+++ b/src/example_camera_capture.cpp
@@ -46,8 +46,10 @@ static void usage(const char* prog) {
             "  --force-trigger           Push EDID before the first timing query\n"
             "  --no-force-trigger        Query timings first and only push on failure\n"
             "  --no-hdmi-sync            Skip HDMI EDID/timing sync and use VI directly\n"
+            "  --require-exact-resolution\n"
+            "                            Fail if negotiated mode differs from requested width/height\n"
             "  --allow-resolution-mismatch\n"
-            "                            Accept whatever mode the source negotiated\n"
+            "                            Deprecated alias; default already accepts negotiated mode\n"
             "  --allow-uniform-frames    Keep all-same HDMI frames instead of retrying\n"
             "  --help                    Show this help\n",
             prog);
@@ -222,6 +224,8 @@ static int parse_options(int argc, char* argv[], Options* opts) {
             opts->camera.force_trigger = false;
         } else if (strcmp(arg, "--no-hdmi-sync") == 0) {
             opts->camera.enable_hdmi_sync = false;
+        } else if (strcmp(arg, "--require-exact-resolution") == 0) {
+            opts->camera.require_exact_resolution = true;
         } else if (strcmp(arg, "--allow-resolution-mismatch") == 0) {
             opts->camera.require_exact_resolution = false;
         } else if (strcmp(arg, "--allow-uniform-frames") == 0) {

--- a/src/frame_service_main.cpp
+++ b/src/frame_service_main.cpp
@@ -54,7 +54,7 @@ void usage(const char* program) {
     fprintf(stderr,
             "Usage: %s [--socket PATH] [--device PATH] [--width N] [--height N] "
             "[--pixel-format FMT] [--subdev PATH] [--edid PATH] [--ring-size N] "
-            "[--fps N] [--no-hdmi-sync]\n",
+            "[--fps N] [--no-hdmi-sync] [--require-exact-resolution]\n",
             program);
 }
 
@@ -106,6 +106,10 @@ bool parse_options(int argc, char** argv, Options* options) {
             if (!parse_double_arg(argv[++i], &options->fps) || options->fps < 0.0) return false;
         } else if (arg == "--no-hdmi-sync") {
             options->camera.enable_hdmi_sync = false;
+        } else if (arg == "--require-exact-resolution") {
+            options->camera.require_exact_resolution = true;
+        } else if (arg == "--allow-resolution-mismatch") {
+            options->camera.require_exact_resolution = false;
         } else if (arg == "--help") {
             usage(argv[0]);
             exit(0);

--- a/src/hid_server_html.h
+++ b/src/hid_server_html.h
@@ -118,7 +118,7 @@ select { padding: 8px; background: #333; border: 1px solid #444; border-radius: 
 <script>
 let autoTimer = null;
 let captureInFlight = false;
-let imgNaturalW = 1920, imgNaturalH = 1080;
+let imgNaturalW = 0, imgNaturalH = 0;
 let activeArea = null;
 const STANDARD_COORD_MAX = 32767;
 const DEFAULT_COORDS_TEXT = 'Click the screenshot to send a left click';

--- a/tests/frame_service_defaults_test.cpp
+++ b/tests/frame_service_defaults_test.cpp
@@ -9,6 +9,7 @@ TEST_CASE("frame_service defaults use 1080p30 EDID with modest sampling fps") {
     CHECK(camera.width == 1920);
     CHECK(camera.height == 1080);
     CHECK(camera.edid_path == nullptr);
+    CHECK(camera.require_exact_resolution == false);
     CHECK(aiden::kDefaultFrameServiceRingSize == 3);
     CHECK(aiden::kDefaultFrameServiceFps == 3.0);
     CHECK(aiden::kDefaultScreenshotMaxEdge == 960);


### PR DESCRIPTION
## Summary
- allow screenshot/capture flows to accept negotiated HDMI resolutions instead of requiring 1920x1080 by default
- keep strict resolution checks available behind explicit CLI flags and update related docs/tests
- document the exact files to copy to a device after ./build.sh, including the minimal runtime set and optional tools

## Testing
- go test ./internal/agent -run 'TestResolvePointerPositionPixelUses720pActiveArea|TestResolvePointerPositionPixelUsesActiveArea|TestMobileGymScreenshotToolCallsBridgeWithEpisodeAndToken'
- /tmp/aiden-host-tests/bin/aiden_tests --test-case='*frame_service defaults*'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded deployment guide with detailed manual binary installation instructions and configuration steps
  * Documented new Frame Service parameter for resolution validation control
  * Updated SDK documentation for resolution handling

* **New Features**
  * Added command-line parameter support for controlling resolution matching behavior across camera utilities and Frame Service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->