### PR TITLE
fix: make rootfs reproducible and speed up compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,18 +126,10 @@ jobs:
         scripts/validate_ota_pubkey.sh "$public_key"
         echo "OTA_PUBLIC_KEY_PATH=/home/.ota-ci/ota_ed25519_public_key.pem" >> "$GITHUB_ENV"
 
-    - name: Clean previous release image artifacts
+    - name: Clean previous build artifacts
       run: |
-        rm -f \
-          pico-sdk/output/image/boot.img \
-          pico-sdk/output/image/boot_a.img \
-          pico-sdk/output/image/boot_b.img \
-          pico-sdk/output/image/misc.img \
-          pico-sdk/output/image/oem.img \
-          pico-sdk/output/image/rootfs.img \
-          pico-sdk/output/image/update.img \
-          pico-sdk/output/image/*.img.tar.gz \
-          pico-sdk/output/image/manifest.json
+        rm -rf pico-sdk/output/image/*.img pico-sdk/output/image/*.img.tar.gz pico-sdk/output/image/manifest.json
+        rm -rf pico-sdk/output/out
 
     - name: Generate release name
       id: release_info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,10 +126,18 @@ jobs:
         scripts/validate_ota_pubkey.sh "$public_key"
         echo "OTA_PUBLIC_KEY_PATH=/home/.ota-ci/ota_ed25519_public_key.pem" >> "$GITHUB_ENV"
 
-    - name: Clean previous build artifacts
+    - name: Clean previous release image artifacts
       run: |
-        rm -rf pico-sdk/output/image/*.img pico-sdk/output/image/*.img.tar.gz pico-sdk/output/image/manifest.json
-        rm -rf pico-sdk/output/out
+        rm -f \
+          pico-sdk/output/image/boot.img \
+          pico-sdk/output/image/boot_a.img \
+          pico-sdk/output/image/boot_b.img \
+          pico-sdk/output/image/misc.img \
+          pico-sdk/output/image/oem.img \
+          pico-sdk/output/image/rootfs.img \
+          pico-sdk/output/image/update.img \
+          pico-sdk/output/image/*.img.tar.gz \
+          pico-sdk/output/image/manifest.json
 
     - name: Generate release name
       id: release_info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,6 @@ jobs:
     - name: Clean previous build artifacts
       run: |
         rm -rf pico-sdk/output/image/*.img pico-sdk/output/image/*.img.tar.gz pico-sdk/output/image/manifest.json
-        rm -rf pico-sdk/output/out
 
     - name: Generate release name
       id: release_info

--- a/_build.sh
+++ b/_build.sh
@@ -4,20 +4,20 @@
 
 set -e
 
-ROOT_DIR="./"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="$ROOT_DIR/build"
 TOOLCHAIN_FILE="$ROOT_DIR/cmake/toolchain-arm-rockchip830.cmake"
 
 echo "Building Aiden SDK..."
 
-rm -rf "$BUILD_DIR"
 cmake -S "$ROOT_DIR" -B "$BUILD_DIR" -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE"
-cmake --build "$BUILD_DIR"
+CMAKE_JOBS="${CMAKE_BUILD_PARALLEL_LEVEL:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)}"
+cmake --build "$BUILD_DIR" --parallel "$CMAKE_JOBS"
 
 echo "Build complete!"
 echo "Library: $ROOT_DIR/build/lib/libaiden.a"
 echo "Binaries in: $ROOT_DIR/build/bin/"
-ls -lh "$ROOT_DIR/build/bin/"
+ls -lh "$BUILD_DIR/bin/"
 
 # Build Go tools. The build environment must provide a verified Go in PATH.
 # GOTOOLCHAIN=local disables automatic toolchain downloads; if the installed Go
@@ -31,20 +31,22 @@ if ! command -v go >/dev/null 2>&1; then
     exit 1
 fi
 
-export GOCACHE="/tmp/go-cache"
-export GOMODCACHE="/tmp/go-mod"
-export GOPATH="/tmp/gopath"
+BUILD_CACHE_DIR="${AIDEN_BUILD_CACHE_DIR:-$ROOT_DIR/build/.cache}"
+export GOCACHE="${AIDEN_GOCACHE:-$BUILD_CACHE_DIR/go-build}"
+export GOMODCACHE="${AIDEN_GOMODCACHE:-$BUILD_CACHE_DIR/go-mod}"
+export GOPATH="${AIDEN_GOPATH:-$BUILD_CACHE_DIR/gopath}"
 export GOTOOLCHAIN=local
+mkdir -p "$GOCACHE" "$GOMODCACHE" "$GOPATH"
 
 AGENT_COMMIT="$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 AGENT_BUILD_VERSION="$(date -u +"%Y%m%d-%H%M%S")-${AGENT_COMMIT}"
 AGENT_LDFLAGS="-X aiden-agent/internal/agent.buildCommit=${AGENT_COMMIT} -X aiden-agent/internal/agent.buildVersion=${AGENT_BUILD_VERSION}"
 
-cd src/agent
-GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -ldflags "${AGENT_LDFLAGS}" -o "../../${BUILD_DIR}/bin/agent" ./cmd/daemon
-GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -ldflags "${AGENT_LDFLAGS}" -o "../../${BUILD_DIR}/bin/ota" ./cmd/ota
-GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -ldflags "${AGENT_LDFLAGS}" -o "../../${BUILD_DIR}/bin/abctl" ./cmd/abctl
-cd ../..
+cd "$ROOT_DIR/src/agent"
+GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -ldflags "${AGENT_LDFLAGS}" -o "$BUILD_DIR/bin/agent" ./cmd/daemon
+GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -ldflags "${AGENT_LDFLAGS}" -o "$BUILD_DIR/bin/ota" ./cmd/ota
+GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -ldflags "${AGENT_LDFLAGS}" -o "$BUILD_DIR/bin/abctl" ./cmd/abctl
+cd "$ROOT_DIR"
 
 echo "Go binaries built:"
 ls -lh "${BUILD_DIR}/bin/agent" "${BUILD_DIR}/bin/ota" "${BUILD_DIR}/bin/abctl"

--- a/_build.sh
+++ b/_build.sh
@@ -4,12 +4,13 @@
 
 set -e
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="./"
 BUILD_DIR="$ROOT_DIR/build"
 TOOLCHAIN_FILE="$ROOT_DIR/cmake/toolchain-arm-rockchip830.cmake"
 
 echo "Building Aiden SDK..."
 
+rm -rf "$BUILD_DIR"
 cmake -S "$ROOT_DIR" -B "$BUILD_DIR" -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE"
 CMAKE_JOBS="${CMAKE_BUILD_PARALLEL_LEVEL:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)}"
 cmake --build "$BUILD_DIR" --parallel "$CMAKE_JOBS"
@@ -17,7 +18,7 @@ cmake --build "$BUILD_DIR" --parallel "$CMAKE_JOBS"
 echo "Build complete!"
 echo "Library: $ROOT_DIR/build/lib/libaiden.a"
 echo "Binaries in: $ROOT_DIR/build/bin/"
-ls -lh "$BUILD_DIR/bin/"
+ls -lh "$ROOT_DIR/build/bin/"
 
 # Build Go tools. The build environment must provide a verified Go in PATH.
 # GOTOOLCHAIN=local disables automatic toolchain downloads; if the installed Go
@@ -31,22 +32,20 @@ if ! command -v go >/dev/null 2>&1; then
     exit 1
 fi
 
-BUILD_CACHE_DIR="${AIDEN_BUILD_CACHE_DIR:-$ROOT_DIR/build/.cache}"
-export GOCACHE="${AIDEN_GOCACHE:-$BUILD_CACHE_DIR/go-build}"
-export GOMODCACHE="${AIDEN_GOMODCACHE:-$BUILD_CACHE_DIR/go-mod}"
-export GOPATH="${AIDEN_GOPATH:-$BUILD_CACHE_DIR/gopath}"
+export GOCACHE="/tmp/go-cache"
+export GOMODCACHE="/tmp/go-mod"
+export GOPATH="/tmp/gopath"
 export GOTOOLCHAIN=local
-mkdir -p "$GOCACHE" "$GOMODCACHE" "$GOPATH"
 
 AGENT_COMMIT="$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 AGENT_BUILD_VERSION="$(date -u +"%Y%m%d-%H%M%S")-${AGENT_COMMIT}"
 AGENT_LDFLAGS="-X aiden-agent/internal/agent.buildCommit=${AGENT_COMMIT} -X aiden-agent/internal/agent.buildVersion=${AGENT_BUILD_VERSION}"
 
-cd "$ROOT_DIR/src/agent"
-GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -ldflags "${AGENT_LDFLAGS}" -o "$BUILD_DIR/bin/agent" ./cmd/daemon
-GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -ldflags "${AGENT_LDFLAGS}" -o "$BUILD_DIR/bin/ota" ./cmd/ota
-GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -ldflags "${AGENT_LDFLAGS}" -o "$BUILD_DIR/bin/abctl" ./cmd/abctl
-cd "$ROOT_DIR"
+cd src/agent
+GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -ldflags "${AGENT_LDFLAGS}" -o "../../${BUILD_DIR}/bin/agent" ./cmd/daemon
+GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -ldflags "${AGENT_LDFLAGS}" -o "../../${BUILD_DIR}/bin/ota" ./cmd/ota
+GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -ldflags "${AGENT_LDFLAGS}" -o "../../${BUILD_DIR}/bin/abctl" ./cmd/abctl
+cd ../..
 
 echo "Go binaries built:"
 ls -lh "${BUILD_DIR}/bin/agent" "${BUILD_DIR}/bin/ota" "${BUILD_DIR}/bin/abctl"

--- a/_build_image.sh
+++ b/_build_image.sh
@@ -226,6 +226,8 @@ if [ -d "$OVERLAY/oem" ]; then
         "usr/lib/librknnmrt.so" \
         "usr/model"
     clean_generated_binaries "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin"
+    # Keep Aiden-managed /oem/usr/bin exact when pico-sdk/output/out is reused.
+    rsync -a --delete "$OVERLAY/oem/usr/bin/" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin/"
     rsync -a "$OVERLAY/oem/" "$RK_PROJECT_PACKAGE_OEM_DIR/"
     echo "  ✓ OEM content copied"
 fi

--- a/_build_image.sh
+++ b/_build_image.sh
@@ -47,7 +47,7 @@ cd "$SCRIPT_DIR"
 # Step 2: 准备 overlay 目录
 echo "[2/6] Preparing overlay directories..."
 mkdir -p "$OVERLAY/oem/usr/bin" "$OVERLAY/oem/usr/lib" "$OVERLAY/oem/etc"
-cp -a "$SCRIPT_DIR/build/bin"/. "$OVERLAY/oem/usr/bin/"
+rsync -a --delete "$SCRIPT_DIR/build/bin/" "$OVERLAY/oem/usr/bin/"
 echo "  ✓ Binaries copied to overlay/oem/usr/bin"
 
 BENCHMARK_SRC="$SCRIPT_DIR/benchmark"
@@ -167,7 +167,6 @@ fi
 
 # 设置默认值
 : ${RK_CHIP:=rv1106}
-: ${RK_LIBC_TPYE:=glibc}
 SDK_ROOT_DIR="$PICO_SDK"
 RK_PROJECT_OUTPUT="${SDK_ROOT_DIR}/output/out"
 RK_PROJECT_OUTPUT_IMAGE="${SDK_ROOT_DIR}/output/image"

--- a/_build_image.sh
+++ b/_build_image.sh
@@ -35,6 +35,49 @@ require_rknnmrt_version() {
     fi
 }
 
+clean_managed_staging_paths() {
+    local base="$1"
+    shift
+    local rel_path
+
+    mkdir -p "$base"
+    for rel_path in "$@"; do
+        rm -rf "$base/$rel_path"
+    done
+}
+
+AIDEN_GENERATED_BINARIES=(
+    abctl
+    agent
+    audio_service
+    audio_service_cli
+    audio_stream
+    config_web
+    cpu_vad
+    example_audio_capture
+    example_audio_play
+    example_camera_capture
+    example_usb_hid
+    example_wakeup
+    frame_service
+    frame_service_cli
+    hello
+    image_process
+    ota
+    rknn_vad
+    trigger
+)
+
+clean_generated_binaries() {
+    local bin_dir="$1"
+    local binary
+
+    mkdir -p "$bin_dir"
+    for binary in "${AIDEN_GENERATED_BINARIES[@]}"; do
+        rm -f "$bin_dir/$binary"
+    done
+}
+
 echo "=== Aiden Hardware Demo - Image Builder ==="
 echo ""
 
@@ -47,7 +90,8 @@ cd "$SCRIPT_DIR"
 # Step 2: 准备 overlay 目录
 echo "[2/6] Preparing overlay directories..."
 mkdir -p "$OVERLAY/oem/usr/bin" "$OVERLAY/oem/usr/lib" "$OVERLAY/oem/etc"
-rsync -a --delete "$SCRIPT_DIR/build/bin/" "$OVERLAY/oem/usr/bin/"
+clean_generated_binaries "$OVERLAY/oem/usr/bin"
+rsync -a "$SCRIPT_DIR/build/bin/" "$OVERLAY/oem/usr/bin/"
 echo "  ✓ Binaries copied to overlay/oem/usr/bin"
 
 BENCHMARK_SRC="$SCRIPT_DIR/benchmark"
@@ -176,7 +220,12 @@ RK_PROJECT_PACKAGE_USERDATA_DIR="${RK_PROJECT_OUTPUT}/userdata"
 # 复制 oem 内容
 if [ -d "$OVERLAY/oem" ]; then
     echo "  → Copying oem content..."
-    mkdir -p "$RK_PROJECT_PACKAGE_OEM_DIR"
+    clean_managed_staging_paths "$RK_PROJECT_PACKAGE_OEM_DIR" \
+        "etc/ota_pubkey.pem" \
+        "usr/ko" \
+        "usr/lib/librknnmrt.so" \
+        "usr/model"
+    clean_generated_binaries "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin"
     rsync -a "$OVERLAY/oem/" "$RK_PROJECT_PACKAGE_OEM_DIR/"
     echo "  ✓ OEM content copied"
 fi
@@ -205,7 +254,13 @@ rm -rf "$RK_PROJECT_PACKAGE_USERDATA_DIR/agent/model"
 # 复制 userdata 内容
 if [ -d "$OVERLAY/userdata" ] && [ "$(ls -A "$OVERLAY/userdata" 2>/dev/null)" ]; then
     echo "  → Copying userdata content..."
-    mkdir -p "$RK_PROJECT_PACKAGE_USERDATA_DIR"
+    clean_managed_staging_paths "$RK_PROJECT_PACKAGE_USERDATA_DIR" \
+        "agent/agent.toml" \
+        "agent/benchmark" \
+        "agent/model" \
+        "agent_tools" \
+        "system/env" \
+        "wpa_supplicant.conf"
     rsync -a "$OVERLAY/userdata/" "$RK_PROJECT_PACKAGE_USERDATA_DIR/"
     echo "  ✓ USERDATA content copied"
 fi

--- a/_build_image.sh
+++ b/_build_image.sh
@@ -5,11 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OVERLAY="$SCRIPT_DIR/overlay"
 PICO_SDK="$SCRIPT_DIR/pico-sdk"
 DEST_OVERLAY="$PICO_SDK/project/cfg/BoardConfig_IPC/overlay/overlay-luckfox-buildroot-aiden"
+BUILD_IMAGE_ARGS=("$@")
+SDK_STAGE_CACHE_VERSION=1
+SDK_STAGE_STATE_DIR="$PICO_SDK/output/.aiden_stage_state"
 
 if [ -z "${SOURCE_DATE_EPOCH:-}" ]; then
-    # Keep filesystem image metadata stable across releases when their payloads
-    # did not change. Callers can still set SOURCE_DATE_EPOCH explicitly.
-    SOURCE_DATE_EPOCH="${AIDEN_REPRODUCIBLE_IMAGE_EPOCH:-0}"
+    # Keep image metadata stable without relying on every package treating epoch 0
+    # as truthy. Callers can still set SOURCE_DATE_EPOCH explicitly, including 0.
+    SOURCE_DATE_EPOCH="${AIDEN_REPRODUCIBLE_IMAGE_EPOCH:-1}"
 fi
 if ! [[ "$SOURCE_DATE_EPOCH" =~ ^[0-9]+$ ]]; then
     echo "SOURCE_DATE_EPOCH must be an unsigned Unix timestamp: $SOURCE_DATE_EPOCH" >&2
@@ -33,6 +36,107 @@ require_rknnmrt_version() {
         echo "  ✗ Error: RKNN runtime $version is too old for silero_vad_rv1106.rknn; use librknnmrt >= 2.3.x" >&2
         exit 1
     fi
+}
+
+hash_stage_path() {
+    local path="$1"
+    local target resolved
+
+    if [ -L "$path" ]; then
+        target="$(readlink "$path")"
+        printf 'link %s -> %s\n' "$path" "$target"
+        case "$target" in
+            /*) resolved="$target" ;;
+            *) resolved="$(dirname "$path")/$target" ;;
+        esac
+        if [ -e "$resolved" ]; then
+            hash_stage_path "$resolved"
+        fi
+    elif [ -d "$path" ]; then
+        printf 'dir %s\n' "$path"
+        (
+            cd "$path"
+            find . -xdev \( -type f -o -type l \) -print0 |
+                LC_ALL=C sort -z |
+                while IFS= read -r -d '' rel_path; do
+                    if [ -L "$rel_path" ]; then
+                        printf 'link %s/%s -> %s\n' "$path" "$rel_path" "$(readlink "$rel_path")"
+                    else
+                        printf 'file %s/%s\n' "$path" "$rel_path"
+                        sha256sum "$rel_path"
+                    fi
+                done
+        )
+    elif [ -f "$path" ]; then
+        printf 'file %s\n' "$path"
+        sha256sum "$path"
+    else
+        printf 'missing %s\n' "$path"
+    fi
+}
+
+sdk_stage_state() {
+    local stage="$1"
+    shift
+
+    {
+        printf 'cache-version=%s\n' "$SDK_STAGE_CACHE_VERSION"
+        printf 'stage=%s\n' "$stage"
+        printf 'source-date-epoch=%s\n' "$SOURCE_DATE_EPOCH"
+        printf 'sdk-head=%s\n' "$(git -C "$PICO_SDK" rev-parse HEAD 2>/dev/null || echo unknown)"
+        printf 'build-arg-count=%s\n' "${#BUILD_IMAGE_ARGS[@]}"
+        for arg in "${BUILD_IMAGE_ARGS[@]}"; do
+            printf 'build-arg=%q\n' "$arg"
+        done
+        for input in "$@"; do
+            hash_stage_path "$input"
+        done
+    } | sha256sum | awk '{print $1}'
+}
+
+sdk_stage_outputs_exist() {
+    local output_list="$1"
+    local output
+
+    IFS='|' read -r -a outputs <<<"$output_list"
+    for output in "${outputs[@]}"; do
+        if [ ! -e "$output" ]; then
+            return 1
+        fi
+    done
+    return 0
+}
+
+run_cached_sdk_stage() {
+    local stage="$1"
+    local output_list="$2"
+    shift 2
+    local stamp="$SDK_STAGE_STATE_DIR/$stage.sha256"
+    local state
+
+    state="$(sdk_stage_state "$stage" "$@")"
+    if sdk_stage_outputs_exist "$output_list" && [ -f "$stamp" ] && [ "$(cat "$stamp")" = "$state" ]; then
+        echo "  - Skipping pico-sdk $stage (cached outputs match inputs)"
+        return 0
+    fi
+
+    echo "  - Running pico-sdk $stage"
+    ./build.sh "$stage" "${BUILD_IMAGE_ARGS[@]}"
+    if ! sdk_stage_outputs_exist "$output_list"; then
+        echo "  ✗ Error: pico-sdk $stage completed but expected outputs are missing: $output_list" >&2
+        exit 1
+    fi
+    mkdir -p "$SDK_STAGE_STATE_DIR"
+    printf '%s\n' "$state" > "$stamp"
+}
+
+load_sdk_board_config() {
+    if [ -f "$PICO_SDK/.BoardConfig.mk" ]; then
+        source "$PICO_SDK/.BoardConfig.mk"
+    fi
+
+    : "${RK_CHIP:=rv1106}"
+    : "${RK_LIBC_TPYE:=glibc}"
 }
 
 echo "=== Aiden Hardware Demo - Image Builder ==="
@@ -153,21 +257,35 @@ fi
 # Step 4: 运行 pico-sdk 构建，overlay 注入后只打包一次 firmware，避免 A/B 大镜像重复生成。
 echo "[4/6] Running pico-sdk build stages..."
 cd "$PICO_SDK"
-./build.sh sysdrv "$@"
-./build.sh media "$@"
-./build.sh app "$@"
+load_sdk_board_config
+SDK_ROOT_DIR="$PICO_SDK"
+RK_PROJECT_OUTPUT="${SDK_ROOT_DIR}/output/out"
+RK_PROJECT_OUTPUT_IMAGE="${SDK_ROOT_DIR}/output/image"
+RK_PROJECT_PACKAGE_ROOTFS_DIR="${RK_PROJECT_OUTPUT}/rootfs_${RK_LIBC_TPYE}_${RK_CHIP}"
+RK_PROJECT_PACKAGE_OEM_DIR="${RK_PROJECT_OUTPUT}/oem"
+RK_PROJECT_PACKAGE_USERDATA_DIR="${RK_PROJECT_OUTPUT}/userdata"
+
+run_cached_sdk_stage \
+    sysdrv \
+    "$RK_PROJECT_OUTPUT/sysdrv_out|$RK_PROJECT_PACKAGE_ROOTFS_DIR|$RK_PROJECT_OUTPUT_IMAGE/idblock.img|$RK_PROJECT_OUTPUT_IMAGE/uboot.img" \
+    "$PICO_SDK/.BoardConfig.mk" \
+    "$DEST_OVERLAY"
+run_cached_sdk_stage \
+    media \
+    "$RK_PROJECT_OUTPUT/media_out" \
+    "$PICO_SDK/.BoardConfig.mk"
+run_cached_sdk_stage \
+    app \
+    "$RK_PROJECT_OUTPUT/app_out" \
+    "$PICO_SDK/.BoardConfig.mk"
 
 # Step 5: 获取输出路径并复制 oem/userdata 内容
 echo "[5/6] Injecting oem and userdata content..."
 
 # Source board config to get paths
-if [ -f "$PICO_SDK/.BoardConfig.mk" ]; then
-    source "$PICO_SDK/.BoardConfig.mk"
-fi
+load_sdk_board_config
 
 # 设置默认值
-: ${RK_CHIP:=rv1106}
-: ${RK_LIBC_TPYE:=glibc}
 SDK_ROOT_DIR="$PICO_SDK"
 RK_PROJECT_OUTPUT="${SDK_ROOT_DIR}/output/out"
 RK_PROJECT_OUTPUT_IMAGE="${SDK_ROOT_DIR}/output/image"
@@ -219,7 +337,7 @@ cd "$PICO_SDK/project"
 if [ -d "$RK_PROJECT_PACKAGE_OEM_DIR" ] && [ "$(ls -A "$RK_PROJECT_PACKAGE_OEM_DIR")" ]; then
     echo "  → Rebuilding oem.img..."
     firmware_log="$(mktemp)"
-    ./build.sh firmware "$@" > "$firmware_log" 2>&1
+    ./build.sh firmware "${BUILD_IMAGE_ARGS[@]}" > "$firmware_log" 2>&1
     grep -E "(oem|userdata|update)" "$firmware_log" || true
     rm -f "$firmware_log"
     echo "  ✓ Images rebuilt"

--- a/_build_image.sh
+++ b/_build_image.sh
@@ -5,9 +5,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OVERLAY="$SCRIPT_DIR/overlay"
 PICO_SDK="$SCRIPT_DIR/pico-sdk"
 DEST_OVERLAY="$PICO_SDK/project/cfg/BoardConfig_IPC/overlay/overlay-luckfox-buildroot-aiden"
-BUILD_IMAGE_ARGS=("$@")
-SDK_STAGE_CACHE_VERSION=1
-SDK_STAGE_STATE_DIR="$PICO_SDK/output/.aiden_stage_state"
 
 if [ -z "${SOURCE_DATE_EPOCH:-}" ]; then
     # Keep image metadata stable without relying on every package treating epoch 0
@@ -36,107 +33,6 @@ require_rknnmrt_version() {
         echo "  ✗ Error: RKNN runtime $version is too old for silero_vad_rv1106.rknn; use librknnmrt >= 2.3.x" >&2
         exit 1
     fi
-}
-
-hash_stage_path() {
-    local path="$1"
-    local target resolved
-
-    if [ -L "$path" ]; then
-        target="$(readlink "$path")"
-        printf 'link %s -> %s\n' "$path" "$target"
-        case "$target" in
-            /*) resolved="$target" ;;
-            *) resolved="$(dirname "$path")/$target" ;;
-        esac
-        if [ -e "$resolved" ]; then
-            hash_stage_path "$resolved"
-        fi
-    elif [ -d "$path" ]; then
-        printf 'dir %s\n' "$path"
-        (
-            cd "$path"
-            find . -xdev \( -type f -o -type l \) -print0 |
-                LC_ALL=C sort -z |
-                while IFS= read -r -d '' rel_path; do
-                    if [ -L "$rel_path" ]; then
-                        printf 'link %s/%s -> %s\n' "$path" "$rel_path" "$(readlink "$rel_path")"
-                    else
-                        printf 'file %s/%s\n' "$path" "$rel_path"
-                        sha256sum "$rel_path"
-                    fi
-                done
-        )
-    elif [ -f "$path" ]; then
-        printf 'file %s\n' "$path"
-        sha256sum "$path"
-    else
-        printf 'missing %s\n' "$path"
-    fi
-}
-
-sdk_stage_state() {
-    local stage="$1"
-    shift
-
-    {
-        printf 'cache-version=%s\n' "$SDK_STAGE_CACHE_VERSION"
-        printf 'stage=%s\n' "$stage"
-        printf 'source-date-epoch=%s\n' "$SOURCE_DATE_EPOCH"
-        printf 'sdk-head=%s\n' "$(git -C "$PICO_SDK" rev-parse HEAD 2>/dev/null || echo unknown)"
-        printf 'build-arg-count=%s\n' "${#BUILD_IMAGE_ARGS[@]}"
-        for arg in "${BUILD_IMAGE_ARGS[@]}"; do
-            printf 'build-arg=%q\n' "$arg"
-        done
-        for input in "$@"; do
-            hash_stage_path "$input"
-        done
-    } | sha256sum | awk '{print $1}'
-}
-
-sdk_stage_outputs_exist() {
-    local output_list="$1"
-    local output
-
-    IFS='|' read -r -a outputs <<<"$output_list"
-    for output in "${outputs[@]}"; do
-        if [ ! -e "$output" ]; then
-            return 1
-        fi
-    done
-    return 0
-}
-
-run_cached_sdk_stage() {
-    local stage="$1"
-    local output_list="$2"
-    shift 2
-    local stamp="$SDK_STAGE_STATE_DIR/$stage.sha256"
-    local state
-
-    state="$(sdk_stage_state "$stage" "$@")"
-    if sdk_stage_outputs_exist "$output_list" && [ -f "$stamp" ] && [ "$(cat "$stamp")" = "$state" ]; then
-        echo "  - Skipping pico-sdk $stage (cached outputs match inputs)"
-        return 0
-    fi
-
-    echo "  - Running pico-sdk $stage"
-    ./build.sh "$stage" "${BUILD_IMAGE_ARGS[@]}"
-    if ! sdk_stage_outputs_exist "$output_list"; then
-        echo "  ✗ Error: pico-sdk $stage completed but expected outputs are missing: $output_list" >&2
-        exit 1
-    fi
-    mkdir -p "$SDK_STAGE_STATE_DIR"
-    printf '%s\n' "$state" > "$stamp"
-}
-
-load_sdk_board_config() {
-    if [ -f "$PICO_SDK/.BoardConfig.mk" ]; then
-        source "$PICO_SDK/.BoardConfig.mk"
-    fi
-
-    : "${RK_CHIP:=rv1106}"
-    : "${RK_LIBC_TPYE:=glibc}"
 }
 
 echo "=== Aiden Hardware Demo - Image Builder ==="
@@ -257,35 +153,21 @@ fi
 # Step 4: 运行 pico-sdk 构建，overlay 注入后只打包一次 firmware，避免 A/B 大镜像重复生成。
 echo "[4/6] Running pico-sdk build stages..."
 cd "$PICO_SDK"
-load_sdk_board_config
-SDK_ROOT_DIR="$PICO_SDK"
-RK_PROJECT_OUTPUT="${SDK_ROOT_DIR}/output/out"
-RK_PROJECT_OUTPUT_IMAGE="${SDK_ROOT_DIR}/output/image"
-RK_PROJECT_PACKAGE_ROOTFS_DIR="${RK_PROJECT_OUTPUT}/rootfs_${RK_LIBC_TPYE}_${RK_CHIP}"
-RK_PROJECT_PACKAGE_OEM_DIR="${RK_PROJECT_OUTPUT}/oem"
-RK_PROJECT_PACKAGE_USERDATA_DIR="${RK_PROJECT_OUTPUT}/userdata"
-
-run_cached_sdk_stage \
-    sysdrv \
-    "$RK_PROJECT_OUTPUT/sysdrv_out|$RK_PROJECT_PACKAGE_ROOTFS_DIR|$RK_PROJECT_OUTPUT_IMAGE/idblock.img|$RK_PROJECT_OUTPUT_IMAGE/uboot.img" \
-    "$PICO_SDK/.BoardConfig.mk" \
-    "$DEST_OVERLAY"
-run_cached_sdk_stage \
-    media \
-    "$RK_PROJECT_OUTPUT/media_out" \
-    "$PICO_SDK/.BoardConfig.mk"
-run_cached_sdk_stage \
-    app \
-    "$RK_PROJECT_OUTPUT/app_out" \
-    "$PICO_SDK/.BoardConfig.mk"
+./build.sh sysdrv "$@"
+./build.sh media "$@"
+./build.sh app "$@"
 
 # Step 5: 获取输出路径并复制 oem/userdata 内容
 echo "[5/6] Injecting oem and userdata content..."
 
 # Source board config to get paths
-load_sdk_board_config
+if [ -f "$PICO_SDK/.BoardConfig.mk" ]; then
+    source "$PICO_SDK/.BoardConfig.mk"
+fi
 
 # 设置默认值
+: ${RK_CHIP:=rv1106}
+: ${RK_LIBC_TPYE:=glibc}
 SDK_ROOT_DIR="$PICO_SDK"
 RK_PROJECT_OUTPUT="${SDK_ROOT_DIR}/output/out"
 RK_PROJECT_OUTPUT_IMAGE="${SDK_ROOT_DIR}/output/image"
@@ -337,7 +219,7 @@ cd "$PICO_SDK/project"
 if [ -d "$RK_PROJECT_PACKAGE_OEM_DIR" ] && [ "$(ls -A "$RK_PROJECT_PACKAGE_OEM_DIR")" ]; then
     echo "  → Rebuilding oem.img..."
     firmware_log="$(mktemp)"
-    ./build.sh firmware "${BUILD_IMAGE_ARGS[@]}" > "$firmware_log" 2>&1
+    ./build.sh firmware "$@" > "$firmware_log" 2>&1
     grep -E "(oem|userdata|update)" "$firmware_log" || true
     rm -f "$firmware_log"
     echo "  ✓ Images rebuilt"

--- a/build_image.sh
+++ b/build_image.sh
@@ -36,9 +36,9 @@ if [ "$#" -gt 0 ]; then
 fi
 
 if [ -z "${SOURCE_DATE_EPOCH:-}" ]; then
-  # Keep rootfs/oem image metadata stable across releases when their payloads
-  # did not change. Callers can still set SOURCE_DATE_EPOCH explicitly.
-  SOURCE_DATE_EPOCH="${AIDEN_REPRODUCIBLE_IMAGE_EPOCH:-0}"
+  # Keep image metadata stable without relying on every package treating epoch 0
+  # as truthy. Callers can still set SOURCE_DATE_EPOCH explicitly, including 0.
+  SOURCE_DATE_EPOCH="${AIDEN_REPRODUCIBLE_IMAGE_EPOCH:-1}"
 fi
 if ! [[ "$SOURCE_DATE_EPOCH" =~ ^[0-9]+$ ]]; then
   echo "SOURCE_DATE_EPOCH must be an unsigned Unix timestamp: $SOURCE_DATE_EPOCH" >&2

--- a/scripts/compress_release_images.sh
+++ b/scripts/compress_release_images.sh
@@ -77,7 +77,7 @@ create_tar_gz() {
   local source="$1"
   local archive="$2"
   local entry_name="$3"
-  local mtime="${SOURCE_DATE_EPOCH:-0}"
+  local mtime="${SOURCE_DATE_EPOCH:-1}"
   local tmp_archive="${archive}.tmp.$$"
 
   rm -f "$tmp_archive"

--- a/scripts/compress_release_images.sh
+++ b/scripts/compress_release_images.sh
@@ -57,10 +57,14 @@ done
 [ -n "$image_dir" ] || die "missing --image-dir"
 [ -n "$assets" ] || die "missing --assets"
 [ -d "$image_dir" ] || die "missing image directory: $image_dir"
-command -v tar >/dev/null 2>&1 || die "tar is required"
-if ! command -v python3 >/dev/null 2>&1 && ! command -v gzip >/dev/null 2>&1; then
-  die "python3 or gzip is required"
-fi
+command -v python3 >/dev/null 2>&1 || die "python3 is required"
+
+source_date_epoch="${SOURCE_DATE_EPOCH:-1}"
+case "$source_date_epoch" in
+  ''|*[!0-9]*)
+    die "SOURCE_DATE_EPOCH must be an unsigned Unix timestamp: $source_date_epoch"
+    ;;
+esac
 
 emit_output() {
   local key="$1"
@@ -77,12 +81,11 @@ create_tar_gz() {
   local source="$1"
   local archive="$2"
   local entry_name="$3"
-  local mtime="${SOURCE_DATE_EPOCH:-1}"
+  local mtime="$source_date_epoch"
   local tmp_archive="${archive}.tmp.$$"
 
   rm -f "$tmp_archive"
-  if command -v python3 >/dev/null 2>&1; then
-    python3 - "$source" "$tmp_archive" "$entry_name" "$mtime" <<'PY'
+  python3 - "$source" "$tmp_archive" "$entry_name" "$mtime" <<'PY'
 import gzip
 import os
 import sys
@@ -109,48 +112,81 @@ with open(source, "rb") as source_file, open(archive, "wb") as raw_file:
         with tarfile.TarFile(fileobj=gzip_file, mode="w", format=tarfile.USTAR_FORMAT) as tar_file:
             tar_file.addfile(info, source_file)
 PY
-  else
-    tar -cf - -C "$(dirname "$source")" "$entry_name" | gzip -n -9 > "$tmp_archive"
-  fi
 
   mv "$tmp_archive" "$archive"
-}
-
-sha256_file() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$1" | awk '{print $1}'
-  else
-    shasum -a 256 "$1" | awk '{print $1}'
-  fi
-}
-
-sha256_stream() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum | awk '{print $1}'
-  else
-    shasum -a 256 | awk '{print $1}'
-  fi
 }
 
 archive_matches_source() {
   local source="$1"
   local archive="$2"
   local entry_name="$3"
-  local source_sha archive_sha entries
+  local mtime="$source_date_epoch"
 
-  if ! entries="$(tar -tzf "$archive" 2>/dev/null)"; then
-    return 1
-  fi
-  if [ "$entries" != "$entry_name" ]; then
-    return 1
-  fi
+  python3 - "$source" "$archive" "$entry_name" "$mtime" <<'PY'
+import gzip
+import hashlib
+import os
+import sys
+import tarfile
 
-  source_sha="$(sha256_file "$source")" || return 1
-  if ! archive_sha="$(tar -xOzf "$archive" "$entry_name" 2>/dev/null | sha256_stream)"; then
-    return 1
-  fi
+source, archive, entry_name, raw_mtime = sys.argv[1:]
+try:
+    expected_mtime = int(raw_mtime)
+except ValueError:
+    sys.exit(1)
 
-  [ "$source_sha" = "$archive_sha" ]
+def hash_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+def hash_reader(reader):
+    digest = hashlib.sha256()
+    for chunk in iter(lambda: reader.read(1024 * 1024), b""):
+        digest.update(chunk)
+    return digest.hexdigest()
+
+try:
+    with open(archive, "rb") as raw_file:
+        header = raw_file.read(10)
+    if len(header) != 10 or header[:2] != b"\x1f\x8b" or header[2] != 8:
+        sys.exit(1)
+    if header[3] != 0:
+        sys.exit(1)
+    if int.from_bytes(header[4:8], "little") != expected_mtime:
+        sys.exit(1)
+
+    with tarfile.open(archive, mode="r:gz") as tar_file:
+        info = tar_file.next()
+        if info is None:
+            sys.exit(1)
+        if (
+            info.name != entry_name
+            or not info.isfile()
+            or info.size != os.path.getsize(source)
+            or int(info.mtime) != expected_mtime
+            or info.mode != 0o644
+            or info.uid != 0
+            or info.gid != 0
+            or info.uname != ""
+            or info.gname != ""
+        ):
+            sys.exit(1)
+
+        extracted = tar_file.extractfile(info)
+        if extracted is None:
+            sys.exit(1)
+        archive_sha = hash_reader(extracted)
+        if tar_file.next() is not None:
+            sys.exit(1)
+
+    if hash_file(source) != archive_sha:
+        sys.exit(1)
+except (OSError, tarfile.TarError, EOFError):
+    sys.exit(1)
+PY
 }
 
 compressed_assets=()

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -127,6 +127,13 @@ if grep -Fq 'cp -a "$SCRIPT_DIR/build/bin"/. "$OVERLAY/oem/usr/bin/"' "$ROOT_DIR
     exit 1
 fi
 
+oem_bin_sync_line=$(grep -nF 'rsync -a --delete "$OVERLAY/oem/usr/bin/" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin/"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
+oem_full_sync_line=$(grep -nF 'rsync -a "$OVERLAY/oem/" "$RK_PROJECT_PACKAGE_OEM_DIR/"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
+if [ -z "$oem_bin_sync_line" ] || [ -z "$oem_full_sync_line" ] || [ "$oem_bin_sync_line" -ge "$oem_full_sync_line" ]; then
+    echo "_build_image.sh must sync OEM usr/bin with delete semantics before full OEM overlay sync" >&2
+    exit 1
+fi
+
 if ! grep -Fq 'clean_managed_staging_paths "$RK_PROJECT_PACKAGE_OEM_DIR"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq '"usr/model"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq '"etc/ota_pubkey.pem"' "$ROOT_DIR/_build_image.sh" || \

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -52,18 +52,133 @@ if grep -q 'build.sh firmware .*|| true' "$ROOT_DIR/_build_image.sh"; then
     exit 1
 fi
 
+if grep -Fq 'rm -rf "$BUILD_DIR"' "$BUILD_SH"; then
+    echo "_build.sh must preserve the CMake build directory for incremental rebuilds" >&2
+    exit 1
+fi
+
+if ! grep -q 'cmake --build "$BUILD_DIR" --parallel' "$BUILD_SH"; then
+    echo "_build.sh must use parallel CMake builds for changed native targets" >&2
+    exit 1
+fi
+
+if grep -Fq 'GOCACHE="/tmp/go-cache"' "$BUILD_SH" || \
+   grep -Fq 'GOMODCACHE="/tmp/go-mod"' "$BUILD_SH" || \
+   grep -Fq 'GOPATH="/tmp/gopath"' "$BUILD_SH"; then
+    echo "_build.sh must keep Go caches in a persistent workspace directory, not Docker's ephemeral /tmp" >&2
+    exit 1
+fi
+
+if grep -Eq '^ROOT_DIR="\./"?$' "$BUILD_SH"; then
+    echo "_build.sh must resolve ROOT_DIR to an absolute script directory so cache paths are valid for Go" >&2
+    exit 1
+fi
+
+tmp_build_test=$(mktemp -d)
+trap 'rm -rf "$tmp_build_test"' EXIT HUP INT TERM
+mkdir -p "$tmp_build_test/repo/src/agent" "$tmp_build_test/bin"
+cp "$BUILD_SH" "$tmp_build_test/repo/_build.sh"
+chmod +x "$tmp_build_test/repo/_build.sh"
+
+cat >"$tmp_build_test/bin/cmake" <<'EOF'
+#!/bin/sh
+set -eu
+case "$1" in
+  -S)
+    case "$2" in /*) ;; *) echo "cmake source dir must be absolute: $2" >&2; exit 1 ;; esac
+    case "$4" in /*) ;; *) echo "cmake build dir must be absolute: $4" >&2; exit 1 ;; esac
+    mkdir -p "$4/bin" "$4/lib"
+    touch "$4/lib/libaiden.a"
+    ;;
+  --build)
+    case "$2" in /*) ;; *) echo "cmake --build dir must be absolute: $2" >&2; exit 1 ;; esac
+    if [ "$3" != "--parallel" ] || [ -z "${4:-}" ]; then
+      echo "cmake build must pass --parallel with a job count" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "unexpected cmake args: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+
+cat >"$tmp_build_test/bin/go" <<'EOF'
+#!/bin/sh
+set -eu
+if [ "$1" = "build" ]; then
+  case "${GOCACHE:-}" in /*/build/.cache/go-build) ;; *) echo "GOCACHE must be an absolute workspace cache: ${GOCACHE:-}" >&2; exit 1 ;; esac
+  case "${GOMODCACHE:-}" in /*/build/.cache/go-mod) ;; *) echo "GOMODCACHE must be an absolute workspace cache: ${GOMODCACHE:-}" >&2; exit 1 ;; esac
+  case "${GOPATH:-}" in /*/build/.cache/gopath) ;; *) echo "GOPATH must be an absolute workspace cache: ${GOPATH:-}" >&2; exit 1 ;; esac
+  if [ "${GOTOOLCHAIN:-}" != "local" ]; then
+    echo "GOTOOLCHAIN must be local" >&2
+    exit 1
+  fi
+  out=
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+      shift
+      out="$1"
+      break
+    fi
+    shift
+  done
+  case "$out" in
+    /*/build/bin/agent|*/build/bin/ota|*/build/bin/abctl) ;;
+    *) echo "go output must target build/bin with an absolute or repo-local path: $out" >&2; exit 1 ;;
+  esac
+  mkdir -p "$(dirname "$out")"
+  touch "$out"
+  exit 0
+fi
+echo "unexpected go args: $*" >&2
+exit 1
+EOF
+
+cat >"$tmp_build_test/bin/git" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n' testsha
+EOF
+
+chmod +x "$tmp_build_test/bin/cmake" "$tmp_build_test/bin/go" "$tmp_build_test/bin/git"
+(
+  cd "$tmp_build_test"
+  PATH="$tmp_build_test/bin:$PATH" CMAKE_BUILD_PARALLEL_LEVEL=3 "$tmp_build_test/repo/_build.sh" >/dev/null
+)
+
+if grep -Fq 'rm -rf pico-sdk/output/out' "$WORKFLOW"; then
+    echo "build workflow must preserve pico-sdk/output/out so self-hosted release builds can reuse intermediate artifacts" >&2
+    exit 1
+fi
+
+if grep -Eq 'pico-sdk/output/image/\*\.img([[:space:]\\]|$)' "$WORKFLOW"; then
+    echo "build workflow must not delete every pico-sdk output image; cached sysdrv outputs such as idblock.img and uboot.img are reused" >&2
+    exit 1
+fi
+
 if grep -q './build.sh all' "$ROOT_DIR/_build_image.sh"; then
     echo "_build_image.sh must not run build.sh all before overlay injection; it creates large A/B images twice" >&2
     exit 1
 fi
 
