### PR TITLE
feat(agent): support steering active chat runs

### DIFF
--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -363,7 +363,18 @@ func (m *MemoryManager) maintenanceLoop() {
 
 // AppendExchange appends a user input and assistant output pair to the session.
 func (m *MemoryManager) AppendExchange(ctx context.Context, agentName string, input string, output string) error {
+	return m.AppendMessages(ctx, agentName, []MessageRecord{
+		{Role: string(llms.ChatMessageTypeHuman), Content: input},
+		{Role: string(llms.ChatMessageTypeAI), Content: output},
+	})
+}
+
+// AppendMessages appends explicit message records to the session event stream.
+func (m *MemoryManager) AppendMessages(ctx context.Context, agentName string, records []MessageRecord) error {
 	if m.storageDir == "" {
+		return nil
+	}
+	if len(records) == 0 {
 		return nil
 	}
 
@@ -372,7 +383,7 @@ func (m *MemoryManager) AppendExchange(ctx context.Context, agentName string, in
 
 	fl := NewFileLock(m.storageDir)
 	if err := fl.Lock(m.lockTimeout); err != nil {
-		return fmt.Errorf("lock for appending session exchange %q: %w", agentName, err)
+		return fmt.Errorf("lock for appending session messages %q: %w", agentName, err)
 	}
 	defer fl.Unlock()
 
@@ -387,10 +398,7 @@ func (m *MemoryManager) AppendExchange(ctx context.Context, agentName string, in
 
 	now := time.Now().UTC()
 	encoder := json.NewEncoder(file)
-	records := []MessageRecord{
-		{Role: string(llms.ChatMessageTypeHuman), Content: input},
-		{Role: string(llms.ChatMessageTypeAI), Content: output},
-	}
+	records = sanitizeMessageRecords(records)
 	for i, record := range records {
 		select {
 		case <-ctx.Done():
@@ -399,7 +407,7 @@ func (m *MemoryManager) AppendExchange(ctx context.Context, agentName string, in
 		}
 		event := sessionEventFromRecord(record, now, m.eventCount[agentName]+i)
 		if err := encoder.Encode(event); err != nil {
-			return fmt.Errorf("append session exchange for %q: %w", agentName, err)
+			return fmt.Errorf("append session messages for %q: %w", agentName, err)
 		}
 	}
 	m.eventCount[agentName] += len(records)

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -31,6 +31,7 @@ type roleCollaborativeExecutor struct {
 	Recorder          *EpisodeRecorder
 	ScreenshotPruning ScreenshotPruningConfig
 	ForceSimpleLoop   bool
+	SteerProvider     func(context.Context) (RunSteerMessage, bool)
 }
 
 const roleModelCallTimeout = 120 * time.Second
@@ -94,6 +95,7 @@ type roleLoopState struct {
 	ExecutionResults     []roleExecutionResult
 	PlannerEvidence      []roleExecutionResult
 	VerifierResults      []verifierDecision
+	SteerMessages        []RunSteerMessage
 }
 
 type worldState struct {
@@ -136,6 +138,10 @@ type roleOutputHandler interface {
 	HandleRoleOutput(ctx context.Context, role, content string)
 }
 
+type steerMessageHandler interface {
+	HandleSteerMessage(ctx context.Context, steer RunSteerMessage)
+}
+
 func newRoleCollaborativeExecutor(
 	model llms.Model,
 	profiles RoleProfiles,
@@ -146,9 +152,14 @@ func newRoleCollaborativeExecutor(
 	handler callbacks.Handler,
 	recorder *EpisodeRecorder,
 	screenshotPruning ScreenshotPruningConfig,
+	steerProviders ...func(context.Context) (RunSteerMessage, bool),
 ) *roleCollaborativeExecutor {
 	if mem == nil {
 		mem = memory.NewSimple()
+	}
+	var steerProvider func(context.Context) (RunSteerMessage, bool)
+	if len(steerProviders) > 0 {
+		steerProvider = steerProviders[0]
 	}
 	return &roleCollaborativeExecutor{
 		Model:             model,
@@ -162,6 +173,7 @@ func newRoleCollaborativeExecutor(
 		Recorder:          recorder,
 		ScreenshotPruning: screenshotPruning.WithDefaults(),
 		ForceSimpleLoop:   profiles.Planner.SystemPrompt != "" && !profiles.Planner.Capabilities.CanModifyPlan,
+		SteerProvider:     steerProvider,
 	}
 }
 
@@ -189,6 +201,13 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 			}
 			switch turn.Kind {
 			case plannerTurnFinish:
+				consumed, err := e.consumePendingSteer(ctx, inputs, &state)
+				if err != nil {
+					return nil, err
+				}
+				if consumed {
+					continue
+				}
 				if state.Phase == phaseDecision || state.Phase == phaseDefault || state.canAcceptPlannerFinal(turn.Answer) {
 					if e.Recorder != nil {
 						e.Recorder.RecordDefaultFinish(turn.Answer)
@@ -225,6 +244,11 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					state.ToolSteps = append(state.ToolSteps, *turn.Step)
 					state.World.UpdateFromStep(*turn.Step, len(state.ToolSteps))
 				}
+				if turn.Kind == plannerTurnTool {
+					if _, err := e.consumePendingSteer(ctx, inputs, &state); err != nil {
+						return nil, err
+					}
+				}
 			}
 		case phaseExecution:
 			if !state.StepExecutionActive {
@@ -248,6 +272,9 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					state.ExecutionResults = append(state.ExecutionResults, execution)
 					if e.Recorder != nil {
 						e.Recorder.RecordExecution(execution)
+					}
+					if _, err := e.consumePendingSteer(ctx, inputs, &state); err != nil {
+						return nil, err
 					}
 				}
 			case executorTurnFinishStep, executorTurnAbortStep:
@@ -281,6 +308,14 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					finalAnswer := strings.TrimSpace(verification.FinalAnswer)
 					if finalAnswer == "" {
 						finalAnswer = stepSummary
+					}
+					consumed, err := e.consumePendingSteer(ctx, inputs, &state)
+					if err != nil {
+						return nil, err
+					}
+					if consumed {
+						state.Phase = phaseDefault
+						continue
 					}
 					return e.finishRun(ctx, finalAnswer, verification.Reason)
 				}
@@ -511,6 +546,29 @@ func (e *roleCollaborativeExecutor) finishRun(ctx context.Context, finalAnswer, 
 	return map[string]any{e.OutputKey: finalAnswer}, nil
 }
 
+func (e *roleCollaborativeExecutor) consumePendingSteer(ctx context.Context, inputs map[string]string, state *roleLoopState) (bool, error) {
+	if e == nil || e.SteerProvider == nil || state == nil {
+		return false, nil
+	}
+	steer, ok := e.SteerProvider(ctx)
+	if !ok {
+		return false, nil
+	}
+	if steer.Timestamp.IsZero() {
+		steer.Timestamp = time.Now()
+	}
+	if appender, ok := e.Memory.(steerConversationAppender); ok {
+		if err := appender.AppendSteerMessage(ctx, inputs["input"], steer); err != nil {
+			return false, err
+		}
+	}
+	state.SteerMessages = append(state.SteerMessages, steer)
+	if handler, ok := e.CallbacksHandler.(steerMessageHandler); ok {
+		handler.HandleSteerMessage(ctx, steer)
+	}
+	return true, nil
+}
+
 func (e *roleCollaborativeExecutor) callExecutorTurn(
 	ctx context.Context,
 	inputs map[string]string,
@@ -629,7 +687,21 @@ func (e *roleCollaborativeExecutor) roleMessages(profile RoleProfile, inputs map
 		Role:  llms.ChatMessageTypeHuman,
 		Parts: buildRoleUserMessageParts(statePrompt, e.InputAttachments, state.World),
 	})
+	for _, steer := range state.SteerMessages {
+		messages = append(messages, llms.MessageContent{
+			Role:  llms.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextPart(steerHumanMessageContent(steer))},
+		})
+	}
 	return messages
+}
+
+func steerHumanMessageContent(steer RunSteerMessage) string {
+	content := strings.TrimSpace(steer.Content)
+	if content == "" {
+		content = "(empty steering message)"
+	}
+	return content
 }
 
 func hasProfileTool(profile RoleProfile, name string) bool {

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -65,6 +65,7 @@ type RunRequest struct {
 	StreamWriter   io.Writer
 	MaxTokens      int
 	EventHandler   func(RunEvent)
+	SteerProvider  func(context.Context) (RunSteerMessage, bool)
 }
 
 type RunResult struct {
@@ -76,6 +77,13 @@ type RunResult struct {
 	SleepRequested bool            `json:"sleep_requested,omitempty"`
 	SleepReason    string          `json:"sleep_reason,omitempty"`
 	SpeechStreamed bool            `json:"-"`
+}
+
+type RunSteerMessage struct {
+	ID        string    `json:"id,omitempty"`
+	RequestID string    `json:"request_id,omitempty"`
+	Content   string    `json:"content"`
+	Timestamp time.Time `json:"timestamp"`
 }
 
 type RunMetrics struct {
@@ -503,7 +511,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		callOptions = append(callOptions, chains.WithMaxTokens(req.MaxTokens))
 	}
 	var streamCallbackHandler *runtimeCallbackHandler
-	if req.StreamWriter != nil || req.EventHandler != nil || r.logger != nil {
+	if req.StreamWriter != nil || req.EventHandler != nil || req.SteerProvider != nil || r.logger != nil {
 		streamCallbackHandler = &runtimeCallbackHandler{
 			writer:       req.StreamWriter,
 			metrics:      metrics,
@@ -522,7 +530,14 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if historyStore := chatHistoryStoreForConfigDir(r.config.ConfigDir); historyStore != nil {
 		plannerMemory = newChatHistoryPlannerMemory(plannerMemory, historyStore)
 	}
-	executor := newRoleCollaborativeExecutor(model, profiles, availableTools, plannerMemory, maxIterations, req.Attachments, executorHandler, episodeRecorder, r.config.ScreenshotPruningOrDefault())
+	var steerStatus steerConversationStatus
+	if req.SteerProvider != nil {
+		plannerMemory = newSteerConversationMemory(plannerMemory, memoryHandle.History)
+		if status, ok := plannerMemory.(steerConversationStatus); ok {
+			steerStatus = status
+		}
+	}
+	executor := newRoleCollaborativeExecutor(model, profiles, availableTools, plannerMemory, maxIterations, req.Attachments, executorHandler, episodeRecorder, r.config.ScreenshotPruningOrDefault(), req.SteerProvider)
 
 	output, err := chains.Run(ctx, executor, normalizedInput, callOptions...)
 	if err != nil {
@@ -544,9 +559,11 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 
 	metrics.TotalDuration = float64(time.Since(startTime).Milliseconds())
 	r.memories.SetLastPromptTokens(metrics.LastPromptTokens)
-	if err := r.memories.AppendExchange(ctx, "default", normalizedInput, output); err != nil {
-		r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture, boundaryTelemetry)
-		return RunResult{}, err
+	if steerStatus == nil || !steerStatus.HasSteerMessages() {
+		if err := r.memories.AppendExchange(ctx, "default", normalizedInput, output); err != nil {
+			r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture, boundaryTelemetry)
+			return RunResult{}, err
+		}
 	}
 
 	memorySnapshot, err := r.memories.Snapshot(ctx, "default")
@@ -1326,6 +1343,21 @@ func (h *runtimeCallbackHandler) HandleRoleOutput(ctx context.Context, role, con
 			Timestamp: time.Now(),
 		})
 	}
+}
+
+func (h *runtimeCallbackHandler) HandleSteerMessage(ctx context.Context, steer RunSteerMessage) {
+	if h.eventHandler == nil {
+		return
+	}
+	if steer.Timestamp.IsZero() {
+		steer.Timestamp = time.Now()
+	}
+	h.eventHandler(RunEvent{
+		Type:      "steer",
+		EpisodeID: h.episodeID,
+		Content:   steer.Content,
+		Timestamp: steer.Timestamp,
+	})
 }
 
 func (h *runtimeCallbackHandler) HandleRetrieverStart(ctx context.Context, query string) {}

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -559,7 +559,12 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 
 	metrics.TotalDuration = float64(time.Since(startTime).Milliseconds())
 	r.memories.SetLastPromptTokens(metrics.LastPromptTokens)
-	if steerStatus == nil || !steerStatus.HasSteerMessages() {
+	if steerStatus != nil && steerStatus.HasSteerMessages() {
+		if err := r.memories.AppendMessages(ctx, "default", steeredExchangeRecords(normalizedInput, steerStatus.SteerMessages(), output)); err != nil {
+			r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture, boundaryTelemetry)
+			return RunResult{}, err
+		}
+	} else {
 		if err := r.memories.AppendExchange(ctx, "default", normalizedInput, output); err != nil {
 			r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture, boundaryTelemetry)
 			return RunResult{}, err
@@ -585,6 +590,16 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		Memory:    memorySnapshot,
 		Metrics:   metrics,
 	}, nil
+}
+
+func steeredExchangeRecords(input string, steers []RunSteerMessage, output string) []MessageRecord {
+	records := make([]MessageRecord, 0, len(steers)+2)
+	records = append(records, MessageRecord{Role: string(llms.ChatMessageTypeHuman), Content: input})
+	for _, steer := range steers {
+		records = append(records, MessageRecord{Role: string(llms.ChatMessageTypeHuman), Content: steerHumanMessageContent(steer)})
+	}
+	records = append(records, MessageRecord{Role: string(llms.ChatMessageTypeAI), Content: output})
+	return records
 }
 
 func (r *Runtime) currentEnvironmentHints() CurrentEnvironmentHints {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -261,6 +261,66 @@ func TestRuntimeRunPersistsSteerAsConversationHumanMessage(t *testing.T) {
 	}
 }
 
+func TestRuntimeRunPersistsSteerEventsWhenSnapshotWindowIsFull(t *testing.T) {
+	storageDir := filepath.Join(t.TempDir(), "memory")
+	memoryManager := NewMemoryManager(storageDir)
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		if err := memoryManager.AppendExchange(ctx, "default", fmt.Sprintf("prior user %02d", i), fmt.Sprintf("prior assistant %02d", i)); err != nil {
+			t.Fatalf("AppendExchange(%d) error = %v", i, err)
+		}
+	}
+
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			contentResponse("Old answer."),
+			contentResponse("Changed course."),
+		},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Answer directly."},
+		&testModelResolver{model: model},
+		memoryManager,
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+
+	var steerCalls int32
+	result, err := runtime.Run(ctx, RunRequest{
+		Input: "windowed request",
+		SteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
+			if atomic.AddInt32(&steerCalls, 1) != 1 {
+				return RunSteerMessage{}, false
+			}
+			return RunSteerMessage{
+				ID:      "steer-1",
+				Content: "persist even when the hot window is full",
+			}, true
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Output != "Changed course." {
+		t.Fatalf("output = %q, want Changed course.", result.Output)
+	}
+
+	events := readSessionEvents(t, filepath.Join(storageDir, "session", "events.jsonl"))
+	if len(events) != 23 {
+		t.Fatalf("expected 23 session events, got %d: %#v", len(events), events)
+	}
+	last := events[len(events)-3:]
+	for i, want := range []SessionEvent{
+		{Role: "user", Content: "windowed request"},
+		{Role: "user", Content: "persist even when the hot window is full"},
+		{Role: "assistant", Content: "Changed course."},
+	} {
+		if last[i].Role != want.Role || last[i].Content != want.Content {
+			t.Fatalf("last session event %d = %#v, want role=%q content=%q; all events: %#v", i, last[i], want.Role, want.Content, events)
+		}
+	}
+}
+
 func TestRuntimeRunIncludesAvailableSkillCatalog(t *testing.T) {
 	index := NewSkillIndex()
 	index.skills["planner"] = &SkillDefinition{

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -77,6 +77,190 @@ func TestRuntimeRun(t *testing.T) {
 	}
 }
 
+func TestRuntimeRunAttachesPendingSteerToNextToolCall(t *testing.T) {
+	model := &scriptedModel{
+		responses: roleToolResponses("echo", `{"__arg1":"original action"}`, "Changed course."),
+	}
+	tool := &stubTool{
+		name:        "echo",
+		description: "Echo.",
+		output:      "tool output",
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Use tools."},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{"echo": tool}},
+		NewSkillIndex(),
+	)
+
+	var steerCalls int32
+	var events []RunEvent
+	result, err := runtime.Run(context.Background(), RunRequest{
+		Input: "do the original action",
+		EventHandler: func(event RunEvent) {
+			events = append(events, event)
+		},
+		SteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
+			if atomic.AddInt32(&steerCalls, 1) != 1 {
+				return RunSteerMessage{}, false
+			}
+			return RunSteerMessage{
+				ID:        "steer-1",
+				RequestID: "req-1",
+				Content:   "Use the updated instruction instead.",
+				Timestamp: time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC),
+			}, true
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Output != "Changed course." {
+		t.Fatalf("output = %q, want Changed course.", result.Output)
+	}
+	if len(tool.inputs) != 1 || tool.inputs[0] != "original action" {
+		t.Fatalf("tool should run before steer is attached, got inputs %#v", tool.inputs)
+	}
+
+	steerEvent, ok := firstRunEventOfType(events, "steer")
+	if !ok || steerEvent.Content != "Use the updated instruction instead." {
+		t.Fatalf("missing steer event: %#v", events)
+	}
+	toolResult, ok := firstRunEventOfType(events, "tool_result")
+	if !ok {
+		t.Fatalf("missing tool_result event: %#v", events)
+	}
+	if toolResult.Content != "tool output" || toolResult.IsError {
+		t.Fatalf("unexpected steer tool result: %#v", toolResult)
+	}
+	if len(model.messages) < 2 {
+		t.Fatalf("expected follow-up model call with steer message, got %#v", model.messages)
+	}
+	role, text, ok := runtimeLastMessageText(model.messages[1])
+	if !ok || role != llms.ChatMessageTypeHuman || text != "Use the updated instruction instead." {
+		t.Fatalf("second model call missing steer message: %#v", model.messages)
+	}
+	if runtimeModelCallContains(model.messages[1], "User steering update received while the agent was already working") {
+		t.Fatalf("steer should be appended as a human message, not rewritten as prompt text: %#v", model.messages[1])
+	}
+	assertMemoryRecords(t, result.Memory, []MessageRecord{
+		{Role: "human", Content: "do the original action"},
+		{Role: "human", Content: "Use the updated instruction instead."},
+		{Role: "ai", Content: "Changed course."},
+	})
+}
+
+func TestRuntimeRunAttachesPendingSteerBeforeFinalAnswer(t *testing.T) {
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			contentResponse("Old answer."),
+			contentResponse("Changed course."),
+		},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Answer directly."},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+
+	var steerCalls int32
+	var events []RunEvent
+	result, err := runtime.Run(context.Background(), RunRequest{
+		Input: "answer the old request",
+		EventHandler: func(event RunEvent) {
+			events = append(events, event)
+		},
+		SteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
+			if atomic.AddInt32(&steerCalls, 1) != 1 {
+				return RunSteerMessage{}, false
+			}
+			return RunSteerMessage{
+				ID:        "steer-1",
+				RequestID: "req-1",
+				Content:   "Actually change direction before answering.",
+				Timestamp: time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC),
+			}, true
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Output != "Changed course." {
+		t.Fatalf("output = %q, want Changed course.", result.Output)
+	}
+	if _, ok := firstRunEventOfType(events, "steer"); !ok {
+		t.Fatalf("missing steer event: %#v", events)
+	}
+	if len(model.messages) < 2 {
+		t.Fatalf("expected follow-up model call with final-boundary steer message, got %#v", model.messages)
+	}
+	role, text, ok := runtimeLastMessageText(model.messages[1])
+	if !ok || role != llms.ChatMessageTypeHuman || text != "Actually change direction before answering." {
+		t.Fatalf("second model call missing final-boundary steer message: %#v", model.messages)
+	}
+	assertMemoryRecords(t, result.Memory, []MessageRecord{
+		{Role: "human", Content: "answer the old request"},
+		{Role: "human", Content: "Actually change direction before answering."},
+		{Role: "ai", Content: "Changed course."},
+	})
+}
+
+func TestRuntimeRunPersistsSteerAsConversationHumanMessage(t *testing.T) {
+	storageDir := filepath.Join(t.TempDir(), "memory")
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			contentResponse("Old answer."),
+			contentResponse("Changed course."),
+		},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Answer directly."},
+		&testModelResolver{model: model},
+		NewMemoryManager(storageDir),
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+
+	var steerCalls int32
+	result, err := runtime.Run(context.Background(), RunRequest{
+		Input: "original persisted request",
+		SteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
+			if atomic.AddInt32(&steerCalls, 1) != 1 {
+				return RunSteerMessage{}, false
+			}
+			return RunSteerMessage{
+				ID:      "steer-1",
+				Content: "persist this steering message",
+			}, true
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	assertMemoryRecords(t, result.Memory, []MessageRecord{
+		{Role: "human", Content: "original persisted request"},
+		{Role: "human", Content: "persist this steering message"},
+		{Role: "ai", Content: "Changed course."},
+	})
+
+	events := readSessionEvents(t, filepath.Join(storageDir, "session", "events.jsonl"))
+	if len(events) != 3 {
+		t.Fatalf("expected 3 session events, got %d: %#v", len(events), events)
+	}
+	for i, want := range []SessionEvent{
+		{Role: "user", Content: "original persisted request"},
+		{Role: "user", Content: "persist this steering message"},
+		{Role: "assistant", Content: "Changed course."},
+	} {
+		if events[i].Role != want.Role || events[i].Content != want.Content {
+			t.Fatalf("session event %d = %#v, want role=%q content=%q; all events: %#v", i, events[i], want.Role, want.Content, events)
+		}
+	}
+}
+
 func TestRuntimeRunIncludesAvailableSkillCatalog(t *testing.T) {
 	index := NewSkillIndex()
 	index.skills["planner"] = &SkillDefinition{
@@ -347,6 +531,32 @@ func runtimeModelCallContains(messages []llms.MessageContent, want string) bool 
 		}
 	}
 	return false
+}
+
+func runtimeLastMessageText(messages []llms.MessageContent) (llms.ChatMessageType, string, bool) {
+	if len(messages) == 0 {
+		return "", "", false
+	}
+	last := messages[len(messages)-1]
+	var builder strings.Builder
+	for _, part := range last.Parts {
+		if text, ok := part.(llms.TextContent); ok {
+			builder.WriteString(text.Text)
+		}
+	}
+	return last.Role, builder.String(), true
+}
+
+func assertMemoryRecords(t *testing.T, got []MessageRecord, want []MessageRecord) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("memory records length = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("memory record %d = %#v, want %#v; all records: %#v", i, got[i], want[i], got)
+		}
+	}
 }
 
 type scriptedModel struct {

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -58,6 +58,8 @@ type Server struct {
 	pendingResultsMu           sync.Mutex
 	activeRuns                 map[string]context.CancelFunc
 	activeRunsMu               sync.Mutex
+	pendingSteers              map[string]pendingSteerMessage
+	pendingSteersMu            sync.Mutex
 }
 
 type webAudioRecording struct {
@@ -122,6 +124,24 @@ type ChatCancelRequest struct {
 type ChatCancelResponse struct {
 	RequestID string `json:"request_id"`
 	Status    string `json:"status"`
+}
+
+type ChatSteerRequest struct {
+	RequestID string `json:"request_id"`
+	Message   string `json:"message"`
+}
+
+type ChatSteerResponse struct {
+	RequestID string               `json:"request_id"`
+	Status    string               `json:"status"`
+	Steer     *pendingSteerMessage `json:"steer,omitempty"`
+}
+
+type pendingSteerMessage struct {
+	ID        string    `json:"id"`
+	RequestID string    `json:"request_id"`
+	Content   string    `json:"content"`
+	Timestamp time.Time `json:"timestamp"`
 }
 
 // ChatResponse represents a chat response
@@ -201,6 +221,7 @@ func NewServer(runtime *Runtime, addr string, benchmarkDir string) *Server {
 		bridge:              bridge,
 		pendingResults:      make(map[string]*chatPendingResult),
 		activeRuns:          make(map[string]context.CancelFunc),
+		pendingSteers:       make(map[string]pendingSteerMessage),
 	}
 	if runtime.config.ConfigDir != "" {
 		memoryDir := filepath.Join(runtime.config.ConfigDir, "memory")
@@ -247,6 +268,8 @@ func (s *Server) Start() error {
 	// API endpoints
 	mux.HandleFunc("/api/chat", s.handleChat)
 	mux.HandleFunc("/api/chat/cancel", s.handleChatCancel)
+	mux.HandleFunc("/api/chat/steer", s.handleChatSteer)
+	mux.HandleFunc("/api/chat/steer/cancel", s.handleChatSteerCancel)
 	mux.HandleFunc("/api/chat/result", s.handleChatResult)
 	mux.HandleFunc("/api/history", s.handleHistory)
 	mux.HandleFunc("/api/episodes/", s.handleEpisodes)
@@ -426,6 +449,70 @@ func (s *Server) handleChatCancel(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(ChatCancelResponse{RequestID: requestID, Status: "not_running"})
 }
 
+func (s *Server) handleChatSteer(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ChatSteerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+	requestID := strings.TrimSpace(req.RequestID)
+	message := strings.TrimSpace(req.Message)
+	if requestID == "" {
+		http.Error(w, "missing request_id", http.StatusBadRequest)
+		return
+	}
+	if message == "" {
+		http.Error(w, "message is required", http.StatusBadRequest)
+		return
+	}
+
+	steer, ok := s.setPendingSteer(requestID, message)
+	if !ok {
+		http.Error(w, "request_id is not running", http.StatusConflict)
+		return
+	}
+	if s.logger != nil {
+		s.logger.Info("Queued chat steer: request_id=%s len=%d", requestID, len(message))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(ChatSteerResponse{RequestID: requestID, Status: "pending", Steer: &steer})
+}
+
+func (s *Server) handleChatSteerCancel(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ChatSteerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+	requestID := strings.TrimSpace(req.RequestID)
+	if requestID == "" {
+		http.Error(w, "missing request_id", http.StatusBadRequest)
+		return
+	}
+
+	status := "not_found"
+	if s.cancelPendingSteer(requestID) {
+		status = "canceled"
+		if s.logger != nil {
+			s.logger.Info("Canceled chat steer: request_id=%s", requestID)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(ChatSteerResponse{RequestID: requestID, Status: status})
+}
+
 func (s *Server) registerActiveRun(requestID string, cancel context.CancelFunc) bool {
 	if requestID == "" {
 		return true
@@ -460,6 +547,72 @@ func (s *Server) cancelActiveRun(requestID string) bool {
 	}
 	cancel()
 	return true
+}
+
+func (s *Server) setPendingSteer(requestID, content string) (pendingSteerMessage, bool) {
+	s.activeRunsMu.Lock()
+	defer s.activeRunsMu.Unlock()
+	if requestID == "" || s.activeRuns[requestID] == nil {
+		return pendingSteerMessage{}, false
+	}
+	steer := pendingSteerMessage{
+		ID:        createSteerID(),
+		RequestID: requestID,
+		Content:   strings.TrimSpace(content),
+		Timestamp: time.Now(),
+	}
+	s.pendingSteersMu.Lock()
+	if s.pendingSteers == nil {
+		s.pendingSteers = make(map[string]pendingSteerMessage)
+	}
+	s.pendingSteers[requestID] = steer
+	s.pendingSteersMu.Unlock()
+	return steer, true
+}
+
+func (s *Server) cancelPendingSteer(requestID string) bool {
+	s.pendingSteersMu.Lock()
+	defer s.pendingSteersMu.Unlock()
+	if s.pendingSteers == nil {
+		return false
+	}
+	if _, ok := s.pendingSteers[requestID]; !ok {
+		return false
+	}
+	delete(s.pendingSteers, requestID)
+	return true
+}
+
+func (s *Server) clearPendingSteer(requestID string) {
+	if requestID == "" {
+		return
+	}
+	s.pendingSteersMu.Lock()
+	delete(s.pendingSteers, requestID)
+	s.pendingSteersMu.Unlock()
+}
+
+func (s *Server) consumePendingSteer(requestID string) (RunSteerMessage, bool) {
+	if requestID == "" {
+		return RunSteerMessage{}, false
+	}
+	s.pendingSteersMu.Lock()
+	defer s.pendingSteersMu.Unlock()
+	steer, ok := s.pendingSteers[requestID]
+	if !ok {
+		return RunSteerMessage{}, false
+	}
+	delete(s.pendingSteers, requestID)
+	return RunSteerMessage{
+		ID:        steer.ID,
+		RequestID: steer.RequestID,
+		Content:   steer.Content,
+		Timestamp: steer.Timestamp,
+	}, true
+}
+
+func createSteerID() string {
+	return "steer-" + strconv.FormatInt(time.Now().UnixNano(), 36)
 }
 
 // handleChatAsync runs the agent in a background goroutine and returns
@@ -517,6 +670,7 @@ func (s *Server) handleChatAsync(
 	go func() {
 		defer func() {
 			s.unregisterActiveRun(requestID)
+			s.clearPendingSteer(requestID)
 			// Keep the completed result available for polling for 60s,
 			// then clean up. The client (PhoneBridge) polls /api/chat/result
 			// every ~1s; immediate deletion creates a race where the app
@@ -565,6 +719,9 @@ func (s *Server) handleChatAsync(
 			EpisodeID:      userMsg.EpisodeID,
 			RuntimeContext: s.runtimeContext(),
 			EventHandler:   eventHandler,
+			SteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
+				return s.consumePendingSteer(requestID)
+			},
 		}
 
 		var newStream *streamSessionWriter
@@ -920,6 +1077,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 		}
 		defer func() {
 			s.unregisterActiveRun(req.RequestID)
+			s.clearPendingSteer(req.RequestID)
 			cancel()
 		}()
 		ctx = runCtx
@@ -932,6 +1090,9 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 		Skills:         req.Skills,
 		EpisodeID:      episodeID,
 		RuntimeContext: s.runtimeContext(),
+		SteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
+			return s.consumePendingSteer(req.RequestID)
+		},
 		EventHandler: func(event RunEvent) {
 			eventEpisodeID := event.EpisodeID
 			if eventEpisodeID == "" {
@@ -2268,10 +2429,20 @@ const webUI = `<!DOCTYPE html>
             justify-content: flex-end;
         }
 
+        .message.steer .message-shell {
+            justify-content: flex-end;
+        }
+
         .message.user .message-avatar {
             order: 2;
             background: rgba(16, 163, 127, 0.12);
             color: var(--accent-strong);
+        }
+
+        .message.steer .message-avatar {
+            order: 2;
+            background: rgba(183, 107, 47, 0.14);
+            color: var(--tool-call-text);
         }
 
         .message.user .message-body {
@@ -2279,6 +2450,16 @@ const webUI = `<!DOCTYPE html>
             max-width: min(78%, 860px);
             background: var(--user-bubble);
             border: 1px solid var(--line);
+            border-radius: 18px 18px 8px 18px;
+            padding: 13px 15px;
+            box-shadow: var(--shadow-soft);
+        }
+
+        .message.steer .message-body {
+            order: 1;
+            max-width: min(78%, 860px);
+            background: rgba(255, 248, 239, 0.95);
+            border: 1px solid rgba(183, 107, 47, 0.22);
             border-radius: 18px 18px 8px 18px;
             padding: 13px 15px;
             box-shadow: var(--shadow-soft);
@@ -2776,6 +2957,37 @@ const webUI = `<!DOCTYPE html>
             opacity: 1;
         }
 
+        .pending-steer {
+            margin: 0 18px 8px;
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 11px 12px;
+            border-radius: 14px;
+            border: 1px solid rgba(183, 107, 47, 0.2);
+            background: rgba(255, 248, 239, 0.9);
+            box-shadow: var(--shadow-soft);
+        }
+
+        .pending-steer.hidden {
+            display: none;
+        }
+
+        .pending-steer-copy {
+            min-width: 0;
+            display: grid;
+            gap: 4px;
+        }
+
+        .pending-steer-text {
+            color: var(--text);
+            font-size: 0.88rem;
+            line-height: 1.45;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+
         .spinner {
             width: 14px;
             height: 14px;
@@ -2828,7 +3040,8 @@ const webUI = `<!DOCTYPE html>
                 border-radius: 16px;
             }
 
-            .message.user .message-body {
+            .message.user .message-body,
+            .message.steer .message-body {
                 max-width: 100%;
             }
 
@@ -2890,6 +3103,14 @@ const webUI = `<!DOCTYPE html>
                 <span class="spinner" aria-hidden="true"></span>
                 <span>Working on it...</span>
                 <button type="button" class="stop-run-btn" id="stopRunBtn" onclick="cancelCurrentRun()" disabled>Stop</button>
+            </div>
+
+            <div class="pending-steer hidden" id="pendingSteer">
+                <div class="pending-steer-copy">
+                    <div class="message-role">Pending steer</div>
+                    <div class="pending-steer-text" id="pendingSteerText"></div>
+                </div>
+                <button type="button" class="stop-run-btn" id="cancelSteerBtn" onclick="cancelPendingSteer()">Cancel</button>
             </div>
 
             <form class="composer" onsubmit="event.preventDefault(); sendMessage();">
@@ -2980,6 +3201,9 @@ const webUI = `<!DOCTYPE html>
         const draftAttachmentsEl = document.getElementById('draftAttachments');
         const loadingDiv = document.getElementById('loading');
         const stopRunBtn = document.getElementById('stopRunBtn');
+        const pendingSteerEl = document.getElementById('pendingSteer');
+        const pendingSteerTextEl = document.getElementById('pendingSteerText');
+        const cancelSteerBtn = document.getElementById('cancelSteerBtn');
         const emptyStateEl = document.getElementById('emptyState');
         const toolSelectEl = document.getElementById('toolSelect');
         const toolDescriptionEl = document.getElementById('toolDescription');
@@ -3006,6 +3230,8 @@ const webUI = `<!DOCTYPE html>
         let currentChatRequestId = '';
         let currentChatAbortController = null;
         let currentChatCancelRequested = false;
+        let pendingSteer = null;
+        let pendingSteerSubmitting = false;
         let episodeCache = {};
 
         loadHistory();
@@ -3279,6 +3505,10 @@ const webUI = `<!DOCTYPE html>
 
         async function sendMessage() {
             if (sendBtn.disabled) return;
+            if (currentChatRequestId) {
+                await submitSteerMessage();
+                return;
+            }
             if (recorderState.isRecording || recorderState.isStopping) {
                 await stopRecording();
             }
@@ -3349,8 +3579,70 @@ const webUI = `<!DOCTYPE html>
                 currentChatRequestId = '';
                 currentChatAbortController = null;
                 currentChatCancelRequested = false;
+                pendingSteer = null;
+                renderPendingSteer();
                 setComposerState(false);
                 scrollToBottom();
+            }
+        }
+
+        async function submitSteerMessage() {
+            if (!currentChatRequestId || pendingSteerSubmitting) return;
+
+            const message = inputEl.value.trim();
+            if (!message) return;
+            if (draftAttachments.length > 0) {
+                alert('Attachments can be sent after the current run finishes.');
+                return;
+            }
+
+            const requestId = currentChatRequestId;
+            const localSteer = {
+                id: 'local-' + createRequestId(),
+                request_id: requestId,
+                content: message,
+                timestamp: new Date().toISOString()
+            };
+            pendingSteer = localSteer;
+            pendingSteerSubmitting = true;
+            inputEl.value = '';
+            autoResizeInput();
+            renderPendingSteer();
+            setComposerState(true);
+
+            try {
+                const res = await fetch('/api/chat/steer', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        request_id: requestId,
+                        message: message
+                    })
+                });
+                if (!res.ok) {
+                    throw new Error(await res.text() || 'Failed to queue steer.');
+                }
+                const data = await res.json();
+                if (data.steer) {
+                    pendingSteer = data.steer;
+                    renderPendingSteer();
+                }
+            } catch (err) {
+                console.error('Failed to queue steer:', err);
+                if (currentChatRequestId === requestId) {
+                    inputEl.value = message;
+                    autoResizeInput();
+                }
+                pendingSteer = null;
+                renderPendingSteer();
+                addMessage({
+                    type: 'assistant',
+                    content: 'Error: ' + err.message,
+                    timestamp: new Date().toISOString()
+                });
+            } finally {
+                pendingSteerSubmitting = false;
+                setComposerState(!!currentChatRequestId);
             }
         }
 
@@ -3367,6 +3659,8 @@ const webUI = `<!DOCTYPE html>
             currentChatCancelRequested = true;
             stopRunBtn.disabled = true;
             stopRunBtn.textContent = 'Stopping...';
+            pendingSteer = null;
+            renderPendingSteer();
 
 			if (currentChatAbortController) {
 				currentChatAbortController.abort();
@@ -3381,6 +3675,31 @@ const webUI = `<!DOCTYPE html>
 				console.error('Failed to cancel chat request:', err);
 			});
 		}
+
+        async function cancelPendingSteer() {
+            if (!currentChatRequestId || !pendingSteer) return;
+            const requestId = currentChatRequestId;
+            const previous = pendingSteer;
+            pendingSteer = null;
+            renderPendingSteer();
+
+            try {
+                const res = await fetch('/api/chat/steer/cancel', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ request_id: requestId })
+                });
+                if (!res.ok) {
+                    throw new Error(await res.text() || 'Failed to cancel steer.');
+                }
+            } catch (err) {
+                console.error('Failed to cancel steer:', err);
+                if (currentChatRequestId === requestId) {
+                    pendingSteer = previous;
+                    renderPendingSteer();
+                }
+            }
+        }
 
         async function consumeChatStream(res) {
             let sawDone = false;
@@ -3457,6 +3776,10 @@ const webUI = `<!DOCTYPE html>
 
         function handleChatStreamEvent(event) {
             if (event.type === 'message' && event.message) {
+                if (event.message.type === 'steer') {
+                    pendingSteer = null;
+                    renderPendingSteer();
+                }
                 addMessage(event.message);
                 return false;
             }
@@ -3673,13 +3996,27 @@ const webUI = `<!DOCTYPE html>
         }
 
         function setComposerState(isLoading) {
-            sendBtn.disabled = isLoading || recorderState.isStopping;
+            sendBtn.disabled = recorderState.isStopping || pendingSteerSubmitting;
+            sendBtn.textContent = isLoading ? 'Steer' : 'Send';
             imageBtn.disabled = isLoading || recorderState.isRecording || recorderState.isStopping;
             recordBtn.disabled = isLoading || recorderState.isStopping;
             stopRunBtn.disabled = !isLoading;
             stopRunBtn.textContent = 'Stop';
             loadingDiv.classList.toggle('active', isLoading);
+            renderPendingSteer();
             updateRecordButton();
+        }
+
+        function renderPendingSteer() {
+            if (!pendingSteer) {
+                pendingSteerEl.classList.add('hidden');
+                pendingSteerTextEl.textContent = '';
+                cancelSteerBtn.disabled = true;
+                return;
+            }
+            pendingSteerEl.classList.remove('hidden');
+            pendingSteerTextEl.textContent = pendingSteer.content || '';
+            cancelSteerBtn.disabled = pendingSteerSubmitting;
         }
 
         function autoResizeInput() {
@@ -3697,6 +4034,7 @@ const webUI = `<!DOCTYPE html>
 
         function getRoleLabel(type, toolName, role) {
             if (type === 'user') return 'You';
+            if (type === 'steer') return 'Steer';
             if (type === 'episode_status') return 'Task Trace';
             if (type === 'role_output') return 'Role · ' + (role || 'agent');
             if (type === 'tool_call') return toolName ? 'Tool Call · ' + toolName : 'Tool Call';
@@ -3706,6 +4044,7 @@ const webUI = `<!DOCTYPE html>
 
         function getAvatarLabel(type) {
             if (type === 'user') return 'You';
+            if (type === 'steer') return 'Edit';
             if (type === 'episode_status') return 'Task';
             if (type === 'role_output') return 'Role';
             if (type === 'tool_call') return 'Call';

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -458,6 +458,92 @@ func TestServerHandleChatCancelCancelsActiveRun(t *testing.T) {
 	}
 }
 
+func TestServerHandleChatSteerQueuesAndCancelsPendingMessage(t *testing.T) {
+	server := &Server{
+		activeRuns:    make(map[string]context.CancelFunc),
+		pendingSteers: make(map[string]pendingSteerMessage),
+	}
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server.registerActiveRun("req-1", cancel)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/steer", bytes.NewBufferString(`{"request_id":" req-1 ","message":" change direction "}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.handleChatSteer(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp ChatSteerResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != "pending" || resp.RequestID != "req-1" || resp.Steer == nil || resp.Steer.Content != "change direction" {
+		t.Fatalf("unexpected steer response: %#v", resp)
+	}
+	steer, ok := server.consumePendingSteer("req-1")
+	if !ok || steer.Content != "change direction" {
+		t.Fatalf("unexpected consumed steer: %#v ok=%v", steer, ok)
+	}
+	if _, ok := server.consumePendingSteer("req-1"); ok {
+		t.Fatal("pending steer was not consumed exactly once")
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/chat/steer", bytes.NewBufferString(`{"request_id":"req-1","message":"cancel this"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	server.handleChatSteer(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected requeue status: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	cancelReq := httptest.NewRequest(http.MethodPost, "/api/chat/steer/cancel", bytes.NewBufferString(`{"request_id":"req-1"}`))
+	cancelReq.Header.Set("Content-Type", "application/json")
+	cancelRec := httptest.NewRecorder()
+	server.handleChatSteerCancel(cancelRec, cancelReq)
+	if cancelRec.Code != http.StatusOK {
+		t.Fatalf("unexpected cancel status: %d body=%s", cancelRec.Code, cancelRec.Body.String())
+	}
+	var cancelResp ChatSteerResponse
+	if err := json.NewDecoder(cancelRec.Body).Decode(&cancelResp); err != nil {
+		t.Fatalf("decode cancel response: %v", err)
+	}
+	if cancelResp.Status != "canceled" || cancelResp.RequestID != "req-1" {
+		t.Fatalf("unexpected cancel response: %#v", cancelResp)
+	}
+	if _, ok := server.consumePendingSteer("req-1"); ok {
+		t.Fatal("canceled steer was still pending")
+	}
+}
+
+func TestServerHandleChatSteerRejectsNonRunningRequest(t *testing.T) {
+	server := &Server{activeRuns: make(map[string]context.CancelFunc)}
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/steer", bytes.NewBufferString(`{"request_id":"req-1","message":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.handleChatSteer(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestWebUISteerModeControlsArePresent(t *testing.T) {
+	for _, want := range []string{
+		"/api/chat/steer",
+		"/api/chat/steer/cancel",
+		"async function submitSteerMessage()",
+		"sendBtn.textContent = isLoading ? 'Steer' : 'Send';",
+		"id=\"pendingSteer\"",
+	} {
+		if !strings.Contains(webUI, want) {
+			t.Fatalf("web UI missing %q", want)
+		}
+	}
+}
+
 func TestServerHandleChatAsyncDuplicateRequestIDDoesNotAppendHistory(t *testing.T) {
 	server := &Server{
 		activeRuns:     make(map[string]context.CancelFunc),

--- a/src/agent/internal/agent/steer_memory.go
+++ b/src/agent/internal/agent/steer_memory.go
@@ -17,6 +17,7 @@ type steerConversationAppender interface {
 
 type steerConversationStatus interface {
 	HasSteerMessages() bool
+	SteerMessages() []RunSteerMessage
 }
 
 type steerConversationMemory struct {
@@ -26,6 +27,7 @@ type steerConversationMemory struct {
 	mu            sync.Mutex
 	inputAppended bool
 	steerAppended bool
+	steers        []RunSteerMessage
 }
 
 func newSteerConversationMemory(inner schema.Memory, history schema.ChatMessageHistory) schema.Memory {
@@ -72,6 +74,7 @@ func (m *steerConversationMemory) Clear(ctx context.Context) error {
 	m.mu.Lock()
 	m.inputAppended = false
 	m.steerAppended = false
+	m.steers = nil
 	m.mu.Unlock()
 	return m.inner.Clear(ctx)
 }
@@ -81,6 +84,7 @@ func (m *steerConversationMemory) AppendSteerMessage(ctx context.Context, input 
 	if content == "" {
 		content = "(empty steering message)"
 	}
+	steer.Content = content
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -94,6 +98,7 @@ func (m *steerConversationMemory) AppendSteerMessage(ctx context.Context, input 
 		return fmt.Errorf("append steering message: %w", err)
 	}
 	m.steerAppended = true
+	m.steers = append(m.steers, steer)
 	return pruneSteerConversationWindow(ctx, m.inner)
 }
 
@@ -101,6 +106,12 @@ func (m *steerConversationMemory) HasSteerMessages() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.steerAppended
+}
+
+func (m *steerConversationMemory) SteerMessages() []RunSteerMessage {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]RunSteerMessage(nil), m.steers...)
 }
 
 func pruneSteerConversationWindow(ctx context.Context, mem schema.Memory) error {

--- a/src/agent/internal/agent/steer_memory.go
+++ b/src/agent/internal/agent/steer_memory.go
@@ -1,0 +1,125 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/tmc/langchaingo/llms"
+	langmemory "github.com/tmc/langchaingo/memory"
+	"github.com/tmc/langchaingo/schema"
+)
+
+type steerConversationAppender interface {
+	AppendSteerMessage(ctx context.Context, input string, steer RunSteerMessage) error
+}
+
+type steerConversationStatus interface {
+	HasSteerMessages() bool
+}
+
+type steerConversationMemory struct {
+	inner   schema.Memory
+	history schema.ChatMessageHistory
+
+	mu            sync.Mutex
+	inputAppended bool
+	steerAppended bool
+}
+
+func newSteerConversationMemory(inner schema.Memory, history schema.ChatMessageHistory) schema.Memory {
+	if inner == nil || history == nil {
+		return inner
+	}
+	return &steerConversationMemory{inner: inner, history: history}
+}
+
+func (m *steerConversationMemory) GetMemoryKey(ctx context.Context) string {
+	return m.inner.GetMemoryKey(ctx)
+}
+
+func (m *steerConversationMemory) MemoryVariables(ctx context.Context) []string {
+	return m.inner.MemoryVariables(ctx)
+}
+
+func (m *steerConversationMemory) LoadMemoryVariables(ctx context.Context, inputs map[string]any) (map[string]any, error) {
+	return m.inner.LoadMemoryVariables(ctx, inputs)
+}
+
+func (m *steerConversationMemory) SaveContext(ctx context.Context, inputs map[string]any, outputs map[string]any) error {
+	m.mu.Lock()
+	inputAppended := m.inputAppended
+	m.mu.Unlock()
+	if !inputAppended {
+		return m.inner.SaveContext(ctx, inputs, outputs)
+	}
+
+	output, err := langmemory.GetInputValue(outputs, "")
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.history.AddAIMessage(ctx, output); err != nil {
+		return fmt.Errorf("append assistant output after steering: %w", err)
+	}
+	return pruneSteerConversationWindow(ctx, m.inner)
+}
+
+func (m *steerConversationMemory) Clear(ctx context.Context) error {
+	m.mu.Lock()
+	m.inputAppended = false
+	m.steerAppended = false
+	m.mu.Unlock()
+	return m.inner.Clear(ctx)
+}
+
+func (m *steerConversationMemory) AppendSteerMessage(ctx context.Context, input string, steer RunSteerMessage) error {
+	content := strings.TrimSpace(steer.Content)
+	if content == "" {
+		content = "(empty steering message)"
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.inputAppended {
+		if err := m.history.AddUserMessage(ctx, input); err != nil {
+			return fmt.Errorf("append current user input before steering: %w", err)
+		}
+		m.inputAppended = true
+	}
+	if err := m.history.AddUserMessage(ctx, content); err != nil {
+		return fmt.Errorf("append steering message: %w", err)
+	}
+	m.steerAppended = true
+	return pruneSteerConversationWindow(ctx, m.inner)
+}
+
+func (m *steerConversationMemory) HasSteerMessages() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.steerAppended
+}
+
+func pruneSteerConversationWindow(ctx context.Context, mem schema.Memory) error {
+	switch typed := mem.(type) {
+	case *steerConversationMemory:
+		return pruneSteerConversationWindow(ctx, typed.inner)
+	case *chatHistoryPlannerMemory:
+		return pruneSteerConversationWindow(ctx, typed.inner)
+	case *langmemory.ConversationWindowBuffer:
+		messages, err := typed.ChatHistory.Messages(ctx)
+		if err != nil {
+			return err
+		}
+		limit := typed.ConversationWindowSize * 2
+		if limit <= 0 || len(messages) <= limit {
+			return nil
+		}
+		return typed.ChatHistory.SetMessages(ctx, append([]llms.ChatMessage(nil), messages[len(messages)-limit:]...))
+	default:
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary

- Add chat steering endpoints for active runs: `/api/chat/steer` queues one pending steer message for a running request, and `/api/chat/steer/cancel` cancels the pending message before it is consumed.
- Thread `RunRequest.SteerProvider` through runtime execution so the role executor can consume steer messages at safe boundaries after tool calls, execution outputs, and just before final answers.
- Append consumed steer updates as plain human chat messages on the next model turn instead of rewriting them into prompt text.
- Add steer-aware conversation memory so the original user input, any consumed steer updates, and the final assistant output are persisted exactly once in memory/session history.
- Emit `steer` run events when steering is consumed, allowing stream/async clients to render the update and clear pending UI state.
- Update the embedded web UI so the composer switches from Send to Steer during an active run, shows a pending steer banner, supports canceling pending steer messages, blocks attachments while steering, and renders consumed steer messages distinctly in the conversation.
- Cover server queue/cancel behavior, non-running request rejection, web UI controls, tool-call steering, final-answer steering, and persisted steer history with tests.

## Testing

- `git diff --check origin/main...HEAD`
- `go test ./internal/agent` from `src/agent`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for steering messages so users can guide an active chat run
  * API endpoints to queue and cancel steering messages for ongoing runs
  * Web UI: pending-steer panel, Steer/Send composer behavior, and cancel control
  * Agent processes queued steer inputs before subsequent steps, affecting next model/tool calls

* **Tests**
  * Added integration tests validating steer queuing, delivery, persistence, and UI controls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->