### PR TITLE
fix(ci): unlock stale Go module cache before checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,13 @@ jobs:
         else
           echo "::warning::Skipping workspace ownership reclaim because sudo is unavailable and the current user is not root"
         fi
+        # Go extracts module cache directories as read-only. Older builds kept
+        # that cache under build/.cache, which can block actions/checkout's
+        # clean phase from removing stale modules on self-hosted runners.
+        if [ -d "$GITHUB_WORKSPACE/build/.cache/go-mod" ]; then
+          chmod -R u+w "$GITHUB_WORKSPACE/build/.cache/go-mod" || \
+            echo "::warning::Skipping stale Go module cache unlock because chmod failed"
+        fi
 
     - name: Remove unusable pico-sdk submodule checkout
       if: ${{ inputs.runner == 'self-hosted' }}

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -268,6 +268,11 @@ if ! grep -Fq 'owner="$(id -u):$(id -g)"' "$WORKFLOW" || \
     exit 1
 fi
 
+if ! grep -Fq 'chmod -R u+w "$GITHUB_WORKSPACE/build/.cache/go-mod"' "$WORKFLOW"; then
+    echo "self-hosted workspace reclaim must unlock stale read-only Go module cache directories before checkout" >&2
+    exit 1
+fi
+
 if ! grep -q 'go env GOROOT' "$BUILD_IMAGE_SH"; then
     echo "build_image.sh must discover the host Go root with go env GOROOT" >&2
     exit 1

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -100,6 +100,11 @@ if ! grep -Eq 'pico-sdk/output/image/\*\.img([[:space:]\\]|$)' "$WORKFLOW"; then
     exit 1
 fi
 
+if ! grep -Fq 'chmod -R u+w "$GITHUB_WORKSPACE/build/.cache/go-mod"' "$WORKFLOW"; then
+    echo "self-hosted workspace reclaim must unlock stale read-only Go module cache directories before checkout" >&2
+    exit 1
+fi
+
 if grep -q 'apply_pico_sdk_rootfs_reproducibility_patch.sh' "$BUILD_IMAGE_SCRIPT" || \
    [ -e "$ROOT_DIR/scripts/apply_pico_sdk_rootfs_reproducibility_patch.sh" ] || \
    [ -e "$ROOT_DIR/scripts/patches/pico-sdk-rootfs-reproducible-build.patch" ]; then


### PR DESCRIPTION
## Summary
- Unlock stale read-only Go module cache directories under build/.cache/go-mod before actions/checkout runs on self-hosted builds
- Add release/build script checks so the pre-checkout cache unlock is not removed accidentally

## Root Cause
Older builds left Go module cache contents under build/.cache/go-mod. Go extracts module directories as read-only, so actions/checkout could fail during its clean phase with EACCES when removing nested directories such as go.starlark.net/.../.github.

## Verification
- sh scripts/test_release_ci_scripts.sh
- bash scripts/test_github_actions_self_hosted_safety.sh
- bash scripts/test_build_scripts.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow validation and self-hosted workspace cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->