### PR TITLE
fix(rootfs): enable Buildroot reproducible builds

### DIFF
--- a/scripts/test_reproducible_rootfs_policy.sh
+++ b/scripts/test_reproducible_rootfs_policy.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_IMAGE_SH="$ROOT_DIR/build_image.sh"
 INNER_BUILD_IMAGE_SH="$ROOT_DIR/_build_image.sh"
+PICO_SDK="$ROOT_DIR/pico-sdk"
 
 for script in "$BUILD_IMAGE_SH" "$INNER_BUILD_IMAGE_SH"; do
   if ! grep -q 'AIDEN_REPRODUCIBLE_IMAGE_EPOCH' "$script"; then
@@ -19,6 +20,33 @@ done
 
 if grep -Eq 'git .*log -1 --format=%ct|git .*log -1 .*%ct' "$BUILD_IMAGE_SH" "$INNER_BUILD_IMAGE_SH"; then
   echo "image builds must not derive the default SOURCE_DATE_EPOCH from the current commit time" >&2
+  exit 1
+fi
+
+for defconfig in \
+  "$PICO_SDK/sysdrv/tools/board/buildroot/luckfox_pico_defconfig" \
+  "$PICO_SDK/sysdrv/tools/board/buildroot/luckfox_pico_w_defconfig"; do
+  if [ ! -f "$defconfig" ]; then
+    echo "missing Buildroot defconfig: $defconfig" >&2
+    exit 1
+  fi
+
+  if ! grep -q '^BR2_REPRODUCIBLE=y$' "$defconfig"; then
+    echo "$(basename "$defconfig") must enable BR2_REPRODUCIBLE so package builds use Buildroot's reproducible timestamp policy" >&2
+    exit 1
+  fi
+done
+
+if ! grep -q 'define sync_buildroot_board_config' "$PICO_SDK/sysdrv/Makefile" || \
+   ! grep -q '$(call sync_buildroot_board_config)' "$PICO_SDK/sysdrv/Makefile"; then
+  echo "pico-sdk sysdrv Makefile must sync Buildroot board config before each Buildroot build" >&2
+  exit 1
+fi
+
+if ! grep -q 'define refresh_buildroot_config_state' "$PICO_SDK/sysdrv/Makefile" || \
+   ! grep -q '.aiden_buildroot_config_state' "$PICO_SDK/sysdrv/Makefile" || \
+   ! grep -q 'Buildroot configuration changed; rebuilding generated Buildroot state' "$PICO_SDK/sysdrv/Makefile"; then
+  echo "pico-sdk sysdrv Makefile must invalidate generated Buildroot state when reproducible config inputs change" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Revert the cleanup-only approach from the first revision of this PR.
- Point pico-sdk at AidenAI-IO/aiden-sdk#14, which enables Buildroot's BR2_REPRODUCIBLE mode, syncs Buildroot board config before every Buildroot build, and invalidates generated Buildroot state when config inputs change.
- Extend the rootfs reproducibility policy test to assert the SDK defconfigs and sysdrv Makefile keep those source-level controls in place.

## Root cause
release 20260611-094554-001fd62 reused rootfs.img.tar.gz from 20260611-073225-ecb74eb, while 20260611-130538-550b089 rebuilt rootfs.img. The rebuilt image differed even though the firmware repo and pico-sdk submodule pointer had not changed.

Further inspection showed this was not final ext4 metadata drift: both rootfs images had epoch-normalized ext4 superblock and inode timestamps. The changed payload was 12 non-pyc files plus 1553 Python .pyc files. The non-pyc changes were embedded build-date strings in packages such as BusyBox, mpv, socat, ntpd, Python, OpenSSL, zip, and sox. The .pyc bytecode bodies matched; only pyc headers differed between timestamp-based and hash-based invalidation.

On the self-hosted runner, Buildroot .config had BR2_REPRODUCIBLE unset. Exporting SOURCE_DATE_EPOCH alone only reached part of the build. Buildroot's package-level reproducibility machinery was not enabled, and the persistent unpacked Buildroot tree could keep using old board config and package stamps.

## Fix
The source fix is in AidenAI-IO/aiden-sdk#14:
- enable BR2_REPRODUCIBLE in Luckfox Pico Buildroot defconfigs
- sync Buildroot board config and package patches before every Buildroot build
- track config-input state and rebuild generated Buildroot state when those inputs change on persistent runners

This enables Buildroot's package-level controls: TZ/locale normalization, host-fakedate, toolchain wrapper handling for __DATE__/__TIME__, Python pyc time handling, BusyBox KCONFIG_NOTIMESTAMP, mpv --disable-build-date, and final rootfs timestamp normalization.

## Tests
- bash scripts/test_reproducible_rootfs_policy.sh
- sh scripts/test_build_scripts.sh
- sh scripts/test_release_ci_scripts.sh
- bash -n scripts/test_reproducible_rootfs_policy.sh