### PR TITLE
feat(agent): inject bridge device environment into world state

### DIFF
--- a/src/agent/internal/agent/phone_bridge.go
+++ b/src/agent/internal/agent/phone_bridge.go
@@ -419,7 +419,12 @@ func phoneBridgeRuntimeContext(status PhoneBridgeStatus) string {
 			builder.WriteByte('\n')
 		}
 		if status.Environment != nil {
-			appendPhoneEnvironmentContext(&builder, *status.Environment, status.EnvironmentUpdatedAt)
+			builder.WriteString("- device environment is available in World State for structured use\n")
+			if status.EnvironmentUpdatedAt != nil {
+				builder.WriteString("- environment_updated_at: ")
+				builder.WriteString(status.EnvironmentUpdatedAt.UTC().Format(time.RFC3339))
+				builder.WriteByte('\n')
+			}
 		}
 		builder.WriteString("- The phone companion app is connected. Use open_app as the primary path for opening apps, URLs, deeplinks, and phone dialer screens before falling back to screenshot/HID navigation.\n")
 		builder.WriteString("- clipboard, calendar, contacts, and notification tools are available through the companion app: prefer them over manual UI navigation for reading/writing the system clipboard, creating/querying/deleting system calendar events, managing contacts, or sending notifications.\n")