-if ! grep -q './build.sh sysdrv' "$ROOT_DIR/_build_image.sh" || \
-   ! grep -q './build.sh media' "$ROOT_DIR/_build_image.sh" || \
-   ! grep -q './build.sh app' "$ROOT_DIR/_build_image.sh" || \
+if ! grep -q 'SDK_STAGE_STATE_DIR=' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -q 'run_cached_sdk_stage' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -q 'build-arg-count=' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -q 'build-arg=%q' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -q 'Skipping pico-sdk $stage (cached outputs match inputs)' "$ROOT_DIR/_build_image.sh" || \
    ! grep -q './build.sh firmware' "$ROOT_DIR/_build_image.sh"; then
-    echo "_build_image.sh must build components first, inject overlay, then package firmware once" >&2
+    echo "_build_image.sh must cache reusable SDK stages, inject overlay, then package firmware once" >&2
     exit 1
 fi
+
+for sdk_stage in sysdrv media app; do
+    if ! grep -Eq "^[[:space:]]+$sdk_stage[[:space:]]+\\\\" "$ROOT_DIR/_build_image.sh"; then
+        echo "_build_image.sh must run pico-sdk $sdk_stage through the SDK stage cache" >&2
+        exit 1
+    fi
+done
 
 if [ ! -x "$ROOT_DIR/scripts/clean_rootfs_overlay_staging.sh" ]; then
     echo "rootfs overlay cleanup script must exist and be executable" >&2
