### PR TITLE
fix(ci): invalidate stale rootfs buildroot state

### DIFF
--- a/.github/workflows/build-backup.yml
+++ b/.github/workflows/build-backup.yml
@@ -15,6 +15,6 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/heads/') && github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
     uses: ./.github/workflows/build.yml
     with:
-      runner: self-hosted-02
+      runner: aiden-hosted-02
       free_disk_space: false
     secrets: inherit

--- a/.github/workflows/build-scheduled.yml
+++ b/.github/workflows/build-scheduled.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   check:
     if: ${{ startsWith(github.ref, 'refs/heads/') && github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
-    runs-on: self-hosted
+    runs-on: aiden-hosted-01
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
@@ -99,6 +99,6 @@ jobs:
     if: ${{ needs.check.outputs.should_run == 'true' }}
     uses: ./.github/workflows/build.yml
     with:
-      runner: self-hosted
+      runner: aiden-hosted-01
       free_disk_space: false
     secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build:
-    if: ${{ inputs.runner != 'self-hosted' || (startsWith(github.ref, 'refs/heads/') && github.event_name != 'pull_request' && github.event_name != 'pull_request_target') }}
+    if: ${{ (inputs.runner != 'self-hosted' && !startsWith(inputs.runner, 'aiden-hosted-')) || (startsWith(github.ref, 'refs/heads/') && github.event_name != 'pull_request' && github.event_name != 'pull_request_target') }}
     runs-on: ${{ inputs.runner }}
 
     steps:
@@ -30,7 +30,7 @@ jobs:
       # if the previous build was killed by SIGKILL or the host crashed, leaving
       # root-owned files that block actions/checkout's clean phase with EACCES.
       # This step is a defence-in-depth no-op when the trap already ran.
-      if: ${{ inputs.runner == 'self-hosted' }}
+      if: ${{ inputs.runner == 'self-hosted' || startsWith(inputs.runner, 'aiden-hosted-') }}
       shell: bash
       run: |
         set -euo pipefail
@@ -56,7 +56,7 @@ jobs:
         fi
 
     - name: Remove unusable pico-sdk submodule checkout
-      if: ${{ inputs.runner == 'self-hosted' }}
+      if: ${{ inputs.runner == 'self-hosted' || startsWith(inputs.runner, 'aiden-hosted-') }}
       shell: bash
       run: |
         set -euo pipefail
@@ -73,7 +73,7 @@ jobs:
         rm -rf -- "$sdk_dir" "$sdk_git_dir"
 
     - name: Repair stale pico-sdk submodule metadata
-      if: ${{ inputs.runner == 'self-hosted' }}
+      if: ${{ inputs.runner == 'self-hosted' || startsWith(inputs.runner, 'aiden-hosted-') }}
       shell: bash
       run: |
         set -euo pipefail

--- a/actionlint.yaml
+++ b/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - aiden-hosted-01
+    - aiden-hosted-02

--- a/scripts/test_github_actions_self_hosted_safety.sh
+++ b/scripts/test_github_actions_self_hosted_safety.sh
@@ -25,9 +25,15 @@ def dynamic_self_hosted_capable?(runs_on)
   runs_on_values(runs_on).any? { |value| value.include?("inputs.runner") }
 end
 
+def aiden_hosted_label?(value)
+  value.start_with?("aiden-hosted-")
+end
+
 def self_hosted_capable?(runs_on)
   values = runs_on_values(runs_on)
-  values.include?("self-hosted") || dynamic_self_hosted_capable?(runs_on)
+  values.include?("self-hosted") ||
+    values.any? { |value| aiden_hosted_label?(value) } ||
+    dynamic_self_hosted_capable?(runs_on)
 end
 
 def repo_branch_guarded?(condition, dynamic_runner)
@@ -41,7 +47,8 @@ def repo_branch_guarded?(condition, dynamic_runner)
   runner_guard =
     !dynamic_runner ||
     normalized.include?("inputs.runner != 'self-hosted'") ||
-    normalized.include?("inputs.runner == 'self-hosted'")
+    normalized.include?("inputs.runner == 'self-hosted'") ||
+    normalized.include?("startsWith(inputs.runner, 'aiden-hosted-')")
 
   blocks_pr_events && requires_repo_branch && runner_guard
 end
@@ -85,5 +92,10 @@ if ! grep -Fq 'git -C "$sdk_dir" rev-parse --verify HEAD' "$build_workflow" || \
    ! grep -Fq 'sdk_git_dir="$GITHUB_WORKSPACE/.git/modules/pico-sdk"' "$build_workflow" || \
    ! grep -Fq 'rm -rf -- "$sdk_dir" "$sdk_git_dir"' "$build_workflow"; then
   echo "self-hosted build workflow must detect and remove pico-sdk checkouts whose current revision is unavailable" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'startsWith(inputs.runner, '\''aiden-hosted-'\'')' "$build_workflow"; then
+  echo "self-hosted build workflow must treat dedicated Aiden hosted labels as self-hosted runners" >&2
   exit 1
 fi

--- a/scripts/test_github_actions_self_hosted_safety.sh
+++ b/scripts/test_github_actions_self_hosted_safety.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 build_workflow="$repo_root/.github/workflows/build.yml"
+actionlint_config="$repo_root/actionlint.yaml"
 
 ruby - "$repo_root" <<'RUBY'
 require "yaml"
@@ -79,6 +80,29 @@ if failures.any?
 end
 
 puts "GitHub Actions self-hosted repo-branch safety check passed."
+RUBY
+
+if [[ ! -f "$actionlint_config" ]]; then
+  echo "actionlint config must declare dedicated Aiden hosted runner labels" >&2
+  exit 1
+fi
+
+ruby - "$actionlint_config" <<'RUBY'
+require "yaml"
+
+config_path = ARGV.fetch(0)
+config = YAML.load_file(config_path) || {}
+labels = config.dig("self-hosted-runner", "labels")
+unless labels.is_a?(Array)
+  warn "actionlint config must define self-hosted-runner.labels"
+  exit 1
+end
+
+missing_labels = %w[aiden-hosted-01 aiden-hosted-02] - labels
+if missing_labels.any?
+  warn "actionlint config is missing dedicated Aiden hosted runner labels: #{missing_labels.join(", ")}"
+  exit 1
+end
 RUBY
 
 sanitize_line="$(grep -n 'Remove unusable pico-sdk submodule checkout' "$build_workflow" | sed 's/:.*//' | head -n 1 || true)"

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -117,6 +117,17 @@ if ! grep -q 'cancel-in-progress: false' "$SCHEDULED_WORKFLOW"; then
     exit 1
 fi
 
+if ! grep -q 'runs-on: aiden-hosted-01' "$SCHEDULED_WORKFLOW" || \
+   ! grep -q 'runner: aiden-hosted-01' "$SCHEDULED_WORKFLOW"; then
+    echo "scheduled build workflow must use the primary dedicated Aiden hosted runner label" >&2
+    exit 1
+fi
+
+if ! grep -q 'runner: aiden-hosted-02' "$ROOT_DIR/.github/workflows/build-backup.yml"; then
+    echo "backup build workflow must use the backup dedicated Aiden hosted runner label" >&2
+    exit 1
+fi
+
 if grep -q 'git submodule update.*pico-sdk' "$CI_WORKFLOW"; then
     echo "CI release script checks must not fetch the large pico-sdk submodule" >&2
     exit 1

--- a/scripts/test_reproducible_rootfs_policy.sh
+++ b/scripts/test_reproducible_rootfs_policy.sh
@@ -61,4 +61,20 @@ if ! grep -q 'define refresh_buildroot_config_state' "$PICO_SDK/sysdrv/Makefile"
   exit 1
 fi
 
+refresh_buildroot_config_state="$(sed -n '/^define refresh_buildroot_config_state$/,/^endef$/p' "$PICO_SDK/sysdrv/Makefile")"
+if ! printf '%s\n' "$refresh_buildroot_config_state" | grep -q 'SOURCE_DATE_EPOCH'; then
+  echo "pico-sdk Buildroot state must include SOURCE_DATE_EPOCH so stale package outputs are rebuilt when the reproducible epoch changes" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$refresh_buildroot_config_state" | grep -q 'AIDEN_BUILDROOT_REPRODUCIBLE_STATE_VERSION'; then
+  echo "pico-sdk Buildroot state must include an Aiden reproducibility state version to invalidate older runner caches" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$refresh_buildroot_config_state" | grep -Fq 'sha256sum "$(SYSDRV_DIR)/Makefile"'; then
+  echo "pico-sdk Buildroot state must include sysdrv/Makefile so reproducibility policy changes invalidate stale package outputs" >&2
+  exit 1
+fi
+
 echo "reproducible rootfs timestamp policy tests passed"

--- a/scripts/test_reproducible_rootfs_policy.sh
+++ b/scripts/test_reproducible_rootfs_policy.sh
@@ -77,4 +77,38 @@ if ! printf '%s\n' "$refresh_buildroot_config_state" | grep -Fq 'sha256sum "$(SY
   exit 1
 fi
 
+if ! grep -q 'define refresh_boardtools_config_state' "$PICO_SDK/sysdrv/Makefile" || \
+   ! grep -q '.aiden_boardtools_config_state' "$PICO_SDK/sysdrv/Makefile" || \
+   ! grep -q 'Board tools reproducibility inputs changed; rebuilding generated board tool state' "$PICO_SDK/sysdrv/Makefile"; then
+  echo "pico-sdk sysdrv Makefile must invalidate generated board tool state when reproducible inputs change" >&2
+  exit 1
+fi
+
+refresh_boardtools_config_state="$(sed -n '/^define refresh_boardtools_config_state$/,/^endef$/p' "$PICO_SDK/sysdrv/Makefile")"
+if ! printf '%s\n' "$refresh_boardtools_config_state" | grep -q 'SOURCE_DATE_EPOCH'; then
+  echo "pico-sdk board tool state must include SOURCE_DATE_EPOCH so stale board tool outputs are rebuilt when the reproducible epoch changes" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$refresh_boardtools_config_state" | grep -q 'AIDEN_BOARDTOOLS_REPRODUCIBLE_STATE_VERSION'; then
+  echo "pico-sdk board tool state must include an Aiden reproducibility state version to invalidate older runner caches" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$refresh_boardtools_config_state" | grep -q 'tools_board-clean'; then
+  echo "pico-sdk board tool state must clean generated board tool outputs when reproducibility inputs change" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$refresh_boardtools_config_state" | grep -q 'tools/board/toolkits/openssl'; then
+  echo "pico-sdk board tool state must include board OpenSSL inputs because adbd links against that cached output" >&2
+  exit 1
+fi
+
+if ! grep -q '^boardtools: refresh_boardtools_config_state$' "$PICO_SDK/sysdrv/Makefile" || \
+   ! sed -n '/^boardtools:/,/^$/p' "$PICO_SDK/sysdrv/Makefile" | grep -q 'tools_board-builds'; then
+  echo "pico-sdk boardtools target must refresh board tool state before reusing cached outputs" >&2
+  exit 1
+fi
+
 echo "reproducible rootfs timestamp policy tests passed"


### PR DESCRIPTION
Summary:
- Update pico-sdk to include Buildroot and boardtools reproducibility state invalidation from AidenAI-IO/aiden-sdk#16.
- Extend the reproducible rootfs policy test so stale Buildroot package outputs and cached board tool outputs are invalidated when SOURCE_DATE_EPOCH or the reproducibility policy changes.
- Add dedicated Aiden hosted runner labels and bind scheduled release builds to aiden-hosted-01 and backup builds to aiden-hosted-02.

Tests:
- bash scripts/test_reproducible_rootfs_policy.sh
- bash scripts/test_build_scripts.sh
- bash scripts/test_release_ci_scripts.sh
- bash scripts/test_github_actions_self_hosted_safety.sh
- mock-toolchain make -C pico-sdk/sysdrv -n boardtools

Notes:
- Scope is limited to rootfs consistency and deterministic self-hosted release routing. Release upload/network behavior and Go cache behavior are intentionally unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated build workflows to dedicated Aiden-hosted runners for improved reliability and performance.
  * Updated pico-sdk dependency.

* **Tests**
  * Enhanced reproducibility validation for build state and artifacts.
  * Strengthened runner configuration validation in CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->