### PR TITLE
fix(ci): keep rootfs policy check out of safety job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,9 @@ jobs:
         git submodule update --init --depth=1 pico-sdk
         git -C pico-sdk clean -f -- .gitmodules
 
+    - name: Verify reproducible rootfs policy
+      run: bash scripts/test_reproducible_rootfs_policy.sh
+
     - name: Free hosted runner disk space
       if: ${{ inputs.free_disk_space }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         run: |
           sh scripts/test_release_ci_scripts.sh
           bash scripts/test_clean_rootfs_overlay_staging.sh
-          bash scripts/test_reproducible_rootfs_policy.sh
           bash scripts/test_compress_release_images.sh
           bash scripts/test_ota_manifest_generation.sh
           bash scripts/test_github_release_upload.sh

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -302,9 +302,23 @@ if grep -q 'git submodule update.*pico-sdk' "$CI_WORKFLOW"; then
     exit 1
 fi
 
+if grep -q 'scripts/test_reproducible_rootfs_policy.sh' "$CI_WORKFLOW"; then
+    echo "CI release script checks must not run submodule-dependent reproducible rootfs policy checks" >&2
+    exit 1
+fi
+
 if ! grep -q 'scripts/test_release_ci_scripts.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_github_release_upload.sh' "$CI_WORKFLOW"; then
     echo "CI must run repo-only release workflow and upload script tests" >&2
+    exit 1
+fi
+
+fetch_sdk_line=$(grep -n 'Fetch pico-sdk submodule' "$WORKFLOW" | sed 's/:.*//' | head -n 1)
+policy_line=$(grep -n 'scripts/test_reproducible_rootfs_policy.sh' "$WORKFLOW" | sed 's/:.*//' | head -n 1)
+run_build_line=$(grep -n 'Run build script' "$WORKFLOW" | sed 's/:.*//' | head -n 1)
+if [ -z "$fetch_sdk_line" ] || [ -z "$policy_line" ] || [ -z "$run_build_line" ] || \
+   [ "$fetch_sdk_line" -ge "$policy_line" ] || [ "$policy_line" -ge "$run_build_line" ]; then
+    echo "build workflow must verify reproducible rootfs policy after fetching pico-sdk and before building images" >&2
     exit 1
 fi
 

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -112,6 +112,11 @@ if grep -q 'scripts/test_build_scripts.sh' "$CI_WORKFLOW"; then
     exit 1
 fi
 
+if grep -q 'scripts/test_reproducible_rootfs_policy.sh' "$CI_WORKFLOW"; then
+    echo "CI release script checks must not run submodule-dependent reproducible rootfs policy checks" >&2
+    exit 1
+fi
+
 if ! grep -q 'scripts/test_release_ci_scripts.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_clean_rootfs_overlay_staging.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_github_release_upload.sh' "$CI_WORKFLOW" || \


### PR DESCRIPTION
## Summary
- move the reproducible rootfs policy check from the repo-only safety CI job into the build workflow after fetching pico-sdk
- add regression checks so submodule-dependent rootfs policy tests do not run in the hosted safety job

## Tests
- sh scripts/test_release_ci_scripts.sh
- sh scripts/test_build_scripts.sh
- bash scripts/test_github_actions_self_hosted_safety.sh
- bash scripts/test_reproducible_rootfs_policy.sh
- bash scripts/test_clean_rootfs_overlay_staging.sh
- bash scripts/test_compress_release_images.sh
- bash scripts/test_ota_manifest_generation.sh
- bash scripts/test_github_release_upload.sh
- bash scripts/test_reusable_rootfs_release_asset.sh