@@ -131,7 +246,9 @@ if ! grep -q 'normalize_image_tree_ownership' "$ROOT_DIR/pico-sdk/project/build.
 fi
 
 for required in \
-    'SOURCE_DATE_EPOCH ?= 0' \
+    'SOURCE_DATE_EPOCH ?=' \
+    'local epoch="${SOURCE_DATE_EPOCH:-' \
+    'source_date_epoch="${SOURCE_DATE_EPOCH:-' \
     '--sort=name' \
     '--mtime="@$(SOURCE_DATE_EPOCH)"' \
     'Build Time:  $(reproducible_build_utc)' \

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -97,6 +97,11 @@ if grep -q 'SDK_STAGE_STATE_DIR=' "$ROOT_DIR/_build_image.sh" || \
     exit 1
 fi
 
+if grep -q 'RK_LIBC_TPYE:=glibc' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must not guess the SDK libc type; pico-sdk derives it from RK_TOOLCHAIN_CROSS" >&2
+    exit 1
+fi
+
 if ! grep -q './build.sh sysdrv' "$ROOT_DIR/_build_image.sh" || \
    ! grep -q './build.sh media' "$ROOT_DIR/_build_image.sh" || \
    ! grep -q './build.sh app' "$ROOT_DIR/_build_image.sh" || \
