### PR TITLE
feat(session): detect voice session boundaries

### DIFF
--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -153,6 +153,9 @@ Optional. Place `memory/extraction.yaml` under the config directory to control s
 | `context_window` | `32000` | Fallback context window for compaction when the active model is not present in `model_specs`. Runtime normally derives this from `ModelResolver.Spec()`; this value is only used for unknown models. |
 | `compress_at_percent` | `50` | Percentage trigger: compaction starts when `prompt_tokens / context_window >= compress_at_percent%`. |
 | `summary_max_chunks` | `10` | Number of chunk summaries kept in the Recent Chunks section of `summary.md`. Older entries move to the archive and are folded into the Rolling Summary. |
+| `session_boundary_enabled` | `true` | Classify each new user turn as continuing the current session or starting a new one. A `new` boundary archives the current `memory/session/` directory and recreates an empty active session. |
+| `session_boundary_short_gap_seconds` | default boundary config | Gap below which a turn is treated as continuation regardless of lexical signals. |
+| `session_boundary_long_gap_seconds` | default boundary config | Gap above which a turn is treated as a fresh session regardless of lexical signals. |
 | `tag_candidates` | see defaults | Candidate keywords matched when tagging chunk summaries. |
 | `entity_suffixes` | `["App","app","APP"]` | Suffixes recognized during entity extraction. |
 

--- a/docs/04-agent/context-lifecycle.md
+++ b/docs/04-agent/context-lifecycle.md
@@ -130,9 +130,17 @@ memory/session/events.jsonl
 
 When compressed history exists, prompt construction wraps the rendered hot window with boundary markers. Those markers are prompt-only and are never persisted.
 
+When session-boundary detection classifies a user turn as a new session, the
+runtime archives the whole active `memory/session/` directory into
+`memory/session_archive/<closed_session_id>/`, recreates an empty
+`memory/session/events.jsonl`, and clears the in-memory conversation window.
+Archived sessions are preserved as logs only; they are not restored, listed,
+switched back into, injected into prompts, or searched by
+`recall_session_chunks`.
+
 ### Session Compaction
 
-Session compaction is handled by `MemoryManager.maintainFilesystemMemory`. It reads `events.jsonl`, decides whether compaction is needed, writes compacted chunks, updates `summary.md`, and replaces `events.jsonl` with the retained hot window.
+Session compaction is handled by `MemoryManager.maintainFilesystemMemory`. It reads active `events.jsonl`, decides whether compaction is needed, writes compacted chunks, updates active `summary.md`, and replaces `events.jsonl` with the retained hot window.
 
 Compression can be triggered by:
 
@@ -200,6 +208,8 @@ When a chat-history store exists, planner memory also loads a compact view of re
 |   |-- summary.md               # compressed session summary
 |   |-- summary_archive.md
 |   `-- chunks/
+|-- session_archive/             # closed session logs, not active context
+|   `-- <closed_session_id>/
 |-- long_term/
 |   |-- profile.md               # synthesized profile
 |   |-- index.yaml
@@ -220,7 +230,9 @@ When a chat-history store exists, planner memory also loads a compact view of re
 ## Invariants
 
 - Runtime context is request-local; do not use it as durable memory.
-- Session summaries are durable memory; hot-window boundary markers are not.
+- Active session summaries are durable within the current session; archived
+  session summaries are logs and are not prompt or recall context.
+- Hot-window boundary markers are prompt-only and are not durable memory.
 - Planner owns plans and sees retrieved experience memory.
 - Executor executes exactly one approved step and does not receive global memory.
 - Verifier is the only role allowed to finish a run and receives failure/conflict memory.

--- a/docs/04-agent/memory-plane.md
+++ b/docs/04-agent/memory-plane.md
@@ -7,9 +7,9 @@
 现有 Go Agent 的 memory 已经有几类能力：
 
 - `MemoryManager` 维护 langchaingo 的 conversation window，并把会话事件写入 `/userdata/agent/memory/session/events.jsonl`。
-- `SessionMemoryStore` 将较老事件压缩为 chunks，生成 `session/summary.md`，并提供 `recall_session_chunks`。
+- `SessionMemoryStore` compresses older events from the active session into chunks, writes `session/summary.md`, and provides `recall_session_chunks` for active-session chunks only.
 - `LongTermMemoryStore` 将 profile、rule、preference、procedure、fact 存为 markdown frontmatter，生成 `long_term/index.yaml` 和 `long_term/profile.md`，并提供 `recall_memory`、`save_memory`、`forget_memory`。
-- `Runtime.Run` 当前只把 `session/summary.md` 和 `long_term/profile.md` 拼入 prompt。长期记忆检索主要依赖模型主动调用工具，不是每次任务规划的稳定输入。
+- `Runtime.Run` reads only the current active `session/summary.md` and `long_term/profile.md` for prompt context. Closed sessions under `session_archive/` are logs and are not prompt or recall context.
 - Agent loop 已拆成 `planner`、`executor`、`verifier`。`planner` 和 `verifier` 能看到历史、工具目录和 world state；`executor` 被刻意限制为只执行 planner 批准的 `next_step`。
 
 新设计应保留这个分层：自动检索进入 `planner` 和 `verifier`，不要把所有历史经验直接暴露给 `executor`。
@@ -32,7 +32,7 @@ RunRequest
   ▼
 MemoryPlane.Retrieve
   │
-  ├─ session summary/profile
+  ├─ active session summary/profile
   ├─ device/app/procedure/calibration/failure memory
   └─ task episode retrieval
   │
@@ -71,6 +71,8 @@ TaskEpisodeWriter
 │   ├── events.jsonl             # 现有热会话事件
 │   ├── summary.md               # 现有压缩摘要
 │   └── chunks/
+├── session_archive/
+│   └── <closed_session_id>/      # closed session logs, excluded from active context
 ├── long_term/
 │   ├── profile.md               # 现有用户 profile
 │   ├── index.yaml

--- a/docs/04-agent/session-memory.md
+++ b/docs/04-agent/session-memory.md
@@ -58,6 +58,19 @@ Archived sessions are preserved as logs only. They are not loaded into prompts,
 do not make `HasCompressedHistory()` true, are not compacted by active-session
 maintenance, and are not searched by `recall_session_chunks`.
 
+## Recall Result Sources
+
+`recall_session_chunks` returns each result with a `source` field. Indexed
+chunks from `memory/session/chunks/index.yaml` use `source: "active"` even when
+their `chunk_id` has a legacy or pending-derived prefix such as `pending-...`.
+Live pending-file recall paths must use `source: "pending"` until those files
+are consumed into normal indexed chunks.
+
+Telemetry uses this explicit source field. `pending_chunks_recalled` counts only
+results with `source: "pending"`; it does not infer source from the chunk ID.
+Chunk IDs are opaque identifiers and must not be used as pending/live-state
+signals.
+
 ## Session Boundary Rotation
 
 When session-boundary detection classifies a turn as `new`, `MemoryManager`

--- a/docs/04-agent/session-memory.md
+++ b/docs/04-agent/session-memory.md
@@ -31,7 +31,7 @@ re-read session/events.jsonl under FileLock and merge new appends
 replaceEvents --> keep only the hot window in events.jsonl
 ```
 
-The storage layout reuses `/userdata/agent/memory/session/`:
+`/userdata/agent/memory/session/` is always the current active session:
 
 ```text
 session/
@@ -42,6 +42,33 @@ session/
     ├── index.yaml        # chunk index, with optional cut_meta
     └── <chunk_id>.jsonl  # full compacted events, retrievable by recall_session_chunks
 ```
+
+Closed sessions are archived outside the active directory:
+
+```text
+session_archive/
+└── <closed_session_id>/
+    ├── events.jsonl
+    ├── summary.md
+    ├── summary_archive.md
+    └── chunks/
+```
+
+Archived sessions are preserved as logs only. They are not loaded into prompts,
+do not make `HasCompressedHistory()` true, are not compacted by active-session
+maintenance, and are not searched by `recall_session_chunks`.
+
+## Session Boundary Rotation
+
+When session-boundary detection classifies a turn as `new`, `MemoryManager`
+closes the current active session by atomically moving the whole
+`memory/session/` directory to `memory/session_archive/<closed_session_id>/`.
+It then recreates `memory/session/events.jsonl` as an empty file and clears the
+in-memory conversation window and event counters.
+
+This implements only multi-session storage isolation. Aiden does not restore,
+list, or switch back to old sessions yet. There is always exactly one active
+session, and the new active session starts with empty conversation context.
 
 ## Concurrency and Event Preservation
 
@@ -115,7 +142,8 @@ The prefix summary is intentionally written to both the chunk summary and the ho
 
 ## summary.md and Rolling Summary
 
-`summary.md` is injected into the planner prompt and has two sections:
+The active session's `summary.md` is injected into the planner prompt and has
+two sections:
 
 ```markdown
 # Session History (compressed chunks)
@@ -136,7 +164,9 @@ The Rolling Summary currently has a 100-line cap (`maxRollingSummaryLines`). Whe
 
 ## Hot-Window Boundary Markers
 
