### PR TITLE
feat(benchmark): add perception v1 unit runner

### DIFF
--- a/benchmark/runner/agent_client.py
+++ b/benchmark/runner/agent_client.py
@@ -89,6 +89,22 @@ class AgentClient:
         except (AgentRequestError, AgentTimeoutError):
             return False
 
+    def get_tools(self) -> Any:
+        status, body_bytes = self._get("/api/tools", timeout=5)
+        if status != 200:
+            raise AgentRequestError(f"tools returned {status}")
+        return json.loads(body_bytes)
+
+    def get_tool_description(self, name: str) -> str:
+        target = name.strip()
+        if not target:
+            return ""
+        for item in _walk_tool_catalog(self.get_tools()):
+            if item.get("name") == target:
+                description = item.get("description")
+                return description if isinstance(description, str) else ""
+        return ""
+
     def clear_history(self, timeout: int = 30) -> None:
         self._post("/api/clear", timeout=timeout)
 
@@ -164,3 +180,13 @@ class AgentClient:
     def close(self) -> None:
         # urllib doesn't keep persistent connections by default; nothing to clean up.
         pass
+
+
+def _walk_tool_catalog(value: Any):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_tool_catalog(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_tool_catalog(child)

--- a/benchmark/runner/perception.py
+++ b/benchmark/runner/perception.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+import dataclasses as dc
+import re
+from typing import Any
+
+from runner.models import RubricVerdict, ToolCall, Trace
+from runner.suite import RubricItem, Suite, TaskSpec
+
+
+CLICK_TOOLS = {"mouse_click", "touch_gesture"}
+
+FALLBACK_MOUSE_CLICK_DESCRIPTION = (
+    'Move mouse to a position and click. Input JSON: {"x": 500, "y": 300, '
+    '"button": "left", "coord_space": "normalized"}. Normalized coordinates '
+    "use 0-1000 range where (0,0) is top-left, (1000,1000) is bottom-right, "
+    "and (500,500) is center."
+)
+
+_COORD_RANGE_RE = re.compile(
+    r"\bx\b[^\[]*\[\s*(?P<x_min>-?\d+(?:\.\d+)?)\s*,\s*"
+    r"(?P<x_max>-?\d+(?:\.\d+)?)\s*\].*?"
+    r"\by\b[^\[]*\[\s*(?P<y_min>-?\d+(?:\.\d+)?)\s*,\s*"
+    r"(?P<y_max>-?\d+(?:\.\d+)?)\s*\]",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+@dc.dataclass
+class CoordinateRange:
+    x_min: float
+    x_max: float
+    y_min: float
+    y_max: float
+
+
+@dc.dataclass
+class FirstClickEvaluation:
+    verdicts: list[RubricVerdict]
+    first_click: dict[str, Any] | None
+    expected: dict[str, float] | None
+    passed: bool
+
+
+def is_perception_first_click_task(suite: Suite, task: TaskSpec) -> bool:
+    return (
+        suite.name == "perception_v1"
+        and task.category == "perception"
+        and bool(task.input_screenshot)
+    )
+
+
+def build_perception_prompt(prompt: str, mouse_click_description: str) -> str:
+    description = mouse_click_description.strip() or FALLBACK_MOUSE_CLICK_DESCRIPTION
+    return (
+        f"{prompt.rstrip()}\n\n"
+        "Available click tool description. Follow this exact coordinate convention "
+        "when selecting the first click target:\n"
+        f"mouse_click: {description}\n\n"
+        'For this static perception benchmark, prefer mouse_click with '
+        'coord_space:"normalized" and x/y in the 0-1000 range. Do not use 0-1 '
+        "unit coordinates."
+    )
+
+
+def evaluate_first_click_rubric(
+    trace: Trace, rubric: list[RubricItem]
+) -> FirstClickEvaluation | None:
+    if not _rubric_is_locally_supported(rubric):
+        return None
+
+    first = first_click_tool_call(trace)
+    coords = first_click_coordinates(first) if first is not None else None
+    first_summary = _first_click_summary(first, coords)
+    verdicts: list[RubricVerdict] = []
+    expected: CoordinateRange | None = None
+
+    for item in rubric:
+        check = item.check
+        lower = f"{item.id} {check}".lower()
+        coord_range = parse_coordinate_range(check)
+        if coord_range is not None:
+            expected = coord_range
+            passed = _coordinates_in_range(first, coords, coord_range)
+            verdicts.append(
+                RubricVerdict(
+                    id=item.id,
+                    verdict="yes" if passed else "no",
+                    reason=_coordinate_reason(first, coords, coord_range, passed),
+                )
+            )
+        elif "called_click_tool" in lower or (
+            "touch_gesture" in lower and "mouse_click" in lower and "at least one" in lower
+        ):
+            verdicts.append(
+                RubricVerdict(
+                    id=item.id,
+                    verdict="yes" if first is not None else "no",
+                    reason=(
+                        f"First click-like tool call is {first.tool} at step {first.step}."
+                        if first is not None
+                        else "No mouse_click or touch_gesture call was found."
+                    ),
+                )
+            )
+        elif "0-1" in lower or "0..1" in lower:
+            passed = coords is not None and not _looks_like_unit_coordinates(coords)
+            verdicts.append(
+                RubricVerdict(
+                    id=item.id,
+                    verdict="yes" if passed else "no",
+                    reason=(
+                        f"First click coordinates are x={coords[0]:g}, y={coords[1]:g}."
+                        if coords is not None
+                        else "No first click coordinates were available."
+                    ),
+                )
+            )
+
+    return FirstClickEvaluation(
+        verdicts=verdicts,
+        first_click=first_summary,
+        expected=_range_summary(expected),
+        passed=bool(verdicts) and all(v.verdict == "yes" for v in verdicts),
+    )
+
+
+def parse_coordinate_range(text: str) -> CoordinateRange | None:
+    match = _COORD_RANGE_RE.search(text or "")
+    if not match:
+        return None
+    return CoordinateRange(
+        x_min=float(match.group("x_min")),
+        x_max=float(match.group("x_max")),
+        y_min=float(match.group("y_min")),
+        y_max=float(match.group("y_max")),
+    )
+
+
+def first_click_tool_call(trace: Trace) -> ToolCall | None:
+    for call in trace.tool_calls:
+        if call.tool in CLICK_TOOLS:
+            return call
+    return None
+
+
+def first_click_coordinates(call: ToolCall | None) -> tuple[float, float] | None:
+    if call is None:
+        return None
+    payload = call.input if isinstance(call.input, dict) else {}
+    if call.tool == "mouse_click":
+        return _xy_from_mapping(payload)
+    if call.tool == "touch_gesture":
+        for key in ("point", "start"):
+            point = payload.get(key)
+            if isinstance(point, dict):
+                coords = _xy_from_mapping(point)
+                if coords is not None:
+                    return coords
+        return _xy_from_mapping(payload)
+    return None
+
+
+def _rubric_is_locally_supported(rubric: list[RubricItem]) -> bool:
+    if not rubric:
+        return False
+    for item in rubric:
+        lower = f"{item.id} {item.check}".lower()
+        if parse_coordinate_range(item.check) is not None:
+            continue
+        if "called_click_tool" in lower:
+            continue
+        if "touch_gesture" in lower and "mouse_click" in lower and "at least one" in lower:
+            continue
+        if "0-1" in lower or "0..1" in lower:
+            continue
+        return False
+    return True
+
+
+def _xy_from_mapping(payload: dict[str, Any]) -> tuple[float, float] | None:
+    x = _as_float(payload.get("x"))
+    y = _as_float(payload.get("y"))
+    if x is None or y is None:
+        return None
+    return x, y
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coordinate_space_allows_normalized(call: ToolCall | None) -> bool:
+    if call is None or not isinstance(call.input, dict):
+        return False
+    coord_space = str(call.input.get("coord_space") or "auto").strip().lower()
+    return coord_space in {"", "auto", "normalized"}
+
+
+def _coordinates_in_range(
+    call: ToolCall | None, coords: tuple[float, float] | None, expected: CoordinateRange
+) -> bool:
+    if coords is None or not _coordinate_space_allows_normalized(call):
+        return False
+    x, y = coords
+    return expected.x_min <= x <= expected.x_max and expected.y_min <= y <= expected.y_max
+
+
+def _looks_like_unit_coordinates(coords: tuple[float, float]) -> bool:
+    x, y = coords
+    return 0 <= x <= 1 and 0 <= y <= 1
+
+
+def _coordinate_reason(
+    call: ToolCall | None,
+    coords: tuple[float, float] | None,
+    expected: CoordinateRange,
+    passed: bool,
+) -> str:
+    expected_text = (
+        f"x in [{expected.x_min:g}, {expected.x_max:g}], "
+        f"y in [{expected.y_min:g}, {expected.y_max:g}]"
+    )
+    if call is None:
+        return f"No first click-like tool call was found; expected {expected_text}."
+    if coords is None:
+        return f"First click-like tool call has no usable x/y coordinates; expected {expected_text}."
+    coord_space = str(call.input.get("coord_space") or "auto") if isinstance(call.input, dict) else "auto"
+    x, y = coords
+    if not _coordinate_space_allows_normalized(call):
+        return (
+            f"First {call.tool} uses coord_space={coord_space!r}, not normalized/auto; "
+            f"raw coordinates are x={x:g}, y={y:g}; expected {expected_text}."
+        )
+    status = "within" if passed else "outside"
+    return (
+        f"First {call.tool} raw normalized coordinates are x={x:g}, y={y:g}, "
+        f"{status} expected {expected_text}."
+    )
+
+
+def _first_click_summary(
+    call: ToolCall | None, coords: tuple[float, float] | None
+) -> dict[str, Any] | None:
+    if call is None:
+        return None
+    summary: dict[str, Any] = {
+        "step": call.step,
+        "tool": call.tool,
+        "input": call.input,
+    }
+    if coords is not None:
+        summary["x"] = coords[0]
+        summary["y"] = coords[1]
+    if isinstance(call.input, dict):
+        summary["coord_space"] = call.input.get("coord_space") or "auto"
+    return summary
+
+
+def _range_summary(expected: CoordinateRange | None) -> dict[str, float] | None:
+    if expected is None:
+        return None
+    return {
+        "x_min": expected.x_min,
+        "x_max": expected.x_max,
+        "y_min": expected.y_min,
+        "y_max": expected.y_max,
+    }

--- a/benchmark/runner/runtask.py
+++ b/benchmark/runner/runtask.py
@@ -15,6 +15,11 @@ from runner.assertions import (
 from runner.capture import take_screenshot, write_step_screenshot
 from runner.judge import judge_task, JudgeConfig
 from runner.models import TaskResult, RubricVerdict, HardAssertionResults
+from runner.perception import (
+    build_perception_prompt,
+    evaluate_first_click_rubric,
+    is_perception_first_click_task,
+)
 from runner.recovery import prepare_task_isolation, recover_agent_after_timeout
 from runner.reset import ResetError
 from runner.suite import Suite, TaskSpec
@@ -102,6 +107,9 @@ def run_one_task(
         prompt = task.prompt
         if suite.prompt_prefix:
             prompt = f"{suite.prompt_prefix.rstrip()}\n\n{task.prompt}"
+        perception_first_click = is_perception_first_click_task(suite, task)
+        if perception_first_click:
+            prompt = build_perception_prompt(prompt, _tool_description(client, "mouse_click"))
         chat = client.chat(
             prompt,
             timeout_sec=task.hard_assertions.must_complete_within_sec,
@@ -119,6 +127,17 @@ def run_one_task(
     (artifact_dir / "history.json").write_text(
         json.dumps(history, ensure_ascii=False, indent=2), encoding="utf-8")
     trace = extract_trace(history)
+    perception_eval = (
+        evaluate_first_click_rubric(trace, task.rubric)
+        if is_perception_first_click_task(suite, task)
+        else None
+    )
+    if perception_eval is not None:
+        base.metrics["perception_first_click"] = {
+            "first_click": perception_eval.first_click,
+            "expected": perception_eval.expected,
+            "passed": perception_eval.passed,
+        }
     wall_ms = int((time.monotonic() - started_mono) * 1000)
     if suite.trace_observations:
         observation_results = evaluate_trace_observations(trace, suite.trace_observations)
@@ -149,6 +168,20 @@ def run_one_task(
     base.metrics.update({"wall_ms": wall_ms, "tool_calls": trace.total_tool_calls,
                          "screenshots_taken": sum(1 for tc in trace.tool_calls if tc.has_screenshot)})
     outcome = evaluate_hard_assertions(trace, task.hard_assertions, timed_out=timed_out)
+    if (
+        perception_eval is not None
+        and perception_eval.first_click is not None
+        and outcome.results.response_exists is False
+        and task.hard_assertions.response_required
+    ):
+        outcome.results.response_exists = True
+        base.metrics["response_required_satisfied_by_first_click"] = True
+        outcome.all_passed = bool(
+            outcome.results.min_tool_calls
+            and outcome.results.max_tool_calls
+            and outcome.results.timeout
+            and outcome.results.response_exists
+        )
     base.hard_assertions = outcome.results
     if not outcome.all_passed:
         base.status = "timeout" if timed_out else "failed"
@@ -180,6 +213,17 @@ def run_one_task(
             base.status = "failed"
             base.finished_at = now_iso()
             return base
+    if perception_eval is not None:
+        base.rubric = perception_eval.verdicts
+        base.rubric_pass_count = sum(1 for v in perception_eval.verdicts if v.verdict == "yes")
+        (artifact_dir / "judge.json").write_text(json.dumps({
+            "verdicts": [dc.asdict(v) for v in perception_eval.verdicts],
+            "overall_notes": "Local first-click perception evaluation.",
+            "cache_key": "local-perception-first-click",
+        }, ensure_ascii=False, indent=2), encoding="utf-8")
+        base.status = "passed" if perception_eval.passed else "failed"
+        base.finished_at = now_iso()
+        return base
     if judge_cfg is None:
         base.status = "passed"
         base.finished_at = now_iso()
@@ -218,3 +262,13 @@ def client_history_or_empty(client: AgentClient) -> list[dict]:
     except Exception:
         pass
     return []
+
+
+def _tool_description(client: AgentClient, name: str) -> str:
+    get_tool_description = getattr(client, "get_tool_description", None)
+    if not callable(get_tool_description):
+        return ""
+    try:
+        return get_tool_description(name)
+    except Exception:
+        return ""

--- a/benchmark/runner/runtask.py
+++ b/benchmark/runner/runtask.py
@@ -127,9 +127,10 @@ def run_one_task(
     (artifact_dir / "history.json").write_text(
         json.dumps(history, ensure_ascii=False, indent=2), encoding="utf-8")
     trace = extract_trace(history)
+    perception_first_click = is_perception_first_click_task(suite, task)
     perception_eval = (
         evaluate_first_click_rubric(trace, task.rubric)
-        if is_perception_first_click_task(suite, task)
+        if perception_first_click
         else None
     )
     if perception_eval is not None:
@@ -138,6 +139,10 @@ def run_one_task(
             "expected": perception_eval.expected,
             "passed": perception_eval.passed,
         }
+    elif perception_first_click:
+        base.metrics["perception_first_click_error"] = (
+            "unsupported rubric for local first-click perception evaluation"
+        )
     wall_ms = int((time.monotonic() - started_mono) * 1000)
     if suite.trace_observations:
         observation_results = evaluate_trace_observations(trace, suite.trace_observations)
@@ -185,6 +190,10 @@ def run_one_task(
     base.hard_assertions = outcome.results
     if not outcome.all_passed:
         base.status = "timeout" if timed_out else "failed"
+        base.finished_at = now_iso()
+        return base
+    if perception_first_click and perception_eval is None:
+        base.status = "failed"
         base.finished_at = now_iso()
         return base
     if task.expected_answer is not None:

--- a/benchmark/runner/unit.py
+++ b/benchmark/runner/unit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import dataclasses as dc
 import html
 import json
@@ -13,9 +14,21 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from runner.agent_client import AgentClient
+from runner.agent_client import AgentClient, AgentTimeoutError
+from runner.assertions import (
+    evaluate_expected_answer,
+    evaluate_expected_recalled_memory_ids,
+    evaluate_hard_assertions,
+)
 from runner.html_report import upload_report
+from runner.perception import (
+    build_perception_prompt,
+    evaluate_first_click_rubric,
+    is_perception_first_click_task,
+)
 from runner.report import git_sha, now_iso, write_manifest
+from runner.suite import Suite, TaskSpec, load_suite
+from runner.trace import extract_trace
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -117,7 +130,10 @@ def _collect_suites(args: argparse.Namespace) -> list[Path]:
     if args.suite:
         path = Path(args.suite)
         if not is_unit_suite(path):
-            raise SystemExit(f"not a unit suite: {path}")
+            try:
+                load_suite(path)
+            except Exception as e:
+                raise SystemExit(f"not a unit or benchmark suite: {path}: {e}") from e
         return [path]
     root = Path(args.suite_dir)
     return sorted(p for p in root.rglob("*.json") if is_unit_suite(p))
@@ -132,6 +148,14 @@ def _benchmark_url(agent_url: str) -> str:
 def _run_suite(client: AgentClient, suite_path: Path) -> list[UnitCaseResult]:
     data = json.loads(suite_path.read_text(encoding="utf-8"))
     if data.get("kind") != "unit":
+        return _run_agent_unit_suite(client, load_suite(suite_path))
+    return _run_tool_unit_suite(client, suite_path, data)
+
+
+def _run_tool_unit_suite(
+    client: AgentClient, suite_path: Path, data: dict[str, Any]
+) -> list[UnitCaseResult]:
+    if data.get("kind") != "unit":
         raise ValueError(f"{suite_path} is not a unit suite")
     target = data.get("target") or {}
     target_type = target.get("type")
@@ -144,6 +168,151 @@ def _run_suite(client: AgentClient, suite_path: Path) -> list[UnitCaseResult]:
     for test in data.get("tests") or []:
         results.append(_run_case(client, suite_name, suite_path, target_name, defaults, test))
     return results
+
+
+def _run_agent_unit_suite(client: AgentClient, suite: Suite) -> list[UnitCaseResult]:
+    results: list[UnitCaseResult] = []
+    for task in suite.tasks:
+        results.append(_run_agent_unit_case(client, suite, task))
+    return results
+
+
+def _run_agent_unit_case(
+    client: AgentClient, suite: Suite, task: TaskSpec
+) -> UnitCaseResult:
+    started = time.monotonic()
+    prompt = task.prompt
+    if suite.prompt_prefix:
+        prompt = f"{suite.prompt_prefix.rstrip()}\n\n{task.prompt}"
+    if is_perception_first_click_task(suite, task):
+        prompt = build_perception_prompt(prompt, _tool_description(client, "mouse_click"))
+
+    attachments = None
+    if task.input_screenshot:
+        screenshot_path = suite.source_path.parent / task.input_screenshot
+        if not screenshot_path.exists():
+            return _agent_unit_failure(
+                suite, task, started, prompt, f"input_screenshot not found: {screenshot_path}"
+            )
+        img_b64 = base64.b64encode(screenshot_path.read_bytes()).decode("ascii")
+        attachments = [{"kind": "image", "mime_type": "image/jpeg", "data": img_b64}]
+
+    history: list[dict[str, Any]] = []
+    response = ""
+    timed_out = False
+    agent_error = ""
+    try:
+        _clear_history_best_effort(client)
+        chat = client.chat(
+            prompt,
+            timeout_sec=task.hard_assertions.must_complete_within_sec,
+            attachments=attachments,
+        )
+        history = chat.history
+        response = chat.response
+    except AgentTimeoutError as e:
+        timed_out = True
+        agent_error = str(e)[:300]
+        history = _client_history_or_empty(client)
+    except Exception as e:
+        agent_error = str(e)[:300]
+        history = _client_history_or_empty(client)
+    finally:
+        _clear_history_best_effort(client)
+
+    trace = extract_trace(history)
+    perception_eval = (
+        evaluate_first_click_rubric(trace, task.rubric)
+        if is_perception_first_click_task(suite, task)
+        else None
+    )
+    hard = evaluate_hard_assertions(trace, task.hard_assertions, timed_out=timed_out)
+    if (
+        perception_eval is not None
+        and perception_eval.first_click is not None
+        and hard.results.response_exists is False
+        and task.hard_assertions.response_required
+    ):
+        hard.results.response_exists = True
+        hard.all_passed = bool(
+            hard.results.min_tool_calls
+            and hard.results.max_tool_calls
+            and hard.results.timeout
+            and hard.results.response_exists
+        )
+
+    errors: list[str] = []
+    if agent_error and not trace.tool_calls:
+        errors.append(f"agent error: {agent_error}")
+    if not hard.all_passed:
+        errors.append(_hard_assertion_error(hard.results))
+
+    expected_answer = None
+    if task.expected_answer is not None:
+        expected_answer = evaluate_expected_answer(
+            trace.final_response or response,
+            task.expected_answer,
+            task.answer_format or "option_letter",
+        )
+        if not expected_answer.passed:
+            errors.append(
+                f"expected_answer mismatch: expected {expected_answer.expected_answer}, "
+                f"got {expected_answer.predicted_answer}"
+            )
+
+    expected_recall = None
+    if task.expected_recalled_memory_ids:
+        expected_recall = evaluate_expected_recalled_memory_ids(
+            history, task.expected_recalled_memory_ids
+        )
+        if not expected_recall.passed:
+            errors.append(
+                "expected recalled memory ids missing: "
+                + ", ".join(task.expected_recalled_memory_ids)
+            )
+
+    if perception_eval is not None and not perception_eval.passed:
+        failed = [v for v in perception_eval.verdicts if v.verdict != "yes"]
+        errors.extend(v.reason for v in failed)
+
+    output_json: dict[str, Any] = {
+        "trace": {
+            "tool_calls": [dc.asdict(tc) for tc in trace.tool_calls],
+            "final_response": trace.final_response,
+            "total_tool_calls": trace.total_tool_calls,
+        },
+        "hard_assertions": dc.asdict(hard.results),
+        "agent_error": agent_error,
+    }
+    if perception_eval is not None:
+        output_json["perception_first_click"] = {
+            "first_click": perception_eval.first_click,
+            "expected": perception_eval.expected,
+            "passed": perception_eval.passed,
+            "verdicts": [dc.asdict(v) for v in perception_eval.verdicts],
+        }
+    if expected_answer is not None:
+        output_json["expected_answer"] = dc.asdict(expected_answer)
+    if expected_recall is not None:
+        output_json["expected_recalled_memory"] = dc.asdict(expected_recall)
+
+    return UnitCaseResult(
+        suite_name=suite.name,
+        suite_path=str(suite.source_path),
+        test_id=task.id,
+        target_type="agent",
+        target_name="chat",
+        status="failed" if errors else "passed",
+        input={
+            "message": prompt,
+            "attachments": _attachment_summary(attachments),
+        },
+        output=trace.final_response or response or agent_error,
+        output_json=output_json,
+        is_error=bool(errors),
+        duration_ms=int((time.monotonic() - started) * 1000),
+        error="; ".join(e for e in errors if e),
+    )
 
 
 def _run_case(
@@ -267,6 +436,77 @@ def _check_expectation(
                 if "max_len" in rule and actual_len > int(rule["max_len"]):
                     return f"{path} length above {rule['max_len']}"
     return ""
+
+
+def _tool_description(client: AgentClient, name: str) -> str:
+    get_tool_description = getattr(client, "get_tool_description", None)
+    if not callable(get_tool_description):
+        return ""
+    try:
+        return get_tool_description(name)
+    except Exception:
+        return ""
+
+
+def _clear_history_best_effort(client: AgentClient) -> None:
+    try:
+        client.clear_history()
+    except Exception:
+        pass
+
+
+def _client_history_or_empty(client: AgentClient) -> list[dict[str, Any]]:
+    try:
+        return client.get_history()
+    except Exception:
+        return []
+
+
+def _attachment_summary(attachments: list[dict[str, str]] | None) -> list[dict[str, Any]]:
+    summary = []
+    for item in attachments or []:
+        summary.append({
+            "kind": item.get("kind"),
+            "mime_type": item.get("mime_type"),
+            "data_len": len(item.get("data") or ""),
+        })
+    return summary
+
+
+def _hard_assertion_error(results: Any) -> str:
+    failures = []
+    if results.min_tool_calls is False:
+        failures.append("min_tool_calls")
+    if results.max_tool_calls is False:
+        failures.append("max_tool_calls")
+    if results.timeout is False:
+        failures.append("timeout")
+    if results.response_exists is False:
+        failures.append("response_required")
+    return "hard assertions failed: " + ", ".join(failures)
+
+
+def _agent_unit_failure(
+    suite: Suite,
+    task: TaskSpec,
+    started: float,
+    prompt: str,
+    error: str,
+) -> UnitCaseResult:
+    return UnitCaseResult(
+        suite_name=suite.name,
+        suite_path=str(suite.source_path),
+        test_id=task.id,
+        target_type="agent",
+        target_name="chat",
+        status="failed",
+        input={"message": prompt, "attachments": []},
+        output="",
+        output_json=None,
+        is_error=True,
+        duration_ms=int((time.monotonic() - started) * 1000),
+        error=error,
+    )
 
 
 def _resolve_path(data: Any, path: str) -> tuple[bool, Any]:

--- a/benchmark/runner/unit.py
+++ b/benchmark/runner/unit.py
@@ -184,7 +184,8 @@ def _run_agent_unit_case(
     prompt = task.prompt
     if suite.prompt_prefix:
         prompt = f"{suite.prompt_prefix.rstrip()}\n\n{task.prompt}"
-    if is_perception_first_click_task(suite, task):
+    perception_first_click = is_perception_first_click_task(suite, task)
+    if perception_first_click:
         prompt = build_perception_prompt(prompt, _tool_description(client, "mouse_click"))
 
     attachments = None
@@ -223,7 +224,7 @@ def _run_agent_unit_case(
     trace = extract_trace(history)
     perception_eval = (
         evaluate_first_click_rubric(trace, task.rubric)
-        if is_perception_first_click_task(suite, task)
+        if perception_first_click
         else None
     )
     hard = evaluate_hard_assertions(trace, task.hard_assertions, timed_out=timed_out)
@@ -271,7 +272,9 @@ def _run_agent_unit_case(
                 + ", ".join(task.expected_recalled_memory_ids)
             )
 
-    if perception_eval is not None and not perception_eval.passed:
+    if perception_first_click and perception_eval is None:
+        errors.append("unsupported rubric for local first-click perception evaluation")
+    elif perception_eval is not None and not perception_eval.passed:
         failed = [v for v in perception_eval.verdicts if v.verdict != "yes"]
         errors.extend(v.reason for v in failed)
 
@@ -291,6 +294,10 @@ def _run_agent_unit_case(
             "passed": perception_eval.passed,
             "verdicts": [dc.asdict(v) for v in perception_eval.verdicts],
         }
+    elif perception_first_click:
+        output_json["perception_first_click_error"] = (
+            "unsupported rubric for local first-click perception evaluation"
+        )
     if expected_answer is not None:
         output_json["expected_answer"] = dc.asdict(expected_answer)
     if expected_recall is not None:

--- a/benchmark/tests/test_agent_client.py
+++ b/benchmark/tests/test_agent_client.py
@@ -71,6 +71,22 @@ def test_get_history_returns_current_history():
     assert result == history
 
 
+def test_get_tool_description_finds_nested_tool_catalog_entry():
+    seen = {}
+    client = AgentClient(base_url="http://test")
+    body = {
+        "tools": [
+            {"name": "shell", "description": "run shell"},
+            {"name": "mouse_click", "description": "click with 0-1000 coordinates"},
+        ]
+    }
+    with patch("urllib.request.urlopen", _captured(seen, body=body)):
+        result = client.get_tool_description("mouse_click")
+    assert seen["method"] == "GET"
+    assert seen["url"].endswith("/api/tools")
+    assert result == "click with 0-1000 coordinates"
+
+
 def test_chat_includes_skills_when_provided():
     seen = {}
     client = AgentClient(base_url="http://test")

--- a/benchmark/tests/test_perception.py
+++ b/benchmark/tests/test_perception.py
@@ -1,0 +1,64 @@
+from runner.models import ToolCall, Trace
+from runner.perception import (
+    evaluate_first_click_rubric,
+    parse_coordinate_range,
+)
+from runner.suite import RubricItem
+
+
+def test_parse_coordinate_range_supports_current_perception_text():
+    expected = parse_coordinate_range(
+        "For normalized 0-1000 coordinates, x should be roughly in "
+        "[750, 980] and y in [380, 550]."
+    )
+
+    assert expected is not None
+    assert expected.x_min == 750
+    assert expected.x_max == 980
+    assert expected.y_min == 380
+    assert expected.y_max == 550
+
+
+def test_first_click_rubric_uses_raw_0_1000_values_without_scaling_unit_coordinates():
+    rubric = [
+        RubricItem(
+            id="called_click_tool",
+            check="The tool trace contains at least one touch_gesture or mouse_click call.",
+        ),
+        RubricItem(
+            id="does_not_use_0_1_coordinates",
+            check=(
+                "No touch_gesture, mouse_click, or mouse_move call uses 0-1 style "
+                "normalized coordinates."
+            ),
+        ),
+        RubricItem(
+            id="click_targets_settings",
+            check=(
+                "The touch/click coordinates target the Settings icon area. "
+                "For normalized 0-1000 coordinates, x should be roughly in "
+                "[750, 980] and y in [380, 550]."
+            ),
+        ),
+    ]
+    trace = Trace(
+        tool_calls=[
+            ToolCall(
+                step=1,
+                tool="mouse_click",
+                input={"x": "0.935", "y": "0.083", "coord_space": "normalized"},
+            )
+        ],
+        final_response="",
+        total_tool_calls=1,
+        total_duration_ms=0,
+    )
+
+    result = evaluate_first_click_rubric(trace, rubric)
+
+    assert result is not None
+    assert result.passed is False
+    verdicts = {item.id: item.verdict for item in result.verdicts}
+    assert verdicts["called_click_tool"] == "yes"
+    assert verdicts["does_not_use_0_1_coordinates"] == "no"
+    assert verdicts["click_targets_settings"] == "no"

--- a/benchmark/tests/test_runtask.py
+++ b/benchmark/tests/test_runtask.py
@@ -295,3 +295,36 @@ def test_perception_task_can_pass_from_history_after_agent_413(tmp_path: Path):
     assert result.metrics["agent_error"].startswith("HTTP 500")
     assert result.metrics["response_required_satisfied_by_first_click"] is True
     assert result.hard_assertions.response_exists is True
+
+
+def test_perception_task_fails_when_local_rubric_evaluation_is_unsupported(tmp_path: Path):
+    history = [
+        {"type": "tool_call", "tool_name": "mouse_click",
+         "tool_input": '{"x":920,"y":90,"coord_space":"normalized"}'},
+        {"type": "tool_result", "tool_name": "mouse_click", "content": "{}"},
+        {"type": "assistant", "content": "done"},
+    ]
+    task = _task_386_spec()
+    task.rubric = [
+        RubricItem(
+            id="requires_visual_semantics",
+            check="The target is semantically correct according to the judge.",
+        )
+    ]
+
+    result = run_one_task(
+        PerceptionClient(history),
+        _perception_suite(tmp_path),
+        task,
+        1,
+        tmp_path / "artifacts",
+        None,
+        None,
+        "run-1",
+    )
+
+    assert result.status == "failed"
+    assert result.metrics["perception_first_click_error"] == (
+        "unsupported rubric for local first-click perception evaluation"
+    )
+    assert not (tmp_path / "artifacts" / "judge.json").exists()

--- a/benchmark/tests/test_runtask.py
+++ b/benchmark/tests/test_runtask.py
@@ -2,7 +2,12 @@ import base64
 import json
 from pathlib import Path
 
-from runner.agent_client import AgentTimeoutError, ChatResponse, ToolInvokeResult
+from runner.agent_client import (
+    AgentRequestError,
+    AgentTimeoutError,
+    ChatResponse,
+    ToolInvokeResult,
+)
 from runner.runtask import run_one_task
 from runner.suite import HardAssertions, RubricItem, Suite, TaskSpec
 
@@ -168,3 +173,125 @@ def test_run_one_task_preserves_history_after_timeout(tmp_path: Path):
     assert result.metrics["tool_calls"] == 1
     history = json.loads((tmp_path / "artifacts" / "history.json").read_text())
     assert history[0]["tool_name"] == "screenshot"
+
+
+class PerceptionClient(FakeClient):
+    def __init__(self, history, fail_chat=False):
+        super().__init__()
+        self.history = history
+        self.fail_chat = fail_chat
+        self.attachments = []
+
+    def get_tool_description(self, name):
+        assert name == "mouse_click"
+        return "Move mouse to a position and click. Normalized coordinates use 0-1000."
+
+    def chat(self, message, timeout_sec=None, attachments=None, skills=None):
+        self.messages.append(message)
+        self.attachments.append(attachments)
+        if self.fail_chat:
+            raise AgentRequestError("HTTP 500: 413 Request Entity Too Large")
+        return ChatResponse(response="", history=self.history)
+
+    def get_history(self):
+        return self.history
+
+
+def _perception_suite(tmp_path: Path) -> Suite:
+    suite_path = tmp_path / "perception_v1.json"
+    screenshots = tmp_path / "screenshots"
+    screenshots.mkdir()
+    (screenshots / "task_386.jpg").write_bytes(b"jpeg")
+    suite_path.write_text("{}", encoding="utf-8")
+    return Suite(
+        name="perception_v1",
+        global_reset={},
+        tasks=[],
+        sha256="sha",
+        source_path=suite_path,
+    )
+
+
+def _task_386_spec() -> TaskSpec:
+    return TaskSpec(
+        id="task_386",
+        category="perception",
+        description_for_judge="Click chat details.",
+        prompt="打开右上角的聊天详情",
+        input_screenshot="screenshots/task_386.jpg",
+        rubric=[
+            RubricItem(
+                id="called_click_tool",
+                check="The tool trace contains at least one touch_gesture or mouse_click call.",
+            ),
+            RubricItem(
+                id="click_targets_",
+                check=(
+                    "The touch/click coordinates target the chat details area: "
+                    "normalized x in [905, 967], y in [82, 97] "
+                    "(0-1000 normalized space, where 500 is center)."
+                ),
+            ),
+        ],
+        hard_assertions=HardAssertions(
+            min_tool_calls=1,
+            max_tool_calls=5,
+            must_complete_within_sec=120,
+            response_required=True,
+        ),
+    )
+
+
+def test_perception_task_injects_mouse_click_description_and_scores_first_click(tmp_path: Path):
+    history = [
+        {"type": "tool_call", "tool_name": "mouse_click",
+         "tool_input": '{"x":"940","y":"90","coord_space":"normalized"}'},
+        {"type": "tool_result", "tool_name": "mouse_click", "content": "{}"},
+        {"type": "tool_call", "tool_name": "mouse_click",
+         "tool_input": '{"x":"0.935","y":"0.083","coord_space":"normalized"}'},
+        {"type": "tool_result", "tool_name": "mouse_click", "content": "{}"},
+    ]
+    client = PerceptionClient(history)
+
+    result = run_one_task(
+        client,
+        _perception_suite(tmp_path),
+        _task_386_spec(),
+        1,
+        tmp_path / "artifacts",
+        None,
+        None,
+        "run-1",
+    )
+
+    assert result.status == "passed"
+    assert result.rubric_pass_count == 2
+    assert result.metrics["perception_first_click"]["first_click"]["x"] == 940
+    assert "mouse_click:" in client.messages[0]
+    assert "0-1000" in client.messages[0]
+    assert client.attachments[0][0]["kind"] == "image"
+
+
+def test_perception_task_can_pass_from_history_after_agent_413(tmp_path: Path):
+    history = [
+        {"type": "tool_call", "tool_name": "mouse_click",
+         "tool_input": '{"x":920,"y":90,"coord_space":"normalized"}'},
+        {"type": "tool_result", "tool_name": "mouse_click", "content": "{}"},
+    ]
+    client = PerceptionClient(history, fail_chat=True)
+
+    result = run_one_task(
+        client,
+        _perception_suite(tmp_path),
+        _task_386_spec(),
+        1,
+        tmp_path / "artifacts",
+        None,
+        None,
+        "run-1",
+    )
+
+    assert result.status == "passed"
+    assert result.metrics["agent_error"].startswith("HTTP 500")
+    assert result.metrics["response_required_satisfied_by_first_click"] is True
+    assert result.hard_assertions.response_exists is True

--- a/benchmark/tests/test_unit.py
+++ b/benchmark/tests/test_unit.py
@@ -156,3 +156,50 @@ def test_run_suite_accepts_benchmark_suite_as_agent_unit(tmp_path: Path):
     assert "mouse_click:" in client.messages[0]["message"]
     assert client.messages[0]["attachments"][0]["kind"] == "image"
     assert client.clear_calls == 2
+
+
+def test_agent_unit_fails_when_perception_rubric_is_unsupported(tmp_path: Path):
+    suite = tmp_path / "perception_v1.json"
+    screenshots = tmp_path / "screenshots"
+    screenshots.mkdir()
+    (screenshots / "task_386.jpg").write_bytes(b"jpeg")
+    suite.write_text(
+        json.dumps({
+            "name": "perception_v1",
+            "tasks": [{
+                "id": "task_386",
+                "category": "perception",
+                "input_screenshot": "screenshots/task_386.jpg",
+                "prompt": "打开右上角的聊天详情",
+                "description_for_judge": "Click chat details.",
+                "rubric": [{
+                    "id": "requires_visual_semantics",
+                    "check": "The target is semantically correct according to the judge.",
+                }],
+                "hard_assertions": {
+                    "min_tool_calls": 1,
+                    "max_tool_calls": 5,
+                    "must_complete_within_sec": 120,
+                    "response_required": True,
+                },
+            }],
+        }),
+        encoding="utf-8",
+    )
+    client = FakeAgentClient([
+        {
+            "type": "tool_call",
+            "tool_name": "mouse_click",
+            "tool_input": '{"x":940,"y":90,"coord_space":"normalized"}',
+        },
+        {"type": "tool_result", "tool_name": "mouse_click", "content": "{}"},
+        {"type": "assistant", "content": "done"},
+    ])
+
+    results = _run_suite(client, suite)
+
+    assert results[0].status == "failed"
+    assert "unsupported rubric" in results[0].error
+    assert results[0].output_json["perception_first_click_error"] == (
+        "unsupported rubric for local first-click perception evaluation"
+    )

--- a/benchmark/tests/test_unit.py
+++ b/benchmark/tests/test_unit.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from runner.agent_client import ToolInvokeResult
+from runner.agent_client import ChatResponse, ToolInvokeResult
 from runner.unit import _check_expectation, _collect_suites, _run_suite, is_unit_suite
 
 
@@ -74,3 +74,85 @@ def test_collect_suites_filters_unit_kind(tmp_path: Path):
 
     assert is_unit_suite(unit) is True
     assert _collect_suites(Args()) == [unit]
+
+
+class FakeAgentClient:
+    def __init__(self, history):
+        self.history = history
+        self.messages = []
+        self.clear_calls = 0
+
+    def clear_history(self):
+        self.clear_calls += 1
+
+    def get_tool_description(self, name):
+        assert name == "mouse_click"
+        return "Move mouse to a position and click. Normalized coordinates use 0-1000."
+
+    def chat(self, message, timeout_sec=None, attachments=None, skills=None):
+        self.messages.append({
+            "message": message,
+            "timeout_sec": timeout_sec,
+            "attachments": attachments,
+        })
+        return ChatResponse(response="", history=self.history)
+
+    def get_history(self):
+        return self.history
+
+
+def test_run_suite_accepts_benchmark_suite_as_agent_unit(tmp_path: Path):
+    suite = tmp_path / "perception_v1.json"
+    screenshots = tmp_path / "screenshots"
+    screenshots.mkdir()
+    (screenshots / "task_386.jpg").write_bytes(b"jpeg")
+    suite.write_text(
+        json.dumps({
+            "name": "perception_v1",
+            "tasks": [{
+                "id": "task_386",
+                "category": "perception",
+                "input_screenshot": "screenshots/task_386.jpg",
+                "prompt": "打开右上角的聊天详情",
+                "description_for_judge": "Click chat details.",
+                "rubric": [
+                    {
+                        "id": "called_click_tool",
+                        "check": "The tool trace contains at least one touch_gesture or mouse_click call.",
+                    },
+                    {
+                        "id": "click_targets_",
+                        "check": (
+                            "The touch/click coordinates target the chat details area: "
+                            "normalized x in [905, 967], y in [82, 97] "
+                            "(0-1000 normalized space)."
+                        ),
+                    },
+                ],
+                "hard_assertions": {
+                    "min_tool_calls": 1,
+                    "max_tool_calls": 5,
+                    "must_complete_within_sec": 120,
+                    "response_required": True,
+                },
+            }],
+        }),
+        encoding="utf-8",
+    )
+    client = FakeAgentClient([
+        {
+            "type": "tool_call",
+            "tool_name": "mouse_click",
+            "tool_input": '{"x":940,"y":90,"coord_space":"normalized"}',
+        },
+        {"type": "tool_result", "tool_name": "mouse_click", "content": "{}"},
+    ])
+
+    results = _run_suite(client, suite)
+
+    assert results[0].status == "passed"
+    assert results[0].target_type == "agent"
+    assert results[0].output_json["perception_first_click"]["first_click"]["x"] == 940
+    assert "mouse_click:" in client.messages[0]["message"]
+    assert client.messages[0]["attachments"][0]["kind"] == "image"
+    assert client.clear_calls == 2

--- a/src/agent/internal/agent/benchmark_html.go
+++ b/src/agent/internal/agent/benchmark_html.go
@@ -87,7 +87,7 @@ input[type=text]{width:260px}
 </div>
 <div id="unitCard" class="card">
 <h2>Unit Tests</h2>
-<div class="muted" style="margin-bottom:12px">Direct tool-level tests. Run one platform suite, or run all unit suites under suites/unit.</div>
+<div class="muted" style="margin-bottom:12px">Agent-only runs for benchmark suites; direct tool-level runs for unit suites. Skips reset, judge, and recovery flow.</div>
 <div class="control-grid">
 <div>
 <label class="field-label" for="unitSelect">Unit suite</label>
@@ -224,7 +224,12 @@ syncDelBtn();return;
 }
 var groups={aiden:[],mobilegym_builtin:[]};
 d.forEach(function(x){
-if(mode!=='mobilegym'&&x.kind==='unit'){unitSuiteCount++;return}
+if(mode!=='mobilegym'){
+var uo=document.createElement('option');uo.value=x.path||x.name;
+uo.textContent=x.name+(x.kind==='unit'?' (tool)':' (agent)')+(x.custom?' (custom)':'');
+u.appendChild(uo);suiteIndex[x.path||x.name]=x;unitSuiteCount++;
+if(x.kind==='unit')return;
+}
 (groups[x.type]||groups.aiden).push(x);benchmarkSuiteCount++;
 });
 function appendGroup(label,arr){
@@ -243,15 +248,7 @@ s.appendChild(og);
 appendGroup('Aiden Suites',groups.aiden);
 if(mode==='mobilegym')appendGroup('MobileGym Built-in',groups.mobilegym_builtin);
 if(!benchmarkSuiteCount){var bo=document.createElement('option');bo.value='';bo.textContent='(no benchmark suites)';s.appendChild(bo)}
-if(mode!=='mobilegym'){
-d.forEach(function(x){
-if(x.kind!=='unit')return;
-var o=document.createElement('option');o.value=x.path||x.name;
-o.textContent=x.name+(x.custom?' (custom)':'');
-u.appendChild(o);suiteIndex[x.path||x.name]=x;
-});
-if(!unitSuiteCount){var uo=document.createElement('option');uo.value='';uo.textContent='(no unit suites)';u.appendChild(uo)}
-}
+if(mode!=='mobilegym'&&!unitSuiteCount){var uo=document.createElement('option');uo.value='';uo.textContent='(no suites)';u.appendChild(uo)}
 syncDelBtn();
 }).catch(function(e){
 var s=document.getElementById('suiteSelect');var u=document.getElementById('unitSelect');s.innerHTML='';u.innerHTML='';suiteIndex={};
@@ -408,7 +405,7 @@ document.getElementById('runUnitBtn').disabled=true;
 document.getElementById('statusText').textContent='running';
 document.getElementById('statusText').className='status running';
 fetch('/benchmark/run',{method:'POST',headers:{'Content-Type':'application/json'},
-body:JSON.stringify({suite:suite,mode:'aiden'})}).then(jsonOrError).then(function(){
+body:JSON.stringify({suite:suite,mode:'unit'})}).then(jsonOrError).then(function(){
 loadLog();
 polling=setInterval(pollStatus,3000);
 if(!logPolling)logPolling=setInterval(loadLog,1000)}).catch(function(e){

--- a/src/agent/internal/agent/benchmark_runner.go
+++ b/src/agent/internal/agent/benchmark_runner.go
@@ -111,9 +111,13 @@ func (s *Server) handleBenchmarkRun(w http.ResponseWriter, r *http.Request) {
 	if req.Mode == "" {
 		req.Mode = "aiden"
 	}
+	runMode := req.Mode
+	if req.Mode == "unit" {
+		runMode = "aiden"
+	}
 	statePath := s.benchmarkStateFile()
 
-	switch req.Mode {
+	switch runMode {
 	case "aiden":
 		if req.Suite == "" && req.SuiteDir == "" {
 			s.writeBenchmarkRunError(w, req.Mode, http.StatusBadRequest, "missing suite or suite_dir field")
@@ -128,6 +132,8 @@ func (s *Server) handleBenchmarkRun(w http.ResponseWriter, r *http.Request) {
 		if req.SuiteDir != "" {
 			spec.Kind = "unit"
 			stateSuite = req.SuiteDir
+		} else if req.Mode == "unit" {
+			spec.Kind = "unit"
 		} else if benchmarkSuiteKind(req.Suite) == "unit" {
 			spec.Kind = "unit"
 		}
@@ -150,7 +156,7 @@ func (s *Server) handleBenchmarkRun(w http.ResponseWriter, r *http.Request) {
 		}
 		stateJSON, _ := json.Marshal(map[string]any{
 			"status": "running",
-			"mode":   "aiden",
+			"mode":   req.Mode,
 			"suite":  stateSuite,
 			"model":  agentModel,
 		})

--- a/src/agent/internal/agent/benchmark_test.go
+++ b/src/agent/internal/agent/benchmark_test.go
@@ -410,7 +410,9 @@ func TestHandleBenchmarkIndex_ServesHTMLWithRouterButtons(t *testing.T) {
 		`id="unitSelect"`,
 		`id="runUnitBtn"`,
 		`function startRunUnit()`,
-		`x.kind==='unit'`,
+		`x.kind==='unit'?' (tool)':' (agent)'`,
+		` (agent)`,
+		`mode:'unit'`,
 		`reportCell(r)`,
 		`Not ready`,
 		`payload.suite=mobileGymSuiteName(item,key);`,
@@ -531,6 +533,33 @@ func TestHandleBenchmarkRun_RejectsMissingJudgeAPIKey(t *testing.T) {
 	}
 	if !strings.Contains(string(logData), "benchmark judge api_key is not configured") {
 		t.Fatalf("log missing run error: %s", logData)
+	}
+}
+
+func TestHandleBenchmarkRun_UnitModeForBenchmarkSuite(t *testing.T) {
+	root := t.TempDir()
+	statePath := filepath.Join(root, "state.json")
+	benchmarkSuite := filepath.Join(root, "suites", "perception_v1.json")
+	os.MkdirAll(filepath.Dir(benchmarkSuite), 0o755)
+	os.WriteFile(benchmarkSuite, []byte(`{"name":"perception_v1","tasks":[]}`), 0o644)
+	var got benchmarkLaunchSpec
+	s := &Server{
+		benchmarkDir:       root,
+		benchmarkStatePath: statePath,
+		benchmarkLauncher: func(spec benchmarkLaunchSpec, judge, apiKey, agentModel string) error {
+			got = spec
+			return nil
+		},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/benchmark/run",
+		strings.NewReader(fmt.Sprintf(`{"suite":%q,"mode":"unit"}`, benchmarkSuite)))
+	rec := httptest.NewRecorder()
+	s.handleBenchmarkRun(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body %s", rec.Code, rec.Body.String())
+	}
+	if got.Suite != benchmarkSuite || got.Kind != "unit" {
+		t.Fatalf("launch spec = %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add agent-only Unit Tests mode support for benchmark suites such as perception_v1
- inject mouse_click tool guidance into perception prompts and evaluate the first click locally
- allow /benchmark Unit Tests to run benchmark suites without judge/reset/recovery flow

## Tests
- PYTHONPATH=benchmark pytest -q benchmark/tests/test_agent_client.py benchmark/tests/test_perception.py benchmark/tests/test_runtask.py benchmark/tests/test_unit.py
- go test ./internal/agent -run 'TestHandleBenchmarkRun' (from src/agent)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added perception evaluation for first-click interaction tasks in benchmark suites
  * Enabled agent-based unit suite execution with integrated perception-aware scoring
  * Extended tool lookup by fetching tool catalogs and resolving tool descriptions (including nested entries)

* **Updates**
  * Updated the benchmark UI to clearly distinguish tool-level vs agent-level unit modes

* **Tests**
  * Expanded perception and agent-suite test coverage, including prompt injection, rubric handling, and nested tool description lookup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->