@@ -112,6 +117,12 @@ fi
 
 if ! grep -Fq 'scripts/clean_rootfs_overlay_staging.sh" --dest-overlay "$DEST_OVERLAY"' "$ROOT_DIR/_build_image.sh"; then
     echo "_build_image.sh must clean stale rootfs overlay staging before syncing current rootfs assets" >&2
+    exit 1
+fi
+
+if grep -Fq 'cp -a "$SCRIPT_DIR/build/bin"/. "$OVERLAY/oem/usr/bin/"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'rsync -a --delete "$SCRIPT_DIR/build/bin/" "$OVERLAY/oem/usr/bin/"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must sync generated binaries into overlay/oem/usr/bin with delete semantics" >&2
     exit 1
 fi
 

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -52,8 +52,8 @@ if grep -q 'build.sh firmware .*|| true' "$ROOT_DIR/_build_image.sh"; then
     exit 1
 fi
 
-if grep -Fq 'rm -rf "$BUILD_DIR"' "$BUILD_SH"; then
-    echo "_build.sh must preserve the CMake build directory for incremental rebuilds" >&2
+if ! grep -Fq 'rm -rf "$BUILD_DIR"' "$BUILD_SH"; then
+    echo "_build.sh must clean the CMake build directory; this PR only keeps parallel compile speedups, not reused build outputs" >&2
     exit 1
 fi
 