@@ -429,40 +434,6 @@ func phoneBridgeRuntimeContext(status PhoneBridgeStatus) string {
 	builder.WriteString("- connected: false\n")
 	builder.WriteString("- The phone companion app is not connected. Do not assume open_app, clipboard, calendar, contacts, or notification tools can control the phone; use screenshot plus HID/touch fallback for phone UI tasks, and tell the user when calendar/clipboard/contacts/notification actions cannot be completed without the companion app.")
 	return builder.String()
-}
-
-func appendPhoneEnvironmentContext(builder *strings.Builder, env PhoneEnvironment, updatedAt *time.Time) {
-	builder.WriteString("Phone environment summary:\n")
-	if updatedAt != nil {
-		builder.WriteString("- environment_updated_at: ")
-		builder.WriteString(updatedAt.UTC().Format(time.RFC3339))
-		builder.WriteByte('\n')
-	}
-	appendNonEmptyLine(builder, "- system: ", joinNonEmpty(", ",
-		firstNonEmptyPhoneField(env.SystemName, env.Platform),
-		env.SystemVersion,
-		boolLabel("tablet", env.IsTablet),
-	))
-	appendNonEmptyLine(builder, "- locale: ", joinNonEmpty(", ",
-		env.Locale,
-		fieldLabel("language", env.Language),
-		fieldLabel("region", env.Region),
-		fieldLabel("timezone", env.TimeZone),
-		fieldLabel("utc_offset", env.UTCOffset),
-		boolLabel("24h_clock", env.Uses24HourClock),
-	))
-	appendNonEmptyLine(builder, "- screen: ", formatPhoneScreen(env.Screen))
-	if apps := availableAppNames(env.ThirdPartyApps, 30); len(apps) > 0 {
-		builder.WriteString("- confirmed_launchable_third_party_apps: ")
-		builder.WriteString(strings.Join(apps, ", "))
-		builder.WriteByte('\n')
-		builder.WriteString("- App list is sampled from Aiden's prepared candidates; apps not listed may still be installed or openable. If the user asks for another app, try open_app by mapping/deeplink and verify with screenshot/HID if needed.\n")
-	} else if apps := availableAppNames(env.AvailableApps, 30); len(apps) > 0 {
-		builder.WriteString("- confirmed_launchable_third_party_apps: ")
-		builder.WriteString(strings.Join(apps, ", "))
-		builder.WriteByte('\n')
-		builder.WriteString("- App list is sampled from Aiden's prepared candidates; apps not listed may still be installed or openable. If the user asks for another app, try open_app by mapping/deeplink and verify with screenshot/HID if needed.\n")
-	}
 }
 
 func appendNonEmptyLine(builder *strings.Builder, prefix, value string) {
@@ -513,12 +484,15 @@ func boolLabel(label string, value *bool) string {
 }
 
 func formatPhoneScreen(screen PhoneScreenInfo) string {
-	parts := make([]string, 0, 4)
+	parts := make([]string, 0, 8)
+	if screen.Width != nil && screen.Height != nil {
+		parts = append(parts, fmt.Sprintf("%.2fx%.2f pt/dp", *screen.Width, *screen.Height))
+	}
 	if screen.WidthPixels != nil && screen.HeightPixels != nil {
 		parts = append(parts, fmt.Sprintf("%dx%d px", *screen.WidthPixels, *screen.HeightPixels))
 	}
-	if screen.Width != nil && screen.Height != nil {
-		parts = append(parts, fmt.Sprintf("%.0fx%.0f pt/dp", *screen.Width, *screen.Height))
+	if screen.NativeWidthPixels != nil && screen.NativeHeightPixels != nil {
+		parts = append(parts, fmt.Sprintf("native=%dx%d px", *screen.NativeWidthPixels, *screen.NativeHeightPixels))
 	}
 	if screen.Scale != nil {
 		parts = append(parts, fmt.Sprintf("scale=%.2f", *screen.Scale))
@@ -526,8 +500,14 @@ func formatPhoneScreen(screen PhoneScreenInfo) string {
 	if screen.NativeScale != nil {
 		parts = append(parts, fmt.Sprintf("native_scale=%.2f", *screen.NativeScale))
 	}
+	if screen.Density != nil {
+		parts = append(parts, fmt.Sprintf("density=%.2f", *screen.Density))
+	}
 	if screen.DensityDPI != nil {
 		parts = append(parts, fmt.Sprintf("density_dpi=%d", *screen.DensityDPI))
+	}
+	if screen.ScaledDensity != nil {
+		parts = append(parts, fmt.Sprintf("scaled_density=%.2f", *screen.ScaledDensity))
 	}
 	return strings.Join(parts, ", ")
 }

--- a/src/agent/internal/agent/prompt_test.go
+++ b/src/agent/internal/agent/prompt_test.go
@@ -262,19 +262,19 @@ func TestPhoneBridgeRuntimeContextIncludesPhoneEnvironment(t *testing.T) {
 	})
 
 	for _, want := range []string{
-		"Phone environment summary:",
+		"device environment is available in World State for structured use",
 		"- environment_updated_at: 2026-06-01T02:03:05Z",
-		"- system: iOS, 18.5, tablet=false",
-		"- locale: zh-Hans-CN, language=zh, region=CN, timezone=Asia/Shanghai, utc_offset=+08:00, 24h_clock=true",
-		"- screen: 1179x2556 px, scale=3.00",
-		"- confirmed_launchable_third_party_apps: WeChat, Alipay",
-		"apps not listed may still be installed or openable",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("runtime context missing %q:\n%s", want, got)
 		}
 	}
 	for _, notWant := range []string{
+		"Phone environment summary:",
+		"- system:",
+		"- locale:",
+		"- screen:",
+		"confirmed_launchable_third_party_apps",
 		"User device",
 		"- device:",
 		"- battery:",

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -30,6 +30,7 @@ type roleCollaborativeExecutor struct {
 	OutputKey         string
 	Recorder          *EpisodeRecorder
 	ScreenshotPruning ScreenshotPruningConfig
+	InitialWorldState worldState
 	ForceSimpleLoop   bool
 	SteerProvider     func(context.Context) (RunSteerMessage, bool)
 }
@@ -99,8 +100,14 @@ type roleLoopState struct {
 }
 
 type worldState struct {
-	LatestScreenshot *worldScreenshot
-	Observation      *worldStateObservation
+	LatestScreenshot  *worldScreenshot
+	Observation       *worldStateObservation
+	DeviceEnvironment *worldDeviceEnvironment
+}
+
+type worldDeviceEnvironment struct {
+	PhoneEnvironment
+	UpdatedAt time.Time
 }
 
 type worldScreenshot struct {
@@ -152,6 +159,7 @@ func newRoleCollaborativeExecutor(
 	handler callbacks.Handler,
 	recorder *EpisodeRecorder,
 	screenshotPruning ScreenshotPruningConfig,
+	deviceEnvironment *PhoneEnvironment,
 	steerProviders ...func(context.Context) (RunSteerMessage, bool),
 ) *roleCollaborativeExecutor {
 	if mem == nil {
@@ -161,6 +169,8 @@ func newRoleCollaborativeExecutor(
 	if len(steerProviders) > 0 {
 		steerProvider = steerProviders[0]
 	}
+	world := worldState{}
+	world.UpdateDeviceEnvironment(deviceEnvironment)
 	return &roleCollaborativeExecutor{
 		Model:             model,
 		Profiles:          profiles,
@@ -172,6 +182,7 @@ func newRoleCollaborativeExecutor(
 		OutputKey:         "output",
 		Recorder:          recorder,
 		ScreenshotPruning: screenshotPruning.WithDefaults(),
+		InitialWorldState: world,
 		ForceSimpleLoop:   profiles.Planner.SystemPrompt != "" && !profiles.Planner.Capabilities.CanModifyPlan,
 		SteerProvider:     steerProvider,
 	}
@@ -191,7 +202,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 	if e.ForceSimpleLoop {
 		initialPhase = phaseDefault
 	}
-	state := roleLoopState{Phase: initialPhase, ForceSimpleLoop: e.ForceSimpleLoop}
+	state := roleLoopState{Phase: initialPhase, ForceSimpleLoop: e.ForceSimpleLoop, World: e.InitialWorldState}
 	for i := 0; i < e.MaxIterations; i++ {
 		switch state.Phase {
 		case phaseDecision, phaseDefault, phasePlan:
@@ -993,6 +1004,41 @@ func buildRoleUserMessageParts(input string, attachments []InputAttachment, worl
 
 func writeWorldState(builder *strings.Builder, world worldState) {
 	builder.WriteString("\n\nWorld State (shared across planner, executor, and verifier):\n")
+	if world.DeviceEnvironment != nil {
+		env := world.DeviceEnvironment
+		builder.WriteString("- Device environment: available")
+		if platform := strings.TrimSpace(env.Platform); platform != "" {
+			builder.WriteString(fmt.Sprintf(" platform=%s", platform))
+		}
+		if system := strings.TrimSpace(firstNonEmptyPhoneField(env.SystemName, env.Platform)); system != "" {
+			builder.WriteString(fmt.Sprintf(" system=%s", system))
+		}
+		if version := strings.TrimSpace(env.SystemVersion); version != "" {
+			builder.WriteString(fmt.Sprintf(" version=%s", version))
+		}
+		if env.IsTablet != nil {
+			builder.WriteString(fmt.Sprintf(" tablet=%t", *env.IsTablet))
+		}
+		if !env.UpdatedAt.IsZero() {
+			builder.WriteString(fmt.Sprintf(" updated_at=%s", env.UpdatedAt.UTC().Format(time.RFC3339)))
+		}
+		builder.WriteByte('\n')
+		appendWorldStateLine(builder, "- Device source: ", joinNonEmpty(", ", env.Source, fieldLabel("captured_at", env.CapturedAt)))
+		appendWorldStateLine(builder, "- Device locale: ", joinNonEmpty(", ", env.Locale, fieldLabel("language", env.Language), fieldLabel("region", env.Region), fieldLabel("timezone", env.TimeZone)))
+		appendWorldStateLine(builder, "- Device time: ", joinNonEmpty(", ", fieldLabel("utc_offset", env.UTCOffset), intLabel("utc_offset_minutes", env.UTCOffsetMinutes), boolLabel("24h_clock", env.Uses24HourClock)))
+		appendWorldStateLine(builder, "- Device hardware: ", joinNonEmpty(", ", fieldLabel("manufacturer", env.Manufacturer), fieldLabel("brand", env.Brand), fieldLabel("model", env.Model), fieldLabel("device_name", env.DeviceName)))
+		appendWorldStateLine(builder, "- Device screen: ", formatPhoneScreen(env.Screen))
+		appendWorldStateLine(builder, "- Device battery: ", formatPhoneBattery(env.Battery))
+		if apps := availableAppNames(env.ThirdPartyApps, 12); len(apps) > 0 {
+			builder.WriteString("- Confirmed third-party apps: ")
+			builder.WriteString(strings.Join(apps, ", "))
+			builder.WriteByte('\n')
+		} else if apps := availableAppNames(env.AvailableApps, 12); len(apps) > 0 {
+			builder.WriteString("- Confirmed third-party apps: ")
+			builder.WriteString(strings.Join(apps, ", "))
+			builder.WriteByte('\n')
+		}
+	}
 	if world.LatestScreenshot == nil {
 		builder.WriteString("- Latest screenshot: none yet.\n")
 	} else {
@@ -1053,6 +1099,23 @@ func writeWorldState(builder *strings.Builder, world worldState) {
 			builder.WriteByte('\n')
 		}
 	}
+}
+
+func appendWorldStateLine(builder *strings.Builder, prefix, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	builder.WriteString(prefix)
+	builder.WriteString(value)
+	builder.WriteByte('\n')
+}
+
+func intLabel(label string, value *int) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s=%d", label, *value)
 }
 
 func writeRequestObjectiveAndCriteria(builder *strings.Builder, inputs map[string]string, state roleLoopState) {
@@ -1255,6 +1318,33 @@ func (s *worldState) UpdateObservedState(observed observedWorldState, source Rol
 		SourceRole:         source,
 		ObservedAt:         time.Now(),
 		ScreenshotStep:     step,
+	}
+}
+
+func (s *worldState) UpdateDeviceEnvironment(env *PhoneEnvironment) {
+	if env == nil {
+		return
+	}
+	cloned := clonePhoneEnvironment(*env)
+	now := time.Now()
+	s.DeviceEnvironment = &worldDeviceEnvironment{
+		PhoneEnvironment: cloned,
+		UpdatedAt:        now,
+	}
+	platform := normalizeObservedWorldState(observedWorldState{Platform: cloned.Platform}).Platform
+	if platform == "" {
+		return
+	}
+	if s.Observation == nil {
+		s.Observation = &worldStateObservation{
+			observedWorldState: observedWorldState{Platform: platform, Confidence: 1},
+			SourceRole:         RoleVerifier,
+			ObservedAt:         now,
+		}
+		return
+	}
+	if strings.TrimSpace(s.Observation.Platform) == "" {
+		s.Observation.Platform = platform
 	}
 }
 

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -43,6 +43,7 @@ func TestEnterPlanModePreservesToolSteps(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{
 		Phase: phaseDefault,
@@ -80,6 +81,7 @@ func TestCommitPlanOnlyInPlanMode(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{Phase: phaseDefault}
 	turn := executor.handlePlannerMetaTool(phaseDefault, state, schema.AgentAction{
@@ -109,6 +111,7 @@ func TestDecisionPhaseEntersPlanModeBeforeDomainTools(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{Phase: phaseDecision}
 	toolSpecs := NewToolSpecs([]langtools.Tool{tool})
@@ -152,6 +155,7 @@ func TestDecisionPhaseUseSimpleModeSwitchesToDefaultWithoutToolStep(t *testing.T
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{Phase: phaseDecision}
 	inputs := map[string]string{"input": "simple task", "history": ""}
@@ -186,6 +190,7 @@ func TestRoutePolicyOverridesSimpleForMultiStageRequests(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{Phase: phaseDecision}
 	inputs := map[string]string{
@@ -220,6 +225,7 @@ func TestPlanRequiresCommitBeforeExecutionToolUse(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{Phase: phasePlan, PlanCommitRequired: true}
 	toolSpecs := NewToolSpecs([]langtools.Tool{tool})
@@ -258,6 +264,7 @@ func TestAutoPlanRejectsCancelBeforeCommit(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{Phase: phasePlan, PlanCommitRequired: true}
 	inputs := map[string]string{"input": "multi-step task", "history": ""}
@@ -293,6 +300,7 @@ func TestPlanModeAllowsReadOnlyToolBeforeCommit(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{Phase: phasePlan, PlanCommitRequired: true}
 	toolSpecs := NewToolSpecs([]langtools.Tool{tool})
@@ -332,6 +340,7 @@ func TestPlanModeRejectsDomainToolsAfterCommit(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{Phase: phasePlan, PlanCommitted: true}
 	toolSpecs := NewToolSpecs([]langtools.Tool{tool})
@@ -367,6 +376,7 @@ func TestPlanModeAllowsEvidenceBackedFinalAnswer(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{
 		Phase:         phasePlan,
@@ -398,6 +408,7 @@ func TestCommitPlanEntersExecutionMode(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{Phase: phasePlan, PlanCommitRequired: true}
 	turn := executor.handlePlannerMetaTool(phasePlan, state, schema.AgentAction{
@@ -450,6 +461,7 @@ func TestCancelPlanReturnsToDefaultMode(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{
 		Phase:     phasePlan,
@@ -497,6 +509,7 @@ func TestFinishStepEntersVerifierReview(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{
 		Phase:               phaseExecution,
@@ -526,6 +539,7 @@ func TestFinishStepStoresKeyInfo(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{
 		Phase:               phaseExecution,
@@ -561,6 +575,7 @@ func TestAbortStepEntersVerifierReview(t *testing.T) {
 		nil,
 		nil,
 		ScreenshotPruningConfig{},
+		nil,
 	)
 	state := &roleLoopState{
 		Phase:               phaseExecution,

--- a/src/agent/internal/agent/role_profile_test.go
+++ b/src/agent/internal/agent/role_profile_test.go
@@ -859,3 +859,66 @@ func finalHumanMessageHasTextBeforeImage(messages []llms.MessageContent, imageUR
 	}
 	return false
 }
+
+func TestWriteWorldStateIncludesDeviceEnvironment(t *testing.T) {
+	state := worldState{}
+	isTablet := true
+	state.UpdateDeviceEnvironment(&PhoneEnvironment{
+		CapturedAt:       "2026-06-15T01:41:43.469Z",
+		Source:           "aiden-app",
+		Platform:         "android",
+		SystemName:       "Android",
+		SystemVersion:    "15",
+		Locale:           "zh_CN",
+		Language:         "zh",
+		Region:           "CN",
+		TimeZone:         "Asia/Shanghai",
+		UTCOffsetMinutes: intPtr(480),
+		UTCOffset:        "+08:00",
+		IsTablet:         &isTablet,
+		Manufacturer:     "LENOVO",
+		Brand:            "Lenovo",
+		Model:            "TB322FC",
+		DeviceName:       "阿兴",
+		Screen: PhoneScreenInfo{
+			Width:         float64Ptr(692.3636363636),
+			Height:        float64Ptr(1105.4545454545),
+			WidthPixels:   intPtr(1904),
+			HeightPixels:  intPtr(3040),
+			Scale:         float64Ptr(2.75),
+			Density:       float64Ptr(2.75),
+			DensityDPI:    intPtr(440),
+			ScaledDensity: float64Ptr(2.75),
+		},
+		Battery: PhoneBatteryInfo{
+			Level:    float64Ptr(0.94),
+			Charging: boolPtrRoleProfile(true),
+			State:    "charging",
+		},
+		ThirdPartyApps: []AvailableAppInfo{{Name: "微信", Available: true}},
+	})
+
+	var builder strings.Builder
+	writeWorldState(&builder, state)
+	text := builder.String()
+	for _, want := range []string{
+		"Device environment: available platform=android system=Android version=15 tablet=true",
+		"Device source: aiden-app, captured_at=2026-06-15T01:41:43.469Z",
+		"Device locale: zh_CN, language=zh, region=CN, timezone=Asia/Shanghai",
+		"Device time: utc_offset=+08:00, utc_offset_minutes=480",
+		"Device hardware: manufacturer=LENOVO, brand=Lenovo, model=TB322FC, device_name=阿兴",
+		"Device screen: 692.36x1105.45 pt/dp, 1904x3040 px, scale=2.75, density=2.75, density_dpi=440, scaled_density=2.75",
+		"Device battery: level=94%, charging=true, state=charging",
+		"Confirmed third-party apps: 微信",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("world state text missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func intPtr(v int) *int { return &v }
+
+func float64Ptr(v float64) *float64 { return &v }
+
+func boolPtrRoleProfile(v bool) *bool { return &v }

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -55,10 +55,11 @@ type Runtime struct {
 }
 
 type RunRequest struct {
-	Input       string
-	Attachments []InputAttachment
-	Skills      []string
-	EpisodeID   string
+	Input             string
+	Attachments       []InputAttachment
+	Skills            []string
+	EpisodeID         string
+	DeviceEnvironment *PhoneEnvironment
 	// RuntimeContext is dynamic per-turn system context, such as connected
 	// hardware/app state. It is not persisted as user configuration.
 	RuntimeContext string
@@ -537,7 +538,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			steerStatus = status
 		}
 	}
-	executor := newRoleCollaborativeExecutor(model, profiles, availableTools, plannerMemory, maxIterations, req.Attachments, executorHandler, episodeRecorder, r.config.ScreenshotPruningOrDefault(), req.SteerProvider)
+	executor := newRoleCollaborativeExecutor(model, profiles, availableTools, plannerMemory, maxIterations, req.Attachments, executorHandler, episodeRecorder, r.config.ScreenshotPruningOrDefault(), req.DeviceEnvironment, req.SteerProvider)
 
 	output, err := chains.Run(ctx, executor, normalizedInput, callOptions...)
 	if err != nil {

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -713,12 +713,13 @@ func (s *Server) handleChatAsync(
 		}
 
 		runReq := RunRequest{
-			Input:          inputText,
-			Attachments:    runAttachments,
-			Skills:         req.Skills,
-			EpisodeID:      userMsg.EpisodeID,
-			RuntimeContext: s.runtimeContext(),
-			EventHandler:   eventHandler,
+			Input:             inputText,
+			Attachments:       runAttachments,
+			Skills:            req.Skills,
+			EpisodeID:         userMsg.EpisodeID,
+			DeviceEnvironment: s.bridgeEnvironment(),
+			RuntimeContext:    s.runtimeContext(),
+			EventHandler:      eventHandler,
 			SteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
 				return s.consumePendingSteer(requestID)
 			},
@@ -923,11 +924,12 @@ func (s *Server) handleChatSync(
 	s.appendHistory(userMsg)
 
 	runReq := RunRequest{
-		Input:          inputText,
-		Attachments:    runAttachments,
-		Skills:         req.Skills,
-		EpisodeID:      episodeID,
-		RuntimeContext: s.runtimeContext(),
+		Input:             inputText,
+		Attachments:       runAttachments,
+		Skills:            req.Skills,
+		EpisodeID:         episodeID,
+		DeviceEnvironment: s.bridgeEnvironment(),
+		RuntimeContext:    s.runtimeContext(),
 		EventHandler: func(event RunEvent) {
 			eventEpisodeID := event.EpisodeID
 			if eventEpisodeID == "" {
@@ -1026,6 +1028,18 @@ func (s *Server) runtimeContext() string {
 	return phoneBridgeRuntimeContext(s.bridge.Status())
 }
 
+func (s *Server) bridgeEnvironment() *PhoneEnvironment {
+	if s == nil || s.bridge == nil {
+		return nil
+	}
+	status := s.bridge.Status()
+	if status.Environment == nil {
+		return nil
+	}
+	env := clonePhoneEnvironment(*status.Environment)
+	return &env
+}
+
 func wantsChatStream(r *http.Request) bool {
 	return strings.Contains(r.Header.Get("Accept"), "application/x-ndjson") ||
 		strings.EqualFold(r.Header.Get("X-Aiden-Stream"), "ndjson") ||
@@ -1085,11 +1099,12 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 	s.appendHistory(userMessage)
 
 	result, err := s.runtime.Run(ctx, RunRequest{
-		Input:          inputText,
-		Attachments:    runAttachments,
-		Skills:         req.Skills,
-		EpisodeID:      episodeID,
-		RuntimeContext: s.runtimeContext(),
+		Input:             inputText,
+		Attachments:       runAttachments,
+		Skills:            req.Skills,
+		EpisodeID:         episodeID,
+		DeviceEnvironment: s.bridgeEnvironment(),
+		RuntimeContext:    s.runtimeContext(),
 		SteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
 			return s.consumePendingSteer(req.RequestID)
 		},


### PR DESCRIPTION
## Summary
- inject bridge app device environment into the agent world state
- keep runtime context minimal and point structured consumers to world state
- preserve existing screenshot/context fallback behavior when the bridge app is unavailable
- keep quick_action behavior unchanged by continuing to require explicit platform input

## Changes
- add `DeviceEnvironment` to `RunRequest`
- pass the current bridge environment from `Server` into each run
- extend `worldState` and `writeWorldState()` to include structured device environment details
- reduce phone bridge runtime context to a short connection summary
- expand screen formatting used in device environment output
- update agent tests for runtime context and world state behavior

## Testing
- `go test ./internal/agent/...`
- deployed updated `build/bin/agent` to device
- manually verified agent responses with bridge app connected
- manually verified no regression in behavior during normal chat usage

## Notes
- long app lists are intentionally excluded from world state to avoid prompt bloat
- device environment remains available only for runs where the bridge app is connected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device environment snapshots with timestamps are now integrated into agent world state for structured context
  * Screen information now includes comprehensive metrics: scale, native scale, density, and pixel dimensions
  * Per-request device environment support for all chat execution types

* **Improvements**
  * Simplified device environment context reporting in phone bridge notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->