-When compressed history exists (`HasCompressedHistory`, meaning `summary.md` exists), prompt construction wraps the hot window with boundary markers:
+When compressed history exists in the active session (`HasCompressedHistory`,
+meaning `memory/session/summary.md` exists), prompt construction wraps the hot
+window with boundary markers:
 
 ```text
 === Recent session context (hot window) ===

--- a/docs/04-agent/telemetry-langfuse.md
+++ b/docs/04-agent/telemetry-langfuse.md
@@ -137,6 +137,9 @@ Langfuse 支持导出 dataset items（UI 或 [Public API](https://langfuse.com/d
 | `agent_commit` | Agent 二进制构建时的 git commit（`_build.sh` ldflags 注入） |
 | `agent_build` | Agent 构建版本号（`YYYYMMDD-HHMMSS-<commit>`） |
 | `firmware_version` | 设备 OTA 状态 `/userdata/ota/state.json` 中的 `current_version` |
+| `session_boundary_decision` / `session_boundary_reason` | Session-boundary classifier output for the run. |
+| `session_rotated` | Whether the run archived the previous active session before handling the user turn. |
+| `pending_chunks_recalled` | Number of `recall_session_chunks` results whose explicit result `source` is `pending`; `chunk_id` prefixes are ignored. |
 
 **Langfuse trace 字段映射：**
 

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -1,8 +1,6 @@
 package agent
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -593,36 +591,19 @@ func (m *MemoryManager) loadSessionMessageRecords(agentName string) ([]MessageRe
 	}
 	defer fl.Unlock()
 
-	file, err := os.Open(m.sessionEventsPath())
+	session := NewSessionMemoryStore(filepath.Join(m.storageDir, "session"), m.extraction.SummaryMaxChunks)
+	result, err := session.readActiveEventsRepairingTruncatedTail()
 	if err != nil {
-		if os.IsNotExist(err) {
+		if isPathNotExistError(err) {
 			return nil, 0, false, nil
 		}
 		return nil, 0, false, fmt.Errorf("read session events for %q: %w", agentName, err)
 	}
-	defer file.Close()
+	m.logSessionEventsRepair(agentName, result)
 
-	var records []MessageRecord
+	records := make([]MessageRecord, 0, len(result.events))
 	hotWindowTokens := 0
-	validData := make([]byte, 0)
-	repairedTruncatedTail := false
-	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 0), 1<<20)
-	for scanner.Scan() {
-		line := bytes.Trim(scanner.Bytes(), "\x00 \t\r\n")
-		if len(line) == 0 {
-			continue
-		}
-		var event SessionEvent
-		if err := json.Unmarshal(line, &event); err != nil {
-			if isTruncatedJSONLineError(err) {
-				repairedTruncatedTail = true
-				break
-			}
-			return nil, 0, false, fmt.Errorf("decode session event for %q: %w", agentName, err)
-		}
-		validData = append(validData, line...)
-		validData = append(validData, '\n')
+	for _, event := range result.events {
 		// Accumulate the token estimate over every persisted event (not just
 		// those that become message records) so the seeded value matches
 		// sumSessionEventTokens over the same on-disk hot window.
@@ -632,19 +613,18 @@ func (m *MemoryManager) loadSessionMessageRecords(agentName string) ([]MessageRe
 			records = append(records, record)
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, 0, false, fmt.Errorf("scan session events for %q: %w", agentName, err)
-	}
-	if repairedTruncatedTail {
-		if err := writeFileAtomic(m.sessionEventsPath(), validData, 0o644); err != nil {
-			if m.logger != nil {
-				m.logger.Warn("[memory] failed to repair truncated session events for %q: %v", agentName, err)
-			}
-		} else if m.logger != nil {
-			m.logger.Warn("[memory] repaired truncated session events for %q", agentName)
-		}
-	}
 	return records, hotWindowTokens, true, nil
+}
+
+func (m *MemoryManager) logSessionEventsRepair(agentName string, result sessionEventsReadResult) {
+	if m == nil || m.logger == nil || !result.truncatedTail {
+		return
+	}
+	if result.repairErr != nil {
+		m.logger.Warn("[memory] failed to repair truncated session events for %q: %v", agentName, result.repairErr)
+		return
+	}
+	m.logger.Warn("[memory] repaired truncated session events for %q", agentName)
 }
 
 func (m *MemoryManager) persistSnapshot(agentName string, records []MessageRecord) error {

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -411,6 +411,9 @@ func (m *MemoryManager) AppendExchange(ctx context.Context, agentName string, in
 // RotateSessionEvents atomically moves the current hot session event stream
 // aside so a newly detected task can start with a clean events.jsonl. The
 // rotated file is consumed later by maintenance as a closed pending session.
+// Existing compressed summaries/chunks are intentionally preserved: using task
+// summaries as cross-task historical context is acceptable, while the hot
+// window is limited to the newly detected task.
 func (m *MemoryManager) RotateSessionEvents() (string, error) {
 	if m.storageDir == "" {
 		return "", nil

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,19 +47,20 @@ type ContextWindowFn func() int
 // and long-term profile generation. It coordinates between in-memory chat history
 // and persistent filesystem storage.
 type MemoryManager struct {
-	mu                    sync.Mutex
-	handles               map[string]*MemoryHandle
-	eventCount            map[string]int
-	storageDir            string
-	extraction            MemoryExtractionConfig
-	lastPromptTokens      int
-	summarizeFn           SummarizeFn
-	structuredSummarizeFn StructuredSummarizeFn
-	profileFn             ProfileFn
-	contextWindowFn       ContextWindowFn
-	profileDebouncer      *ProfileDebouncer
-	lockTimeout           time.Duration
-	logger                *Logger
+	mu                             sync.Mutex
+	handles                        map[string]*MemoryHandle
+	eventCount                     map[string]int
+	storageDir                     string
+	extraction                     MemoryExtractionConfig
+	lastPromptTokens               int
+	summarizeFn                    SummarizeFn
+	structuredSummarizeFn          StructuredSummarizeFn
+	profileFn                      ProfileFn
+	contextWindowFn                ContextWindowFn
+	profileDebouncer               *ProfileDebouncer
+	lockTimeout                    time.Duration
+	logger                         *Logger
+	sessionBoundaryEnabledOverride *bool
 
 	maintenanceMu      sync.Mutex
 	maintenanceRunning bool
@@ -104,6 +106,13 @@ type MemoryManagerOption func(*MemoryManager)
 // WithExtractionConfig sets the memory extraction configuration.
 func WithExtractionConfig(cfg MemoryExtractionConfig) MemoryManagerOption {
 	return func(m *MemoryManager) { m.extraction = normalizeMemoryExtractionConfig(cfg) }
+}
+
+// WithSessionBoundaryEnabled explicitly overrides session boundary detection.
+func WithSessionBoundaryEnabled(enabled bool) MemoryManagerOption {
+	return func(m *MemoryManager) {
+		m.sessionBoundaryEnabledOverride = &enabled
+	}
 }
 
 // WithSummarizeFn sets the plain-text summarization function.
@@ -153,6 +162,11 @@ func NewMemoryManager(storageDir string, opts ...MemoryManagerOption) *MemoryMan
 	}
 	for _, opt := range opts {
 		opt(manager)
+	}
+	manager.extraction = normalizeMemoryExtractionConfig(manager.extraction)
+	if manager.sessionBoundaryEnabledOverride != nil {
+		manager.extraction.SessionBoundaryEnabled = *manager.sessionBoundaryEnabledOverride
+		manager.extraction.SessionBoundaryEnabledConfigured = true
 	}
 	return manager
 }
@@ -354,8 +368,15 @@ func (m *MemoryManager) AppendExchange(ctx context.Context, agentName string, in
 	if m.storageDir == "" {
 		return nil
 	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	fl := NewFileLock(m.storageDir)
+	if err := fl.Lock(m.lockTimeout); err != nil {
+		return fmt.Errorf("lock for appending session exchange %q: %w", agentName, err)
+	}
+	defer fl.Unlock()
 
 	if err := os.MkdirAll(filepath.Dir(m.sessionEventsPath()), 0o755); err != nil {
 		return fmt.Errorf("create session memory directory: %w", err)
@@ -385,6 +406,74 @@ func (m *MemoryManager) AppendExchange(ctx context.Context, agentName string, in
 	}
 	m.eventCount[agentName] += len(records)
 	return nil
+}
+
+// RotateSessionEvents atomically moves the current hot session event stream
+// aside so a newly detected task can start with a clean events.jsonl. The
+// rotated file is consumed later by maintenance as a closed pending session.
+func (m *MemoryManager) RotateSessionEvents() (string, error) {
+	if m.storageDir == "" {
+		return "", nil
+	}
+	pendingPath, err := func() (string, error) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		sessionDir := filepath.Join(m.storageDir, "session")
+		eventsPath := filepath.Join(sessionDir, "events.jsonl")
+
+		fl := NewFileLock(m.storageDir)
+		if err := fl.Lock(m.lockTimeout); err != nil {
+			return "", fmt.Errorf("lock for rotating session events: %w", err)
+		}
+		defer fl.Unlock()
+
+		if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+			return "", fmt.Errorf("create session directory for rotation: %w", err)
+		}
+		info, err := os.Stat(eventsPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				if err := os.WriteFile(eventsPath, nil, 0o644); err != nil {
+					return "", fmt.Errorf("create empty session events after missing rotation source: %w", err)
+				}
+				return "", nil
+			}
+			return "", fmt.Errorf("stat session events for rotation: %w", err)
+		}
+		if info.Size() == 0 {
+			return "", nil
+		}
+
+		pendingPath := filepath.Join(sessionDir, fmt.Sprintf("events.pending-%d.jsonl", time.Now().UTC().UnixNano()))
+		if err := os.Rename(eventsPath, pendingPath); err != nil {
+			return "", fmt.Errorf("rotate session events: %w", err)
+		}
+		if err := os.WriteFile(eventsPath, nil, 0o644); err != nil {
+			return "", fmt.Errorf("create empty session events after rotation: %w", err)
+		}
+
+		for agentName := range m.eventCount {
+			m.eventCount[agentName] = 0
+		}
+		for _, handle := range m.handles {
+			if handle != nil && handle.Memory != nil {
+				_ = handle.Memory.Clear(context.Background())
+			}
+		}
+		return pendingPath, nil
+	}()
+	if err != nil {
+		return "", err
+	}
+
+	if pendingPath != "" && m.logger != nil {
+		m.logger.Info("[memory] session rotated: pending=%s", filepath.Base(pendingPath))
+	}
+	if pendingPath != "" {
+		m.RequestMaintenance()
+	}
+	return pendingPath, nil
 }
 
 func (m *MemoryManager) loadPersistedMessages(history *langmemory.ChatMessageHistory, agentName string) error {
@@ -522,6 +611,9 @@ func (m *MemoryManager) persistSnapshot(agentName string, records []MessageRecor
 		return fmt.Errorf("create memory directory: %w", err)
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fl := NewFileLock(m.storageDir)
 	if err := fl.Lock(m.lockTimeout); err != nil {
 		return fmt.Errorf("lock for persisting memory %q: %w", agentName, err)
@@ -562,15 +654,22 @@ func (m *MemoryManager) removeSessionPersisted(agentName string) error {
 	if m.storageDir == "" {
 		return nil
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fl := NewFileLock(m.storageDir)
+	if err := fl.Lock(m.lockTimeout); err != nil {
+		return fmt.Errorf("lock for removing session memory %q: %w", agentName, err)
+	}
+	defer fl.Unlock()
+
 	if err := os.Remove(m.memoryPath(agentName)); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove persisted memory for %q: %w", agentName, err)
 	}
 	if err := os.RemoveAll(filepath.Join(m.storageDir, "session")); err != nil {
 		return fmt.Errorf("remove session memory for %q: %w", agentName, err)
 	}
-	m.mu.Lock()
 	m.eventCount[agentName] = 0
-	m.mu.Unlock()
 	return nil
 }
 
@@ -578,6 +677,9 @@ func (m *MemoryManager) removeAllPersisted(agentName string) error {
 	if m.storageDir == "" {
 		return nil
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	fl := NewFileLock(m.storageDir)
 	if err := fl.Lock(m.lockTimeout); err != nil {
@@ -599,9 +701,7 @@ func (m *MemoryManager) removeAllPersisted(agentName string) error {
 			return fmt.Errorf("remove filesystem memory path %q for %q: %w", path, agentName, err)
 		}
 	}
-	m.mu.Lock()
 	m.eventCount[agentName] = 0
-	m.mu.Unlock()
 	return nil
 }
 
@@ -610,6 +710,11 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 		return nil
 	}
 	session := NewSessionMemoryStore(filepath.Join(m.storageDir, "session"), m.extraction.SummaryMaxChunks)
+	if consumed, err := m.consumePendingSessionEvents(ctx, session); err != nil {
+		return err
+	} else if consumed > 0 && m.logger != nil {
+		m.logger.Info("[memory] pending consumed: count=%d, merged=false", consumed)
+	}
 	eventsPath := session.eventsPath()
 
 	// Phase 1: Read events snapshot under FileLock to serialize with append paths.
@@ -734,14 +839,26 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 	// phase 1 unlock and now). If new events were appended, merge them into
 	// hotEvents before replacing the file. This prevents data loss when
 	// persistSnapshot runs concurrently with maintenance.
+	m.mu.Lock()
 	if err := fl.Lock(m.lockTimeout); err != nil {
+		m.mu.Unlock()
 		return fmt.Errorf("lock for writing session events: %w", err)
 	}
-	defer fl.Unlock()
 
 	currentEvents, err := session.readEvents(eventsPath)
 	if err != nil {
+		fl.Unlock()
+		m.mu.Unlock()
 		return fmt.Errorf("re-read session events for merge: %w", err)
+	}
+	if !sessionEventsHavePrefix(currentEvents, events) {
+		fl.Unlock()
+		m.mu.Unlock()
+		if m.logger != nil {
+			m.logger.Info("[memory] active session changed during compression; deferring compaction")
+		}
+		m.RequestMaintenance()
+		return nil
 	}
 
 	// Merge incremental events that were appended during compression
@@ -757,6 +874,8 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 	// replaceEvents succeeds. This prevents "ghost compression records" where
 	// summary/index claim compression happened but events.jsonl was never updated.
 	if err := session.replaceEvents(hotEvents); err != nil {
+		fl.Unlock()
+		m.mu.Unlock()
 		return err
 	}
 
@@ -768,6 +887,8 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 		CutMeta:    cutMeta,
 	})
 	if err != nil {
+		fl.Unlock()
+		m.mu.Unlock()
 		if m.logger != nil {
 			m.logger.Error("[memory] compression metadata write failed: %v", err)
 		}
@@ -783,12 +904,10 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 	// checks maintenancePending and may run again immediately; if we left
 	// lastPromptTokens at the pre-compression high value, shouldCompress would
 	// continue returning true and trigger redundant compaction rounds.
-	m.SetLastPromptTokens(cutMeta.KeptTokensEstimate)
-
 	// Sync in-memory state to match the compressed hot window on disk.
 	// Without this, eventCount and handle.History remain at pre-compression size,
 	// causing appendSessionEvents() to skip writes or use stale indices.
-	m.mu.Lock()
+	m.lastPromptTokens = cutMeta.KeptTokensEstimate
 	for agentName := range m.eventCount {
 		m.eventCount[agentName] = len(hotEvents)
 	}
@@ -804,9 +923,14 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 			messages = append(messages, messageFromRecord(record))
 		}
 		if err := handle.History.SetMessages(context.Background(), messages); err != nil {
+			fl.Unlock()
 			m.mu.Unlock()
 			return fmt.Errorf("sync in-memory history for %q after compaction: %w", agentName, err)
 		}
+	}
+	if err := fl.Unlock(); err != nil {
+		m.mu.Unlock()
+		return err
 	}
 	m.mu.Unlock()
 
@@ -816,6 +940,78 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 		m.logger.Info("[memory] profile.md regenerated")
 	}
 	return nil
+}
+
+func (m *MemoryManager) consumePendingSessionEvents(ctx context.Context, session *SessionMemoryStore) (int, error) {
+	paths, err := session.pendingEventsPaths()
+	if err != nil {
+		return 0, fmt.Errorf("scan pending session events: %w", err)
+	}
+	consumed := 0
+	for _, path := range paths {
+		select {
+		case <-ctx.Done():
+			return consumed, ctx.Err()
+		default:
+		}
+
+		events, err := session.readEvents(path)
+		if err != nil {
+			if isPathNotExistError(err) {
+				continue
+			}
+			return consumed, fmt.Errorf("read pending session events %q: %w", path, err)
+		}
+		if len(events) == 0 {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return consumed, fmt.Errorf("remove empty pending session events %q: %w", path, err)
+			}
+			continue
+		}
+
+		summary, structured := m.buildEventSummary(ctx, events)
+		if err := ctx.Err(); err != nil {
+			return consumed, err
+		}
+
+		fl := NewFileLock(m.storageDir)
+		if err := fl.Lock(m.lockTimeout); err != nil {
+			return consumed, fmt.Errorf("lock for consuming pending session events: %w", err)
+		}
+
+		if _, err := os.Stat(path); err != nil {
+			_ = fl.Unlock()
+			if os.IsNotExist(err) {
+				continue
+			}
+			return consumed, fmt.Errorf("stat pending session events %q: %w", path, err)
+		}
+
+		chunkSummary, err := session.compressEvents(ctx, events, CompressOption{
+			ChunkID:    pendingChunkIDFromPath(path),
+			Summary:    summary,
+			Structured: structured,
+			Tags:       m.extraction.extractMemoryTags(events),
+			Entities:   m.extraction.extractMemoryEntities(events),
+		})
+		if err != nil {
+			_ = fl.Unlock()
+			return consumed, fmt.Errorf("compress pending session events %q: %w", path, err)
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			_ = fl.Unlock()
+			return consumed, fmt.Errorf("remove consumed pending session events %q: %w", path, err)
+		}
+		if err := fl.Unlock(); err != nil {
+			return consumed, err
+		}
+
+		consumed++
+		if m.logger != nil {
+			m.logger.Info("[memory] pending chunk created: id=%s, events=%d", chunkSummary.ID, len(events))
+		}
+	}
+	return consumed, nil
 }
 
 // compactionPlan describes the chosen split of the event stream.
@@ -1070,6 +1266,26 @@ func summarizeSessionEvents(events []SessionEvent) string {
 	return strings.Join(parts, " / ")
 }
 
+func sessionEventsHavePrefix(current []SessionEvent, prefix []SessionEvent) bool {
+	if len(current) < len(prefix) {
+		return false
+	}
+	for i := range prefix {
+		if current[i].EventID != prefix[i].EventID ||
+			current[i].Ts != prefix[i].Ts ||
+			current[i].Type != prefix[i].Type ||
+			current[i].Role != prefix[i].Role ||
+			current[i].Source != prefix[i].Source ||
+			current[i].Content != prefix[i].Content ||
+			current[i].AppName != prefix[i].AppName ||
+			current[i].RiskLevel != prefix[i].RiskLevel ||
+			current[i].ToolCallID != prefix[i].ToolCallID {
+			return false
+		}
+	}
+	return true
+}
+
 func (cfg MemoryExtractionConfig) extractMemoryTags(events []SessionEvent) []string {
 	seen := map[string]bool{}
 	var tags []string
@@ -1247,6 +1463,10 @@ func memoryFileName(agentName string) string {
 
 func isTruncatedJSONLineError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "unexpected end of JSON input")
+}
+
+func isPathNotExistError(err error) bool {
+	return os.IsNotExist(err) || errors.Is(err, os.ErrNotExist)
 }
 
 func sessionEventFromRecord(record MessageRecord, ts time.Time, offset int) SessionEvent {

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -408,17 +408,16 @@ func (m *MemoryManager) AppendExchange(ctx context.Context, agentName string, in
 	return nil
 }
 
-// RotateSessionEvents atomically moves the current hot session event stream
-// aside so a newly detected task can start with a clean events.jsonl. The
-// rotated file is consumed later by maintenance as a closed pending session.
-// Existing compressed summaries/chunks are intentionally preserved: using task
-// summaries as cross-task historical context is acceptable, while the hot
-// window is limited to the newly detected task.
+// RotateSessionEvents atomically archives the current active session directory
+// so a newly detected session starts from empty filesystem and in-memory
+// context. Archived sessions are preserved as logs only; they are not consumed
+// by active prompt construction, HasCompressedHistory, maintenance, or chunk
+// recall.
 func (m *MemoryManager) RotateSessionEvents() (string, error) {
 	if m.storageDir == "" {
 		return "", nil
 	}
-	pendingPath, err := func() (string, error) {
+	archiveDir, err := func() (string, error) {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 
@@ -431,26 +430,33 @@ func (m *MemoryManager) RotateSessionEvents() (string, error) {
 		}
 		defer fl.Unlock()
 
-		if err := os.MkdirAll(sessionDir, 0o755); err != nil {
-			return "", fmt.Errorf("create session directory for rotation: %w", err)
-		}
-		info, err := os.Stat(eventsPath)
+		hasData, err := sessionDirHasData(sessionDir)
 		if err != nil {
-			if os.IsNotExist(err) {
-				if err := os.WriteFile(eventsPath, nil, 0o644); err != nil {
-					return "", fmt.Errorf("create empty session events after missing rotation source: %w", err)
-				}
-				return "", nil
-			}
-			return "", fmt.Errorf("stat session events for rotation: %w", err)
+			return "", fmt.Errorf("inspect active session for rotation: %w", err)
 		}
-		if info.Size() == 0 {
+		if !hasData {
+			if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+				return "", fmt.Errorf("create empty session directory after no-op rotation: %w", err)
+			}
+			if err := os.WriteFile(eventsPath, nil, 0o644); err != nil {
+				return "", fmt.Errorf("create empty session events after no-op rotation: %w", err)
+			}
 			return "", nil
 		}
 
-		pendingPath := filepath.Join(sessionDir, fmt.Sprintf("events.pending-%d.jsonl", time.Now().UTC().UnixNano()))
-		if err := os.Rename(eventsPath, pendingPath); err != nil {
-			return "", fmt.Errorf("rotate session events: %w", err)
+		archiveParent := filepath.Join(m.storageDir, "session_archive")
+		if err := os.MkdirAll(archiveParent, 0o755); err != nil {
+			return "", fmt.Errorf("create session archive directory: %w", err)
+		}
+		archiveDir, err := nextSessionArchiveDir(archiveParent, time.Now().UTC())
+		if err != nil {
+			return "", err
+		}
+		if err := os.Rename(sessionDir, archiveDir); err != nil {
+			return "", fmt.Errorf("archive active session: %w", err)
+		}
+		if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+			return "", fmt.Errorf("create active session directory after rotation: %w", err)
 		}
 		if err := os.WriteFile(eventsPath, nil, 0o644); err != nil {
 			return "", fmt.Errorf("create empty session events after rotation: %w", err)
@@ -459,24 +465,59 @@ func (m *MemoryManager) RotateSessionEvents() (string, error) {
 		for agentName := range m.eventCount {
 			m.eventCount[agentName] = 0
 		}
+		m.lastPromptTokens = 0
 		for _, handle := range m.handles {
 			if handle != nil && handle.Memory != nil {
 				_ = handle.Memory.Clear(context.Background())
 			}
 		}
-		return pendingPath, nil
+		return archiveDir, nil
 	}()
 	if err != nil {
 		return "", err
 	}
 
-	if pendingPath != "" && m.logger != nil {
-		m.logger.Info("[memory] session rotated: pending=%s", filepath.Base(pendingPath))
+	if archiveDir != "" && m.logger != nil {
+		m.logger.Info("[memory] session rotated: archive=%s", filepath.Base(archiveDir))
 	}
-	if pendingPath != "" {
-		m.RequestMaintenance()
+	return archiveDir, nil
+}
+
+func sessionDirHasData(sessionDir string) (bool, error) {
+	entries, err := os.ReadDir(sessionDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
 	}
-	return pendingPath, nil
+	for _, entry := range entries {
+		if entry.Name() != "events.jsonl" || entry.IsDir() {
+			return true, nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return false, err
+		}
+		if info.Size() > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func nextSessionArchiveDir(parent string, now time.Time) (string, error) {
+	for i := int64(0); i < 100; i++ {
+		id := strconv.FormatInt(now.UnixNano()+i, 10)
+		path := filepath.Join(parent, id)
+		if _, err := os.Stat(path); err != nil {
+			if os.IsNotExist(err) {
+				return path, nil
+			}
+			return "", fmt.Errorf("stat session archive candidate: %w", err)
+		}
+	}
+	return "", fmt.Errorf("allocate session archive path: too many collisions")
 }
 
 func (m *MemoryManager) loadPersistedMessages(history *langmemory.ChatMessageHistory, agentName string) error {
@@ -713,11 +754,6 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 		return nil
 	}
 	session := NewSessionMemoryStore(filepath.Join(m.storageDir, "session"), m.extraction.SummaryMaxChunks)
-	if consumed, err := m.consumePendingSessionEvents(ctx, session); err != nil {
-		return err
-	} else if consumed > 0 && m.logger != nil {
-		m.logger.Info("[memory] pending consumed: count=%d, merged=false", consumed)
-	}
 	eventsPath := session.eventsPath()
 
 	// Phase 1: Read events snapshot under FileLock to serialize with append paths.
@@ -943,78 +979,6 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 		m.logger.Info("[memory] profile.md regenerated")
 	}
 	return nil
-}
-
-func (m *MemoryManager) consumePendingSessionEvents(ctx context.Context, session *SessionMemoryStore) (int, error) {
-	paths, err := session.pendingEventsPaths()
-	if err != nil {
-		return 0, fmt.Errorf("scan pending session events: %w", err)
-	}
-	consumed := 0
-	for _, path := range paths {
-		select {
-		case <-ctx.Done():
-			return consumed, ctx.Err()
-		default:
-		}
-
-		events, err := session.readEvents(path)
-		if err != nil {
-			if isPathNotExistError(err) {
-				continue
-			}
-			return consumed, fmt.Errorf("read pending session events %q: %w", path, err)
-		}
-		if len(events) == 0 {
-			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-				return consumed, fmt.Errorf("remove empty pending session events %q: %w", path, err)
-			}
-			continue
-		}
-
-		summary, structured := m.buildEventSummary(ctx, events)
-		if err := ctx.Err(); err != nil {
-			return consumed, err
-		}
-
-		fl := NewFileLock(m.storageDir)
-		if err := fl.Lock(m.lockTimeout); err != nil {
-			return consumed, fmt.Errorf("lock for consuming pending session events: %w", err)
-		}
-
-		if _, err := os.Stat(path); err != nil {
-			_ = fl.Unlock()
-			if os.IsNotExist(err) {
-				continue
-			}
-			return consumed, fmt.Errorf("stat pending session events %q: %w", path, err)
-		}
-
-		chunkSummary, err := session.compressEvents(ctx, events, CompressOption{
-			ChunkID:    pendingChunkIDFromPath(path),
-			Summary:    summary,
-			Structured: structured,
-			Tags:       m.extraction.extractMemoryTags(events),
-			Entities:   m.extraction.extractMemoryEntities(events),
-		})
-		if err != nil {
-			_ = fl.Unlock()
-			return consumed, fmt.Errorf("compress pending session events %q: %w", path, err)
-		}
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			_ = fl.Unlock()
-			return consumed, fmt.Errorf("remove consumed pending session events %q: %w", path, err)
-		}
-		if err := fl.Unlock(); err != nil {
-			return consumed, err
-		}
-
-		consumed++
-		if m.logger != nil {
-			m.logger.Info("[memory] pending chunk created: id=%s, events=%d", chunkSummary.ID, len(events))
-		}
-	}
-	return consumed, nil
 }
 
 // compactionPlan describes the chosen split of the event stream.

--- a/src/agent/internal/agent/memory_config.go
+++ b/src/agent/internal/agent/memory_config.go
@@ -36,20 +36,35 @@ type MemoryExtractionConfig struct {
 	// alongside ReserveTokens inside the active window. Borrowed from pi's
 	// keepRecentTokens.
 	KeepRecentTokens int `yaml:"keep_recent_tokens"`
+	// SessionBoundaryEnabled controls voice multi-task session detection.
+	// When true, each new user_input is classified as "continue" or "new";
+	// "new" rotates events.jsonl into a pending session so the current turn
+	// starts with a clean hot window.
+	SessionBoundaryEnabled bool `yaml:"session_boundary_enabled"`
+	// SessionBoundaryShortGapSeconds is the gap below which a new turn is
+	// treated as a continuation regardless of lexical signals.
+	SessionBoundaryShortGapSeconds int `yaml:"session_boundary_short_gap_seconds"`
+	// SessionBoundaryLongGapSeconds is the gap above which a new turn is
+	// treated as a fresh session regardless of lexical signals.
+	SessionBoundaryLongGapSeconds int `yaml:"session_boundary_long_gap_seconds"`
 
 	countCompressAfterEventsConfigured bool
+	SessionBoundaryEnabledConfigured   bool `yaml:"-"`
 }
 
 type rawMemoryExtractionConfig struct {
-	TagCandidates            *[]string `yaml:"tag_candidates"`
-	EntitySuffixes           *[]string `yaml:"entity_suffixes"`
-	HotWindowEvents          *int      `yaml:"hot_window_events"`
-	CountCompressAfterEvents *int      `yaml:"count_compress_after_events"`
-	ContextWindow            *int      `yaml:"context_window"`
-	CompressAtPercent        *int      `yaml:"compress_at_percent"`
-	SummaryMaxChunks         *int      `yaml:"summary_max_chunks"`
-	ReserveTokens            *int      `yaml:"reserve_tokens"`
-	KeepRecentTokens         *int      `yaml:"keep_recent_tokens"`
+	TagCandidates                  *[]string `yaml:"tag_candidates"`
+	EntitySuffixes                 *[]string `yaml:"entity_suffixes"`
+	HotWindowEvents                *int      `yaml:"hot_window_events"`
+	CountCompressAfterEvents       *int      `yaml:"count_compress_after_events"`
+	ContextWindow                  *int      `yaml:"context_window"`
+	CompressAtPercent              *int      `yaml:"compress_at_percent"`
+	SummaryMaxChunks               *int      `yaml:"summary_max_chunks"`
+	ReserveTokens                  *int      `yaml:"reserve_tokens"`
+	KeepRecentTokens               *int      `yaml:"keep_recent_tokens"`
+	SessionBoundaryEnabled         *bool     `yaml:"session_boundary_enabled"`
+	SessionBoundaryShortGapSeconds *int      `yaml:"session_boundary_short_gap_seconds"`
+	SessionBoundaryLongGapSeconds  *int      `yaml:"session_boundary_long_gap_seconds"`
 }
 
 const (
@@ -67,14 +82,17 @@ func DefaultMemoryExtractionConfig() MemoryExtractionConfig {
 			"报销", "支付", "付款", "提交", "登录", "验证码",
 			"发票", "项目编码", "风险", "确认", "开发板", "agent",
 		},
-		EntitySuffixes:           []string{"App", "app", "APP"},
-		HotWindowEvents:          defaultHotWindowEvents,
-		CountCompressAfterEvents: defaultCountCompressAfterEvents,
-		ContextWindow:            32000,
-		CompressAtPercent:        50,
-		SummaryMaxChunks:         10,
-		ReserveTokens:            defaultReserveTokens,
-		KeepRecentTokens:         defaultKeepRecentTokens,
+		EntitySuffixes:                 []string{"App", "app", "APP"},
+		HotWindowEvents:                defaultHotWindowEvents,
+		CountCompressAfterEvents:       defaultCountCompressAfterEvents,
+		ContextWindow:                  32000,
+		CompressAtPercent:              50,
+		SummaryMaxChunks:               10,
+		ReserveTokens:                  defaultReserveTokens,
+		KeepRecentTokens:               defaultKeepRecentTokens,
+		SessionBoundaryEnabled:         true,
+		SessionBoundaryShortGapSeconds: DefaultBoundaryConfig().ShortGapSeconds,
+		SessionBoundaryLongGapSeconds:  DefaultBoundaryConfig().LongGapSeconds,
 	}
 }
 
@@ -102,6 +120,19 @@ func normalizeMemoryExtractionConfig(cfg MemoryExtractionConfig) MemoryExtractio
 	}
 	if cfg.KeepRecentTokens <= 0 {
 		cfg.KeepRecentTokens = defaultKeepRecentTokens
+	}
+	if !cfg.SessionBoundaryEnabledConfigured {
+		cfg.SessionBoundaryEnabled = true
+	}
+	defaultBoundary := DefaultBoundaryConfig()
+	if cfg.SessionBoundaryShortGapSeconds <= 0 {
+		cfg.SessionBoundaryShortGapSeconds = defaultBoundary.ShortGapSeconds
+	}
+	if cfg.SessionBoundaryLongGapSeconds <= cfg.SessionBoundaryShortGapSeconds {
+		cfg.SessionBoundaryLongGapSeconds = defaultBoundary.LongGapSeconds
+	}
+	if cfg.SessionBoundaryLongGapSeconds <= cfg.SessionBoundaryShortGapSeconds {
+		cfg.SessionBoundaryLongGapSeconds = cfg.SessionBoundaryShortGapSeconds + defaultBoundary.LongGapSeconds
 	}
 	return cfg
 }
@@ -151,6 +182,16 @@ func LoadMemoryExtractionConfig(configDir string) MemoryExtractionConfig {
 	}
 	if raw.KeepRecentTokens != nil {
 		cfg.KeepRecentTokens = *raw.KeepRecentTokens
+	}
+	if raw.SessionBoundaryEnabled != nil {
+		cfg.SessionBoundaryEnabled = *raw.SessionBoundaryEnabled
+		cfg.SessionBoundaryEnabledConfigured = true
+	}
+	if raw.SessionBoundaryShortGapSeconds != nil {
+		cfg.SessionBoundaryShortGapSeconds = *raw.SessionBoundaryShortGapSeconds
+	}
+	if raw.SessionBoundaryLongGapSeconds != nil {
+		cfg.SessionBoundaryLongGapSeconds = *raw.SessionBoundaryLongGapSeconds
 	}
 	return normalizeMemoryExtractionConfig(cfg)
 }

--- a/src/agent/internal/agent/memory_config.go
+++ b/src/agent/internal/agent/memory_config.go
@@ -39,7 +39,8 @@ type MemoryExtractionConfig struct {
 	// SessionBoundaryEnabled controls voice multi-task session detection.
 	// When true, each new user_input is classified as "continue" or "new";
 	// "new" rotates events.jsonl into a pending session so the current turn
-	// starts with a clean hot window.
+	// starts with a clean hot window. Compressed session summaries remain
+	// available across task boundaries as acceptable historical context.
 	SessionBoundaryEnabled bool `yaml:"session_boundary_enabled"`
 	// SessionBoundaryShortGapSeconds is the gap below which a new turn is
 	// treated as a continuation regardless of lexical signals.

--- a/src/agent/internal/agent/memory_config.go
+++ b/src/agent/internal/agent/memory_config.go
@@ -38,9 +38,9 @@ type MemoryExtractionConfig struct {
 	KeepRecentTokens int `yaml:"keep_recent_tokens"`
 	// SessionBoundaryEnabled controls voice multi-task session detection.
 	// When true, each new user_input is classified as "continue" or "new";
-	// "new" rotates events.jsonl into a pending session so the current turn
-	// starts with a clean hot window. Compressed session summaries remain
-	// available across task boundaries as acceptable historical context.
+	// "new" archives memory/session/ into session_archive/<closed_session_id>/
+	// and recreates an empty active session. Archived sessions are not used as
+	// prompt context or active recall sources.
 	SessionBoundaryEnabled bool `yaml:"session_boundary_enabled"`
 	// SessionBoundaryShortGapSeconds is the gap below which a new turn is
 	// treated as a continuation regardless of lexical signals.

--- a/src/agent/internal/agent/memory_plane.go
+++ b/src/agent/internal/agent/memory_plane.go
@@ -111,9 +111,9 @@ func (p *FilesystemMemoryPlane) Retrieve(ctx context.Context, req MemoryRetrieve
 	if p == nil || p.memoryDir == "" {
 		return out, nil
 	}
-	// Session summaries can span earlier closed tasks. They are intentionally
-	// retained as compact historical context; session boundary rotation only
-	// resets the hot event window.
+	// Session summaries belong only to the current active session. Closed
+	// sessions are archived under session_archive/ and are not injected into
+	// prompts or retrieved through the active memory plane.
 	out.Common.SessionSummary = readTextFileIfExists(filepath.Join(p.memoryDir, "session", "summary.md"))
 	out.Common.Profile = readTextFileIfExists(filepath.Join(p.memoryDir, "long_term", "profile.md"))
 

--- a/src/agent/internal/agent/memory_plane.go
+++ b/src/agent/internal/agent/memory_plane.go
@@ -111,6 +111,9 @@ func (p *FilesystemMemoryPlane) Retrieve(ctx context.Context, req MemoryRetrieve
 	if p == nil || p.memoryDir == "" {
 		return out, nil
 	}
+	// Session summaries can span earlier closed tasks. They are intentionally
+	// retained as compact historical context; session boundary rotation only
+	// resets the hot event window.
 	out.Common.SessionSummary = readTextFileIfExists(filepath.Join(p.memoryDir, "session", "summary.md"))
 	out.Common.Profile = readTextFileIfExists(filepath.Join(p.memoryDir, "long_term", "profile.md"))
 

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -1063,6 +1063,361 @@ func TestMaintainFilesystemMemoryChineseCountFallbackNoOrphanToolResult(t *testi
 	}
 }
 
+func TestSessionRotationMovesActiveEventsToPending(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	releaseMaintenance := make(chan struct{})
+	manager := NewMemoryManager(storageDir, WithSummarizeFn(func(ctx context.Context, events []SessionEvent) string {
+		select {
+		case <-ctx.Done():
+			return ""
+		case <-releaseMaintenance:
+			return "rotated summary"
+		}
+	}))
+	defer func() {
+		close(releaseMaintenance)
+		waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := manager.WaitMaintenance(waitCtx); err != nil {
+			t.Fatalf("WaitMaintenance() error = %v", err)
+		}
+	}()
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	now := time.Now().UTC()
+	for i := 0; i < 5; i++ {
+		if _, err := session.AppendEvent(ctx, SessionEvent{
+			EventID: fmt.Sprintf("evt_rotate_%d", i),
+			Ts:      now.Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
+			Type:    "user_input",
+			Role:    "user",
+			Content: fmt.Sprintf("old task event %d", i),
+		}); err != nil {
+			t.Fatalf("AppendEvent() error = %v", err)
+		}
+	}
+
+	pendingPath, err := manager.RotateSessionEvents()
+	if err != nil {
+		t.Fatalf("RotateSessionEvents() error = %v", err)
+	}
+	if pendingPath == "" {
+		t.Fatal("RotateSessionEvents() returned empty pending path")
+	}
+
+	if got := readSessionEvents(t, session.eventsPath()); len(got) != 0 {
+		t.Fatalf("expected new events.jsonl to be empty, got %d events", len(got))
+	}
+	pending := readSessionEvents(t, pendingPath)
+	if len(pending) != 5 {
+		t.Fatalf("expected pending file to contain 5 old events, got %d", len(pending))
+	}
+	if pending[0].EventID != "evt_rotate_0" || pending[4].EventID != "evt_rotate_4" {
+		t.Fatalf("pending events not preserved in order: %#v", pending)
+	}
+}
+
+func TestSessionRotationAppendAfterRotateWritesNewEventsFile(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	releaseMaintenance := make(chan struct{})
+	manager := NewMemoryManager(storageDir, WithSummarizeFn(func(ctx context.Context, events []SessionEvent) string {
+		select {
+		case <-ctx.Done():
+			return ""
+		case <-releaseMaintenance:
+			return "rotated summary"
+		}
+	}))
+	defer func() {
+		close(releaseMaintenance)
+		waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := manager.WaitMaintenance(waitCtx); err != nil {
+			t.Fatalf("WaitMaintenance() error = %v", err)
+		}
+	}()
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	now := time.Now().UTC()
+	if _, err := session.AppendEvent(ctx, SessionEvent{
+		EventID: "evt_before_rotate",
+		Ts:      now.Format(time.RFC3339Nano),
+		Type:    "user_input",
+		Role:    "user",
+		Content: "old task",
+	}); err != nil {
+		t.Fatalf("AppendEvent() before rotate error = %v", err)
+	}
+
+	pendingPath, err := manager.RotateSessionEvents()
+	if err != nil {
+		t.Fatalf("RotateSessionEvents() error = %v", err)
+	}
+	if _, err := session.AppendEvent(ctx, SessionEvent{
+		EventID: "evt_after_rotate",
+		Ts:      now.Add(time.Second).Format(time.RFC3339Nano),
+		Type:    "user_input",
+		Role:    "user",
+		Content: "new task",
+	}); err != nil {
+		t.Fatalf("AppendEvent() after rotate error = %v", err)
+	}
+
+	active := readSessionEvents(t, session.eventsPath())
+	if len(active) != 1 || active[0].EventID != "evt_after_rotate" {
+		t.Fatalf("expected only new event in active events.jsonl, got %#v", active)
+	}
+	pending := readSessionEvents(t, pendingPath)
+	if len(pending) != 1 || pending[0].EventID != "evt_before_rotate" {
+		t.Fatalf("expected old event in pending file, got %#v", pending)
+	}
+}
+
+func TestSessionRotationDoesNotDeadlockWithMemoryLoad(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	manager := NewMemoryManager(storageDir)
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	now := time.Now().UTC()
+	if _, err := session.AppendEvent(ctx, SessionEvent{
+		EventID: "evt_before_deadlock_check",
+		Ts:      now.Format(time.RFC3339Nano),
+		Type:    "user_input",
+		Role:    "user",
+		Content: "old task",
+	}); err != nil {
+		t.Fatalf("AppendEvent() error = %v", err)
+	}
+
+	done := make(chan error, 2)
+	go func() {
+		_, err := manager.RotateSessionEvents()
+		done <- err
+	}()
+	go func() {
+		_, err := manager.Get("default", MemoryConfig{Type: "window", WindowSize: 10})
+		done <- err
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("concurrent operation error = %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("RotateSessionEvents and Get appear to be deadlocked")
+		}
+	}
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := manager.WaitMaintenance(waitCtx); err != nil {
+		t.Fatalf("WaitMaintenance() error = %v", err)
+	}
+}
+
+func TestMaintainFilesystemMemorySkipsActiveWriteAfterRotation(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	cfg := DefaultMemoryExtractionConfig()
+	cfg.HotWindowEvents = 4
+	cfg.CountCompressAfterEvents = 8
+
+	summaryStarted := make(chan struct{})
+	releaseSummary := make(chan struct{})
+	var summaryStartedOnce sync.Once
+	manager := NewMemoryManager(storageDir, WithExtractionConfig(cfg), WithSummarizeFn(func(ctx context.Context, events []SessionEvent) string {
+		summaryStartedOnce.Do(func() { close(summaryStarted) })
+		select {
+		case <-ctx.Done():
+			return ""
+		case <-releaseSummary:
+			return "old active summary"
+		}
+	}))
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	now := time.Now().UTC()
+	for i := 0; i < 10; i++ {
+		if _, err := session.AppendEvent(ctx, SessionEvent{
+			EventID: fmt.Sprintf("evt_old_active_%02d", i),
+			Ts:      now.Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
+			Type:    "user_input",
+			Role:    "user",
+			Content: fmt.Sprintf("old active %d", i),
+		}); err != nil {
+			t.Fatalf("AppendEvent() old error = %v", err)
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.maintainFilesystemMemory(ctx)
+	}()
+	select {
+	case <-summaryStarted:
+	case <-time.After(time.Second):
+		t.Fatal("maintenance did not start summary")
+	}
+	if _, err := manager.RotateSessionEvents(); err != nil {
+		t.Fatalf("RotateSessionEvents() error = %v", err)
+	}
+	if _, err := session.AppendEvent(ctx, SessionEvent{
+		EventID: "evt_new_active",
+		Ts:      now.Add(time.Minute).Format(time.RFC3339Nano),
+		Type:    "user_input",
+		Role:    "user",
+		Content: "new active",
+	}); err != nil {
+		t.Fatalf("AppendEvent() new error = %v", err)
+	}
+	close(releaseSummary)
+	if err := <-done; err != nil {
+		t.Fatalf("maintainFilesystemMemory() error = %v", err)
+	}
+
+	active := readSessionEvents(t, session.eventsPath())
+	if len(active) != 1 || active[0].EventID != "evt_new_active" {
+		t.Fatalf("maintenance wrote old session back into active events: %#v", active)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := manager.WaitMaintenance(waitCtx); err != nil {
+		t.Fatalf("WaitMaintenance() error = %v", err)
+	}
+}
+
+func TestSessionMemoryRecallIncludesPendingChunks(t *testing.T) {
+	ctx := context.Background()
+	session := NewSessionMemoryStore(filepath.Join(t.TempDir(), "session"))
+	if err := os.MkdirAll(session.rootDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll session dir: %v", err)
+	}
+	pendingPath := filepath.Join(session.rootDir, "events.pending-123.jsonl")
+	pendingEvents := []SessionEvent{{
+		EventID: "evt_pending_1",
+		Ts:      time.Now().UTC().Format(time.RFC3339Nano),
+		Type:    "user_input",
+		Role:    "user",
+		Content: "查一下明天天气",
+		AppName: "WeatherApp",
+	}}
+	data, _, err := encodeSessionEventsJSONL(pendingEvents)
+	if err != nil {
+		t.Fatalf("encode pending events: %v", err)
+	}
+	if err := os.WriteFile(pendingPath, data, 0o644); err != nil {
+		t.Fatalf("write pending file: %v", err)
+	}
+
+	results, err := session.RecallChunks(ctx, ChunkRecallQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("RecallChunks() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected one pending recall result, got %#v", results)
+	}
+	if results[0].ChunkID != "pending-123" {
+		t.Fatalf("expected pending chunk id, got %q", results[0].ChunkID)
+	}
+	if len(results[0].Evidence) != 1 || results[0].Evidence[0].EventID != "evt_pending_1" {
+		t.Fatalf("unexpected pending evidence: %#v", results[0].Evidence)
+	}
+	if !strings.Contains(results[0].Summary, "Pending compression") {
+		t.Fatalf("pending summary should describe pending compression, got %q", results[0].Summary)
+	}
+}
+
+func TestSessionMemoryRecallKeepsPendingSlotWhenLimitFilled(t *testing.T) {
+	ctx := context.Background()
+	session := NewSessionMemoryStore(filepath.Join(t.TempDir(), "session"))
+	for i := 0; i < 3; i++ {
+		if _, err := session.AppendEvent(ctx, SessionEvent{
+			EventID: fmt.Sprintf("evt_active_%d", i),
+			Type:    "user_input",
+			Role:    "user",
+			Content: fmt.Sprintf("active %d", i),
+		}); err != nil {
+			t.Fatalf("AppendEvent() active error = %v", err)
+		}
+		if _, err := session.Compress(ctx, CompressOption{
+			ChunkID: fmt.Sprintf("chunk_%03d", i),
+			Summary: fmt.Sprintf("active summary %d", i),
+		}); err != nil {
+			t.Fatalf("Compress() error = %v", err)
+		}
+	}
+	pendingPath := filepath.Join(session.rootDir, "events.pending-999.jsonl")
+	data, _, err := encodeSessionEventsJSONL([]SessionEvent{{
+		EventID: "evt_pending_slot",
+		Type:    "user_input",
+		Role:    "user",
+		Content: "pending should be visible",
+	}})
+	if err != nil {
+		t.Fatalf("encode pending: %v", err)
+	}
+	if err := os.WriteFile(pendingPath, data, 0o644); err != nil {
+		t.Fatalf("write pending: %v", err)
+	}
+
+	results, err := session.RecallChunks(ctx, ChunkRecallQuery{Limit: 2})
+	if err != nil {
+		t.Fatalf("RecallChunks() error = %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %#v", results)
+	}
+	if results[1].ChunkID != "pending-999" {
+		t.Fatalf("expected pending result to keep one limited slot, got %#v", results)
+	}
+}
+
+func TestMaintainFilesystemMemoryConsumesPendingFiles(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	if err := os.MkdirAll(session.rootDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll session dir: %v", err)
+	}
+	pendingPath := filepath.Join(session.rootDir, "events.pending-123.jsonl")
+	now := time.Now().UTC()
+	pendingEvents := []SessionEvent{
+		{EventID: "evt_pending_1", Ts: now.Format(time.RFC3339Nano), Type: "user_input", Role: "user", Content: "打开微信"},
+		{EventID: "evt_pending_2", Ts: now.Add(time.Second).Format(time.RFC3339Nano), Type: "assistant_output", Role: "assistant", Content: "已打开"},
+	}
+	data, _, err := encodeSessionEventsJSONL(pendingEvents)
+	if err != nil {
+		t.Fatalf("encode pending events: %v", err)
+	}
+	if err := os.WriteFile(pendingPath, data, 0o644); err != nil {
+		t.Fatalf("write pending file: %v", err)
+	}
+
+	manager := NewMemoryManager(storageDir, WithSummarizeFn(func(ctx context.Context, events []SessionEvent) string {
+		return fmt.Sprintf("pending summary with %d events", len(events))
+	}))
+	if err := manager.maintainFilesystemMemory(ctx); err != nil {
+		t.Fatalf("maintainFilesystemMemory() error = %v", err)
+	}
+	if _, err := os.Stat(pendingPath); !os.IsNotExist(err) {
+		t.Fatalf("expected pending file to be deleted after consumption, stat err = %v", err)
+	}
+	results, err := session.RecallChunks(ctx, ChunkRecallQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("RecallChunks() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected one consumed chunk, got %#v", results)
+	}
+	if results[0].Summary != "pending summary with 2 events" {
+		t.Fatalf("unexpected consumed summary: %q", results[0].Summary)
+	}
+	if len(results[0].Evidence) != 2 {
+		t.Fatalf("expected consumed chunk evidence, got %#v", results[0].Evidence)
+	}
+}
+
 func readSessionEvents(t *testing.T, path string) []SessionEvent {
 	t.Helper()
 	file, err := os.Open(path)
@@ -1179,6 +1534,23 @@ func TestFormatSessionSummaryWithWindowAppendsToExistingArchive(t *testing.T) {
 	}
 }
 
+func TestFormatSessionSummaryWithWindowUpsertsExistingChunk(t *testing.T) {
+	existing := []byte("# Session History (compressed chunks)\n\n" +
+		"## Recent Chunks\n\n" +
+		"- **pending-123**\n  Old summary\n")
+
+	summary, archive := formatSessionSummaryWithWindow(existing, nil, chunkIndexEntry{ID: "pending-123", Summary: "New summary"}, 10)
+	if archive != "" {
+		t.Fatalf("expected no archive, got:\n%s", archive)
+	}
+	if strings.Count(summary, "pending-123") != 1 {
+		t.Fatalf("expected pending-123 to appear once, got:\n%s", summary)
+	}
+	if !strings.Contains(summary, "New summary") || strings.Contains(summary, "Old summary") {
+		t.Fatalf("expected summary to be updated, got:\n%s", summary)
+	}
+}
+
 func TestSessionMemoryStoreCompressCreatesArchive(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
@@ -1274,18 +1646,52 @@ func TestSummaryMaxChunksConfigDefaultAndCustom(t *testing.T) {
 	if cfg.SummaryMaxChunks != 10 {
 		t.Fatalf("expected default SummaryMaxChunks=10, got %d", cfg.SummaryMaxChunks)
 	}
+	if !cfg.SessionBoundaryEnabled {
+		t.Fatalf("expected session boundary detection to be enabled by default")
+	}
+	if cfg.SessionBoundaryShortGapSeconds != 30 {
+		t.Fatalf("expected default short gap 30s, got %d", cfg.SessionBoundaryShortGapSeconds)
+	}
+	if cfg.SessionBoundaryLongGapSeconds != 300 {
+		t.Fatalf("expected default long gap 300s, got %d", cfg.SessionBoundaryLongGapSeconds)
+	}
 
 	dir := t.TempDir()
 	memDir := filepath.Join(dir, "memory")
 	if err := os.MkdirAll(memDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(memDir, "extraction.yaml"), []byte("summary_max_chunks: 5\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(memDir, "extraction.yaml"), []byte(strings.Join([]string{
+		"summary_max_chunks: 5",
+		"session_boundary_enabled: false",
+		"session_boundary_short_gap_seconds: 15",
+		"session_boundary_long_gap_seconds: 120",
+		"",
+	}, "\n")), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	loaded := LoadMemoryExtractionConfig(dir)
 	if loaded.SummaryMaxChunks != 5 {
 		t.Fatalf("expected loaded SummaryMaxChunks=5, got %d", loaded.SummaryMaxChunks)
+	}
+	if loaded.SessionBoundaryEnabled {
+		t.Fatalf("expected loaded SessionBoundaryEnabled=false")
+	}
+	if loaded.SessionBoundaryShortGapSeconds != 15 || loaded.SessionBoundaryLongGapSeconds != 120 {
+		t.Fatalf("unexpected loaded session boundary gaps: short=%d long=%d",
+			loaded.SessionBoundaryShortGapSeconds, loaded.SessionBoundaryLongGapSeconds)
+	}
+}
+
+func TestWithSessionBoundaryEnabledOverridesProgrammaticConfig(t *testing.T) {
+	manager := NewMemoryManager(t.TempDir(), WithSessionBoundaryEnabled(false))
+	if manager.extraction.SessionBoundaryEnabled {
+		t.Fatalf("expected explicit programmatic override to disable session boundary")
+	}
+
+	manager = NewMemoryManager(t.TempDir(), WithSessionBoundaryEnabled(false), WithExtractionConfig(DefaultMemoryExtractionConfig()))
+	if manager.extraction.SessionBoundaryEnabled {
+		t.Fatalf("expected later normalization to preserve explicit disable")
 	}
 }
 

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -1063,26 +1063,10 @@ func TestMaintainFilesystemMemoryChineseCountFallbackNoOrphanToolResult(t *testi
 	}
 }
 
-func TestSessionRotationMovesActiveEventsToPending(t *testing.T) {
+func TestSessionRotationArchivesActiveSessionDirectory(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()
-	releaseMaintenance := make(chan struct{})
-	manager := NewMemoryManager(storageDir, WithSummarizeFn(func(ctx context.Context, events []SessionEvent) string {
-		select {
-		case <-ctx.Done():
-			return ""
-		case <-releaseMaintenance:
-			return "rotated summary"
-		}
-	}))
-	defer func() {
-		close(releaseMaintenance)
-		waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		if err := manager.WaitMaintenance(waitCtx); err != nil {
-			t.Fatalf("WaitMaintenance() error = %v", err)
-		}
-	}()
+	manager := NewMemoryManager(storageDir)
 	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
 	now := time.Now().UTC()
 	for i := 0; i < 5; i++ {
@@ -1096,47 +1080,76 @@ func TestSessionRotationMovesActiveEventsToPending(t *testing.T) {
 			t.Fatalf("AppendEvent() error = %v", err)
 		}
 	}
+	if _, err := session.Compress(ctx, CompressOption{
+		ChunkID:  "chunk_old_session",
+		Summary:  "OLD SESSION SUMMARY SENTINEL",
+		Tags:     []string{"old"},
+		Entities: []string{"OldApp"},
+	}); err != nil {
+		t.Fatalf("Compress() error = %v", err)
+	}
+	if !manager.HasCompressedHistory() {
+		t.Fatal("expected active session to report compressed history before rotation")
+	}
+	handle, err := manager.Get("default", MemoryConfig{Type: "window", WindowSize: 10})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
 
-	pendingPath, err := manager.RotateSessionEvents()
+	archiveDir, err := manager.RotateSessionEvents()
 	if err != nil {
 		t.Fatalf("RotateSessionEvents() error = %v", err)
 	}
-	if pendingPath == "" {
-		t.Fatal("RotateSessionEvents() returned empty pending path")
+	if archiveDir == "" {
+		t.Fatal("RotateSessionEvents() returned empty archive path")
 	}
 
 	if got := readSessionEvents(t, session.eventsPath()); len(got) != 0 {
 		t.Fatalf("expected new events.jsonl to be empty, got %d events", len(got))
 	}
-	pending := readSessionEvents(t, pendingPath)
-	if len(pending) != 5 {
-		t.Fatalf("expected pending file to contain 5 old events, got %d", len(pending))
+	if manager.HasCompressedHistory() {
+		t.Fatal("old summary.md must not make the new active session report compressed history")
 	}
-	if pending[0].EventID != "evt_rotate_0" || pending[4].EventID != "evt_rotate_4" {
-		t.Fatalf("pending events not preserved in order: %#v", pending)
+	if _, err := os.Stat(filepath.Join(storageDir, "session", "summary.md")); !os.IsNotExist(err) {
+		t.Fatalf("active summary.md should be absent after rotation, stat err = %v", err)
+	}
+	archived := readSessionEvents(t, filepath.Join(archiveDir, "events.jsonl"))
+	if len(archived) != 5 {
+		t.Fatalf("expected archive to contain 5 old events, got %d", len(archived))
+	}
+	if archived[0].EventID != "evt_rotate_0" || archived[4].EventID != "evt_rotate_4" {
+		t.Fatalf("archived events not preserved in order: %#v", archived)
+	}
+	archivedSummary, err := os.ReadFile(filepath.Join(archiveDir, "summary.md"))
+	if err != nil {
+		t.Fatalf("read archived summary.md: %v", err)
+	}
+	if !strings.Contains(string(archivedSummary), "OLD SESSION SUMMARY SENTINEL") {
+		t.Fatalf("archived summary missing old summary sentinel:\n%s", archivedSummary)
+	}
+	if _, err := os.Stat(filepath.Join(archiveDir, "chunks", "index.yaml")); err != nil {
+		t.Fatalf("archived chunks/index.yaml missing: %v", err)
+	}
+	results, err := NewSessionMemoryStore(filepath.Join(storageDir, "session")).RecallChunks(ctx, ChunkRecallQuery{ChunkIDs: []string{"chunk_old_session"}})
+	if err != nil {
+		t.Fatalf("RecallChunks() error = %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("archived chunks must not be recalled from active session, got %#v", results)
+	}
+	messages, err := handle.History.Messages(ctx)
+	if err != nil {
+		t.Fatalf("Messages() error = %v", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("conversation window should be empty after rotation, got %#v", messages)
 	}
 }
 
 func TestSessionRotationAppendAfterRotateWritesNewEventsFile(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()
-	releaseMaintenance := make(chan struct{})
-	manager := NewMemoryManager(storageDir, WithSummarizeFn(func(ctx context.Context, events []SessionEvent) string {
-		select {
-		case <-ctx.Done():
-			return ""
-		case <-releaseMaintenance:
-			return "rotated summary"
-		}
-	}))
-	defer func() {
-		close(releaseMaintenance)
-		waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		if err := manager.WaitMaintenance(waitCtx); err != nil {
-			t.Fatalf("WaitMaintenance() error = %v", err)
-		}
-	}()
+	manager := NewMemoryManager(storageDir)
 	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
 	now := time.Now().UTC()
 	if _, err := session.AppendEvent(ctx, SessionEvent{
@@ -1149,7 +1162,7 @@ func TestSessionRotationAppendAfterRotateWritesNewEventsFile(t *testing.T) {
 		t.Fatalf("AppendEvent() before rotate error = %v", err)
 	}
 
-	pendingPath, err := manager.RotateSessionEvents()
+	archiveDir, err := manager.RotateSessionEvents()
 	if err != nil {
 		t.Fatalf("RotateSessionEvents() error = %v", err)
 	}
@@ -1167,9 +1180,9 @@ func TestSessionRotationAppendAfterRotateWritesNewEventsFile(t *testing.T) {
 	if len(active) != 1 || active[0].EventID != "evt_after_rotate" {
 		t.Fatalf("expected only new event in active events.jsonl, got %#v", active)
 	}
-	pending := readSessionEvents(t, pendingPath)
-	if len(pending) != 1 || pending[0].EventID != "evt_before_rotate" {
-		t.Fatalf("expected old event in pending file, got %#v", pending)
+	archived := readSessionEvents(t, filepath.Join(archiveDir, "events.jsonl"))
+	if len(archived) != 1 || archived[0].EventID != "evt_before_rotate" {
+		t.Fatalf("expected old event in archive, got %#v", archived)
 	}
 }
 
@@ -1287,7 +1300,7 @@ func TestMaintainFilesystemMemorySkipsActiveWriteAfterRotation(t *testing.T) {
 	}
 }
 
-func TestSessionMemoryRecallIncludesPendingChunks(t *testing.T) {
+func TestSessionMemoryRecallIgnoresPendingFiles(t *testing.T) {
 	ctx := context.Background()
 	session := NewSessionMemoryStore(filepath.Join(t.TempDir(), "session"))
 	if err := os.MkdirAll(session.rootDir, 0o755); err != nil {
@@ -1314,21 +1327,12 @@ func TestSessionMemoryRecallIncludesPendingChunks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RecallChunks() error = %v", err)
 	}
-	if len(results) != 1 {
-		t.Fatalf("expected one pending recall result, got %#v", results)
-	}
-	if results[0].ChunkID != "pending-123" {
-		t.Fatalf("expected pending chunk id, got %q", results[0].ChunkID)
-	}
-	if len(results[0].Evidence) != 1 || results[0].Evidence[0].EventID != "evt_pending_1" {
-		t.Fatalf("unexpected pending evidence: %#v", results[0].Evidence)
-	}
-	if !strings.Contains(results[0].Summary, "Pending compression") {
-		t.Fatalf("pending summary should describe pending compression, got %q", results[0].Summary)
+	if len(results) != 0 {
+		t.Fatalf("pending files must not be recalled from active session, got %#v", results)
 	}
 }
 
-func TestSessionMemoryRecallKeepsPendingSlotWhenLimitFilled(t *testing.T) {
+func TestSessionMemoryRecallDoesNotLetPendingReplaceActive(t *testing.T) {
 	ctx := context.Background()
 	session := NewSessionMemoryStore(filepath.Join(t.TempDir(), "session"))
 	for i := 0; i < 3; i++ {
@@ -1368,12 +1372,14 @@ func TestSessionMemoryRecallKeepsPendingSlotWhenLimitFilled(t *testing.T) {
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results, got %#v", results)
 	}
-	if results[1].ChunkID != "pending-999" {
-		t.Fatalf("expected pending result to keep one limited slot, got %#v", results)
+	for _, result := range results {
+		if strings.HasPrefix(result.ChunkID, "pending-") {
+			t.Fatalf("pending file replaced an active recall result: %#v", results)
+		}
 	}
 }
 
-func TestMaintainFilesystemMemoryConsumesPendingFiles(t *testing.T) {
+func TestMaintainFilesystemMemoryIgnoresPendingFiles(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()
 	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
@@ -1400,21 +1406,18 @@ func TestMaintainFilesystemMemoryConsumesPendingFiles(t *testing.T) {
 	if err := manager.maintainFilesystemMemory(ctx); err != nil {
 		t.Fatalf("maintainFilesystemMemory() error = %v", err)
 	}
-	if _, err := os.Stat(pendingPath); !os.IsNotExist(err) {
-		t.Fatalf("expected pending file to be deleted after consumption, stat err = %v", err)
+	if _, err := os.Stat(pendingPath); err != nil {
+		t.Fatalf("pending file should remain inert and uncompressed, stat err = %v", err)
 	}
 	results, err := session.RecallChunks(ctx, ChunkRecallQuery{Limit: 10})
 	if err != nil {
 		t.Fatalf("RecallChunks() error = %v", err)
 	}
-	if len(results) != 1 {
-		t.Fatalf("expected one consumed chunk, got %#v", results)
+	if len(results) != 0 {
+		t.Fatalf("pending file must not be compressed into active chunks, got %#v", results)
 	}
-	if results[0].Summary != "pending summary with 2 events" {
-		t.Fatalf("unexpected consumed summary: %q", results[0].Summary)
-	}
-	if len(results[0].Evidence) != 2 {
-		t.Fatalf("expected consumed chunk evidence, got %#v", results[0].Evidence)
+	if _, err := os.Stat(filepath.Join(session.rootDir, "summary.md")); !os.IsNotExist(err) {
+		t.Fatalf("pending file must not create active summary.md, stat err = %v", err)
 	}
 }
 

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -1655,8 +1655,8 @@ func TestSummaryMaxChunksConfigDefaultAndCustom(t *testing.T) {
 	if cfg.SessionBoundaryShortGapSeconds != 180 {
 		t.Fatalf("expected default short gap 180s, got %d", cfg.SessionBoundaryShortGapSeconds)
 	}
-	if cfg.SessionBoundaryLongGapSeconds != 300 {
-		t.Fatalf("expected default long gap 300s, got %d", cfg.SessionBoundaryLongGapSeconds)
+	if cfg.SessionBoundaryLongGapSeconds != 1800 {
+		t.Fatalf("expected default long gap 1800s, got %d", cfg.SessionBoundaryLongGapSeconds)
 	}
 
 	dir := t.TempDir()

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -1652,8 +1652,8 @@ func TestSummaryMaxChunksConfigDefaultAndCustom(t *testing.T) {
 	if !cfg.SessionBoundaryEnabled {
 		t.Fatalf("expected session boundary detection to be enabled by default")
 	}
-	if cfg.SessionBoundaryShortGapSeconds != 30 {
-		t.Fatalf("expected default short gap 30s, got %d", cfg.SessionBoundaryShortGapSeconds)
+	if cfg.SessionBoundaryShortGapSeconds != 180 {
+		t.Fatalf("expected default short gap 180s, got %d", cfg.SessionBoundaryShortGapSeconds)
 	}
 	if cfg.SessionBoundaryLongGapSeconds != 300 {
 		t.Fatalf("expected default long gap 300s, got %d", cfg.SessionBoundaryLongGapSeconds)

--- a/src/agent/internal/agent/memory_tools_test.go
+++ b/src/agent/internal/agent/memory_tools_test.go
@@ -49,6 +49,46 @@ func TestRecallSessionChunksToolReturnsMatchingEvidence(t *testing.T) {
 	}
 }
 
+func TestRecallSessionChunksToolIgnoresAppNameInput(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	session := NewSessionMemoryStore(filepath.Join(root, "session"))
+
+	if _, err := session.AppendEvent(ctx, SessionEvent{EventID: "evt_mail", Type: "user_input", Role: "user", Content: "打开邮件", AppName: "Mail"}); err != nil {
+		t.Fatalf("AppendEvent() mail error = %v", err)
+	}
+	if _, err := session.Compress(ctx, CompressOption{ChunkID: "chunk_mail", Tags: []string{"navigation"}, Summary: "Mail navigation"}); err != nil {
+		t.Fatalf("Compress() mail error = %v", err)
+	}
+	if err := session.replaceEvents(nil); err != nil {
+		t.Fatalf("replaceEvents() after mail error = %v", err)
+	}
+	if _, err := session.AppendEvent(ctx, SessionEvent{EventID: "evt_calendar", Type: "user_input", Role: "user", Content: "打开日历", AppName: "Calendar"}); err != nil {
+		t.Fatalf("AppendEvent() calendar error = %v", err)
+	}
+	if _, err := session.Compress(ctx, CompressOption{ChunkID: "chunk_calendar", Tags: []string{"navigation"}, Summary: "Calendar navigation"}); err != nil {
+		t.Fatalf("Compress() calendar error = %v", err)
+	}
+
+	tool := NewRecallSessionChunksTool(session)
+	out, err := tool.Call(ctx, `{"app_name":"Mail","limit":10}`)
+	if err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+
+	var decoded struct {
+		Results []struct {
+			ChunkID string `json:"chunk_id"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("decode output %q: %v", out, err)
+	}
+	if len(decoded.Results) != 2 {
+		t.Fatalf("app_name input should not filter session chunks, got %#v", decoded.Results)
+	}
+}
+
 func TestRecallMemoryToolReturnsMatchingLongTermMemory(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -601,14 +601,14 @@ func (r *Runtime) handleSessionBoundary(input string, hints CurrentEnvironmentHi
 	if r.logger != nil {
 		r.logger.Info("[memory] session boundary detected: reason=%s app=%s", reason, hints.AppName)
 	}
-	pendingPath, err := r.memories.RotateSessionEvents()
+	archiveDir, err := r.memories.RotateSessionEvents()
 	if err != nil {
 		if r.logger != nil {
 			r.logger.Warn("[memory] session rotation failed: %v", err)
 		}
 		return telemetry
 	}
-	if pendingPath != "" {
+	if archiveDir != "" {
 		telemetry.Rotated = true
 	}
 	return telemetry

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -620,15 +620,15 @@ func (r *Runtime) handleSessionBoundary(input string, hints CurrentEnvironmentHi
 		return telemetry
 	}
 	boundaryCfg := BoundaryConfig{
-		ShortGapSeconds:        cfg.SessionBoundaryShortGapSeconds,
-		LongGapSeconds:         cfg.SessionBoundaryLongGapSeconds,
-		ContinueScoreThreshold: DefaultBoundaryConfig().ContinueScoreThreshold,
+		ShortGapSeconds:            cfg.SessionBoundaryShortGapSeconds,
+		LongGapSeconds:             cfg.SessionBoundaryLongGapSeconds,
+		SmallSessionEventThreshold: DefaultBoundaryConfig().SmallSessionEventThreshold,
+		ContinueScoreThreshold:     DefaultBoundaryConfig().ContinueScoreThreshold,
 	}
-	episodeCtx := BoundaryEpisodeContext{
-		HasRunning:     runningEpisodeExists(r.memoryPlane),
-		CurrentAppName: hints.AppName,
-	}
-	boundary, reason := ClassifyTurnBoundary(events, input, time.Now().UTC(), boundaryCfg, episodeCtx)
+	now := time.Now().UTC()
+	episodeCtx := recentEpisodeContext(r.memoryPlane, now, time.Duration(boundaryCfg.LongGapSeconds)*time.Second)
+	episodeCtx.CurrentAppName = hints.AppName
+	boundary, reason := ClassifyTurnBoundary(events, input, now, boundaryCfg, episodeCtx)
 	telemetry.Decision = boundary
 	telemetry.Reason = reason
 
@@ -675,21 +675,42 @@ func loadLastNSessionEvents(manager *MemoryManager, n int) ([]SessionEvent, erro
 	return append([]SessionEvent(nil), events[len(events)-n:]...), nil
 }
 
-func runningEpisodeExists(plane MemoryPlane) bool {
+func recentEpisodeContext(plane MemoryPlane, now time.Time, activeMaxAge time.Duration) BoundaryEpisodeContext {
+	var ctx BoundaryEpisodeContext
 	fs, ok := plane.(*FilesystemMemoryPlane)
 	if !ok || fs == nil || fs.episodes == nil {
-		return false
+		return ctx
 	}
 	index, err := fs.episodes.loadIndex()
 	if err != nil {
-		return false
+		return ctx
 	}
 	for _, entry := range index.Episodes {
-		if entry.Status == "running" {
-			return true
+		switch entry.Status {
+		case "running":
+			ctx.HasRunning = true
+		case "active":
+			if recentEpisodeEndedAt(entry.EndedAt, now, activeMaxAge) {
+				ctx.HasActive = true
+			}
+		}
+		if ctx.HasRunning && ctx.HasActive {
+			return ctx
 		}
 	}
-	return false
+	return ctx
+}
+
+func recentEpisodeEndedAt(endedAt string, now time.Time, maxAge time.Duration) bool {
+	if maxAge <= 0 {
+		return false
+	}
+	ended, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(endedAt))
+	if err != nil {
+		return false
+	}
+	age := now.Sub(ended)
+	return age >= 0 && age <= maxAge
 }
 
 func (r *Runtime) effectiveContextWindow() int {

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -661,13 +661,15 @@ func loadLastNSessionEvents(manager *MemoryManager, n int) ([]SessionEvent, erro
 		return nil, fmt.Errorf("lock for boundary session events: %w", err)
 	}
 	defer fl.Unlock()
-	events, err := session.readEvents(session.eventsPath())
+	result, err := session.readActiveEventsRepairingTruncatedTail()
 	if err != nil {
 		if isPathNotExistError(err) {
 			return nil, nil
 		}
 		return nil, err
 	}
+	manager.logSessionEventsRepair("boundary", result)
+	events := result.events
 	if len(events) <= n {
 		return events, nil
 	}

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -44,6 +44,7 @@ type Runtime struct {
 	skillsLoaded       bool
 	skillsReloadMu     sync.Mutex
 	skillsDirty        bool
+	runGateInit        sync.Once
 	mergeWorker        *MergeWorker
 	logger             *Logger
 	profileDebouncer   *ProfileDebouncer
@@ -51,7 +52,7 @@ type Runtime struct {
 	memoryPlane        MemoryPlane
 	telemetrySessionID string
 	mobileGym          *mobileGymSessionStore
-	runMu              sync.Mutex
+	runGate            chan struct{}
 }
 
 type RunRequest struct {
@@ -307,7 +308,40 @@ func NewRuntimeWithDeps(cfg Config, models ModelResolver, memories *MemoryManage
 		rt.memoryPlane = NewFilesystemMemoryPlane(filepath.Join(cfg.ConfigDir, "memory"), LoadMemoryExtractionConfig(cfg.ConfigDir), nil)
 		rt.markInterruptedEpisodesBestEffort()
 	}
+	rt.initRunGate()
 	return rt
+}
+
+func (r *Runtime) initRunGate() {
+	if r == nil {
+		return
+	}
+	r.runGateInit.Do(func() {
+		r.runGate = make(chan struct{}, 1)
+		r.runGate <- struct{}{}
+	})
+}
+
+func (r *Runtime) lockRun(ctx context.Context) (func(), error) {
+	if r == nil {
+		return func() {}, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	r.initRunGate()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-r.runGate:
+		if err := ctx.Err(); err != nil {
+			r.runGate <- struct{}{}
+			return nil, err
+		}
+		return func() {
+			r.runGate <- struct{}{}
+		}, nil
+	}
 }
 
 func (r *Runtime) NewEpisodeID() string {
@@ -367,10 +401,14 @@ func (r *Runtime) exportInterruptedEpisodesBestEffort(episodes []TaskEpisode) {
 }
 
 func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
-	if r != nil {
-		r.runMu.Lock()
-		defer r.runMu.Unlock()
+	if ctx == nil {
+		ctx = context.Background()
 	}
+	unlockRun, err := r.lockRun(ctx)
+	if err != nil {
+		return RunResult{}, err
+	}
+	defer unlockRun()
 
 	startTime := time.Now()
 	metrics := &RunMetrics{}
@@ -464,7 +502,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		episodeRecorder = r.memoryPlane.NewEpisodeRecorder(retrieveReq, memoryContext)
 		if episodeRecorder != nil {
 			retrieveReq.EpisodeID = episodeRecorder.ID()
-			if err := episodeRecorder.Start(context.Background()); err != nil && r.logger != nil {
+			if err := episodeRecorder.Start(ctx); err != nil && r.logger != nil {
 				r.logger.Warn("[memory] start episode failed: %v", err)
 			}
 		}

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -627,7 +627,6 @@ func (r *Runtime) handleSessionBoundary(input string, hints CurrentEnvironmentHi
 	}
 	now := time.Now().UTC()
 	episodeCtx := recentEpisodeContext(r.memoryPlane, now, time.Duration(boundaryCfg.LongGapSeconds)*time.Second)
-	episodeCtx.CurrentAppName = hints.AppName
 	boundary, reason := ClassifyTurnBoundary(events, input, now, boundaryCfg, episodeCtx)
 	telemetry.Decision = boundary
 	telemetry.Reason = reason
@@ -637,7 +636,7 @@ func (r *Runtime) handleSessionBoundary(input string, hints CurrentEnvironmentHi
 	}
 
 	if r.logger != nil {
-		r.logger.Info("[memory] session boundary detected: reason=%s app=%s", reason, hints.AppName)
+		r.logger.Info("[memory] session boundary detected: reason=%s", reason)
 	}
 	archiveDir, err := r.memories.RotateSessionEvents()
 	if err != nil {

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -893,7 +893,7 @@ func (t *sessionRecallTelemetryTool) ReturnsVisualObservation() bool {
 func countPendingRecallResults(output string) int {
 	var payload struct {
 		Results []struct {
-			ChunkID string `json:"chunk_id"`
+			Source string `json:"source"`
 		} `json:"results"`
 	}
 	if err := json.Unmarshal([]byte(output), &payload); err != nil {
@@ -901,7 +901,7 @@ func countPendingRecallResults(output string) int {
 	}
 	count := 0
 	for _, result := range payload.Results {
-		if strings.HasPrefix(result.ChunkID, "pending-") {
+		if strings.EqualFold(strings.TrimSpace(result.Source), chunkRecallSourcePending) {
 			count++
 		}
 	}

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -50,6 +51,7 @@ type Runtime struct {
 	memoryPlane        MemoryPlane
 	telemetrySessionID string
 	mobileGym          *mobileGymSessionStore
+	runMu              sync.Mutex
 }
 
 type RunRequest struct {
@@ -90,6 +92,13 @@ type RunMetrics struct {
 	// the cumulative sum. Using the largest single prompt keeps a small verifier
 	// call from masking a much larger planner prompt.
 	LastPromptTokens int `json:"-"`
+}
+
+type sessionBoundaryTelemetry struct {
+	Decision             string
+	Reason               string
+	Rotated              bool
+	PendingRecallCounter *atomic.Int64
 }
 
 type RunEvent struct {
@@ -358,6 +367,11 @@ func (r *Runtime) exportInterruptedEpisodesBestEffort(episodes []TaskEpisode) {
 }
 
 func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if r != nil {
+		r.runMu.Lock()
+		defer r.runMu.Unlock()
+	}
+
 	startTime := time.Now()
 	metrics := &RunMetrics{}
 	normalizedInput := normalizeRunInput(req.Input, req.Attachments)
@@ -412,12 +426,19 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	promptCapture := newTelemetryPromptCapture(r.config.Telemetry.EnabledOrDefault())
 	model = &usageTrackingModel{inner: model, metrics: metrics, promptCapture: promptCapture, contextWindowFn: r.effectiveContextWindow}
 
+	currentHints := r.currentEnvironmentHints()
+	boundaryTelemetry := r.handleSessionBoundary(normalizedInput, currentHints)
+	if boundaryTelemetry.PendingRecallCounter == nil {
+		boundaryTelemetry.PendingRecallCounter = &atomic.Int64{}
+	}
+
 	memoryHandle, err := r.memories.Get("default", MemoryConfig{Type: "window", WindowSize: 10})
 	if err != nil {
 		return RunResult{}, err
 	}
 
 	availableTools := r.resolveTools(resolvedSkills)
+	availableTools = wrapSessionRecallTelemetry(availableTools, boundaryTelemetry.PendingRecallCounter)
 	retrieveReq := MemoryRetrieveRequest{
 		Input:        normalizedInput,
 		Attachments:  req.Attachments,
@@ -425,7 +446,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		ToolNames:    toolNamesFromTools(availableTools),
 		EpisodeID:    req.EpisodeID,
 		DeviceID:     defaultMemoryDeviceID,
-		CurrentHints: r.currentEnvironmentHints(),
+		CurrentHints: currentHints,
 	}
 	memoryContext := MemoryContext{}
 	if r.memoryPlane != nil {
@@ -501,7 +522,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			}
 		}
 		if err != nil {
-			r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture)
+			r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture, boundaryTelemetry)
 			return RunResult{}, err
 		}
 	}
@@ -509,21 +530,21 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	metrics.TotalDuration = float64(time.Since(startTime).Milliseconds())
 	r.memories.SetLastPromptTokens(metrics.LastPromptTokens)
 	if err := r.memories.AppendExchange(ctx, "default", normalizedInput, output); err != nil {
-		r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture)
+		r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture, boundaryTelemetry)
 		return RunResult{}, err
 	}
 
 	memorySnapshot, err := r.memories.Snapshot(ctx, "default")
 	if err != nil {
-		r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture)
+		r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture, boundaryTelemetry)
 		return RunResult{}, err
 	}
 	if err := r.memories.SaveSnapshot(ctx, "default", memorySnapshot); err != nil {
-		r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture)
+		r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture, boundaryTelemetry)
 		return RunResult{}, err
 	}
 	r.memories.RequestMaintenance()
-	r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, nil, promptCapture)
+	r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, nil, promptCapture, boundaryTelemetry)
 
 	sleepRequested, sleepReason := r.sleep.Consume()
 	return RunResult{
@@ -542,6 +563,95 @@ func (r *Runtime) currentEnvironmentHints() CurrentEnvironmentHints {
 		return r.tools.CurrentEnvironmentHints(currentEnvironmentHintMaxAge)
 	}
 	return CurrentEnvironmentHints{}
+}
+
+func (r *Runtime) handleSessionBoundary(input string, hints CurrentEnvironmentHints) sessionBoundaryTelemetry {
+	var telemetry sessionBoundaryTelemetry
+	if r == nil || r.memories == nil || r.memories.storageDir == "" {
+		return telemetry
+	}
+	cfg := r.memories.extraction
+	if !cfg.SessionBoundaryEnabled {
+		return telemetry
+	}
+	events, err := loadLastNSessionEvents(r.memories, 20)
+	if err != nil {
+		if r.logger != nil {
+			r.logger.Warn("[memory] session boundary load failed: %v", err)
+		}
+		return telemetry
+	}
+	boundaryCfg := BoundaryConfig{
+		ShortGapSeconds:        cfg.SessionBoundaryShortGapSeconds,
+		LongGapSeconds:         cfg.SessionBoundaryLongGapSeconds,
+		ContinueScoreThreshold: DefaultBoundaryConfig().ContinueScoreThreshold,
+	}
+	episodeCtx := BoundaryEpisodeContext{
+		HasRunning:     runningEpisodeExists(r.memoryPlane),
+		CurrentAppName: hints.AppName,
+	}
+	boundary, reason := ClassifyTurnBoundary(events, input, time.Now().UTC(), boundaryCfg, episodeCtx)
+	telemetry.Decision = boundary
+	telemetry.Reason = reason
+
+	if boundary != BoundaryNew || len(events) == 0 {
+		return telemetry
+	}
+
+	if r.logger != nil {
+		r.logger.Info("[memory] session boundary detected: reason=%s app=%s", reason, hints.AppName)
+	}
+	pendingPath, err := r.memories.RotateSessionEvents()
+	if err != nil {
+		if r.logger != nil {
+			r.logger.Warn("[memory] session rotation failed: %v", err)
+		}
+		return telemetry
+	}
+	if pendingPath != "" {
+		telemetry.Rotated = true
+	}
+	return telemetry
+}
+
+func loadLastNSessionEvents(manager *MemoryManager, n int) ([]SessionEvent, error) {
+	if manager == nil || strings.TrimSpace(manager.storageDir) == "" || n <= 0 {
+		return nil, nil
+	}
+	session := NewSessionMemoryStore(filepath.Join(manager.storageDir, "session"), manager.extraction.SummaryMaxChunks)
+	fl := NewFileLock(manager.storageDir)
+	if err := fl.Lock(manager.lockTimeout); err != nil {
+		return nil, fmt.Errorf("lock for boundary session events: %w", err)
+	}
+	defer fl.Unlock()
+	events, err := session.readEvents(session.eventsPath())
+	if err != nil {
+		if isPathNotExistError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(events) <= n {
+		return events, nil
+	}
+	return append([]SessionEvent(nil), events[len(events)-n:]...), nil
+}
+
+func runningEpisodeExists(plane MemoryPlane) bool {
+	fs, ok := plane.(*FilesystemMemoryPlane)
+	if !ok || fs == nil || fs.episodes == nil {
+		return false
+	}
+	index, err := fs.episodes.loadIndex()
+	if err != nil {
+		return false
+	}
+	for _, entry := range index.Episodes {
+		if entry.Status == "running" {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Runtime) effectiveContextWindow() int {
@@ -674,7 +784,71 @@ func toolNamesFromTools(tools []langtools.Tool) []string {
 	return uniqueNonEmpty(names)
 }
 
-func (r *Runtime) commitEpisodeBestEffort(recorder *EpisodeRecorder, input string, output string, metrics *RunMetrics, runErr error, promptCapture *telemetryPromptCapture) {
+func wrapSessionRecallTelemetry(tools []langtools.Tool, counter *atomic.Int64) []langtools.Tool {
+	if counter == nil {
+		return tools
+	}
+	wrapped := make([]langtools.Tool, 0, len(tools))
+	for _, tool := range tools {
+		if tool != nil && tool.Name() == "recall_session_chunks" {
+			wrapped = append(wrapped, &sessionRecallTelemetryTool{inner: tool, counter: counter})
+			continue
+		}
+		wrapped = append(wrapped, tool)
+	}
+	return wrapped
+}
+
+type sessionRecallTelemetryTool struct {
+	inner   langtools.Tool
+	counter *atomic.Int64
+}
+
+func (t *sessionRecallTelemetryTool) Name() string {
+	return t.inner.Name()
+}
+
+func (t *sessionRecallTelemetryTool) Description() string {
+	return t.inner.Description()
+}
+
+func (t *sessionRecallTelemetryTool) Call(ctx context.Context, input string) (string, error) {
+	output, err := t.inner.Call(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	if t.counter != nil {
+		t.counter.Add(int64(countPendingRecallResults(output)))
+	}
+	return output, nil
+}
+
+func (t *sessionRecallTelemetryTool) ReturnsVisualObservation() bool {
+	if visual, ok := t.inner.(visualObservationTool); ok {
+		return visual.ReturnsVisualObservation()
+	}
+	return false
+}
+
+func countPendingRecallResults(output string) int {
+	var payload struct {
+		Results []struct {
+			ChunkID string `json:"chunk_id"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(output), &payload); err != nil {
+		return 0
+	}
+	count := 0
+	for _, result := range payload.Results {
+		if strings.HasPrefix(result.ChunkID, "pending-") {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *Runtime) commitEpisodeBestEffort(recorder *EpisodeRecorder, input string, output string, metrics *RunMetrics, runErr error, promptCapture *telemetryPromptCapture, boundary sessionBoundaryTelemetry) {
 	if recorder == nil || r.memoryPlane == nil {
 		return
 	}
@@ -689,6 +863,7 @@ func (r *Runtime) commitEpisodeBestEffort(recorder *EpisodeRecorder, input strin
 	episode := recorder.Finish(output, metrics, runErr, tags, entities)
 	enrichEpisodeTelemetry(&episode, r.config)
 	r.enrichEpisodeRuntimeTelemetry(&episode)
+	enrichEpisodeSessionBoundaryTelemetry(&episode, boundary)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := r.memoryPlane.CommitEpisode(ctx, episode); err != nil && r.logger != nil {
@@ -696,6 +871,23 @@ func (r *Runtime) commitEpisodeBestEffort(recorder *EpisodeRecorder, input strin
 		return
 	}
 	r.exportEpisodeBestEffort(episode, promptCapture)
+}
+
+func enrichEpisodeSessionBoundaryTelemetry(episode *TaskEpisode, boundary sessionBoundaryTelemetry) {
+	if episode == nil || boundary.Decision == "" {
+		return
+	}
+	if episode.Extra == nil {
+		episode.Extra = map[string]interface{}{}
+	}
+	episode.Extra["session_boundary_decision"] = boundary.Decision
+	episode.Extra["session_boundary_reason"] = boundary.Reason
+	episode.Extra["session_rotated"] = boundary.Rotated
+	pendingRecalled := int64(0)
+	if boundary.PendingRecallCounter != nil {
+		pendingRecalled = boundary.PendingRecallCounter.Load()
+	}
+	episode.Extra["pending_chunks_recalled"] = pendingRecalled
 }
 
 func (r *Runtime) enrichEpisodeRuntimeTelemetry(episode *TaskEpisode) {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1587,6 +1587,78 @@ func TestRuntimeRunRotatesSessionOnNewBoundary(t *testing.T) {
 	}
 }
 
+func TestRuntimeRunRepairsTruncatedSessionTailBeforeBoundaryRotation(t *testing.T) {
+	configDir := t.TempDir()
+	storageDir := filepath.Join(configDir, "memory")
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	now := time.Now().UTC().Add(-4 * time.Minute)
+	for i := 0; i < DefaultBoundaryConfig().SmallSessionEventThreshold+1; i++ {
+		if _, err := session.AppendEvent(context.Background(), SessionEvent{
+			EventID: fmt.Sprintf("evt_old_%d", i),
+			Ts:      now.Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
+			Type:    "user_input",
+			Role:    "user",
+			Content: fmt.Sprintf("查天气旧任务 %d", i),
+		}); err != nil {
+			t.Fatalf("AppendEvent() error = %v", err)
+		}
+	}
+	file, err := os.OpenFile(session.eventsPath(), os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatalf("OpenFile events.jsonl: %v", err)
+	}
+	if _, err := file.WriteString(`{"event_id":"partial_crash_tail","type":"assistant_output","role":"assistant","content":"cut`); err != nil {
+		file.Close()
+		t.Fatalf("write truncated event tail: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close events.jsonl: %v", err)
+	}
+
+	manager := NewMemoryManager(storageDir)
+	runtime := NewRuntimeWithDeps(
+		Config{
+			ConfigDir:     configDir,
+			Model:         ModelConfig{Provider: "fake"},
+			Instruction:   "Answer directly.",
+			MaxIterations: 1,
+		},
+		&testModelResolver{model: &scriptedModel{responses: roleDirectResponses("ok")}},
+		manager,
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+	runtime.memoryPlane = NewFilesystemMemoryPlane(storageDir, manager.extraction, nil)
+
+	result, err := runtime.Run(context.Background(), RunRequest{Input: "打开微信"})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(result.Memory) != 2 || result.Memory[0].Content != "打开微信" {
+		t.Fatalf("expected clean memory snapshot for new task, got %#v", result.Memory)
+	}
+
+	archiveDirs, err := filepath.Glob(filepath.Join(storageDir, "session_archive", "*"))
+	if err != nil {
+		t.Fatalf("Glob archived sessions: %v", err)
+	}
+	if len(archiveDirs) != 1 {
+		t.Fatalf("expected one archived rotated session, got %v", archiveDirs)
+	}
+	archivedPath := filepath.Join(archiveDirs[0], "events.jsonl")
+	archivedRaw, err := os.ReadFile(archivedPath)
+	if err != nil {
+		t.Fatalf("ReadFile archived events: %v", err)
+	}
+	if strings.Contains(string(archivedRaw), "partial_crash_tail") {
+		t.Fatalf("runtime boundary rotation archived unrepaired truncated tail: %q", archivedRaw)
+	}
+	archived := readSessionEvents(t, archivedPath)
+	if len(archived) != DefaultBoundaryConfig().SmallSessionEventThreshold+1 {
+		t.Fatalf("unexpected archived events after repair: %#v", archived)
+	}
+}
+
 func TestRuntimeRunKeepsSmallSessionOnUnrelatedInput(t *testing.T) {
 	configDir := t.TempDir()
 	storageDir := filepath.Join(configDir, "memory")

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1998,7 +1998,7 @@ func TestSessionRecallTelemetryCountsPendingResults(t *testing.T) {
 	tool := &sessionRecallTelemetryTool{
 		inner: &staticTool{
 			name:   "recall_session_chunks",
-			output: `{"results":[{"chunk_id":"chunk_001"},{"chunk_id":"pending-123"}]}`,
+			output: `{"results":[{"chunk_id":"chunk_001"},{"chunk_id":"pending-123","source":"pending"}]}`,
 		},
 		counter: counter,
 	}
@@ -2007,6 +2007,73 @@ func TestSessionRecallTelemetryCountsPendingResults(t *testing.T) {
 	}
 	if got := counter.Load(); got != 1 {
 		t.Fatalf("pending recall count = %d, want 1", got)
+	}
+}
+
+func TestSessionRecallTelemetryIgnoresActiveChunksWithPendingPrefix(t *testing.T) {
+	counter := &atomic.Int64{}
+	tool := &sessionRecallTelemetryTool{
+		inner: &staticTool{
+			name: "recall_session_chunks",
+			output: `{"results":[` +
+				`{"chunk_id":"pending-archived","source":"active"},` +
+				`{"chunk_id":"pending-live","source":"pending"}` +
+				`]}`,
+		},
+		counter: counter,
+	}
+	if _, err := tool.Call(context.Background(), `{}`); err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+	if got := counter.Load(); got != 1 {
+		t.Fatalf("pending recall count = %d, want 1", got)
+	}
+}
+
+func TestSessionRecallTelemetryIgnoresCompressedChunkWithPendingPrefix(t *testing.T) {
+	ctx := context.Background()
+	session := NewSessionMemoryStore(filepath.Join(t.TempDir(), "session"))
+	if _, err := session.AppendEvent(ctx, SessionEvent{
+		EventID: "evt_pending_consumed",
+		Type:    "user_input",
+		Role:    "user",
+		Content: "already compressed from pending file",
+	}); err != nil {
+		t.Fatalf("AppendEvent() error = %v", err)
+	}
+	if _, err := session.Compress(ctx, CompressOption{
+		ChunkID: "pending-consumed",
+		Summary: "already compressed pending file",
+	}); err != nil {
+		t.Fatalf("Compress() error = %v", err)
+	}
+
+	counter := &atomic.Int64{}
+	tool := &sessionRecallTelemetryTool{
+		inner:   NewRecallSessionChunksTool(session),
+		counter: counter,
+	}
+	output, err := tool.Call(ctx, `{"chunk_ids":["pending-consumed"]}`)
+	if err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+	var decoded struct {
+		Results []struct {
+			ChunkID string `json:"chunk_id"`
+			Source  string `json:"source"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		t.Fatalf("decode output %q: %v", output, err)
+	}
+	if len(decoded.Results) != 1 {
+		t.Fatalf("expected 1 result, got %#v", decoded.Results)
+	}
+	if decoded.Results[0].ChunkID != "pending-consumed" || decoded.Results[0].Source != chunkRecallSourceActive {
+		t.Fatalf("unexpected recall source: %#v", decoded.Results[0])
+	}
+	if got := counter.Load(); got != 0 {
+		t.Fatalf("pending recall count = %d, want 0 for active compressed chunk", got)
 	}
 }
 

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1587,6 +1587,127 @@ func TestRuntimeRunRotatesSessionOnNewBoundary(t *testing.T) {
 	}
 }
 
+func TestRuntimeRunCanceledWhileQueuedDoesNotRotateSessionOrStartEpisode(t *testing.T) {
+	configDir := t.TempDir()
+	storageDir := filepath.Join(configDir, "memory")
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	now := time.Now().UTC().Add(-2 * time.Minute)
+	for i := 0; i < 2; i++ {
+		if _, err := session.AppendEvent(context.Background(), SessionEvent{
+			EventID: fmt.Sprintf("evt_old_%d", i),
+			Ts:      now.Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
+			Type:    "user_input",
+			Role:    "user",
+			Content: fmt.Sprintf("查天气旧任务 %d", i),
+		}); err != nil {
+			t.Fatalf("AppendEvent() error = %v", err)
+		}
+	}
+
+	model := &queuedCancelModel{
+		firstStarted: make(chan struct{}),
+		releaseFirst: make(chan struct{}),
+	}
+	manager := NewMemoryManager(storageDir)
+	runtime := NewRuntimeWithDeps(
+		Config{
+			ConfigDir:     configDir,
+			Model:         ModelConfig{Provider: "fake"},
+			Instruction:   "Answer directly.",
+			MaxIterations: 1,
+		},
+		&testModelResolver{model: model},
+		manager,
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+	runtime.memoryPlane = NewFilesystemMemoryPlane(storageDir, manager.extraction, nil)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := runtime.Run(context.Background(), RunRequest{Input: "继续查天气"})
+		firstDone <- err
+	}()
+	select {
+	case <-model.firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first run did not reach model call")
+	}
+
+	queuedCtx, cancelQueued := context.WithCancel(context.Background())
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := runtime.Run(queuedCtx, RunRequest{Input: "打开微信"})
+		secondDone <- err
+	}()
+	cancelQueued()
+	close(model.releaseFirst)
+
+	if err := <-firstDone; err == nil || !strings.Contains(err.Error(), "first run stopped") {
+		t.Fatalf("first Run() error = %v, want first run stopped", err)
+	}
+	select {
+	case err := <-secondDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("queued Run() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("queued Run() did not return after cancellation")
+	}
+
+	archiveDirs, err := filepath.Glob(filepath.Join(storageDir, "session_archive", "*"))
+	if err != nil {
+		t.Fatalf("Glob archived sessions: %v", err)
+	}
+	if len(archiveDirs) != 0 {
+		t.Fatalf("canceled queued run rotated session: %v", archiveDirs)
+	}
+	active := readSessionEvents(t, session.eventsPath())
+	if len(active) != 2 || active[0].EventID != "evt_old_0" {
+		t.Fatalf("canceled queued run changed active session events: %#v", active)
+	}
+
+	index, err := NewTaskEpisodeStore(filepath.Join(storageDir, "episodes")).loadIndex()
+	if err != nil {
+		t.Fatalf("load episode index: %v", err)
+	}
+	if len(index.Episodes) != 1 {
+		t.Fatalf("episode index contains %d entries, want only the first run: %#v", len(index.Episodes), index.Episodes)
+	}
+	if index.Episodes[0].UserGoal != "继续查天气" {
+		t.Fatalf("unexpected episode goal: %#v", index.Episodes[0])
+	}
+}
+
+type queuedCancelModel struct {
+	firstStarted     chan struct{}
+	releaseFirst     chan struct{}
+	firstStartedOnce atomic.Bool
+	callCount        atomic.Int64
+}
+
+func (m *queuedCancelModel) GenerateContent(ctx context.Context, _ []llms.MessageContent, _ ...llms.CallOption) (*llms.ContentResponse, error) {
+	if m.callCount.Add(1) == 1 {
+		if m.firstStartedOnce.CompareAndSwap(false, true) {
+			close(m.firstStarted)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-m.releaseFirst:
+			return nil, errors.New("first run stopped")
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, errors.New("queued run reached model")
+}
+
+func (m *queuedCancelModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	panic("unexpected Call invocation")
+}
+
 func numericExtraValue(v interface{}) int64 {
 	switch n := v.(type) {
 	case int:

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1477,8 +1477,8 @@ func TestRuntimeRunRotatesSessionOnNewBoundary(t *testing.T) {
 	storageDir := filepath.Join(configDir, "memory")
 	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
 	oldSummary := "OLD SESSION SUMMARY MUST NOT ENTER NEW PROMPT"
-	now := time.Now().UTC().Add(-2 * time.Minute)
-	for i := 0; i < 2; i++ {
+	now := time.Now().UTC().Add(-4 * time.Minute)
+	for i := 0; i < DefaultBoundaryConfig().SmallSessionEventThreshold+1; i++ {
 		if _, err := session.AppendEvent(context.Background(), SessionEvent{
 			EventID: fmt.Sprintf("evt_old_%d", i),
 			Ts:      now.Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
@@ -1545,7 +1545,7 @@ func TestRuntimeRunRotatesSessionOnNewBoundary(t *testing.T) {
 		t.Fatalf("expected one archived rotated session, got %v", archiveDirs)
 	}
 	archived := readSessionEvents(t, filepath.Join(archiveDirs[0], "events.jsonl"))
-	if len(archived) != 2 || archived[0].EventID != "evt_old_0" {
+	if len(archived) != DefaultBoundaryConfig().SmallSessionEventThreshold+1 || archived[0].EventID != "evt_old_0" {
 		t.Fatalf("unexpected archived events: %#v", archived)
 	}
 	if _, err := os.Stat(filepath.Join(storageDir, "session", "summary.md")); !os.IsNotExist(err) {
@@ -1584,6 +1584,202 @@ func TestRuntimeRunRotatesSessionOnNewBoundary(t *testing.T) {
 	}
 	if got := numericExtraValue(episode.Extra["pending_chunks_recalled"]); got != 0 {
 		t.Fatalf("pending_chunks_recalled = %#v, want 0 without recall tool call", got)
+	}
+}
+
+func TestRuntimeRunKeepsSmallSessionOnUnrelatedInput(t *testing.T) {
+	configDir := t.TempDir()
+	storageDir := filepath.Join(configDir, "memory")
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	now := time.Now().UTC().Add(-4 * time.Minute)
+	for i := 0; i < DefaultBoundaryConfig().SmallSessionEventThreshold; i++ {
+		if _, err := session.AppendEvent(context.Background(), SessionEvent{
+			EventID: fmt.Sprintf("evt_small_%d", i),
+			Ts:      now.Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
+			Type:    "user_input",
+			Role:    "user",
+			Content: fmt.Sprintf("查天气小会话 %d", i),
+		}); err != nil {
+			t.Fatalf("AppendEvent() error = %v", err)
+		}
+	}
+
+	manager := NewMemoryManager(storageDir)
+	model := &scriptedModel{responses: roleDirectResponses("ok")}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			ConfigDir:     configDir,
+			Model:         ModelConfig{Provider: "fake"},
+			Instruction:   "Answer directly.",
+			MaxIterations: 1,
+		},
+		&testModelResolver{model: model},
+		manager,
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+	runtime.memoryPlane = NewFilesystemMemoryPlane(storageDir, manager.extraction, nil)
+
+	result, err := runtime.Run(context.Background(), RunRequest{Input: "打开微信"})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(result.Memory) != DefaultBoundaryConfig().SmallSessionEventThreshold+2 {
+		t.Fatalf("small session should keep previous context, got %#v", result.Memory)
+	}
+
+	archiveDirs, err := filepath.Glob(filepath.Join(storageDir, "session_archive", "*"))
+	if err != nil {
+		t.Fatalf("Glob archived sessions: %v", err)
+	}
+	if len(archiveDirs) != 0 {
+		t.Fatalf("small session with unrelated input rotated session: %v", archiveDirs)
+	}
+
+	episode, err := NewTaskEpisodeStore(filepath.Join(storageDir, "episodes")).Get(context.Background(), result.EpisodeID)
+	if err != nil {
+		t.Fatalf("Get episode: %v", err)
+	}
+	if got := episode.Extra["session_boundary_decision"]; got != BoundaryContinue {
+		t.Fatalf("session_boundary_decision = %#v, want %q", got, BoundaryContinue)
+	}
+	if got := episode.Extra["session_boundary_reason"]; got != BoundaryReasonSmallSession {
+		t.Fatalf("session_boundary_reason = %#v, want %q", got, BoundaryReasonSmallSession)
+	}
+}
+
+func TestRuntimeRunKeepsNeutralFollowUpWithActiveEpisode(t *testing.T) {
+	configDir := t.TempDir()
+	storageDir := filepath.Join(configDir, "memory")
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	now := time.Now().UTC().Add(-4 * time.Minute)
+	for i, content := range []string{"查一下今天天气", "今天多云"} {
+		role := "user"
+		eventType := "user_input"
+		if i == 1 {
+			role = "assistant"
+			eventType = "assistant_output"
+		}
+		if _, err := session.AppendEvent(context.Background(), SessionEvent{
+			EventID: fmt.Sprintf("evt_prev_%d", i),
+			Ts:      now.Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
+			Type:    eventType,
+			Role:    role,
+			Content: content,
+		}); err != nil {
+			t.Fatalf("AppendEvent() error = %v", err)
+		}
+	}
+
+	episodeStore := NewTaskEpisodeStore(filepath.Join(storageDir, "episodes"))
+	if _, err := episodeStore.AddEpisode(context.Background(), TaskEpisode{
+		ID:        "ep_weather_done",
+		Status:    "active",
+		StartedAt: now.Add(-30 * time.Second).Format(time.RFC3339Nano),
+		EndedAt:   now.Add(time.Second).Format(time.RFC3339Nano),
+		UserGoal:  "查一下今天天气",
+		Outcome:   TaskEpisodeOutcome{Success: true, FinalAnswer: "今天多云"},
+	}); err != nil {
+		t.Fatalf("AddEpisode() error = %v", err)
+	}
+
+	manager := NewMemoryManager(storageDir)
+	model := &scriptedModel{responses: roleDirectResponses("ok")}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			ConfigDir:     configDir,
+			Model:         ModelConfig{Provider: "fake"},
+			Instruction:   "Answer directly.",
+			MaxIterations: 1,
+		},
+		&testModelResolver{model: model},
+		manager,
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+	runtime.memoryPlane = NewFilesystemMemoryPlane(storageDir, manager.extraction, nil)
+
+	result, err := runtime.Run(context.Background(), RunRequest{Input: "好的"})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(result.Memory) != 4 || result.Memory[0].Content != "查一下今天天气" {
+		t.Fatalf("neutral follow-up should keep previous session context, got %#v", result.Memory)
+	}
+
+	archiveDirs, err := filepath.Glob(filepath.Join(storageDir, "session_archive", "*"))
+	if err != nil {
+		t.Fatalf("Glob archived sessions: %v", err)
+	}
+	if len(archiveDirs) != 0 {
+		t.Fatalf("neutral follow-up with active episode rotated session: %v", archiveDirs)
+	}
+
+	episode, err := episodeStore.Get(context.Background(), result.EpisodeID)
+	if err != nil {
+		t.Fatalf("Get episode: %v", err)
+	}
+	if got := episode.Extra["session_boundary_decision"]; got != BoundaryContinue {
+		t.Fatalf("session_boundary_decision = %#v, want %q", got, BoundaryContinue)
+	}
+	if got := episode.Extra["session_boundary_reason"]; got != BoundaryReasonActiveEpisode {
+		t.Fatalf("session_boundary_reason = %#v, want %q", got, BoundaryReasonActiveEpisode)
+	}
+}
+
+func TestRecentEpisodeContextIncludesRunningAndRecentActiveEpisodes(t *testing.T) {
+	storageDir := filepath.Join(t.TempDir(), "memory")
+	store := NewTaskEpisodeStore(filepath.Join(storageDir, "episodes"))
+	now := time.Now().UTC()
+
+	if _, err := store.StartEpisode(context.Background(), TaskEpisode{
+		ID:        "ep_running",
+		StartedAt: now.Add(-time.Minute).Format(time.RFC3339Nano),
+		UserGoal:  "继续处理天气",
+	}); err != nil {
+		t.Fatalf("StartEpisode() error = %v", err)
+	}
+	if _, err := store.AddEpisode(context.Background(), TaskEpisode{
+		ID:        "ep_active_recent",
+		Status:    "active",
+		StartedAt: now.Add(-3 * time.Minute).Format(time.RFC3339Nano),
+		EndedAt:   now.Add(-time.Minute).Format(time.RFC3339Nano),
+		UserGoal:  "查天气",
+		Outcome:   TaskEpisodeOutcome{Success: true},
+	}); err != nil {
+		t.Fatalf("AddEpisode() error = %v", err)
+	}
+
+	plane := NewFilesystemMemoryPlane(storageDir, DefaultMemoryExtractionConfig(), nil)
+	ctx := recentEpisodeContext(plane, now, 5*time.Minute)
+	if !ctx.HasRunning {
+		t.Fatalf("expected running episode context")
+	}
+	if !ctx.HasActive {
+		t.Fatalf("expected recent active episode context")
+	}
+}
+
+func TestRecentEpisodeContextIgnoresOldActiveEpisode(t *testing.T) {
+	storageDir := filepath.Join(t.TempDir(), "memory")
+	store := NewTaskEpisodeStore(filepath.Join(storageDir, "episodes"))
+	now := time.Now().UTC()
+
+	if _, err := store.AddEpisode(context.Background(), TaskEpisode{
+		ID:        "ep_active_old",
+		Status:    "active",
+		StartedAt: now.Add(-10 * time.Minute).Format(time.RFC3339Nano),
+		EndedAt:   now.Add(-6 * time.Minute).Format(time.RFC3339Nano),
+		UserGoal:  "查天气",
+		Outcome:   TaskEpisodeOutcome{Success: true},
+	}); err != nil {
+		t.Fatalf("AddEpisode() error = %v", err)
+	}
+
+	plane := NewFilesystemMemoryPlane(storageDir, DefaultMemoryExtractionConfig(), nil)
+	ctx := recentEpisodeContext(plane, now, 5*time.Minute)
+	if ctx.HasActive {
+		t.Fatalf("old active episode should not bias session boundary")
 	}
 }
 

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -358,6 +358,17 @@ type scriptedModel struct {
 	tools        [][]llms.Tool
 }
 
+type staticTool struct {
+	name   string
+	output string
+}
+
+func (t *staticTool) Name() string { return t.name }
+
+func (t *staticTool) Description() string { return "static test tool" }
+
+func (t *staticTool) Call(context.Context, string) (string, error) { return t.output, nil }
+
 func (m *scriptedModel) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
 	var callOptions llms.CallOptions
 	for _, option := range options {
@@ -1459,6 +1470,128 @@ func TestRuntimeRunSchedulesMemoryMaintenanceAsync(t *testing.T) {
 		t.Fatal("async memory maintenance did not start")
 	}
 	releaseMaintenance()
+}
+
+func TestRuntimeRunRotatesSessionOnNewBoundary(t *testing.T) {
+	configDir := t.TempDir()
+	storageDir := filepath.Join(configDir, "memory")
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	now := time.Now().UTC().Add(-2 * time.Minute)
+	for i := 0; i < 2; i++ {
+		if _, err := session.AppendEvent(context.Background(), SessionEvent{
+			EventID: fmt.Sprintf("evt_old_%d", i),
+			Ts:      now.Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
+			Type:    "user_input",
+			Role:    "user",
+			Content: fmt.Sprintf("查天气旧任务 %d", i),
+		}); err != nil {
+			t.Fatalf("AppendEvent() error = %v", err)
+		}
+	}
+
+	releaseMaintenance := make(chan struct{})
+	manager := NewMemoryManager(storageDir, WithSummarizeFn(func(ctx context.Context, events []SessionEvent) string {
+		select {
+		case <-ctx.Done():
+			return ""
+		case <-releaseMaintenance:
+			return "old task summary"
+		}
+	}))
+	defer func() {
+		close(releaseMaintenance)
+		waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := manager.WaitMaintenance(waitCtx); err != nil {
+			t.Fatalf("WaitMaintenance() error = %v", err)
+		}
+	}()
+	model := &scriptedModel{responses: roleDirectResponses("ok")}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			ConfigDir:     configDir,
+			Model:         ModelConfig{Provider: "fake"},
+			Instruction:   "Answer directly.",
+			MaxIterations: 1,
+		},
+		&testModelResolver{model: model},
+		manager,
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+	runtime.memoryPlane = NewFilesystemMemoryPlane(storageDir, manager.extraction, nil)
+
+	result, err := runtime.Run(context.Background(), RunRequest{Input: "打开微信"})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(result.Memory) != 2 || result.Memory[0].Content != "打开微信" {
+		t.Fatalf("expected clean memory snapshot for new task, got %#v", result.Memory)
+	}
+
+	active := readSessionEvents(t, session.eventsPath())
+	if len(active) != 2 || active[0].Content != "打开微信" {
+		t.Fatalf("expected active events to contain only current exchange, got %#v", active)
+	}
+	pendingPaths, err := filepath.Glob(filepath.Join(storageDir, "session", pendingEventsGlob))
+	if err != nil {
+		t.Fatalf("Glob pending events: %v", err)
+	}
+	if len(pendingPaths) != 1 {
+		t.Fatalf("expected one pending rotated session, got %v", pendingPaths)
+	}
+	pending := readSessionEvents(t, pendingPaths[0])
+	if len(pending) != 2 || pending[0].EventID != "evt_old_0" {
+		t.Fatalf("unexpected pending events: %#v", pending)
+	}
+
+	episode, err := NewTaskEpisodeStore(filepath.Join(storageDir, "episodes")).Get(context.Background(), result.EpisodeID)
+	if err != nil {
+		t.Fatalf("Get episode: %v", err)
+	}
+	if got := episode.Extra["session_boundary_decision"]; got != BoundaryNew {
+		t.Fatalf("session_boundary_decision = %#v, want %q", got, BoundaryNew)
+	}
+	if got := episode.Extra["session_rotated"]; got != true {
+		t.Fatalf("session_rotated = %#v, want true", got)
+	}
+	if got := numericExtraValue(episode.Extra["pending_chunks_recalled"]); got != 0 {
+		t.Fatalf("pending_chunks_recalled = %#v, want 0 without recall tool call", got)
+	}
+}
+
+func numericExtraValue(v interface{}) int64 {
+	switch n := v.(type) {
+	case int:
+		return int64(n)
+	case int64:
+		return n
+	case int32:
+		return int64(n)
+	case uint64:
+		return int64(n)
+	case float64:
+		return int64(n)
+	default:
+		return -1
+	}
+}
+
+func TestSessionRecallTelemetryCountsPendingResults(t *testing.T) {
+	counter := &atomic.Int64{}
+	tool := &sessionRecallTelemetryTool{
+		inner: &staticTool{
+			name:   "recall_session_chunks",
+			output: `{"results":[{"chunk_id":"chunk_001"},{"chunk_id":"pending-123"}]}`,
+		},
+		counter: counter,
+	}
+	if _, err := tool.Call(context.Background(), `{}`); err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+	if got := counter.Load(); got != 1 {
+		t.Fatalf("pending recall count = %d, want 1", got)
+	}
 }
 
 func waitForSessionCompaction(t *testing.T, configDir string) {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1476,6 +1476,7 @@ func TestRuntimeRunRotatesSessionOnNewBoundary(t *testing.T) {
 	configDir := t.TempDir()
 	storageDir := filepath.Join(configDir, "memory")
 	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	oldSummary := "OLD SESSION SUMMARY MUST NOT ENTER NEW PROMPT"
 	now := time.Now().UTC().Add(-2 * time.Minute)
 	for i := 0; i < 2; i++ {
 		if _, err := session.AppendEvent(context.Background(), SessionEvent{
@@ -1487,6 +1488,9 @@ func TestRuntimeRunRotatesSessionOnNewBoundary(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("AppendEvent() error = %v", err)
 		}
+	}
+	if err := os.WriteFile(filepath.Join(storageDir, "session", "summary.md"), []byte(oldSummary), 0o644); err != nil {
+		t.Fatalf("WriteFile old summary.md: %v", err)
 	}
 
 	releaseMaintenance := make(chan struct{})
@@ -1533,16 +1537,39 @@ func TestRuntimeRunRotatesSessionOnNewBoundary(t *testing.T) {
 	if len(active) != 2 || active[0].Content != "打开微信" {
 		t.Fatalf("expected active events to contain only current exchange, got %#v", active)
 	}
-	pendingPaths, err := filepath.Glob(filepath.Join(storageDir, "session", pendingEventsGlob))
+	archiveDirs, err := filepath.Glob(filepath.Join(storageDir, "session_archive", "*"))
 	if err != nil {
-		t.Fatalf("Glob pending events: %v", err)
+		t.Fatalf("Glob archived sessions: %v", err)
 	}
-	if len(pendingPaths) != 1 {
-		t.Fatalf("expected one pending rotated session, got %v", pendingPaths)
+	if len(archiveDirs) != 1 {
+		t.Fatalf("expected one archived rotated session, got %v", archiveDirs)
 	}
-	pending := readSessionEvents(t, pendingPaths[0])
-	if len(pending) != 2 || pending[0].EventID != "evt_old_0" {
-		t.Fatalf("unexpected pending events: %#v", pending)
+	archived := readSessionEvents(t, filepath.Join(archiveDirs[0], "events.jsonl"))
+	if len(archived) != 2 || archived[0].EventID != "evt_old_0" {
+		t.Fatalf("unexpected archived events: %#v", archived)
+	}
+	if _, err := os.Stat(filepath.Join(storageDir, "session", "summary.md")); !os.IsNotExist(err) {
+		t.Fatalf("active summary.md should be absent after rotation, stat err = %v", err)
+	}
+	archivedSummary, err := os.ReadFile(filepath.Join(archiveDirs[0], "summary.md"))
+	if err != nil {
+		t.Fatalf("ReadFile archived summary.md: %v", err)
+	}
+	if string(archivedSummary) != oldSummary {
+		t.Fatalf("old summary not preserved in archive: %q", archivedSummary)
+	}
+	var promptText strings.Builder
+	for _, call := range model.messages {
+		for _, message := range call {
+			for _, part := range message.Parts {
+				if text, ok := part.(llms.TextContent); ok {
+					promptText.WriteString(text.Text)
+				}
+			}
+		}
+	}
+	if strings.Contains(promptText.String(), oldSummary) {
+		t.Fatalf("new-session prompt leaked archived summary:\n%s", promptText.String())
 	}
 
 	episode, err := NewTaskEpisodeStore(filepath.Join(storageDir, "episodes")).Get(context.Background(), result.EpisodeID)
@@ -1710,6 +1737,49 @@ func TestRuntimeRunInjectsMemoryFilesIntoSystemPrompt(t *testing.T) {
 	}
 	if !strings.Contains(systemText.String(), profile) {
 		t.Fatalf("system message missing profile:\n%s", systemText.String())
+	}
+}
+
+func TestRuntimeMemoryContextIgnoresArchivedSessionSummary(t *testing.T) {
+	configDir := t.TempDir()
+	memoryDir := filepath.Join(configDir, "memory")
+	archiveSummary := "ARCHIVED SESSION SUMMARY SENTINEL"
+	profile := "PROFILE STILL ACTIVE"
+
+	archiveDir := filepath.Join(memoryDir, "session_archive", "closed-session")
+	if err := os.MkdirAll(archiveDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll archive: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(archiveDir, "summary.md"), []byte(archiveSummary), 0o644); err != nil {
+		t.Fatalf("WriteFile archive summary.md: %v", err)
+	}
+	longTermDir := filepath.Join(memoryDir, "long_term")
+	if err := os.MkdirAll(longTermDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll long_term: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(longTermDir, "profile.md"), []byte(profile), 0o644); err != nil {
+		t.Fatalf("WriteFile profile.md: %v", err)
+	}
+
+	runtime := &Runtime{config: Config{ConfigDir: configDir}}
+	promptContext := runtime.memoryContextForPrompt()
+	if strings.Contains(promptContext, archiveSummary) {
+		t.Fatalf("memoryContextForPrompt leaked archived summary:\n%s", promptContext)
+	}
+	if !strings.Contains(promptContext, profile) {
+		t.Fatalf("memoryContextForPrompt missing active profile:\n%s", promptContext)
+	}
+
+	plane := NewFilesystemMemoryPlane(memoryDir, DefaultMemoryExtractionConfig(), nil)
+	retrieved, err := plane.Retrieve(context.Background(), MemoryRetrieveRequest{Input: "hello"})
+	if err != nil {
+		t.Fatalf("Retrieve() error = %v", err)
+	}
+	if strings.Contains(retrieved.Common.SessionSummary, archiveSummary) {
+		t.Fatalf("Retrieve() leaked archived summary: %q", retrieved.Common.SessionSummary)
+	}
+	if retrieved.Common.Profile != profile {
+		t.Fatalf("Retrieve() profile = %q, want %q", retrieved.Common.Profile, profile)
 	}
 }
 

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -386,7 +386,7 @@ func TestServerHandleChatSkipsToolDescriptionTTSWhenDisabled(t *testing.T) {
 }
 
 func TestServerHandleChatUsesRequestContextForRun(t *testing.T) {
-	model := &cancelAwareModel{seen: make(chan error, 1)}
+	model := &cancelAwareModel{started: make(chan struct{}), seen: make(chan error, 1)}
 	runtime := NewRuntimeWithDeps(
 		Config{Model: ModelConfig{Provider: "fake"}},
 		&testModelResolver{model: model},
@@ -406,6 +406,12 @@ func TestServerHandleChatUsesRequestContextForRun(t *testing.T) {
 		server.handleChat(rec, req)
 		close(done)
 	}()
+
+	select {
+	case <-model.started:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("runtime did not start model call")
+	}
 	cancel()
 
 	select {
@@ -526,10 +532,17 @@ func TestServerSpeakToolDescriptionUsesCallerContext(t *testing.T) {
 }
 
 type cancelAwareModel struct {
-	seen chan error
+	started chan struct{}
+	seen    chan error
+	once    sync.Once
 }
 
 func (m *cancelAwareModel) GenerateContent(ctx context.Context, _ []llms.MessageContent, _ ...llms.CallOption) (*llms.ContentResponse, error) {
+	m.once.Do(func() {
+		if m.started != nil {
+			close(m.started)
+		}
+	})
 	<-ctx.Done()
 	err := ctx.Err()
 	m.seen <- err
@@ -1080,9 +1093,9 @@ func TestServerMobileGymEpisodeEndpointsRequireControlToken(t *testing.T) {
 	server := NewServer(runtime, "127.0.0.1:0", "")
 
 	for _, tt := range []struct {
-		name      string
-		auth      string
-		wantCode  int
+		name     string
+		auth     string
+		wantCode int
 	}{
 		{name: "missing", wantCode: http.StatusUnauthorized},
 		{name: "wrong", auth: "Bearer wrong", wantCode: http.StatusUnauthorized},

--- a/src/agent/internal/agent/session_boundary.go
+++ b/src/agent/internal/agent/session_boundary.go
@@ -23,6 +23,8 @@ const (
 	BoundaryReasonActionVerb       = "action_verb"
 	BoundaryReasonAppDivergence    = "app_divergence"
 	BoundaryReasonRunningEpisode   = "running_episode"
+	BoundaryReasonActiveEpisode    = "active_episode"
+	BoundaryReasonSmallSession     = "small_session"
 	BoundaryReasonDefaultNew       = "default_new"
 	BoundaryReasonScoreContinue    = "score_continue"
 )
@@ -36,6 +38,11 @@ type BoundaryConfig struct {
 	// LongGapSeconds: time since last event above this threshold forces
 	// a "new" decision regardless of input content.
 	LongGapSeconds int
+	// SmallSessionEventThreshold: when the active session has no more than
+	// this many events, keep the session together in the mid-range gap even if
+	// the new input looks unrelated. Short sessions are cheap to carry and
+	// splitting them early tends to lose useful context.
+	SmallSessionEventThreshold int
 	// ContinueScoreThreshold: total score above which a "continue" decision
 	// overrides the default "new" bias in the mid-range gap. Tuned to favor
 	// false-positive continuation over false-positive new, since continuation
@@ -47,9 +54,10 @@ type BoundaryConfig struct {
 // DefaultBoundaryConfig returns the sane defaults for voice agent usage.
 func DefaultBoundaryConfig() BoundaryConfig {
 	return BoundaryConfig{
-		ShortGapSeconds:        30,
-		LongGapSeconds:         300,
-		ContinueScoreThreshold: 2,
+		ShortGapSeconds:            180,
+		LongGapSeconds:             300,
+		SmallSessionEventThreshold: 16,
+		ContinueScoreThreshold:     2,
 	}
 }
 
@@ -57,10 +65,14 @@ func DefaultBoundaryConfig() BoundaryConfig {
 // the classifier needs. Passing this in (instead of querying a recorder)
 // keeps ClassifyTurnBoundary pure and testable.
 type BoundaryEpisodeContext struct {
-	// HasRunning is true when there is an in-flight TaskEpisode whose Status
-	// is "running" or "active". A running episode biases toward "continue"
-	// because the user is mid-task and is unlikely to be opening a new one.
+	// HasRunning is true when there is an in-flight TaskEpisode. It biases
+	// toward "continue" because the user is mid-task and is unlikely to be
+	// opening a new one.
 	HasRunning bool
+	// HasActive is true when a TaskEpisode recently finished into the active
+	// episode index. Neutral confirmations after completion often refer back
+	// to the just-finished task.
+	HasActive bool
 	// CurrentAppName is the app suggested by the latest environment hints. It
 	// is intentionally a weak signal because app detection can be stale.
 	CurrentAppName string
@@ -89,7 +101,9 @@ var actionVerbStartRe = regexp.MustCompile(
 //  1. No prior events: return "new" (no context to continue).
 //  2. Time gap < ShortGapSeconds: return "continue" (rapid follow-up).
 //  3. Time gap > LongGapSeconds: return "new" (long idle = task switch).
-//  4. Mid-range: accumulate scoring signals; "continue" if score crosses
+//  4. Mid-range with few active session events: bias "continue" to avoid
+//     prematurely splitting a tiny context.
+//  5. Mid-range: accumulate scoring signals; "continue" if score crosses
 //     ContinueScoreThreshold, otherwise default "new".
 //
 // The bias deliberately favors false-positive "continue" over false-positive
@@ -128,6 +142,7 @@ func ClassifyTurnBoundary(
 	primaryReason := BoundaryReasonDefaultNew
 
 	trimmed := strings.TrimSpace(newInput)
+	smallSession := cfg.SmallSessionEventThreshold > 0 && len(prevEvents) <= cfg.SmallSessionEventThreshold
 
 	if continuationMarkerRe.MatchString(trimmed) {
 		score += 2
@@ -148,14 +163,27 @@ func ClassifyTurnBoundary(
 			primaryReason = BoundaryReasonAppDivergence
 		}
 	}
-	if episode.HasRunning {
-		// A running episode means the user is mid-task; a neutral utterance
-		// in that state is overwhelmingly a continuation. Weight equals the
-		// continue threshold so this signal alone carries the decision when
-		// no other evidence contradicts it.
+	if episode.HasRunning || episode.HasActive {
+		// An in-flight or just-finished episode means a neutral utterance is
+		// overwhelmingly a continuation. Weight equals the continue threshold
+		// so this signal alone carries the decision when no other evidence
+		// contradicts it.
 		score += 2
 		if primaryReason == BoundaryReasonDefaultNew {
-			primaryReason = BoundaryReasonRunningEpisode
+			if episode.HasRunning {
+				primaryReason = BoundaryReasonRunningEpisode
+			} else {
+				primaryReason = BoundaryReasonActiveEpisode
+			}
+		}
+	}
+	if smallSession {
+		if score < cfg.ContinueScoreThreshold {
+			score = cfg.ContinueScoreThreshold
+		}
+		switch primaryReason {
+		case BoundaryReasonDefaultNew, BoundaryReasonActionVerb, BoundaryReasonAppDivergence:
+			primaryReason = BoundaryReasonSmallSession
 		}
 	}
 
@@ -196,6 +224,9 @@ func normalizeBoundaryConfig(cfg BoundaryConfig) BoundaryConfig {
 	}
 	if cfg.LongGapSeconds <= cfg.ShortGapSeconds {
 		cfg.LongGapSeconds = cfg.ShortGapSeconds + defaults.LongGapSeconds
+	}
+	if cfg.SmallSessionEventThreshold <= 0 {
+		cfg.SmallSessionEventThreshold = defaults.SmallSessionEventThreshold
 	}
 	if cfg.ContinueScoreThreshold <= 0 {
 		cfg.ContinueScoreThreshold = defaults.ContinueScoreThreshold

--- a/src/agent/internal/agent/session_boundary.go
+++ b/src/agent/internal/agent/session_boundary.go
@@ -21,7 +21,6 @@ const (
 	BoundaryReasonNoPrev           = "no_prev_events"
 	BoundaryReasonContinuationWord = "continuation_word"
 	BoundaryReasonActionVerb       = "action_verb"
-	BoundaryReasonAppDivergence    = "app_divergence"
 	BoundaryReasonRunningEpisode   = "running_episode"
 	BoundaryReasonActiveEpisode    = "active_episode"
 	BoundaryReasonSmallSession     = "small_session"
@@ -73,9 +72,6 @@ type BoundaryEpisodeContext struct {
 	// episode index. Neutral confirmations after completion often refer back
 	// to the just-finished task.
 	HasActive bool
-	// CurrentAppName is the app suggested by the latest environment hints. It
-	// is intentionally a weak signal because app detection can be stale.
-	CurrentAppName string
 }
 
 // continuationMarkerRe matches sentence-initial Chinese continuation cues.
@@ -157,12 +153,6 @@ func ClassifyTurnBoundary(
 			primaryReason = BoundaryReasonActionVerb
 		}
 	}
-	if primaryReason != BoundaryReasonContinuationWord && divergesFromRecentApp(prevEvents, episode.CurrentAppName) {
-		score--
-		if primaryReason == BoundaryReasonDefaultNew {
-			primaryReason = BoundaryReasonAppDivergence
-		}
-	}
 	if episode.HasRunning || episode.HasActive {
 		// An in-flight or just-finished episode means a neutral utterance is
 		// overwhelmingly a continuation. Weight equals the continue threshold
@@ -182,7 +172,7 @@ func ClassifyTurnBoundary(
 			score = cfg.ContinueScoreThreshold
 		}
 		switch primaryReason {
-		case BoundaryReasonDefaultNew, BoundaryReasonActionVerb, BoundaryReasonAppDivergence:
+		case BoundaryReasonDefaultNew, BoundaryReasonActionVerb:
 			primaryReason = BoundaryReasonSmallSession
 		}
 	}
@@ -197,21 +187,6 @@ func ClassifyTurnBoundary(
 		return BoundaryContinue, primaryReason
 	}
 	return BoundaryNew, primaryReason
-}
-
-func divergesFromRecentApp(events []SessionEvent, currentAppName string) bool {
-	currentAppName = strings.TrimSpace(currentAppName)
-	if currentAppName == "" {
-		return false
-	}
-	for i := len(events) - 1; i >= 0 && i >= len(events)-5; i-- {
-		appName := strings.TrimSpace(events[i].AppName)
-		if appName == "" {
-			continue
-		}
-		return !strings.EqualFold(appName, currentAppName)
-	}
-	return false
 }
 
 func normalizeBoundaryConfig(cfg BoundaryConfig) BoundaryConfig {

--- a/src/agent/internal/agent/session_boundary.go
+++ b/src/agent/internal/agent/session_boundary.go
@@ -1,0 +1,219 @@
+package agent
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Boundary decisions returned by ClassifyTurnBoundary.
+const (
+	BoundaryContinue = "continue"
+	BoundaryNew      = "new"
+)
+
+// Reason codes returned alongside a boundary decision. Codes are stable
+// strings so they can be logged and counted for telemetry without parsing
+// natural-language explanations.
+const (
+	BoundaryReasonTimeGapShort     = "time_gap_short"
+	BoundaryReasonTimeGapLong      = "time_gap_long"
+	BoundaryReasonNoPrev           = "no_prev_events"
+	BoundaryReasonContinuationWord = "continuation_word"
+	BoundaryReasonActionVerb       = "action_verb"
+	BoundaryReasonAppDivergence    = "app_divergence"
+	BoundaryReasonRunningEpisode   = "running_episode"
+	BoundaryReasonDefaultNew       = "default_new"
+	BoundaryReasonScoreContinue    = "score_continue"
+)
+
+// BoundaryConfig tunes ClassifyTurnBoundary. All fields are positive; zero
+// values are replaced by DefaultBoundaryConfig at classification time.
+type BoundaryConfig struct {
+	// ShortGapSeconds: time since last event below this threshold forces
+	// a "continue" decision regardless of input content.
+	ShortGapSeconds int
+	// LongGapSeconds: time since last event above this threshold forces
+	// a "new" decision regardless of input content.
+	LongGapSeconds int
+	// ContinueScoreThreshold: total score above which a "continue" decision
+	// overrides the default "new" bias in the mid-range gap. Tuned to favor
+	// false-positive continuation over false-positive new, since continuation
+	// has token-based compression as a backstop while a false new boundary
+	// directly degrades the current turn.
+	ContinueScoreThreshold int
+}
+
+// DefaultBoundaryConfig returns the sane defaults for voice agent usage.
+func DefaultBoundaryConfig() BoundaryConfig {
+	return BoundaryConfig{
+		ShortGapSeconds:        30,
+		LongGapSeconds:         300,
+		ContinueScoreThreshold: 2,
+	}
+}
+
+// BoundaryEpisodeContext carries the minimal snapshot of episode state that
+// the classifier needs. Passing this in (instead of querying a recorder)
+// keeps ClassifyTurnBoundary pure and testable.
+type BoundaryEpisodeContext struct {
+	// HasRunning is true when there is an in-flight TaskEpisode whose Status
+	// is "running" or "active". A running episode biases toward "continue"
+	// because the user is mid-task and is unlikely to be opening a new one.
+	HasRunning bool
+	// CurrentAppName is the app suggested by the latest environment hints. It
+	// is intentionally a weak signal because app detection can be stale.
+	CurrentAppName string
+}
+
+// continuationMarkerRe matches sentence-initial Chinese continuation cues.
+// Anchored to start-of-string after optional whitespace/punctuation so the
+// same words mid-sentence (where they're unlikely to be continuation cues)
+// don't trigger.
+var continuationMarkerRe = regexp.MustCompile(
+	`^[\s,，。.!?！？]*(对了|然后|还有|继续|接着|接下来|刚才|刚刚|刚|上一个|那个|这个|把它|把那个|把刚才|再|再说|再帮|再帮我|再来|再给|再给我)`,
+)
+
+// actionVerbStartRe matches sentence-initial action verbs that typically
+// kick off a new task. The match is intentionally loose: anything starting
+// with "打开/帮我/查/找/发/订" etc. is suspect of opening a new task.
+var actionVerbStartRe = regexp.MustCompile(
+	`^[\s,，。.!?！？]*(打开|关闭|启动|帮我|给我|查一下|查看|查询|查|找一下|找|搜一下|搜索|搜|发消息|发条|发给|发|订|预订|订一张|播放|播|定个闹钟|设置)`,
+)
+
+// ClassifyTurnBoundary decides whether a new user input continues the
+// previous session or starts a new one. It is pure, side-effect-free, and
+// uses only local signals (timestamps, regex on input, episode state).
+//
+// Decision flow:
+//  1. No prior events: return "new" (no context to continue).
+//  2. Time gap < ShortGapSeconds: return "continue" (rapid follow-up).
+//  3. Time gap > LongGapSeconds: return "new" (long idle = task switch).
+//  4. Mid-range: accumulate scoring signals; "continue" if score crosses
+//     ContinueScoreThreshold, otherwise default "new".
+//
+// The bias deliberately favors false-positive "continue" over false-positive
+// "new": accidental continuation is recoverable via token-based compression,
+// but an accidental new boundary directly degrades the response by dropping
+// live context.
+func ClassifyTurnBoundary(
+	prevEvents []SessionEvent,
+	newInput string,
+	now time.Time,
+	cfg BoundaryConfig,
+	episode BoundaryEpisodeContext,
+) (boundary string, reason string) {
+	cfg = normalizeBoundaryConfig(cfg)
+
+	// 1. No previous events means there is no session to continue.
+	if len(prevEvents) == 0 {
+		return BoundaryNew, BoundaryReasonNoPrev
+	}
+
+	// 2. Time gap shortcuts. Walk events in reverse to find the most recent
+	// parseable timestamp; tolerate malformed Ts on individual events.
+	if lastTs, ok := mostRecentEventTime(prevEvents); ok {
+		gap := now.Sub(lastTs)
+		if gap >= 0 && gap < time.Duration(cfg.ShortGapSeconds)*time.Second {
+			return BoundaryContinue, BoundaryReasonTimeGapShort
+		}
+		if gap > time.Duration(cfg.LongGapSeconds)*time.Second {
+			return BoundaryNew, BoundaryReasonTimeGapLong
+		}
+	}
+
+	// 3. Mid-range scoring. Score accumulates "continue" weight; an action
+	// verb that opens a new task counts as negative weight (toward "new").
+	score := 0
+	primaryReason := BoundaryReasonDefaultNew
+
+	trimmed := strings.TrimSpace(newInput)
+
+	if continuationMarkerRe.MatchString(trimmed) {
+		score += 2
+		primaryReason = BoundaryReasonContinuationWord
+	}
+	if actionVerbStartRe.MatchString(trimmed) {
+		// Action verb opening usually signals a fresh task, but a sentence that
+		// also starts with a continuation marker remains ambiguous and should
+		// not erase the stronger continuation cue.
+		if primaryReason != BoundaryReasonContinuationWord {
+			score -= 2
+			primaryReason = BoundaryReasonActionVerb
+		}
+	}
+	if primaryReason != BoundaryReasonContinuationWord && divergesFromRecentApp(prevEvents, episode.CurrentAppName) {
+		score--
+		if primaryReason == BoundaryReasonDefaultNew {
+			primaryReason = BoundaryReasonAppDivergence
+		}
+	}
+	if episode.HasRunning {
+		// A running episode means the user is mid-task; a neutral utterance
+		// in that state is overwhelmingly a continuation. Weight equals the
+		// continue threshold so this signal alone carries the decision when
+		// no other evidence contradicts it.
+		score += 2
+		if primaryReason == BoundaryReasonDefaultNew {
+			primaryReason = BoundaryReasonRunningEpisode
+		}
+	}
+
+	if score >= cfg.ContinueScoreThreshold {
+		// If the dominant signal was a marker or running episode, that's
+		// the more informative reason; otherwise fall back to a generic
+		// score-based reason.
+		if primaryReason == BoundaryReasonDefaultNew {
+			primaryReason = BoundaryReasonScoreContinue
+		}
+		return BoundaryContinue, primaryReason
+	}
+	return BoundaryNew, primaryReason
+}
+
+func divergesFromRecentApp(events []SessionEvent, currentAppName string) bool {
+	currentAppName = strings.TrimSpace(currentAppName)
+	if currentAppName == "" {
+		return false
+	}
+	for i := len(events) - 1; i >= 0 && i >= len(events)-5; i-- {
+		appName := strings.TrimSpace(events[i].AppName)
+		if appName == "" {
+			continue
+		}
+		return !strings.EqualFold(appName, currentAppName)
+	}
+	return false
+}
+
+func normalizeBoundaryConfig(cfg BoundaryConfig) BoundaryConfig {
+	defaults := DefaultBoundaryConfig()
+	if cfg.ShortGapSeconds <= 0 {
+		cfg.ShortGapSeconds = defaults.ShortGapSeconds
+	}
+	if cfg.LongGapSeconds <= cfg.ShortGapSeconds {
+		cfg.LongGapSeconds = defaults.LongGapSeconds
+	}
+	if cfg.LongGapSeconds <= cfg.ShortGapSeconds {
+		cfg.LongGapSeconds = cfg.ShortGapSeconds + defaults.LongGapSeconds
+	}
+	if cfg.ContinueScoreThreshold <= 0 {
+		cfg.ContinueScoreThreshold = defaults.ContinueScoreThreshold
+	}
+	return cfg
+}
+
+// mostRecentEventTime returns the latest parseable Ts from the given events.
+// Walks in reverse order so a single malformed entry doesn't poison the
+// signal; most events are well-formed and the last one is usually fine.
+func mostRecentEventTime(events []SessionEvent) (time.Time, bool) {
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Ts == "" {
+			continue
+		}
+		if t, err := time.Parse(time.RFC3339Nano, events[i].Ts); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}

--- a/src/agent/internal/agent/session_boundary.go
+++ b/src/agent/internal/agent/session_boundary.go
@@ -54,7 +54,7 @@ type BoundaryConfig struct {
 func DefaultBoundaryConfig() BoundaryConfig {
 	return BoundaryConfig{
 		ShortGapSeconds:            180,
-		LongGapSeconds:             300,
+		LongGapSeconds:             1800,
 		SmallSessionEventThreshold: 16,
 		ContinueScoreThreshold:     2,
 	}
@@ -74,19 +74,20 @@ type BoundaryEpisodeContext struct {
 	HasActive bool
 }
 
-// continuationMarkerRe matches sentence-initial Chinese continuation cues.
+// continuationMarkerRe matches sentence-initial continuation cues.
 // Anchored to start-of-string after optional whitespace/punctuation so the
 // same words mid-sentence (where they're unlikely to be continuation cues)
 // don't trigger.
 var continuationMarkerRe = regexp.MustCompile(
-	`^[\s,，。.!?！？]*(对了|然后|还有|继续|接着|接下来|刚才|刚刚|刚|上一个|那个|这个|把它|把那个|把刚才|再|再说|再帮|再帮我|再来|再给|再给我)`,
+	`(?i)^[\s,，。.!?！？]*(对了|然后|还有|继续|接着|接下来|刚才|刚刚|刚|上一个|那个|这个|把它|把那个|把刚才|再|再说|再帮|再帮我|再来|再给|再给我|also\b|and\b|then\b|continue\b|next\b|again\b|previous\b|same\b|that\b|this\b|what about\b|how about\b|one more\b|another\b)`,
 )
 
 // actionVerbStartRe matches sentence-initial action verbs that typically
 // kick off a new task. The match is intentionally loose: anything starting
-// with "打开/帮我/查/找/发/订" etc. is suspect of opening a new task.
+// with "打开/open/帮我/help me/查/search/发/send/订/book" etc. is suspect
+// of opening a new task.
 var actionVerbStartRe = regexp.MustCompile(
-	`^[\s,，。.!?！？]*(打开|关闭|启动|帮我|给我|查一下|查看|查询|查|找一下|找|搜一下|搜索|搜|发消息|发条|发给|发|订|预订|订一张|播放|播|定个闹钟|设置)`,
+	`(?i)^[\s,，。.!?！？]*(打开|关闭|启动|帮我|给我|查一下|查看|查询|查|找一下|找|搜一下|搜索|搜|发消息|发条|发给|发|订|预订|订一张|播放|播|定个闹钟|设置|open\b|close\b|launch\b|start\b|help me\b|show me\b|check\b|look up\b|look for\b|find\b|search\b|google\b|send\b|message\b|text\b|book\b|reserve\b|order\b|play\b|set\b|create\b|turn on\b|turn off\b)`,
 )
 
 // ClassifyTurnBoundary decides whether a new user input continues the

--- a/src/agent/internal/agent/session_boundary_test.go
+++ b/src/agent/internal/agent/session_boundary_test.go
@@ -16,6 +16,14 @@ func eventAt(t time.Time, eventType, content string) SessionEvent {
 	}
 }
 
+func eventsAt(t time.Time, count int, eventType, content string) []SessionEvent {
+	events := make([]SessionEvent, 0, count)
+	for i := 0; i < count; i++ {
+		events = append(events, eventAt(t.Add(time.Duration(i)*time.Second), eventType, content))
+	}
+	return events
+}
+
 func TestClassifyTurnBoundary_NoPrevEvents(t *testing.T) {
 	// First-ever input: no prior events. Should default to "new" (no context to continue).
 	cfg := DefaultBoundaryConfig()
@@ -27,10 +35,10 @@ func TestClassifyTurnBoundary_NoPrevEvents(t *testing.T) {
 }
 
 func TestClassifyTurnBoundary_TimeGapShort(t *testing.T) {
-	// Short gap (< 30s default): strong continuation, even on a generic action verb.
+	// Short gap (< 3m default): strong continuation, even on a generic action verb.
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := []SessionEvent{eventAt(now.Add(-10*time.Second), "user_input", "打开微信")}
+	prev := []SessionEvent{eventAt(now.Add(-2*time.Minute), "user_input", "打开微信")}
 	boundary, reason := ClassifyTurnBoundary(prev, "再发一条消息", now, cfg, BoundaryEpisodeContext{})
 	if boundary != BoundaryContinue {
 		t.Fatalf("short time gap should force 'continue', got %q (reason=%s)", boundary, reason)
@@ -58,7 +66,7 @@ func TestClassifyTurnBoundary_ContinuationMarker(t *testing.T) {
 	// Mid-range gap + sentence-initial continuation marker → continue.
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := []SessionEvent{eventAt(now.Add(-90*time.Second), "user_input", "查一下今天天气")}
+	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
 	cases := []string{
 		"对了再帮我看下后天的",
 		"然后呢？",
@@ -79,7 +87,7 @@ func TestClassifyTurnBoundary_ActionVerbStartsNewTask(t *testing.T) {
 	// Mid-range gap + sentence-initial action verb on new entity → new.
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := []SessionEvent{eventAt(now.Add(-2*time.Minute), "user_input", "查一下今天天气")}
+	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
 	cases := []string{
 		"打开微信",
 		"发消息给老婆",
@@ -97,14 +105,10 @@ func TestClassifyTurnBoundary_ActionVerbStartsNewTask(t *testing.T) {
 func TestClassifyTurnBoundary_AppDivergenceIsWeakNewSignal(t *testing.T) {
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := []SessionEvent{{
-		EventID: "evt_app",
-		Ts:      now.Add(-2 * time.Minute).Format(time.RFC3339Nano),
-		Type:    "user_input",
-		Role:    "user",
-		Content: "查天气",
-		AppName: "WeatherApp",
-	}}
+	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查天气")
+	for i := range prev {
+		prev[i].AppName = "WeatherApp"
+	}
 	boundary, reason := ClassifyTurnBoundary(prev, "好的", now, cfg, BoundaryEpisodeContext{CurrentAppName: "WeChat"})
 	if boundary != BoundaryNew {
 		t.Fatalf("app divergence with neutral input should keep default new, got %q", boundary)
@@ -119,12 +123,26 @@ func TestClassifyTurnBoundary_AppDivergenceIsWeakNewSignal(t *testing.T) {
 	}
 }
 
+func TestClassifyTurnBoundary_SmallSessionContinuesUnrelatedMidGap(t *testing.T) {
+	cfg := DefaultBoundaryConfig()
+	now := time.Now()
+	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold, "user_input", "查一下今天天气")
+
+	boundary, reason := ClassifyTurnBoundary(prev, "打开微信", now, cfg, BoundaryEpisodeContext{})
+	if boundary != BoundaryContinue {
+		t.Fatalf("small session should continue even for unrelated action input, got %q (reason=%s)", boundary, reason)
+	}
+	if reason != BoundaryReasonSmallSession {
+		t.Fatalf("expected reason %q, got %q", BoundaryReasonSmallSession, reason)
+	}
+}
+
 func TestClassifyTurnBoundary_RunningEpisodeBiasesContinue(t *testing.T) {
 	// Mid-range gap + neutral input + running episode → continue.
 	// Same input + no episode → new (default bias).
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := []SessionEvent{eventAt(now.Add(-2*time.Minute), "user_input", "查一下今天天气")}
+	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
 	neutralInput := "好的"
 
 	withEpisode := BoundaryEpisodeContext{HasRunning: true}
@@ -140,6 +158,20 @@ func TestClassifyTurnBoundary_RunningEpisodeBiasesContinue(t *testing.T) {
 	}
 }
 
+func TestClassifyTurnBoundary_ActiveEpisodeBiasesNeutralFollowUpContinue(t *testing.T) {
+	cfg := DefaultBoundaryConfig()
+	now := time.Now()
+	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
+
+	boundary, reason := ClassifyTurnBoundary(prev, "确认", now, cfg, BoundaryEpisodeContext{HasActive: true})
+	if boundary != BoundaryContinue {
+		t.Fatalf("active episode + neutral confirmation should yield 'continue', got %q (reason=%s)", boundary, reason)
+	}
+	if reason != BoundaryReasonActiveEpisode {
+		t.Fatalf("expected reason %q, got %q", BoundaryReasonActiveEpisode, reason)
+	}
+}
+
 func TestClassifyTurnBoundary_BiasFavorsFalsePositiveContinue(t *testing.T) {
 	// Per design: prefer 误连 over 误切. Mid-range gap, ambiguous input (no
 	// clear marker, no clear action verb) — should still bias toward 'new'
@@ -147,7 +179,7 @@ func TestClassifyTurnBoundary_BiasFavorsFalsePositiveContinue(t *testing.T) {
 	// a single weak continuation signal appears.
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := []SessionEvent{eventAt(now.Add(-2*time.Minute), "user_input", "查一下天气")}
+	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下天气")
 	// Weak marker "把它" should be enough.
 	boundary, _ := ClassifyTurnBoundary(prev, "把它保存下来", now, cfg, BoundaryEpisodeContext{})
 	if boundary != BoundaryContinue {
@@ -175,6 +207,12 @@ func TestClassifyTurnBoundary_MalformedTimestampFallsBack(t *testing.T) {
 
 func TestDefaultBoundaryConfig_SaneDefaults(t *testing.T) {
 	cfg := DefaultBoundaryConfig()
+	if cfg.ShortGapSeconds != 180 {
+		t.Errorf("ShortGapSeconds = %d, want 180", cfg.ShortGapSeconds)
+	}
+	if cfg.SmallSessionEventThreshold != 16 {
+		t.Errorf("SmallSessionEventThreshold = %d, want 16", cfg.SmallSessionEventThreshold)
+	}
 	if cfg.ShortGapSeconds <= 0 {
 		t.Errorf("ShortGapSeconds should be positive, got %d", cfg.ShortGapSeconds)
 	}

--- a/src/agent/internal/agent/session_boundary_test.go
+++ b/src/agent/internal/agent/session_boundary_test.go
@@ -1,0 +1,194 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+// Helper: build a SessionEvent with a timestamp at offset duration from now.
+func eventAt(t time.Time, eventType, content string) SessionEvent {
+	return SessionEvent{
+		EventID: "evt_test_" + t.Format("150405.000000000"),
+		Ts:      t.Format(time.RFC3339Nano),
+		Type:    eventType,
+		Role:    "user",
+		Content: content,
+	}
+}
+
+func TestClassifyTurnBoundary_NoPrevEvents(t *testing.T) {
+	// First-ever input: no prior events. Should default to "new" (no context to continue).
+	cfg := DefaultBoundaryConfig()
+	now := time.Now()
+	boundary, _ := ClassifyTurnBoundary(nil, "打开微信", now, cfg, BoundaryEpisodeContext{})
+	if boundary != BoundaryNew {
+		t.Fatalf("empty prev events should yield 'new', got %q", boundary)
+	}
+}
+
+func TestClassifyTurnBoundary_TimeGapShort(t *testing.T) {
+	// Short gap (< 30s default): strong continuation, even on a generic action verb.
+	cfg := DefaultBoundaryConfig()
+	now := time.Now()
+	prev := []SessionEvent{eventAt(now.Add(-10*time.Second), "user_input", "打开微信")}
+	boundary, reason := ClassifyTurnBoundary(prev, "再发一条消息", now, cfg, BoundaryEpisodeContext{})
+	if boundary != BoundaryContinue {
+		t.Fatalf("short time gap should force 'continue', got %q (reason=%s)", boundary, reason)
+	}
+	if reason != BoundaryReasonTimeGapShort {
+		t.Fatalf("expected reason %q, got %q", BoundaryReasonTimeGapShort, reason)
+	}
+}
+
+func TestClassifyTurnBoundary_TimeGapLong(t *testing.T) {
+	// Long gap (> 5min default): strong new-session, even with a continuation marker.
+	cfg := DefaultBoundaryConfig()
+	now := time.Now()
+	prev := []SessionEvent{eventAt(now.Add(-10*time.Minute), "user_input", "打开微信")}
+	boundary, reason := ClassifyTurnBoundary(prev, "对了再帮我看一下", now, cfg, BoundaryEpisodeContext{})
+	if boundary != BoundaryNew {
+		t.Fatalf("long time gap should force 'new', got %q (reason=%s)", boundary, reason)
+	}
+	if reason != BoundaryReasonTimeGapLong {
+		t.Fatalf("expected reason %q, got %q", BoundaryReasonTimeGapLong, reason)
+	}
+}
+
+func TestClassifyTurnBoundary_ContinuationMarker(t *testing.T) {
+	// Mid-range gap + sentence-initial continuation marker → continue.
+	cfg := DefaultBoundaryConfig()
+	now := time.Now()
+	prev := []SessionEvent{eventAt(now.Add(-90*time.Second), "user_input", "查一下今天天气")}
+	cases := []string{
+		"对了再帮我看下后天的",
+		"然后呢？",
+		"还有北京的天气",
+		"继续往下翻",
+		"接着说",
+		"刚才那个网页打开",
+	}
+	for _, input := range cases {
+		boundary, reason := ClassifyTurnBoundary(prev, input, now, cfg, BoundaryEpisodeContext{})
+		if boundary != BoundaryContinue {
+			t.Errorf("input %q should yield 'continue', got %q (reason=%s)", input, boundary, reason)
+		}
+	}
+}
+
+func TestClassifyTurnBoundary_ActionVerbStartsNewTask(t *testing.T) {
+	// Mid-range gap + sentence-initial action verb on new entity → new.
+	cfg := DefaultBoundaryConfig()
+	now := time.Now()
+	prev := []SessionEvent{eventAt(now.Add(-2*time.Minute), "user_input", "查一下今天天气")}
+	cases := []string{
+		"打开微信",
+		"发消息给老婆",
+		"帮我订一张机票",
+		"找一下附近的咖啡店",
+	}
+	for _, input := range cases {
+		boundary, reason := ClassifyTurnBoundary(prev, input, now, cfg, BoundaryEpisodeContext{})
+		if boundary != BoundaryNew {
+			t.Errorf("input %q should yield 'new', got %q (reason=%s)", input, boundary, reason)
+		}
+	}
+}
+
+func TestClassifyTurnBoundary_AppDivergenceIsWeakNewSignal(t *testing.T) {
+	cfg := DefaultBoundaryConfig()
+	now := time.Now()
+	prev := []SessionEvent{{
+		EventID: "evt_app",
+		Ts:      now.Add(-2 * time.Minute).Format(time.RFC3339Nano),
+		Type:    "user_input",
+		Role:    "user",
+		Content: "查天气",
+		AppName: "WeatherApp",
+	}}
+	boundary, reason := ClassifyTurnBoundary(prev, "好的", now, cfg, BoundaryEpisodeContext{CurrentAppName: "WeChat"})
+	if boundary != BoundaryNew {
+		t.Fatalf("app divergence with neutral input should keep default new, got %q", boundary)
+	}
+	if reason != BoundaryReasonAppDivergence {
+		t.Fatalf("expected app divergence reason, got %q", reason)
+	}
+
+	boundary, reason = ClassifyTurnBoundary(prev, "再帮我看后天的", now, cfg, BoundaryEpisodeContext{CurrentAppName: "WeChat"})
+	if boundary != BoundaryContinue {
+		t.Fatalf("continuation marker should override weak app divergence, got %q (reason=%s)", boundary, reason)
+	}
+}
+
+func TestClassifyTurnBoundary_RunningEpisodeBiasesContinue(t *testing.T) {
+	// Mid-range gap + neutral input + running episode → continue.
+	// Same input + no episode → new (default bias).
+	cfg := DefaultBoundaryConfig()
+	now := time.Now()
+	prev := []SessionEvent{eventAt(now.Add(-2*time.Minute), "user_input", "查一下今天天气")}
+	neutralInput := "好的"
+
+	withEpisode := BoundaryEpisodeContext{HasRunning: true}
+	boundary, _ := ClassifyTurnBoundary(prev, neutralInput, now, cfg, withEpisode)
+	if boundary != BoundaryContinue {
+		t.Errorf("running episode + neutral input should yield 'continue', got %q", boundary)
+	}
+
+	noEpisode := BoundaryEpisodeContext{HasRunning: false}
+	boundary2, _ := ClassifyTurnBoundary(prev, neutralInput, now, cfg, noEpisode)
+	if boundary2 != BoundaryNew {
+		t.Errorf("no episode + neutral input should default to 'new', got %q", boundary2)
+	}
+}
+
+func TestClassifyTurnBoundary_BiasFavorsFalsePositiveContinue(t *testing.T) {
+	// Per design: prefer 误连 over 误切. Mid-range gap, ambiguous input (no
+	// clear marker, no clear action verb) — should still bias toward 'new'
+	// only when no other signal is present, but clearly continue when even
+	// a single weak continuation signal appears.
+	cfg := DefaultBoundaryConfig()
+	now := time.Now()
+	prev := []SessionEvent{eventAt(now.Add(-2*time.Minute), "user_input", "查一下天气")}
+	// Weak marker "把它" should be enough.
+	boundary, _ := ClassifyTurnBoundary(prev, "把它保存下来", now, cfg, BoundaryEpisodeContext{})
+	if boundary != BoundaryContinue {
+		t.Errorf("weak continuation marker '把它' should yield 'continue', got %q", boundary)
+	}
+}
+
+func TestClassifyTurnBoundary_MalformedTimestampFallsBack(t *testing.T) {
+	// Bad Ts on prev events shouldn't crash; should fall back to scoring path
+	// with no time-gap shortcut.
+	cfg := DefaultBoundaryConfig()
+	now := time.Now()
+	prev := []SessionEvent{{
+		EventID: "evt_bad",
+		Ts:      "not-a-timestamp",
+		Type:    "user_input",
+		Role:    "user",
+		Content: "查天气",
+	}}
+	boundary, _ := ClassifyTurnBoundary(prev, "对了再帮我看下", now, cfg, BoundaryEpisodeContext{})
+	if boundary != BoundaryContinue {
+		t.Errorf("malformed timestamp + continuation marker should yield 'continue', got %q", boundary)
+	}
+}
+
+func TestDefaultBoundaryConfig_SaneDefaults(t *testing.T) {
+	cfg := DefaultBoundaryConfig()
+	if cfg.ShortGapSeconds <= 0 {
+		t.Errorf("ShortGapSeconds should be positive, got %d", cfg.ShortGapSeconds)
+	}
+	if cfg.LongGapSeconds <= cfg.ShortGapSeconds {
+		t.Errorf("LongGapSeconds should exceed ShortGapSeconds; got short=%d long=%d",
+			cfg.ShortGapSeconds, cfg.LongGapSeconds)
+	}
+}
+
+func TestClassifyTurnBoundary_ZeroConfigUsesDefaults(t *testing.T) {
+	now := time.Now()
+	prev := []SessionEvent{eventAt(now.Add(-10*time.Second), "user_input", "打开微信")}
+	boundary, reason := ClassifyTurnBoundary(prev, "打开天气", now, BoundaryConfig{}, BoundaryEpisodeContext{})
+	if boundary != BoundaryContinue {
+		t.Fatalf("zero config should use default short gap and continue, got %q (reason=%s)", boundary, reason)
+	}
+}

--- a/src/agent/internal/agent/session_boundary_test.go
+++ b/src/agent/internal/agent/session_boundary_test.go
@@ -102,22 +102,22 @@ func TestClassifyTurnBoundary_ActionVerbStartsNewTask(t *testing.T) {
 	}
 }
 
-func TestClassifyTurnBoundary_AppDivergenceIsWeakNewSignal(t *testing.T) {
+func TestClassifyTurnBoundary_IgnoresAppDivergence(t *testing.T) {
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
 	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查天气")
 	for i := range prev {
 		prev[i].AppName = "WeatherApp"
 	}
-	boundary, reason := ClassifyTurnBoundary(prev, "好的", now, cfg, BoundaryEpisodeContext{CurrentAppName: "WeChat"})
+	boundary, reason := ClassifyTurnBoundary(prev, "好的", now, cfg, BoundaryEpisodeContext{})
 	if boundary != BoundaryNew {
-		t.Fatalf("app divergence with neutral input should keep default new, got %q", boundary)
+		t.Fatalf("neutral input should keep default new, got %q", boundary)
 	}
-	if reason != BoundaryReasonAppDivergence {
-		t.Fatalf("expected app divergence reason, got %q", reason)
+	if reason != BoundaryReasonDefaultNew {
+		t.Fatalf("expected default reason, got %q", reason)
 	}
 
-	boundary, reason = ClassifyTurnBoundary(prev, "再帮我看后天的", now, cfg, BoundaryEpisodeContext{CurrentAppName: "WeChat"})
+	boundary, reason = ClassifyTurnBoundary(prev, "再帮我看后天的", now, cfg, BoundaryEpisodeContext{})
 	if boundary != BoundaryContinue {
 		t.Fatalf("continuation marker should override weak app divergence, got %q (reason=%s)", boundary, reason)
 	}

--- a/src/agent/internal/agent/session_boundary_test.go
+++ b/src/agent/internal/agent/session_boundary_test.go
@@ -49,10 +49,10 @@ func TestClassifyTurnBoundary_TimeGapShort(t *testing.T) {
 }
 
 func TestClassifyTurnBoundary_TimeGapLong(t *testing.T) {
-	// Long gap (> 5min default): strong new-session, even with a continuation marker.
+	// Long gap (> 30min default): strong new-session, even with a continuation marker.
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := []SessionEvent{eventAt(now.Add(-10*time.Minute), "user_input", "打开微信")}
+	prev := []SessionEvent{eventAt(now.Add(-31*time.Minute), "user_input", "打开微信")}
 	boundary, reason := ClassifyTurnBoundary(prev, "对了再帮我看一下", now, cfg, BoundaryEpisodeContext{})
 	if boundary != BoundaryNew {
 		t.Fatalf("long time gap should force 'new', got %q (reason=%s)", boundary, reason)
@@ -74,6 +74,11 @@ func TestClassifyTurnBoundary_ContinuationMarker(t *testing.T) {
 		"继续往下翻",
 		"接着说",
 		"刚才那个网页打开",
+		"also check tomorrow",
+		"then scroll down",
+		"continue from there",
+		"what about next week",
+		"and open the same page",
 	}
 	for _, input := range cases {
 		boundary, reason := ClassifyTurnBoundary(prev, input, now, cfg, BoundaryEpisodeContext{})
@@ -93,11 +98,19 @@ func TestClassifyTurnBoundary_ActionVerbStartsNewTask(t *testing.T) {
 		"发消息给老婆",
 		"帮我订一张机票",
 		"找一下附近的咖啡店",
+		"open Gmail",
+		"search nearby coffee shops",
+		"send a message to Alex",
+		"book a flight",
+		"set an alarm",
 	}
 	for _, input := range cases {
 		boundary, reason := ClassifyTurnBoundary(prev, input, now, cfg, BoundaryEpisodeContext{})
 		if boundary != BoundaryNew {
 			t.Errorf("input %q should yield 'new', got %q (reason=%s)", input, boundary, reason)
+		}
+		if reason != BoundaryReasonActionVerb {
+			t.Errorf("input %q should use action verb reason, got %q", input, reason)
 		}
 	}
 }

--- a/src/agent/internal/agent/session_memory.go
+++ b/src/agent/internal/agent/session_memory.go
@@ -115,10 +115,16 @@ type ChunkRecallQuery struct {
 // ChunkRecallResult returns a recalled chunk with its summary and events.
 type ChunkRecallResult struct {
 	ChunkID    string                  `json:"chunk_id"`
+	Source     string                  `json:"source,omitempty"`
 	Summary    string                  `json:"summary"`
 	Structured *ChunkStructuredSummary `json:"structured,omitempty"`
 	Evidence   []SessionEvent          `json:"evidence"`
 }
+
+const (
+	chunkRecallSourceActive  = "active"
+	chunkRecallSourcePending = "pending"
+)
 
 type chunkIndex struct {
 	Version   int               `yaml:"version"`
@@ -331,7 +337,7 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 			if err != nil {
 				return nil, err
 			}
-			results = append(results, ChunkRecallResult{ChunkID: entry.ID, Summary: entry.Summary, Structured: entry.Structured, Evidence: events})
+			results = append(results, ChunkRecallResult{ChunkID: entry.ID, Source: chunkRecallSourceActive, Summary: entry.Summary, Structured: entry.Structured, Evidence: events})
 		}
 		return results, nil
 	}
@@ -367,7 +373,7 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 		if err != nil {
 			return nil, err
 		}
-		results = append(results, ChunkRecallResult{ChunkID: entry.ID, Summary: entry.Summary, Structured: entry.Structured, Evidence: events})
+		results = append(results, ChunkRecallResult{ChunkID: entry.ID, Source: chunkRecallSourceActive, Summary: entry.Summary, Structured: entry.Structured, Evidence: events})
 	}
 	return results, nil
 }

--- a/src/agent/internal/agent/session_memory.go
+++ b/src/agent/internal/agent/session_memory.go
@@ -25,6 +25,8 @@ const (
 	// until true rolling checkpointing (re-summarizing the rolling summary
 	// itself) is implemented in phase 2.
 	maxRollingSummaryLines = 100
+
+	pendingEventsGlob = "events.pending-*.jsonl"
 )
 
 // SessionMemoryStore manages session event compression, chunk storage, and
@@ -310,6 +312,7 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 	if err != nil {
 		return nil, err
 	}
+	pendingChunks := s.loadPendingChunks()
 	limit := query.Limit
 	if limit <= 0 {
 		limit = 3
@@ -321,12 +324,15 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 			idSet[id] = true
 		}
 		var results []ChunkRecallResult
-		for _, entry := range index.Chunks {
+		for _, entry := range append(append([]chunkIndexEntry(nil), index.Chunks...), pendingChunks...) {
 			if !idSet[entry.ID] {
 				continue
 			}
-			events, err := s.readEvents(filepath.Join(s.chunksDir(), entry.File))
+			events, err := s.readEventsForIndexEntry(entry)
 			if err != nil {
+				if entry.Status == "pending" && isPathNotExistError(err) {
+					continue
+				}
 				return nil, err
 			}
 			results = append(results, ChunkRecallResult{ChunkID: entry.ID, Summary: entry.Summary, Structured: entry.Structured, Evidence: events})
@@ -337,9 +343,12 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 	entries := make([]chunkIndexEntry, 0)
 	allActive := make([]chunkIndexEntry, 0)
 	hasFilter := query.AppName != "" || len(query.Tags) > 0 || len(query.Entities) > 0
-	for _, entry := range index.Chunks {
+	usedFilterFallback := false
+	for _, entry := range append(append([]chunkIndexEntry(nil), index.Chunks...), pendingChunks...) {
 		if entry.Status != "active" {
-			continue
+			if entry.Status != "pending" {
+				continue
+			}
 		}
 		allActive = append(allActive, entry)
 		if query.AppName != "" && entry.AppName != query.AppName {
@@ -355,17 +364,38 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 	}
 	if len(entries) == 0 && hasFilter {
 		entries = allActive
+		usedFilterFallback = true
 	}
 	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Status == "pending" && entries[j].Status != "pending" {
+			return false
+		}
+		if entries[i].Status != "pending" && entries[j].Status == "pending" {
+			return true
+		}
 		return entries[i].ID > entries[j].ID
 	})
+	if len(pendingChunks) > 0 && len(entries) >= limit && !containsPendingEntry(entries[:minInt(limit, len(entries))]) {
+		for _, pending := range pendingChunks {
+			if !hasFilter || usedFilterFallback || entryMatchesRecallQuery(pending, query, hasFilter) {
+				replaceAt := minInt(limit, len(entries)) - 1
+				if replaceAt >= 0 {
+					entries[replaceAt] = pending
+				}
+				break
+			}
+		}
+	}
 	results := make([]ChunkRecallResult, 0, minInt(limit, len(entries)))
 	for _, entry := range entries {
 		if len(results) >= limit {
 			break
 		}
-		events, err := s.readEvents(filepath.Join(s.chunksDir(), entry.File))
+		events, err := s.readEventsForIndexEntry(entry)
 		if err != nil {
+			if entry.Status == "pending" && isPathNotExistError(err) {
+				continue
+			}
 			return nil, err
 		}
 		results = append(results, ChunkRecallResult{ChunkID: entry.ID, Summary: entry.Summary, Structured: entry.Structured, Evidence: events})
@@ -373,8 +403,80 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 	return results, nil
 }
 
+func containsPendingEntry(entries []chunkIndexEntry) bool {
+	for _, entry := range entries {
+		if entry.Status == "pending" {
+			return true
+		}
+	}
+	return false
+}
+
+func entryMatchesRecallQuery(entry chunkIndexEntry, query ChunkRecallQuery, hasFilter bool) bool {
+	if entry.Status != "active" && entry.Status != "pending" {
+		return false
+	}
+	if query.AppName != "" && entry.AppName != query.AppName {
+		return false
+	}
+	if hasFilter && len(query.Tags) > 0 && !matchesAny(query.Tags, entry.Tags) {
+		return false
+	}
+	if hasFilter && len(query.Entities) > 0 && !matchesAny(query.Entities, entry.Entities) {
+		return false
+	}
+	return true
+}
+
 func (s *SessionMemoryStore) eventsPath() string {
 	return filepath.Join(s.rootDir, "events.jsonl")
+}
+
+func (s *SessionMemoryStore) pendingEventsPaths() ([]string, error) {
+	paths, err := filepath.Glob(filepath.Join(s.rootDir, pendingEventsGlob))
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(paths, func(i, j int) bool {
+		return pendingEventsSortKey(paths[i]) < pendingEventsSortKey(paths[j])
+	})
+	return paths, nil
+}
+
+func (s *SessionMemoryStore) loadPendingChunks() []chunkIndexEntry {
+	paths, err := s.pendingEventsPaths()
+	if err != nil {
+		return nil
+	}
+	chunks := make([]chunkIndexEntry, 0, len(paths))
+	for _, path := range paths {
+		events, err := s.readEvents(path)
+		if err != nil || len(events) == 0 {
+			continue
+		}
+		_, checksum, err := encodeSessionEventsJSONL(events)
+		if err != nil {
+			continue
+		}
+		sessionID := pendingSessionIDFromPath(path)
+		chunks = append(chunks, chunkIndexEntry{
+			ID:         pendingChunkIDFromPath(path),
+			File:       filepath.Base(path),
+			Status:     "pending",
+			Summary:    fmt.Sprintf("[Pending compression] %d events from session %s", len(events), sessionID),
+			AppName:    firstNonEmptyAppName(events),
+			EventCount: len(events),
+			Checksum:   checksum,
+		})
+	}
+	return chunks
+}
+
+func (s *SessionMemoryStore) readEventsForIndexEntry(entry chunkIndexEntry) ([]SessionEvent, error) {
+	if entry.Status == "pending" {
+		return s.readEvents(filepath.Join(s.rootDir, filepath.Base(entry.File)))
+	}
+	return s.readEvents(filepath.Join(s.chunksDir(), entry.File))
 }
 
 func (s *SessionMemoryStore) summaryPath() string {
@@ -565,7 +667,7 @@ func renderArchiveMD(chunks []chunkLine) string {
 
 func formatSessionSummaryWithWindow(existingSummary []byte, existingArchive []byte, newChunk chunkIndexEntry, maxChunks int) (summaryContent string, archiveContent string) {
 	chunks := parseChunkLines(existingSummary)
-	chunks = append(chunks, chunkLine{ID: newChunk.ID, Summary: strings.TrimSpace(newChunk.Summary)})
+	chunks = upsertChunkLine(chunks, chunkLine{ID: newChunk.ID, Summary: strings.TrimSpace(newChunk.Summary)})
 	rollingSummary := extractRollingSummary(existingSummary)
 
 	if maxChunks <= 0 || len(chunks) <= maxChunks {
@@ -580,6 +682,16 @@ func formatSessionSummaryWithWindow(existingSummary []byte, existingArchive []by
 
 	updatedRollingSummary := mergeArchivedChunksIntoRollingSummary(rollingSummary, overflow)
 	return renderSummaryMD(keep, updatedRollingSummary), renderArchiveMD(archived)
+}
+
+func upsertChunkLine(chunks []chunkLine, next chunkLine) []chunkLine {
+	for i := range chunks {
+		if chunks[i].ID == next.ID {
+			chunks[i] = next
+			return chunks
+		}
+	}
+	return append(chunks, next)
 }
 
 func mergeArchivedChunksIntoRollingSummary(existingRollingSummary string, archivedChunks []chunkLine) string {
@@ -633,4 +745,27 @@ func minInt(a int, b int) int {
 		return a
 	}
 	return b
+}
+
+func pendingSessionIDFromPath(path string) string {
+	base := filepath.Base(path)
+	sessionID := strings.TrimSuffix(base, ".jsonl")
+	sessionID = strings.TrimPrefix(sessionID, "events.pending-")
+	return strings.TrimSpace(sessionID)
+}
+
+func pendingChunkIDFromPath(path string) string {
+	sessionID := pendingSessionIDFromPath(path)
+	if sessionID == "" {
+		return "pending-unknown"
+	}
+	return "pending-" + sessionID
+}
+
+func pendingEventsSortKey(path string) string {
+	key := pendingSessionIDFromPath(path)
+	if key == "" {
+		return filepath.Base(path)
+	}
+	return key
 }

--- a/src/agent/internal/agent/session_memory.go
+++ b/src/agent/internal/agent/session_memory.go
@@ -25,8 +25,6 @@ const (
 	// until true rolling checkpointing (re-summarizing the rolling summary
 	// itself) is implemented in phase 2.
 	maxRollingSummaryLines = 100
-
-	pendingEventsGlob = "events.pending-*.jsonl"
 )
 
 // SessionMemoryStore manages session event compression, chunk storage, and
@@ -312,7 +310,6 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 	if err != nil {
 		return nil, err
 	}
-	pendingChunks := s.loadPendingChunks()
 	limit := query.Limit
 	if limit <= 0 {
 		limit = 3
@@ -324,15 +321,15 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 			idSet[id] = true
 		}
 		var results []ChunkRecallResult
-		for _, entry := range append(append([]chunkIndexEntry(nil), index.Chunks...), pendingChunks...) {
+		for _, entry := range index.Chunks {
 			if !idSet[entry.ID] {
+				continue
+			}
+			if entry.Status != "active" {
 				continue
 			}
 			events, err := s.readEventsForIndexEntry(entry)
 			if err != nil {
-				if entry.Status == "pending" && isPathNotExistError(err) {
-					continue
-				}
 				return nil, err
 			}
 			results = append(results, ChunkRecallResult{ChunkID: entry.ID, Summary: entry.Summary, Structured: entry.Structured, Evidence: events})
@@ -343,12 +340,9 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 	entries := make([]chunkIndexEntry, 0)
 	allActive := make([]chunkIndexEntry, 0)
 	hasFilter := query.AppName != "" || len(query.Tags) > 0 || len(query.Entities) > 0
-	usedFilterFallback := false
-	for _, entry := range append(append([]chunkIndexEntry(nil), index.Chunks...), pendingChunks...) {
+	for _, entry := range index.Chunks {
 		if entry.Status != "active" {
-			if entry.Status != "pending" {
-				continue
-			}
+			continue
 		}
 		allActive = append(allActive, entry)
 		if query.AppName != "" && entry.AppName != query.AppName {
@@ -364,28 +358,10 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 	}
 	if len(entries) == 0 && hasFilter {
 		entries = allActive
-		usedFilterFallback = true
 	}
 	sort.SliceStable(entries, func(i, j int) bool {
-		if entries[i].Status == "pending" && entries[j].Status != "pending" {
-			return false
-		}
-		if entries[i].Status != "pending" && entries[j].Status == "pending" {
-			return true
-		}
 		return entries[i].ID > entries[j].ID
 	})
-	if len(pendingChunks) > 0 && len(entries) >= limit && !containsPendingEntry(entries[:minInt(limit, len(entries))]) {
-		for _, pending := range pendingChunks {
-			if !hasFilter || usedFilterFallback || entryMatchesRecallQuery(pending, query, hasFilter) {
-				replaceAt := minInt(limit, len(entries)) - 1
-				if replaceAt >= 0 {
-					entries[replaceAt] = pending
-				}
-				break
-			}
-		}
-	}
 	results := make([]ChunkRecallResult, 0, minInt(limit, len(entries)))
 	for _, entry := range entries {
 		if len(results) >= limit {
@@ -393,9 +369,6 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 		}
 		events, err := s.readEventsForIndexEntry(entry)
 		if err != nil {
-			if entry.Status == "pending" && isPathNotExistError(err) {
-				continue
-			}
 			return nil, err
 		}
 		results = append(results, ChunkRecallResult{ChunkID: entry.ID, Summary: entry.Summary, Structured: entry.Structured, Evidence: events})
@@ -403,79 +376,11 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 	return results, nil
 }
 
-func containsPendingEntry(entries []chunkIndexEntry) bool {
-	for _, entry := range entries {
-		if entry.Status == "pending" {
-			return true
-		}
-	}
-	return false
-}
-
-func entryMatchesRecallQuery(entry chunkIndexEntry, query ChunkRecallQuery, hasFilter bool) bool {
-	if entry.Status != "active" && entry.Status != "pending" {
-		return false
-	}
-	if query.AppName != "" && entry.AppName != query.AppName {
-		return false
-	}
-	if hasFilter && len(query.Tags) > 0 && !matchesAny(query.Tags, entry.Tags) {
-		return false
-	}
-	if hasFilter && len(query.Entities) > 0 && !matchesAny(query.Entities, entry.Entities) {
-		return false
-	}
-	return true
-}
-
 func (s *SessionMemoryStore) eventsPath() string {
 	return filepath.Join(s.rootDir, "events.jsonl")
 }
 
-func (s *SessionMemoryStore) pendingEventsPaths() ([]string, error) {
-	paths, err := filepath.Glob(filepath.Join(s.rootDir, pendingEventsGlob))
-	if err != nil {
-		return nil, err
-	}
-	sort.SliceStable(paths, func(i, j int) bool {
-		return pendingEventsSortKey(paths[i]) < pendingEventsSortKey(paths[j])
-	})
-	return paths, nil
-}
-
-func (s *SessionMemoryStore) loadPendingChunks() []chunkIndexEntry {
-	paths, err := s.pendingEventsPaths()
-	if err != nil {
-		return nil
-	}
-	chunks := make([]chunkIndexEntry, 0, len(paths))
-	for _, path := range paths {
-		events, err := s.readEvents(path)
-		if err != nil || len(events) == 0 {
-			continue
-		}
-		_, checksum, err := encodeSessionEventsJSONL(events)
-		if err != nil {
-			continue
-		}
-		sessionID := pendingSessionIDFromPath(path)
-		chunks = append(chunks, chunkIndexEntry{
-			ID:         pendingChunkIDFromPath(path),
-			File:       filepath.Base(path),
-			Status:     "pending",
-			Summary:    fmt.Sprintf("[Pending compression] %d events from session %s", len(events), sessionID),
-			AppName:    firstNonEmptyAppName(events),
-			EventCount: len(events),
-			Checksum:   checksum,
-		})
-	}
-	return chunks
-}
-
 func (s *SessionMemoryStore) readEventsForIndexEntry(entry chunkIndexEntry) ([]SessionEvent, error) {
-	if entry.Status == "pending" {
-		return s.readEvents(filepath.Join(s.rootDir, filepath.Base(entry.File)))
-	}
 	return s.readEvents(filepath.Join(s.chunksDir(), entry.File))
 }
 
@@ -745,27 +650,4 @@ func minInt(a int, b int) int {
 		return a
 	}
 	return b
-}
-
-func pendingSessionIDFromPath(path string) string {
-	base := filepath.Base(path)
-	sessionID := strings.TrimSuffix(base, ".jsonl")
-	sessionID = strings.TrimPrefix(sessionID, "events.pending-")
-	return strings.TrimSpace(sessionID)
-}
-
-func pendingChunkIDFromPath(path string) string {
-	sessionID := pendingSessionIDFromPath(path)
-	if sessionID == "" {
-		return "pending-unknown"
-	}
-	return "pending-" + sessionID
-}
-
-func pendingEventsSortKey(path string) string {
-	key := pendingSessionIDFromPath(path)
-	if key == "" {
-		return filepath.Base(path)
-	}
-	return key
 }

--- a/src/agent/internal/agent/session_memory.go
+++ b/src/agent/internal/agent/session_memory.go
@@ -109,7 +109,6 @@ type ChunkRecallQuery struct {
 	ChunkIDs []string `json:"chunk_ids,omitempty"`
 	Tags     []string `json:"tags,omitempty"`
 	Entities []string `json:"entities,omitempty"`
-	AppName  string   `json:"app_name,omitempty"`
 	Limit    int      `json:"limit,omitempty"`
 }
 
@@ -339,15 +338,12 @@ func (s *SessionMemoryStore) RecallChunks(ctx context.Context, query ChunkRecall
 
 	entries := make([]chunkIndexEntry, 0)
 	allActive := make([]chunkIndexEntry, 0)
-	hasFilter := query.AppName != "" || len(query.Tags) > 0 || len(query.Entities) > 0
+	hasFilter := len(query.Tags) > 0 || len(query.Entities) > 0
 	for _, entry := range index.Chunks {
 		if entry.Status != "active" {
 			continue
 		}
 		allActive = append(allActive, entry)
-		if query.AppName != "" && entry.AppName != query.AppName {
-			continue
-		}
 		if hasFilter && len(query.Tags) > 0 && !matchesAny(query.Tags, entry.Tags) {
 			continue
 		}

--- a/src/agent/internal/agent/session_memory.go
+++ b/src/agent/internal/agent/session_memory.go
@@ -397,12 +397,41 @@ func (s *SessionMemoryStore) chunkIndexPath() string {
 }
 
 func (s *SessionMemoryStore) readEvents(path string) ([]SessionEvent, error) {
+	result, err := readSessionEventsJSONL(path, filepath.Clean(path) == filepath.Clean(s.eventsPath()))
+	if err != nil {
+		return nil, err
+	}
+	return result.events, nil
+}
+
+func (s *SessionMemoryStore) readActiveEventsRepairingTruncatedTail() (sessionEventsReadResult, error) {
+	path := s.eventsPath()
+	result, err := readSessionEventsJSONL(path, true)
+	if err != nil {
+		return sessionEventsReadResult{}, err
+	}
+	if result.truncatedTail {
+		if err := writeFileAtomic(path, result.validData, 0o644); err != nil {
+			result.repairErr = fmt.Errorf("repair session events %q: %w", path, err)
+		}
+	}
+	return result, nil
+}
+
+type sessionEventsReadResult struct {
+	events        []SessionEvent
+	validData     []byte
+	truncatedTail bool
+	repairErr     error
+}
+
+func readSessionEventsJSONL(path string, tolerateTruncatedTail bool) (sessionEventsReadResult, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("read session events %q: %w", path, err)
+		return sessionEventsReadResult{}, fmt.Errorf("read session events %q: %w", path, err)
 	}
 	defer file.Close()
-	var events []SessionEvent
+	var result sessionEventsReadResult
 	scanner := bufio.NewScanner(file)
 	scanner.Buffer(make([]byte, 0), 1<<20)
 	for scanner.Scan() {
@@ -412,17 +441,20 @@ func (s *SessionMemoryStore) readEvents(path string) ([]SessionEvent, error) {
 		}
 		var event SessionEvent
 		if err := json.Unmarshal(line, &event); err != nil {
-			if isTruncatedJSONLineError(err) && filepath.Clean(path) == filepath.Clean(s.eventsPath()) {
+			if tolerateTruncatedTail && isTruncatedJSONLineError(err) {
+				result.truncatedTail = true
 				break
 			}
-			return nil, fmt.Errorf("decode session event %q: %w", path, err)
+			return sessionEventsReadResult{}, fmt.Errorf("decode session event %q: %w", path, err)
 		}
-		events = append(events, event)
+		result.validData = append(result.validData, line...)
+		result.validData = append(result.validData, '\n')
+		result.events = append(result.events, event)
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan session events %q: %w", path, err)
+		return sessionEventsReadResult{}, fmt.Errorf("scan session events %q: %w", path, err)
 	}
-	return events, nil
+	return result, nil
 }
 
 func (s *SessionMemoryStore) loadChunkIndex() (chunkIndex, error) {

--- a/src/agent/internal/agent/session_memory_chain_test.go
+++ b/src/agent/internal/agent/session_memory_chain_test.go
@@ -50,7 +50,7 @@ func TestFilesystemMemoryChainCompressRecallAndLongTermSearch(t *testing.T) {
 		t.Fatalf("unexpected chunk summary: %#v", chunk)
 	}
 
-	recalled, err := session.RecallChunks(ctx, ChunkRecallQuery{Tags: []string{"验证码"}, AppName: "某政务App", Limit: 1})
+	recalled, err := session.RecallChunks(ctx, ChunkRecallQuery{Tags: []string{"验证码"}, Entities: []string{"某政务App"}, Limit: 1})
 	if err != nil {
 		t.Fatalf("RecallChunks() error = %v", err)
 	}

--- a/src/agent/internal/agent/tool_input.go
+++ b/src/agent/internal/agent/tool_input.go
@@ -121,7 +121,6 @@ func decodeChunkRecallQuery(input string) (ChunkRecallQuery, error) {
 		ChunkIDs flexStringSlice `json:"chunk_ids"`
 		Tags     flexStringSlice `json:"tags"`
 		Entities flexStringSlice `json:"entities"`
-		AppName  string          `json:"app_name"`
 		Limit    flexInt         `json:"limit"`
 	}
 	if err := json.Unmarshal([]byte(input), &flex); err != nil {
@@ -131,7 +130,6 @@ func decodeChunkRecallQuery(input string) (ChunkRecallQuery, error) {
 		ChunkIDs: flex.ChunkIDs,
 		Tags:     flex.Tags,
 		Entities: flex.Entities,
-		AppName:  flex.AppName,
 		Limit:    int(flex.Limit),
 	}, nil
 }

--- a/src/agent/internal/agent/tool_input_test.go
+++ b/src/agent/internal/agent/tool_input_test.go
@@ -166,11 +166,10 @@ func TestDecodeChunkRecallQueryWellFormed(t *testing.T) {
 			},
 		},
 		{
-			name:  "app_name filter",
+			name:  "app_name ignored",
 			input: `{"app_name":"Gmail","limit":10}`,
 			want: ChunkRecallQuery{
-				AppName: "Gmail",
-				Limit:   10,
+				Limit: 10,
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Add a local session-boundary classifier for voice multi-task turns using time gaps, continuation markers, action intent, app divergence, and recent episode state.
- Rotate a newly closed active session into `memory/session_archive/<closed_session_id>/`, recreate an empty active session, and keep archived sessions out of prompt and recall context.
- Return explicit `source` metadata from `recall_session_chunks` results so active indexed chunks are reported as `active` even if their IDs use a `pending-` prefix.
- Count `pending_chunks_recalled` from explicit `source: "pending"` results instead of inferring pending state from `chunk_id` prefixes.
- Document the recall source contract and the session-boundary telemetry metadata fields.

## Testing
- `go test ./internal/agent -run 'Test(SessionRecallTelemetry|RecallSessionChunksTool|SessionMemoryRecall)'`
- `go test ./internal/agent -run 'Test(SessionMemoryStore|SessionMemory|MaintainFilesystemMemory|FormatSessionSummary)'`
- `git diff --check`

Note: full `go test ./internal/agent` still has an unrelated existing prompt test failure in `TestFunctionAgentSystemMessageIncludesGlobalEnvironmentAndDeviceGuidance` around the expected `type "back"` guidance.