@@ -62,99 +62,26 @@ if ! grep -q 'cmake --build "$BUILD_DIR" --parallel' "$BUILD_SH"; then
     exit 1
 fi
 
-if grep -Fq 'GOCACHE="/tmp/go-cache"' "$BUILD_SH" || \
-   grep -Fq 'GOMODCACHE="/tmp/go-mod"' "$BUILD_SH" || \
-   grep -Fq 'GOPATH="/tmp/gopath"' "$BUILD_SH"; then
-    echo "_build.sh must keep Go caches in a persistent workspace directory, not Docker's ephemeral /tmp" >&2
+if grep -Fq 'AIDEN_BUILD_CACHE_DIR' "$BUILD_SH" || \
+   grep -Fq 'build/.cache' "$BUILD_SH"; then
+    echo "_build.sh must not add workspace build-output reuse caches in this PR" >&2
     exit 1
 fi
 
-if grep -Eq '^ROOT_DIR="\./"?$' "$BUILD_SH"; then
-    echo "_build.sh must resolve ROOT_DIR to an absolute script directory so cache paths are valid for Go" >&2
+if ! grep -Fq 'GOCACHE="/tmp/go-cache"' "$BUILD_SH" || \
+   ! grep -Fq 'GOMODCACHE="/tmp/go-mod"' "$BUILD_SH" || \
+   ! grep -Fq 'GOPATH="/tmp/gopath"' "$BUILD_SH"; then
+    echo "_build.sh must keep Go caches ephemeral; persistent cache reuse is out of scope for this PR" >&2
     exit 1
 fi
 
-tmp_build_test=$(mktemp -d)
-trap 'rm -rf "$tmp_build_test"' EXIT HUP INT TERM
-mkdir -p "$tmp_build_test/repo/src/agent" "$tmp_build_test/bin"
-cp "$BUILD_SH" "$tmp_build_test/repo/_build.sh"
-chmod +x "$tmp_build_test/repo/_build.sh"
-
-cat >"$tmp_build_test/bin/cmake" <<'EOF'
-#!/bin/sh
-set -eu
-case "$1" in
-  -S)
-    case "$2" in /*) ;; *) echo "cmake source dir must be absolute: $2" >&2; exit 1 ;; esac
-    case "$4" in /*) ;; *) echo "cmake build dir must be absolute: $4" >&2; exit 1 ;; esac
-    mkdir -p "$4/bin" "$4/lib"
-    touch "$4/lib/libaiden.a"
-    ;;
-  --build)
-    case "$2" in /*) ;; *) echo "cmake --build dir must be absolute: $2" >&2; exit 1 ;; esac
-    if [ "$3" != "--parallel" ] || [ -z "${4:-}" ]; then
-      echo "cmake build must pass --parallel with a job count" >&2
-      exit 1
-    fi
-    ;;
-  *)
-    echo "unexpected cmake args: $*" >&2
-    exit 1
-    ;;
-esac
-EOF
-
-cat >"$tmp_build_test/bin/go" <<'EOF'
-#!/bin/sh
-set -eu
-if [ "$1" = "build" ]; then
-  case "${GOCACHE:-}" in /*/build/.cache/go-build) ;; *) echo "GOCACHE must be an absolute workspace cache: ${GOCACHE:-}" >&2; exit 1 ;; esac
-  case "${GOMODCACHE:-}" in /*/build/.cache/go-mod) ;; *) echo "GOMODCACHE must be an absolute workspace cache: ${GOMODCACHE:-}" >&2; exit 1 ;; esac
-  case "${GOPATH:-}" in /*/build/.cache/gopath) ;; *) echo "GOPATH must be an absolute workspace cache: ${GOPATH:-}" >&2; exit 1 ;; esac
-  if [ "${GOTOOLCHAIN:-}" != "local" ]; then
-    echo "GOTOOLCHAIN must be local" >&2
-    exit 1
-  fi
-  out=
-  while [ "$#" -gt 0 ]; do
-    if [ "$1" = "-o" ]; then
-      shift
-      out="$1"
-      break
-    fi
-    shift
-  done
-  case "$out" in
-    /*/build/bin/agent|*/build/bin/ota|*/build/bin/abctl) ;;
-    *) echo "go output must target build/bin with an absolute or repo-local path: $out" >&2; exit 1 ;;
-  esac
-  mkdir -p "$(dirname "$out")"
-  touch "$out"
-  exit 0
-fi
-echo "unexpected go args: $*" >&2
-exit 1
-EOF
-
-cat >"$tmp_build_test/bin/git" <<'EOF'
-#!/bin/sh
-set -eu
-printf '%s\n' testsha
-EOF
-
-chmod +x "$tmp_build_test/bin/cmake" "$tmp_build_test/bin/go" "$tmp_build_test/bin/git"
-(
-  cd "$tmp_build_test"
-  PATH="$tmp_build_test/bin:$PATH" CMAKE_BUILD_PARALLEL_LEVEL=3 "$tmp_build_test/repo/_build.sh" >/dev/null
-)
-
-if grep -Fq 'rm -rf pico-sdk/output/out' "$WORKFLOW"; then
-    echo "build workflow must preserve pico-sdk/output/out so self-hosted release builds can reuse intermediate artifacts" >&2
+if ! grep -Fq 'rm -rf pico-sdk/output/out' "$WORKFLOW"; then
+    echo "build workflow must clean pico-sdk/output/out; reused SDK build outputs are out of scope for this PR" >&2
     exit 1
 fi
 
-if grep -Eq 'pico-sdk/output/image/\*\.img([[:space:]\\]|$)' "$WORKFLOW"; then
-    echo "build workflow must not delete every pico-sdk output image; cached sysdrv outputs such as idblock.img and uboot.img are reused" >&2
+if ! grep -Eq 'pico-sdk/output/image/\*\.img([[:space:]\\]|$)' "$WORKFLOW"; then
+    echo "build workflow must clean all generated images before a release build" >&2
     exit 1
 fi
 
@@ -163,22 +90,20 @@ if grep -q './build.sh all' "$ROOT_DIR/_build_image.sh"; then
     exit 1
 fi
 
-if ! grep -q 'SDK_STAGE_STATE_DIR=' "$ROOT_DIR/_build_image.sh" || \
-   ! grep -q 'run_cached_sdk_stage' "$ROOT_DIR/_build_image.sh" || \
-   ! grep -q 'build-arg-count=' "$ROOT_DIR/_build_image.sh" || \
-   ! grep -q 'build-arg=%q' "$ROOT_DIR/_build_image.sh" || \
-   ! grep -q 'Skipping pico-sdk $stage (cached outputs match inputs)' "$ROOT_DIR/_build_image.sh" || \
-   ! grep -q './build.sh firmware' "$ROOT_DIR/_build_image.sh"; then
-    echo "_build_image.sh must cache reusable SDK stages, inject overlay, then package firmware once" >&2
+if grep -q 'SDK_STAGE_STATE_DIR=' "$ROOT_DIR/_build_image.sh" || \
+   grep -q 'run_cached_sdk_stage' "$ROOT_DIR/_build_image.sh" || \
+   grep -q 'Skipping pico-sdk $stage (cached outputs match inputs)' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must not cache or reuse pico-sdk stage outputs in this PR" >&2
     exit 1
 fi
 
-for sdk_stage in sysdrv media app; do
-    if ! grep -Eq "^[[:space:]]+$sdk_stage[[:space:]]+\\\\" "$ROOT_DIR/_build_image.sh"; then
-        echo "_build_image.sh must run pico-sdk $sdk_stage through the SDK stage cache" >&2
-        exit 1
-    fi
-done
+if ! grep -q './build.sh sysdrv' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -q './build.sh media' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -q './build.sh app' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -q './build.sh firmware' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must build components directly, inject overlay, then package firmware once" >&2
+    exit 1
+fi
 
 if [ ! -x "$ROOT_DIR/scripts/clean_rootfs_overlay_staging.sh" ]; then
     echo "rootfs overlay cleanup script must exist and be executable" >&2

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -75,8 +75,8 @@ if ! grep -Fq 'GOCACHE="/tmp/go-cache"' "$BUILD_SH" || \
     exit 1
 fi
 
-if ! grep -Fq 'rm -rf pico-sdk/output/out' "$WORKFLOW"; then
-    echo "build workflow must clean pico-sdk/output/out; reused SDK build outputs are out of scope for this PR" >&2
+if grep -Fq 'rm -rf pico-sdk/output/out' "$WORKFLOW"; then
+    echo "build workflow must preserve pico-sdk/output/out so unchanged SDK code can reuse SDK-managed build outputs" >&2
     exit 1
 fi
 
@@ -121,8 +121,19 @@ if ! grep -Fq 'scripts/clean_rootfs_overlay_staging.sh" --dest-overlay "$DEST_OV
 fi
 
 if grep -Fq 'cp -a "$SCRIPT_DIR/build/bin"/. "$OVERLAY/oem/usr/bin/"' "$ROOT_DIR/_build_image.sh" || \
-   ! grep -Fq 'rsync -a --delete "$SCRIPT_DIR/build/bin/" "$OVERLAY/oem/usr/bin/"' "$ROOT_DIR/_build_image.sh"; then
-    echo "_build_image.sh must sync generated binaries into overlay/oem/usr/bin with delete semantics" >&2
+   ! grep -Fq 'clean_generated_binaries "$OVERLAY/oem/usr/bin"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'clean_generated_binaries "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must remove stale generated binaries from overlay and SDK OEM staging" >&2
+    exit 1
+fi
+
+if ! grep -Fq 'clean_managed_staging_paths "$RK_PROJECT_PACKAGE_OEM_DIR"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq '"usr/model"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq '"etc/ota_pubkey.pem"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'clean_managed_staging_paths "$RK_PROJECT_PACKAGE_USERDATA_DIR"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq '"agent/benchmark"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq '"agent_tools"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must clean Aiden-managed SDK staging paths before preserving pico-sdk/output/out" >&2
     exit 1
 fi
 

--- a/scripts/test_compress_release_images.sh
+++ b/scripts/test_compress_release_images.sh
@@ -28,6 +28,42 @@ sha256_of() {
   fi
 }
 
+assert_archive_mtime() {
+  local archive="$1"
+  local entry_name="$2"
+  local expected_mtime="$3"
+
+  python3 - "$archive" "$entry_name" "$expected_mtime" <<'PY'
+import gzip
+import sys
+import tarfile
+
+archive, entry_name, raw_expected_mtime = sys.argv[1:]
+expected_mtime = int(raw_expected_mtime)
+
+with open(archive, "rb") as raw_file:
+    header = raw_file.read(10)
+if len(header) != 10 or header[:2] != b"\x1f\x8b" or header[2] != 8:
+    raise SystemExit(f"{archive} is not a valid gzip archive")
+gzip_mtime = int.from_bytes(header[4:8], "little")
+if gzip_mtime != expected_mtime:
+    raise SystemExit(
+        f"{archive} gzip mtime is {gzip_mtime}, want {expected_mtime}"
+    )
+
+with gzip.open(archive, "rb") as gzip_file:
+    with tarfile.open(fileobj=gzip_file, mode="r:") as tar_file:
+        members = tar_file.getmembers()
+if len(members) != 1 or members[0].name != entry_name:
+    raise SystemExit(f"{archive} must contain exactly {entry_name}")
+tar_mtime = int(members[0].mtime)
+if tar_mtime != expected_mtime:
+    raise SystemExit(
+        f"{archive} tar mtime is {tar_mtime}, want {expected_mtime}"
+    )
+PY
+}
+
 output_value() {
   local key="$1"
   local file="$2"
@@ -101,5 +137,17 @@ if [ "$(sha256_of "$tmp_dir/rootfs.updated.extracted")" != "$(sha256_of "$image_
   echo "compression script must refresh stale image archives" >&2
   exit 1
 fi
+
+SOURCE_DATE_EPOCH=0 "$compress_script" \
+  --image-dir "$image_dir" \
+  --assets 'update.img' \
+  --output "$outputs_file"
+assert_archive_mtime "$image_dir/update.img.tar.gz" update.img 0
+
+SOURCE_DATE_EPOCH=1 "$compress_script" \
+  --image-dir "$image_dir" \
+  --assets 'update.img' \
+  --output "$outputs_file"
+assert_archive_mtime "$image_dir/update.img.tar.gz" update.img 1
 
 echo "release image compression test passed"

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -90,13 +90,13 @@ if ! grep -q 'SOURCE_DATE_EPOCH' "$DOCKER_BUILD_SCRIPT" || \
     exit 1
 fi
 
-if grep -Fq 'rm -rf pico-sdk/output/out' "$WORKFLOW"; then
-    echo "build workflow must preserve pico-sdk/output/out so self-hosted release builds can reuse intermediate artifacts" >&2
+if ! grep -Fq 'rm -rf pico-sdk/output/out' "$WORKFLOW"; then
+    echo "build workflow must clean pico-sdk/output/out; reused SDK build outputs are out of scope for this PR" >&2
     exit 1
 fi
 
-if grep -Eq 'pico-sdk/output/image/\*\.img([[:space:]\\]|$)' "$WORKFLOW"; then
-    echo "build workflow must not delete every pico-sdk output image; cached sysdrv outputs such as idblock.img and uboot.img are reused" >&2
+if ! grep -Eq 'pico-sdk/output/image/\*\.img([[:space:]\\]|$)' "$WORKFLOW"; then
+    echo "build workflow must clean all generated images before a release build" >&2
     exit 1
 fi
 

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -90,8 +90,8 @@ if ! grep -q 'SOURCE_DATE_EPOCH' "$DOCKER_BUILD_SCRIPT" || \
     exit 1
 fi
 
-if ! grep -Fq 'rm -rf pico-sdk/output/out' "$WORKFLOW"; then
-    echo "build workflow must clean pico-sdk/output/out; reused SDK build outputs are out of scope for this PR" >&2
+if grep -Fq 'rm -rf pico-sdk/output/out' "$WORKFLOW"; then
+    echo "build workflow must preserve pico-sdk/output/out so unchanged SDK code can reuse SDK-managed build outputs" >&2
     exit 1
 fi
 

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -90,6 +90,16 @@ if ! grep -q 'SOURCE_DATE_EPOCH' "$DOCKER_BUILD_SCRIPT" || \
     exit 1
 fi
 
+if grep -Fq 'rm -rf pico-sdk/output/out' "$WORKFLOW"; then
+    echo "build workflow must preserve pico-sdk/output/out so self-hosted release builds can reuse intermediate artifacts" >&2
+    exit 1
+fi
+
+if grep -Eq 'pico-sdk/output/image/\*\.img([[:space:]\\]|$)' "$WORKFLOW"; then
+    echo "build workflow must not delete every pico-sdk output image; cached sysdrv outputs such as idblock.img and uboot.img are reused" >&2
+    exit 1
+fi
+
 if grep -q 'apply_pico_sdk_rootfs_reproducibility_patch.sh' "$BUILD_IMAGE_SCRIPT" || \
    [ -e "$ROOT_DIR/scripts/apply_pico_sdk_rootfs_reproducibility_patch.sh" ] || \
    [ -e "$ROOT_DIR/scripts/patches/pico-sdk-rootfs-reproducible-build.patch" ]; then

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -159,6 +159,13 @@ if ! grep -q 'Compress OTA manifest images' "$WORKFLOW" || \
     exit 1
 fi
 
+oem_bin_sync_line=$(grep -nF 'rsync -a --delete "$OVERLAY/oem/usr/bin/" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin/"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
+oem_full_sync_line=$(grep -nF 'rsync -a "$OVERLAY/oem/" "$RK_PROJECT_PACKAGE_OEM_DIR/"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
+if [ -z "$oem_bin_sync_line" ] || [ -z "$oem_full_sync_line" ] || [ "$oem_bin_sync_line" -ge "$oem_full_sync_line" ]; then
+    echo "_build_image.sh must sync OEM usr/bin with delete semantics before full OEM overlay sync" >&2
+    exit 1
+fi
+
 if ! grep -q 'release_upload_assets.outputs.upload_assets' "$WORKFLOW"; then
     echo "build workflow must upload compressed release image assets" >&2
     exit 1

--- a/scripts/test_reproducible_rootfs_policy.sh
+++ b/scripts/test_reproducible_rootfs_policy.sh
@@ -23,6 +23,17 @@ if grep -Eq 'git .*log -1 --format=%ct|git .*log -1 .*%ct' "$BUILD_IMAGE_SH" "$I
   exit 1
 fi
 
+if grep -Eq 'AIDEN_REPRODUCIBLE_IMAGE_EPOCH:-0' "$BUILD_IMAGE_SH" "$INNER_BUILD_IMAGE_SH"; then
+  echo "image builds must use a non-zero default SOURCE_DATE_EPOCH so falsey-zero package bugs cannot affect releases" >&2
+  exit 1
+fi
+
+if ! grep -Eq 'AIDEN_REPRODUCIBLE_IMAGE_EPOCH:-[1-9][0-9]*' "$BUILD_IMAGE_SH" || \
+   ! grep -Eq 'AIDEN_REPRODUCIBLE_IMAGE_EPOCH:-[1-9][0-9]*' "$INNER_BUILD_IMAGE_SH"; then
+  echo "image builds must keep a deterministic non-zero default SOURCE_DATE_EPOCH" >&2
+  exit 1
+fi
+
 for defconfig in \
   "$PICO_SDK/sysdrv/tools/board/buildroot/luckfox_pico_defconfig" \
   "$PICO_SDK/sysdrv/tools/board/buildroot/luckfox_pico_w_defconfig"; do


### PR DESCRIPTION
## Summary
- use a deterministic non-zero default `SOURCE_DATE_EPOCH=1` for image builds and release image compression
- keep rootfs/release image metadata stable while still allowing callers to override `SOURCE_DATE_EPOCH`, including `0`
- speed up native compilation by passing an explicit parallel job count to `cmake --build`
- keep release CI cleaning SDK output directories so this PR does not rely on reused build outputs

## Scope
- no pico-sdk submodule pointer change
- no reuse of Buildroot, SDK stage, CMake, or Go build outputs in this PR
- no SDK stage cache or wrapper-level cache invalidation logic
- no SDK package patch or package-level dirclean policy change

## Verification
- `bash scripts/test_build_scripts.sh`
- `bash scripts/test_release_ci_scripts.sh`
- `bash scripts/test_reproducible_rootfs_policy.sh`
- `git diff --check`

## Notes
- `pico-sdk` may still appear dirty locally because of the known case-insensitive filesystem issue; it is not staged or included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled parallel compilation support for faster builds.
  * Enhanced cleanup of stale build artifacts to prevent contamination.
  * Improved reproducibility and determinism of generated images through timestamp standardization.
  * Strengthened build validation and CI testing to ensure consistency across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->