### PR TITLE
fix(benchmark): recover MobileGym suite traces

### DIFF
--- a/benchmark/mobilegym/adapter/aiden_go_agent.py
+++ b/benchmark/mobilegym/adapter/aiden_go_agent.py
@@ -224,7 +224,7 @@ class AidenGoAgent(_MobileGymBaseAgent):
                 cleanup_errors=cleanup_errors,
             )
 
-        return complete_action(_response_text(chat_result))
+        return complete_chat_action(chat_result)
 
     def _task_input(self) -> str:
         task = self.task
@@ -388,6 +388,18 @@ def complete_action(response: str) -> Any:
         return action_cls(action_type=action_type, data=data)
     except TypeError:
         return action_cls(action_type, data)
+
+
+def complete_chat_action(payload: Any) -> Any:
+    response = _response_text(payload)
+    action = complete_action(response)
+    data = getattr(action, "data", None)
+    if isinstance(data, dict):
+        data["aiden_last_response"] = response
+        history = _history_payload(payload)
+        if history:
+            data["aiden_last_chat_history"] = history
+    return action
 
 
 def _action_classes() -> tuple[type[Any], Any]:

--- a/benchmark/mobilegym/docker/parallel_run.sh
+++ b/benchmark/mobilegym/docker/parallel_run.sh
@@ -55,13 +55,14 @@ fi
 
 usage() {
     cat <<'EOF'
-Usage: ./parallel_run.sh <task-id> [task-id...] | --suite <suite> [--limit N] | --suites <suite-a,suite-b> [--limit N] | --aiden-suite <name> [--limit N]
+Usage: ./parallel_run.sh <task-id> [task-id...] | --suite <suite> [--limit N] | --suites <suite-a,suite-b> [--limit N] | --aiden-suite <name> [--limit N] | --aiden-suites <name-a,name-b> [--limit N]
 
 Examples:
   ./parallel_run.sh clock.CountAlarms clock.ToggleAlarm
   PARALLEL=4 ./parallel_run.sh --suite phone_control_v1
   PARALLEL=2 MAX_JOBS=2 ./parallel_run.sh --suites clock,phone_control_v1
   PARALLEL=4 ./parallel_run.sh --aiden-suite memory_v1
+  PARALLEL=4 ./parallel_run.sh --aiden-suites memory_v1,perception/perception_v1
 EOF
 }
 
@@ -203,6 +204,20 @@ should_try_cn_compose() {
     [[ -f "$SCRIPT_DIR/docker-compose.cn.yml" ]]
 }
 
+run_report() {
+    local batch_dir="$1"
+    if command -v uv >/dev/null 2>&1; then
+        (cd "$SCRIPT_DIR/../.." && uv run python -m mobilegym.report "$batch_dir")
+        return $?
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        (cd "$SCRIPT_DIR/../.." && python3 -m mobilegym.report "$batch_dir")
+        return $?
+    fi
+    echo "Error: neither uv nor python3 found; cannot generate MobileGym report." >&2
+    return 127
+}
+
 write_preflight_failure_report() {
     local message="$1"
     local suite="preflight"
@@ -217,7 +232,7 @@ EOF
     printf '%s\n' "$message" > "$shard_dir/runner.log"
     update_shard_json_final "$shard_dir/shard.json" 2 0
     set +e
-    (cd "$SCRIPT_DIR/../.." && uv run python -m mobilegym.report "$BATCH_DIR")
+    run_report "$BATCH_DIR"
     set -e
 }
 
@@ -680,6 +695,18 @@ if [[ "$1" == "--aiden-suite" ]]; then
     for i in $(seq 0 $((PARALLEL - 1))); do
         WORK_ITEMS+=("aiden_suite|$2|$i|$PARALLEL||shard-$i")
     done
+elif [[ "$1" == "--aiden-suites" ]]; then
+    if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "Error: --aiden-suites requires a comma-separated suite list" >&2
+        exit 2
+    fi
+    suites="${2//,/ }"
+    for suite in $suites; do
+        validate_suite_name "$suite"
+        for i in $(seq 0 $((PARALLEL - 1))); do
+            WORK_ITEMS+=("aiden_suite|$suite|$i|$PARALLEL||shard-$i")
+        done
+    done
 elif [[ "$1" == "--suite" ]]; then
     if [[ $# -lt 2 || -z "$2" ]]; then
         echo "Error: --suite requires a suite name" >&2
@@ -776,7 +803,7 @@ while [[ ${#PIDS[@]} -gt 0 ]]; do
 done
 
 set +e
-(cd "$SCRIPT_DIR/../.." && uv run python -m mobilegym.report "$BATCH_DIR")
+run_report "$BATCH_DIR"
 report_status=$?
 set -e
 if [[ $report_status -ne 0 ]]; then

--- a/benchmark/mobilegym/report.py
+++ b/benchmark/mobilegym/report.py
@@ -15,6 +15,7 @@ TASK_STATUSES = ("passed", "failed", "timeout", "error", "unknown", "worker_fail
 SUMMARY_STATUSES = TASK_STATUSES + ("empty",)
 _ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 _COMPOSE_TOOL_CALL_RE = re.compile(r"Tool call:\s+name=(?P<name>\S+)\s+input=(?P<input>.*?)(?:\s+description=|$)")
+_COMPOSE_START_RUN_RE = re.compile(r"Starting agent run:\s+input=(?P<input>\"(?:\\.|[^\"\\])*\")")
 
 
 def generate_reports(batch_dir: str | Path) -> dict[str, Any]:
@@ -151,7 +152,9 @@ def _normalize_shard(shard_dir: Path) -> tuple[list[dict[str, Any]], dict[str, A
     console_links = [path.relative_to(shard_dir).as_posix() for path in sorted(raw_dir.glob("**/console.log"))]
 
     selected_task_ids = [str(task_id) for task_id in metadata.get("selected_task_ids") or []]
-    compose_actions_by_task = _read_compose_tool_calls(shard_dir / "compose.log", selected_task_ids)
+    task_rows = dict(results)
+    task_rows.update(errors)
+    compose_actions_by_task = _read_compose_tool_calls(shard_dir / "compose.log", selected_task_ids, task_rows)
     selected_task_count = int(metadata.get("selected_task_count") or len(selected_task_ids))
     exit_code = int(metadata.get("exit_code") or 0)
     shard_name = shard_dir.name
@@ -269,40 +272,70 @@ def _read_bridge_actions(raw_dir: Path) -> dict[str, list[dict[str, Any]]]:
     return actions
 
 
-def _read_compose_tool_calls(compose_path: Path, task_ids: list[str]) -> dict[str, list[dict[str, Any]]]:
+def _read_compose_tool_calls(
+    compose_path: Path,
+    task_ids: list[str],
+    task_rows: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, list[dict[str, Any]]]:
     if not task_ids:
         return {}
     segments = _compose_tool_call_segments(compose_path)
     if not segments:
         return {}
-    if len(segments) >= len(task_ids):
-        segments = segments[-len(task_ids):]
     result: dict[str, list[dict[str, Any]]] = {}
-    for task_id, actions in zip(task_ids, segments):
+    used_segment_indexes: set[int] = set()
+    task_rows = task_rows or {}
+    for task_id in task_ids:
+        prompt = _normalize_compose_text(_task_prompt_for_compose(task_rows.get(task_id)))
+        if not prompt:
+            continue
+        for index, segment in enumerate(segments):
+            if index in used_segment_indexes:
+                continue
+            request = _normalize_compose_text(str(segment.get("request") or ""))
+            if not _compose_request_matches_task(request, prompt):
+                continue
+            actions = [entry for entry in segment.get("actions") or [] if isinstance(entry, dict)]
+            if actions:
+                result[task_id] = actions
+            used_segment_indexes.add(index)
+            break
+    if result or len(segments) != len(task_ids):
+        return result
+    for task_id, segment in zip(task_ids, segments, strict=True):
+        actions = [entry for entry in segment.get("actions") or [] if isinstance(entry, dict)]
         if actions:
             result[task_id] = actions
     return result
 
 
-def _compose_tool_call_segments(compose_path: Path) -> list[list[dict[str, Any]]]:
+def _compose_tool_call_segments(compose_path: Path) -> list[dict[str, Any]]:
     try:
         lines = compose_path.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError:
         return []
-    segments: list[list[dict[str, Any]]] = []
-    current: list[dict[str, Any]] | None = None
+    segments: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
     for raw_line in lines:
         line = _ANSI_RE.sub("", raw_line)
         if "Chat request (" in line:
-            current = []
+            current = {"request": _compose_chat_request_text(line), "actions": []}
             segments.append(current)
             continue
         if current is None:
             continue
+        start_match = _COMPOSE_START_RUN_RE.search(line)
+        if start_match:
+            current["request"] = _jsonish(start_match.group("input"))
+            continue
         match = _COMPOSE_TOOL_CALL_RE.search(line)
         if not match:
             continue
-        current.append(
+        actions = current.setdefault("actions", [])
+        if not isinstance(actions, list):
+            actions = []
+            current["actions"] = actions
+        actions.append(
             {
                 "tool_name": match.group("name"),
                 "tool_input": _jsonish(match.group("input").strip()),
@@ -310,6 +343,38 @@ def _compose_tool_call_segments(compose_path: Path) -> list[list[dict[str, Any]]
             }
         )
     return segments
+
+
+def _compose_chat_request_text(line: str) -> str:
+    marker = "Chat request ("
+    start = line.find(marker)
+    if start < 0:
+        return ""
+    text = line[start + len(marker):]
+    close = text.find("): ")
+    if close >= 0:
+        text = text[close + len("): "):]
+    return re.sub(r"\s+attachments=\d+\s*$", "", text).strip()
+
+
+def _task_prompt_for_compose(row: dict[str, Any] | None) -> str:
+    if not isinstance(row, dict):
+        return ""
+    return _first_text(row, "task_name", "prompt", "instruction", "goal")
+
+
+def _normalize_compose_text(text: str) -> str:
+    return " ".join(str(text or "").split())
+
+
+def _compose_request_matches_task(request: str, prompt: str) -> bool:
+    if not request or not prompt:
+        return False
+    if request == prompt:
+        return True
+    if len(prompt) >= 80 and prompt in request:
+        return True
+    return len(request) >= 80 and request in prompt
 
 
 def _task_id_from_artifact_dir(path: Path) -> str:
@@ -512,7 +577,8 @@ def _drawer_html(title: str, summary: dict[str, Any], rows: list[dict[str, Any]]
     def pct(n: int) -> str:
         return f"{(n / total * 100) if total else 0:.4f}"
 
-    tasks = [_drawer_task(row) for row in rows]
+    display_rows = [row for row in rows if row.get("status") != "empty"]
+    tasks = [_drawer_task(row) for row in display_rows]
     tasks_json = json.dumps(tasks, ensure_ascii=False, indent=2).replace("</", r"<\/")
     rows_html = "".join(_drawer_row_html(index, task) for index, task in enumerate(tasks))
     return HTML_TEMPLATE.format(
@@ -550,7 +616,7 @@ def _drawer_task(row: dict[str, Any]) -> dict[str, Any]:
     description = _first_text(result, "description_for_judge", "task_name", "prompt", "instruction", "goal") or str(row.get("reason") or "")
     response = _first_text(execution, "agent_answer", "agent_message") or _first_text(result, "aiden_last_response", "response", "answer")
     wall_ms = _runtime_ms(result, execution)
-    tool_calls_detail = _tool_calls_detail(history_tool_calls, actions) or links_text
+    tool_calls_detail = _tool_calls_detail(history_tool_calls, actions)
     tool_calls_count = len(history_tool_calls) if history_tool_calls else len(actions)
     errors = []
     if status in {"error", "failed", "timeout", "worker_failed", "unknown"}:
@@ -575,6 +641,7 @@ def _drawer_task(row: dict[str, Any]) -> dict[str, Any]:
         "prompt": prompt,
         "response": response,
         "tool_calls_detail": tool_calls_detail,
+        "artifacts_detail": links_text,
         "rubric": rubric,
         "hard_assertions": hard_assertions,
         "errors": _dedupe_errors(errors),

--- a/benchmark/mobilegym/report.py
+++ b/benchmark/mobilegym/report.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import html
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,8 @@ from runner.html_report import HTML_TEMPLATE
 
 TASK_STATUSES = ("passed", "failed", "timeout", "error", "unknown", "worker_failed")
 SUMMARY_STATUSES = TASK_STATUSES + ("empty",)
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_COMPOSE_TOOL_CALL_RE = re.compile(r"Tool call:\s+name=(?P<name>\S+)\s+input=(?P<input>.*?)(?:\s+description=|$)")
 
 
 def generate_reports(batch_dir: str | Path) -> dict[str, Any]:
@@ -148,6 +151,7 @@ def _normalize_shard(shard_dir: Path) -> tuple[list[dict[str, Any]], dict[str, A
     console_links = [path.relative_to(shard_dir).as_posix() for path in sorted(raw_dir.glob("**/console.log"))]
 
     selected_task_ids = [str(task_id) for task_id in metadata.get("selected_task_ids") or []]
+    compose_actions_by_task = _read_compose_tool_calls(shard_dir / "compose.log", selected_task_ids)
     selected_task_count = int(metadata.get("selected_task_count") or len(selected_task_ids))
     exit_code = int(metadata.get("exit_code") or 0)
     shard_name = shard_dir.name
@@ -211,7 +215,7 @@ def _normalize_shard(shard_dir: Path) -> tuple[list[dict[str, Any]], dict[str, A
                 "reason": reason,
                 "result": result or {},
                 "error": error or {},
-                "actions": actions_by_task.get(task_id, []),
+                "actions": actions_by_task.get(task_id) or compose_actions_by_task.get(task_id, []),
                 "links": links,
             }
         )
@@ -263,6 +267,49 @@ def _read_bridge_actions(raw_dir: Path) -> dict[str, list[dict[str, Any]]]:
             continue
         actions.setdefault(task_id, []).extend(entry for entry in payload if isinstance(entry, dict))
     return actions
+
+
+def _read_compose_tool_calls(compose_path: Path, task_ids: list[str]) -> dict[str, list[dict[str, Any]]]:
+    if not task_ids:
+        return {}
+    segments = _compose_tool_call_segments(compose_path)
+    if not segments:
+        return {}
+    if len(segments) >= len(task_ids):
+        segments = segments[-len(task_ids):]
+    result: dict[str, list[dict[str, Any]]] = {}
+    for task_id, actions in zip(task_ids, segments):
+        if actions:
+            result[task_id] = actions
+    return result
+
+
+def _compose_tool_call_segments(compose_path: Path) -> list[list[dict[str, Any]]]:
+    try:
+        lines = compose_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    segments: list[list[dict[str, Any]]] = []
+    current: list[dict[str, Any]] | None = None
+    for raw_line in lines:
+        line = _ANSI_RE.sub("", raw_line)
+        if "Chat request (" in line:
+            current = []
+            segments.append(current)
+            continue
+        if current is None:
+            continue
+        match = _COMPOSE_TOOL_CALL_RE.search(line)
+        if not match:
+            continue
+        current.append(
+            {
+                "tool_name": match.group("name"),
+                "tool_input": _jsonish(match.group("input").strip()),
+                "source": "compose.log",
+            }
+        )
+    return segments
 
 
 def _task_id_from_artifact_dir(path: Path) -> str:
@@ -504,7 +551,7 @@ def _drawer_task(row: dict[str, Any]) -> dict[str, Any]:
     response = _first_text(execution, "agent_answer", "agent_message") or _first_text(result, "aiden_last_response", "response", "answer")
     wall_ms = _runtime_ms(result, execution)
     tool_calls_detail = _tool_calls_detail(history_tool_calls, actions) or links_text
-    tool_calls_count = len(history_tool_calls) if history_tool_calls else len(actions) if actions else int(execution.get("steps") or result.get("steps") or 0)
+    tool_calls_count = len(history_tool_calls) if history_tool_calls else len(actions)
     errors = []
     if status in {"error", "failed", "timeout", "worker_failed", "unknown"}:
         errors.append([status, str(row.get("reason") or status)])

--- a/benchmark/mobilegym/scripts/install_local_launcher.sh
+++ b/benchmark/mobilegym/scripts/install_local_launcher.sh
@@ -19,6 +19,10 @@ fi
 mkdir -p "$(dirname "$PLIST")" "$LOG_DIR"
 
 ENVIRONMENT_XML=""
+LAUNCHER_PATH="/usr/local/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+ENVIRONMENT_XML="${ENVIRONMENT_XML}    <key>PATH</key>
+    <string>${LAUNCHER_PATH}</string>
+"
 if [[ -n "${MOBILEGYM_DOCKER_PROXY:-}" ]]; then
   ENVIRONMENT_XML="${ENVIRONMENT_XML}    <key>MOBILEGYM_DOCKER_PROXY</key>
     <string>${MOBILEGYM_DOCKER_PROXY}</string>

--- a/benchmark/mobilegym/scripts/local_launcher.py
+++ b/benchmark/mobilegym/scripts/local_launcher.py
@@ -13,7 +13,7 @@ import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import quote, unquote, urlparse
 from urllib.request import Request, urlopen
 
 
@@ -31,6 +31,11 @@ TAIL_BYTES = 64 * 1024
 
 _SAFE_SUITE_SEGMENT = re.compile(r"^[A-Za-z0-9_.\-]+$")
 _SAFE_RUN_ID = re.compile(r"^[A-Za-z0-9_\-]+$")
+COMMON_CLI_PATHS = [
+    "/usr/local/bin",
+    "/opt/homebrew/bin",
+    "/Applications/Docker.app/Contents/Resources/bin",
+]
 
 
 class LauncherError(RuntimeError):
@@ -59,6 +64,33 @@ def valid_suite_name(suite: str) -> bool:
 
 def is_safe_run_id(run_id: str) -> bool:
     return bool(run_id and _SAFE_RUN_ID.match(run_id))
+
+
+def selected_suites(payload: dict[str, Any]) -> list[str]:
+    suites_value = payload.get("suites")
+    if suites_value is not None:
+        if not isinstance(suites_value, list):
+            raise LauncherError("suites must be a JSON array")
+        suites = [str(item).strip() for item in suites_value]
+    else:
+        suites = [str(payload.get("suite") or "").strip()]
+
+    suites = [suite for suite in suites if suite]
+    if not suites:
+        raise LauncherError("missing suite field")
+    for suite in suites:
+        if not valid_suite_name(suite):
+            raise LauncherError(f"invalid suite name: {suite!r}")
+    return suites
+
+
+def add_common_cli_paths(env: dict[str, str]) -> None:
+    current = env.get("PATH") or "/usr/bin:/bin:/usr/sbin:/sbin"
+    parts = [part for part in current.split(os.pathsep) if part]
+    for path in reversed(COMMON_CLI_PATHS):
+        if path not in parts:
+            parts.insert(0, path)
+    env["PATH"] = os.pathsep.join(parts)
 
 
 def scan_suites(benchmark_root: str | Path = BENCHMARK_ROOT) -> list[dict[str, Any]]:
@@ -125,10 +157,10 @@ def build_run_command(
     payload: dict[str, Any] | None = None,
 ) -> RunCommand:
     payload = payload or {}
-    suite = str(payload.get("suite") or "")
+    suites = selected_suites(payload)
     suite_type = str(payload.get("suite_type") or "mobilegym_builtin")
-    if not valid_suite_name(suite):
-        raise LauncherError(f"invalid suite name: {suite!r}")
+    if len(suites) > 1 and suite_type not in {"mobilegym_builtin", "aiden"}:
+        raise LauncherError("multiple suites are only supported for mobilegym_builtin or aiden")
 
     root = Path(benchmark_root)
     docker_dir = root / "mobilegym" / "docker"
@@ -137,9 +169,15 @@ def build_run_command(
         raise LauncherError(f"missing runner script: {runner}")
 
     if suite_type == "aiden":
-        argv = ["./parallel_run.sh", "--aiden-suite", suite]
+        if len(suites) > 1:
+            argv = ["./parallel_run.sh", "--aiden-suites", ",".join(suites)]
+        else:
+            argv = ["./parallel_run.sh", "--aiden-suite", suites[0]]
     elif suite_type in {"mobilegym_builtin", ""}:
-        argv = ["./parallel_run.sh", "--suite", suite]
+        if len(suites) > 1:
+            argv = ["./parallel_run.sh", "--suites", ",".join(suites)]
+        else:
+            argv = ["./parallel_run.sh", "--suite", suites[0]]
     else:
         raise LauncherError(f"unknown suite_type: {suite_type!r}")
 
@@ -151,6 +189,7 @@ def build_run_command(
     if parallel < 1:
         parallel = 1
     env = os.environ.copy()
+    add_common_cli_paths(env)
     env.update(model_config_from_payload(payload))
     env["PARALLEL"] = str(parallel)
     env["MOBILEGYM_RUNS_ROOT"] = str(root / "runs" / "mobilegym")
@@ -165,6 +204,7 @@ def start_run(benchmark_root: Path, payload: dict[str, Any]) -> dict[str, Any]:
             raise LauncherError("MobileGym benchmark is already running")
 
         command = build_run_command(benchmark_root, payload)
+        suites = selected_suites(payload)
         validate_model_environment(command.env)
         LOG_PATH.write_text("Starting Mac-local MobileGym benchmark...\n", encoding="utf-8")
         log_file = LOG_PATH.open("ab")
@@ -187,7 +227,8 @@ def start_run(benchmark_root: Path, payload: dict[str, Any]) -> dict[str, Any]:
                 "status": "running",
                 "mode": "mobilegym",
                 "run_id": command.env.get("MOBILEGYM_BATCH_ID", ""),
-                "suite": payload.get("suite"),
+                "suite": ",".join(suites),
+                "suites": suites,
                 "suite_type": payload.get("suite_type") or "mobilegym_builtin",
                 "parallel": int(payload.get("parallel") or 4),
                 "total": int(payload.get("limit") or 0),
@@ -259,24 +300,133 @@ def list_runs(benchmark_root: Path) -> list[dict[str, Any]]:
         summary = read_json_file(runs_dir / run_id / "summary.json")
         state_for_run = state if state.get("run_id") == run_id and state.get("status") == "running" else {}
         progress = mobilegym_progress(benchmark_root, run_id) if state_for_run else {}
-        totals = {
-            "tasks": int(summary.get("tasks") or progress.get("total") or 0),
-            "passed": int(summary.get("passed") or 0),
-            "failed": int(summary.get("failed") or 0) + int(summary.get("timeout") or 0) + int(summary.get("error") or 0) + int(summary.get("worker_failed") or 0) + int(summary.get("unknown") or 0),
-        }
+        rows = summary_run_items(run_id, summary, state_for_run, progress, runs_dir / run_id)
+        if rows:
+            items.extend(rows)
+            continue
+        items.extend(state_run_items(run_id, state_for_run, progress))
+    return items
+
+
+def summary_run_items(
+    run_id: str,
+    summary: dict[str, Any],
+    state_for_run: dict[str, Any],
+    progress: dict[str, Any],
+    run_dir: Path,
+) -> list[dict[str, Any]]:
+    suites = summary_suite_summaries(summary)
+    if not suites:
+        return []
+    items = []
+    status = str(state_for_run.get("status") or "done")
+    fallback_model = str(summary.get("model") or state_for_run.get("model") or current_model_label())
+    for suite_summary in suites:
+        totals = summary_totals(suite_summary)
         total = totals["tasks"]
         done = int(progress.get("completed") or 0) if state_for_run else total
+        suite = str(suite_summary.get("suite") or "mobilegym")
+        item = {
+            "run_id": run_id,
+            "suite": suite,
+            "status": status,
+            "progress": f"{done}/{total}" if total else "",
+            "model": str(suite_summary.get("model") or fallback_model),
+            "totals": totals,
+        }
+        report_path = report_path_for(run_id, suite, run_dir)
+        if report_path:
+            item["report_path"] = report_path
+        items.append(item)
+    return items
+
+
+def report_path_for(run_id: str, suite: str, run_dir: Path) -> str:
+    if valid_suite_name(suite) and (run_dir / suite / "index.html").is_file():
+        return "/benchmark/report/" + quote(run_id, safe="") + "/" + quote_suite_path(suite)
+    if (run_dir / "index.html").is_file():
+        return "/benchmark/report/" + quote(run_id, safe="")
+    return ""
+
+
+def quote_suite_path(suite: str) -> str:
+    return "/".join(quote(part, safe="") for part in suite.split("/"))
+
+
+def report_file_for(root: Path, report_id: str) -> Path | None:
+    parts = [unquote(part) for part in report_id.split("/") if part]
+    if not parts or not is_safe_run_id(parts[0]):
+        return None
+    run_dir = root / "runs" / "mobilegym" / parts[0]
+    if len(parts) == 1:
+        return run_dir / "index.html"
+    suite = "/".join(parts[1:])
+    if not valid_suite_name(suite):
+        return None
+    return run_dir / suite / "index.html"
+
+
+def state_run_items(run_id: str, state_for_run: dict[str, Any], progress: dict[str, Any]) -> list[dict[str, Any]]:
+    suites = state_suites(state_for_run) or ["mobilegym"]
+    items = []
+    totals = {
+        "tasks": int(progress.get("total") or 0),
+        "passed": 0,
+        "failed": 0,
+    }
+    total = totals["tasks"]
+    done = int(progress.get("completed") or 0) if state_for_run else total
+    for suite in suites:
         items.append(
             {
                 "run_id": run_id,
-                "suite": summary_suite(summary) or str(state_for_run.get("suite") or "mobilegym"),
+                "suite": suite,
                 "status": str(state_for_run.get("status") or "done"),
                 "progress": f"{done}/{total}" if total else "",
-                "model": str(summary.get("model") or state_for_run.get("model") or current_model_label()),
+                "model": str(state_for_run.get("model") or current_model_label()),
                 "totals": totals,
             }
         )
     return items
+
+
+def summary_suite_summaries(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    suites = summary.get("suites")
+    if isinstance(suites, list):
+        rows = []
+        for item in suites:
+            if isinstance(item, dict) and item.get("suite"):
+                row = dict(summary)
+                row.update(item)
+                rows.append(row)
+        if rows:
+            return rows
+    suite = summary_suite(summary)
+    if suite:
+        row = dict(summary)
+        row["suite"] = suite
+        return [row]
+    return []
+
+
+def summary_totals(summary: dict[str, Any]) -> dict[str, int]:
+    return {
+        "tasks": int(summary.get("tasks") or 0),
+        "passed": int(summary.get("passed") or 0),
+        "failed": int(summary.get("failed") or 0)
+        + int(summary.get("timeout") or 0)
+        + int(summary.get("error") or 0)
+        + int(summary.get("worker_failed") or 0)
+        + int(summary.get("unknown") or 0),
+    }
+
+
+def state_suites(state: dict[str, Any]) -> list[str]:
+    raw = state.get("suites")
+    if isinstance(raw, list):
+        return [str(item) for item in raw if str(item)]
+    suite = str(state.get("suite") or "")
+    return [part.strip() for part in suite.split(",") if part.strip()]
 
 
 def mobilegym_progress(benchmark_root: Path, run_id: str) -> dict[str, Any]:
@@ -369,9 +519,13 @@ def summary_suite(summary: dict[str, Any]) -> str:
     if isinstance(suite, str) and suite:
         return suite
     suites = summary.get("suites")
-    if isinstance(suites, list) and len(suites) == 1 and isinstance(suites[0], dict):
-        value = suites[0].get("suite")
-        return str(value) if value else ""
+    if isinstance(suites, list):
+        names = []
+        for item in suites:
+            if isinstance(item, dict) and item.get("suite"):
+                names.append(str(item["suite"]))
+        if names:
+            return ", ".join(names)
     return ""
 
 
@@ -522,11 +676,11 @@ def make_handler(benchmark_root: str | Path = BENCHMARK_ROOT) -> type[BaseHTTPRe
             self.end_headers()
             self.wfile.write(body)
 
-        def send_report(self, run_id: str) -> None:
-            if not is_safe_run_id(run_id):
+        def send_report(self, report_id: str) -> None:
+            report_path = report_file_for(root, report_id)
+            if report_path is None:
                 self.send_error(404, "not found")
                 return
-            report_path = root / "runs" / "mobilegym" / run_id / "index.html"
             try:
                 body = report_path.read_bytes()
             except OSError:

--- a/benchmark/mobilegym/scripts/run_aiden.py
+++ b/benchmark/mobilegym/scripts/run_aiden.py
@@ -96,8 +96,9 @@ class MobileGymTaskAdapter:
         del env
 
     def evaluate(self, input: Any) -> Any:
-        del input
-        failures = _evaluate_aiden_metadata(self.metadata)
+        metadata = _metadata_with_evaluation_input(self.metadata, input)
+        failures = _evaluate_aiden_metadata(metadata)
+        self.metadata.update(metadata)
         if failures:
             return _judge_result(False, "; ".join(failures), progress=0.0)
         return _judge_result(True, "Aiden JSON suite deterministic checks passed", progress=1.0)
@@ -172,6 +173,59 @@ def _evaluate_aiden_metadata(metadata: dict[Any, Any]) -> list[str]:
             failures.append(f"missing expected recalled memory ids: {', '.join(missing)}")
 
     return failures
+
+
+def _metadata_with_evaluation_input(metadata: dict[Any, Any], input: Any) -> dict[Any, Any]:
+    result = dict(metadata)
+    if not result.get("aiden_last_response"):
+        response = _response_from_evaluation_input(input)
+        if response:
+            result["aiden_last_response"] = response
+    if not isinstance(result.get("aiden_last_chat_history"), list):
+        history = _history_from_evaluation_input(input)
+        if history:
+            result["aiden_last_chat_history"] = history
+    return result
+
+
+def _response_from_evaluation_input(input: Any) -> str:
+    for source in _evaluation_payloads(input):
+        if not isinstance(source, dict):
+            continue
+        for key in ("aiden_last_response", "response", "agent_message", "agent_answer", "answer", "message", "output", "result"):
+            value = source.get(key)
+            if isinstance(value, (dict, list)) or value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                return text
+    return ""
+
+
+def _history_from_evaluation_input(input: Any) -> list[dict[str, Any]]:
+    for source in _evaluation_payloads(input):
+        if not isinstance(source, dict):
+            continue
+        for key in ("aiden_last_chat_history", "history"):
+            value = source.get(key)
+            if isinstance(value, list):
+                return [entry for entry in value if isinstance(entry, dict)]
+    return []
+
+
+def _evaluation_payloads(input: Any) -> list[Any]:
+    payloads = [input]
+    if isinstance(input, dict):
+        for key in ("data", "execution", "metadata", "result"):
+            value = input.get(key)
+            if isinstance(value, dict):
+                payloads.append(value)
+        return payloads
+    for name in ("data", "execution", "metadata", "result"):
+        value = getattr(input, name, None)
+        if isinstance(value, dict):
+            payloads.append(value)
+    return payloads
 
 
 def _judge_result(success: bool, reason: str, *, progress: float) -> Any:

--- a/benchmark/mobilegym/scripts/run_aiden.py
+++ b/benchmark/mobilegym/scripts/run_aiden.py
@@ -95,8 +95,8 @@ class MobileGymTaskAdapter:
     def teardown(self, env: Any) -> None:
         del env
 
-    def evaluate(self, input: Any) -> Any:
-        metadata = _metadata_with_evaluation_input(self.metadata, input)
+    def evaluate(self, evaluation_input: Any) -> Any:
+        metadata = _metadata_with_evaluation_input(self.metadata, evaluation_input)
         failures = _evaluate_aiden_metadata(metadata)
         self.metadata.update(metadata)
         if failures:
@@ -175,21 +175,21 @@ def _evaluate_aiden_metadata(metadata: dict[Any, Any]) -> list[str]:
     return failures
 
 
-def _metadata_with_evaluation_input(metadata: dict[Any, Any], input: Any) -> dict[Any, Any]:
+def _metadata_with_evaluation_input(metadata: dict[Any, Any], evaluation_input: Any) -> dict[Any, Any]:
     result = dict(metadata)
     if not result.get("aiden_last_response"):
-        response = _response_from_evaluation_input(input)
+        response = _response_from_evaluation_input(evaluation_input)
         if response:
             result["aiden_last_response"] = response
     if not isinstance(result.get("aiden_last_chat_history"), list):
-        history = _history_from_evaluation_input(input)
+        history = _history_from_evaluation_input(evaluation_input)
         if history:
             result["aiden_last_chat_history"] = history
     return result
 
 
-def _response_from_evaluation_input(input: Any) -> str:
-    for source in _evaluation_payloads(input):
+def _response_from_evaluation_input(evaluation_input: Any) -> str:
+    for source in _evaluation_payloads(evaluation_input):
         if not isinstance(source, dict):
             continue
         for key in ("aiden_last_response", "response", "agent_message", "agent_answer", "answer", "message", "output", "result"):
@@ -202,8 +202,8 @@ def _response_from_evaluation_input(input: Any) -> str:
     return ""
 
 
-def _history_from_evaluation_input(input: Any) -> list[dict[str, Any]]:
-    for source in _evaluation_payloads(input):
+def _history_from_evaluation_input(evaluation_input: Any) -> list[dict[str, Any]]:
+    for source in _evaluation_payloads(evaluation_input):
         if not isinstance(source, dict):
             continue
         for key in ("aiden_last_chat_history", "history"):
@@ -213,16 +213,16 @@ def _history_from_evaluation_input(input: Any) -> list[dict[str, Any]]:
     return []
 
 
-def _evaluation_payloads(input: Any) -> list[Any]:
-    payloads = [input]
-    if isinstance(input, dict):
+def _evaluation_payloads(evaluation_input: Any) -> list[Any]:
+    payloads = [evaluation_input]
+    if isinstance(evaluation_input, dict):
         for key in ("data", "execution", "metadata", "result"):
-            value = input.get(key)
+            value = evaluation_input.get(key)
             if isinstance(value, dict):
                 payloads.append(value)
         return payloads
     for name in ("data", "execution", "metadata", "result"):
-        value = getattr(input, name, None)
+        value = getattr(evaluation_input, name, None)
         if isinstance(value, dict):
             payloads.append(value)
     return payloads

--- a/benchmark/runner/html_report.py
+++ b/benchmark/runner/html_report.py
@@ -375,6 +375,9 @@ function openDrawer(i) {{
   if (t.tool_calls_detail) {{
     body += '<div class="block"><div class="block-head"><strong>Tool Calls</strong><span>' + t.tool_calls_count + ' calls</span></div><pre class="block-body">' + esc(t.tool_calls_detail) + '</pre></div>';
   }}
+  if (t.artifacts_detail) {{
+    body += '<div class="block"><div class="block-head"><strong>Artifacts</strong><span>files</span></div><pre class="block-body">' + esc(t.artifacts_detail) + '</pre></div>';
+  }}
   body += '<div class="block"><div class="block-head"><strong>Agent Response</strong><span>final reply</span></div><pre class="block-body">' + esc(t.response) + '</pre></div>';
   if (t.errors && t.errors.length) {{
     var err = t.errors.map(function(e) {{

--- a/benchmark/tests/mobilegym/test_aiden_go_agent.py
+++ b/benchmark/tests/mobilegym/test_aiden_go_agent.py
@@ -170,10 +170,12 @@ def test_aiden_go_agent_records_chat_history_on_task_for_suite_evaluate():
     )
 
     agent.reset(task)
-    agent.act(obs=None)
+    action = agent.act(obs=None)
 
     assert task.metadata["aiden_last_response"].endswith("<final_answer>(c)</final_answer>")
     assert task.metadata["aiden_last_chat_history"][0]["tool_name"] == "recall_memory"
+    assert action.data["aiden_last_response"].endswith("<final_answer>(c)</final_answer>")
+    assert action.data["aiden_last_chat_history"][0]["tool_name"] == "recall_memory"
 
 
 def test_json_http_client_classifies_urlerror_wrapped_socket_timeout(monkeypatch):

--- a/benchmark/tests/mobilegym/test_parallel_run.py
+++ b/benchmark/tests/mobilegym/test_parallel_run.py
@@ -2,6 +2,7 @@ import json
 import os
 import signal
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -78,6 +79,33 @@ def run_parallel(tmp_path, args, **env_overrides):
             "DOCKER_LOG": str(log_path),
             "MOBILEGYM_RUNS_ROOT": str(tmp_path / "runs"),
             "MOBILEGYM_BATCH_ID": env_overrides.pop("MOBILEGYM_BATCH_ID", "batch-test"),
+            "CHAT_TIMEOUT_SEC": env_overrides.pop("CHAT_TIMEOUT_SEC", "777"),
+        }
+    )
+    env.update(env_overrides)
+    result = subprocess.run(
+        ["./parallel_run.sh", *args],
+        cwd=DOCKER_DIR,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    lines = log_path.read_text().splitlines() if log_path.exists() else []
+    return result, lines, Path(env["MOBILEGYM_RUNS_ROOT"]) / env["MOBILEGYM_BATCH_ID"]
+
+
+def run_parallel_without_uv(tmp_path, args, **env_overrides):
+    log_path = install_fake_docker(tmp_path)
+    (tmp_path / "python3").symlink_to(sys.executable)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{tmp_path}{os.pathsep}/usr/bin:/bin:/usr/sbin:/sbin",
+            "DOCKER_LOG": str(log_path),
+            "MOBILEGYM_RUNS_ROOT": str(tmp_path / "runs"),
+            "MOBILEGYM_BATCH_ID": env_overrides.pop("MOBILEGYM_BATCH_ID", "batch-no-uv"),
             "CHAT_TIMEOUT_SEC": env_overrides.pop("CHAT_TIMEOUT_SEC", "777"),
         }
     )
@@ -267,6 +295,19 @@ def test_parallel_run_uses_isolated_projects_configs_logs_and_reports(tmp_path):
     assert len(command_lines(lines, " down --volumes --remove-orphans")) == 2
     assert (batch_dir / "index.html").exists()
     assert (batch_dir / "tasks" / "summary.json").exists()
+
+
+def test_parallel_run_writes_report_when_uv_is_not_on_path(tmp_path):
+    result, lines, batch_dir = run_parallel_without_uv(
+        tmp_path,
+        ["clock.CountAlarms"],
+        PARALLEL="1",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert len(command_lines(lines, " run --rm test ")) == 1
+    assert (batch_dir / "summary.json").exists()
+    assert (batch_dir / "index.html").exists()
 
 
 def test_parallel_run_shards_suite_and_writes_worker_metadata(tmp_path):

--- a/benchmark/tests/mobilegym/test_report.py
+++ b/benchmark/tests/mobilegym/test_report.py
@@ -139,6 +139,14 @@ def test_generate_reports_handles_fallback_fields_unknown_and_empty_shards(tmp_p
     assert "Fail" in batch_html
     assert read_json(batch / "summary.json")["pass_rate"] < 1
     assert "task.unknown" in batch_html
+    tasks = read_report_tasks(batch / "index.html")
+    assert [task["id"] for task in tasks] == [
+        "task.status-pass",
+        "task.success-false",
+        "task.passed-false",
+        "task.unknown",
+    ]
+    assert all(task["id"] != "phone" for task in tasks)
 
 
 def test_generate_reports_groups_positional_tasks_under_tasks_suite(tmp_path):
@@ -454,12 +462,14 @@ def test_report_falls_back_to_compose_log_tool_calls_when_bridge_artifact_is_mis
         [
             {
                 "id": "loop_planning_v1.direct_answer_no_plan",
+                "task_name": "Select option (b).",
                 "suite": "loop_planning_v1",
                 "is_success": True,
                 "execution": {"steps": 1},
             },
             {
                 "id": "loop_planning_v1.expense_summary_requires_plan",
+                "task_name": "Analyze the expense list.",
                 "suite": "loop_planning_v1",
                 "is_success": True,
             },
@@ -467,8 +477,13 @@ def test_report_falls_back_to_compose_log_tool_calls_when_bridge_artifact_is_mis
     )
     (shard / "compose.log").write_text(
         "daemon-1     | 2026/06/15 10:20:14 [INFO] Chat request (sync): Select option (b).\n"
+        "daemon-1     | 2026/06/15 10:20:14 [INFO] Starting agent run: input=\"Select option (b).\" attachments=0\n"
         "daemon-1     | 2026/06/15 10:20:16 [INFO] Role output: role=planner content=(b)\n"
+        "daemon-1     | 2026/06/15 10:20:16 [INFO] Chat request (sync): setup memory.\n"
+        "daemon-1     | 2026/06/15 10:20:16 [INFO] Starting agent run: input=\"setup memory.\" attachments=0\n"
+        "daemon-1     | 2026/06/15 10:20:16 [INFO] Tool call: name=calculator input={\"expression\": \"1 + 1\"} description=Setup-only call.\n"
         "daemon-1     | 2026/06/15 10:20:17 [INFO] Chat request (sync): Analyze the expense list.\n"
+        "daemon-1     | 2026/06/15 10:20:17 [INFO] Starting agent run: input=\"Analyze the expense list.\" attachments=0\n"
         "daemon-1     | 2026/06/15 10:20:25 [INFO] Tool call: name=calculator input={\"expression\": \"128.40 + 72.60\"} description=Compute travel total.\n",
         encoding="utf-8",
     )
@@ -477,9 +492,54 @@ def test_report_falls_back_to_compose_log_tool_calls_when_bridge_artifact_is_mis
 
     tasks = read_report_tasks(batch / "index.html")
     assert tasks[0]["tool_calls_count"] == 0
+    assert tasks[0]["tool_calls_detail"] == ""
+    assert "results.jsonl" in tasks[0]["artifacts_detail"]
     assert tasks[1]["tool_calls_count"] == 1
     assert "[calculator]" in tasks[1]["tool_calls_detail"]
     assert '"expression": "128.40 + 72.60"' in tasks[1]["tool_calls_detail"]
+
+
+def test_report_omits_empty_aiden_suite_shards_from_task_records(tmp_path):
+    from mobilegym import report
+
+    batch = tmp_path / "batch-aiden-empty-shard"
+    shard = batch / "episode_memory_v1" / "shard-0"
+    write_json(
+        shard / "shard.json",
+        {
+            "batch_id": "batch-aiden-empty-shard",
+            "suite": "episode_memory_v1",
+            "shard_index": 0,
+            "shard_count": 2,
+            "selected_task_count": 1,
+            "selected_task_ids": ["episode_memory_v1.case_one"],
+            "exit_code": 0,
+        },
+    )
+    write_jsonl(
+        shard / "raw" / "run" / "results.jsonl",
+        [{"id": "episode_memory_v1.case_one", "suite": "episode_memory_v1", "is_success": True}],
+    )
+    empty = batch / "episode_memory_v1" / "shard-1"
+    write_json(
+        empty / "shard.json",
+        {
+            "batch_id": "batch-aiden-empty-shard",
+            "suite": "episode_memory_v1",
+            "shard_index": 1,
+            "shard_count": 2,
+            "selected_task_count": 0,
+            "selected_task_ids": [],
+            "exit_code": 0,
+        },
+    )
+
+    summary = report.generate_reports(batch)
+
+    assert summary["empty"] == 1
+    tasks = read_report_tasks(batch / "episode_memory_v1" / "index.html")
+    assert [task["id"] for task in tasks] == ["episode_memory_v1.case_one"]
+    assert "episode_memory_v1.shard" not in (batch / "episode_memory_v1" / "index.html").read_text()
 
 
 def test_report_maps_aiden_suite_rubric_and_hard_assertions_into_drawer_payload(tmp_path):

--- a/benchmark/tests/mobilegym/test_report.py
+++ b/benchmark/tests/mobilegym/test_report.py
@@ -429,6 +429,59 @@ def test_report_maps_aiden_chat_history_tool_calls_into_drawer_payload(tmp_path)
     assert '"tags": [\n    "music"\n  ]' in task["tool_calls_detail"]
 
 
+def test_report_falls_back_to_compose_log_tool_calls_when_bridge_artifact_is_missing(tmp_path):
+    from mobilegym import report
+
+    batch = tmp_path / "batch-compose-tools"
+    shard = batch / "loop_planning_v1" / "shard-0"
+    write_json(
+        shard / "shard.json",
+        {
+            "batch_id": "batch-compose-tools",
+            "suite": "loop_planning_v1",
+            "shard_index": 0,
+            "shard_count": 1,
+            "selected_task_count": 2,
+            "selected_task_ids": [
+                "loop_planning_v1.direct_answer_no_plan",
+                "loop_planning_v1.expense_summary_requires_plan",
+            ],
+            "exit_code": 0,
+        },
+    )
+    write_jsonl(
+        shard / "raw" / "run" / "results.jsonl",
+        [
+            {
+                "id": "loop_planning_v1.direct_answer_no_plan",
+                "suite": "loop_planning_v1",
+                "is_success": True,
+                "execution": {"steps": 1},
+            },
+            {
+                "id": "loop_planning_v1.expense_summary_requires_plan",
+                "suite": "loop_planning_v1",
+                "is_success": True,
+            },
+        ],
+    )
+    (shard / "compose.log").write_text(
+        "daemon-1     | 2026/06/15 10:20:14 [INFO] Chat request (sync): Select option (b).\n"
+        "daemon-1     | 2026/06/15 10:20:16 [INFO] Role output: role=planner content=(b)\n"
+        "daemon-1     | 2026/06/15 10:20:17 [INFO] Chat request (sync): Analyze the expense list.\n"
+        "daemon-1     | 2026/06/15 10:20:25 [INFO] Tool call: name=calculator input={\"expression\": \"128.40 + 72.60\"} description=Compute travel total.\n",
+        encoding="utf-8",
+    )
+
+    report.generate_reports(batch)
+
+    tasks = read_report_tasks(batch / "index.html")
+    assert tasks[0]["tool_calls_count"] == 0
+    assert tasks[1]["tool_calls_count"] == 1
+    assert "[calculator]" in tasks[1]["tool_calls_detail"]
+    assert '"expression": "128.40 + 72.60"' in tasks[1]["tool_calls_detail"]
+
+
 def test_report_maps_aiden_suite_rubric_and_hard_assertions_into_drawer_payload(tmp_path):
     from mobilegym import report
 

--- a/benchmark/tests/mobilegym/test_run_aiden.py
+++ b/benchmark/tests/mobilegym/test_run_aiden.py
@@ -206,6 +206,25 @@ def test_mobilegym_task_adapter_exposes_runner_interface():
     assert judge.progress == 1.0
 
 
+def test_mobilegym_task_adapter_evaluate_uses_runner_action_response_when_metadata_is_empty():
+    module = load_run_aiden_module()
+    task = module.MobileGymTaskAdapter(
+        task_id="loop_planning_v1.direct_answer_no_plan",
+        instruction="Select option (b).",
+        metadata={
+            "aiden_suite_name": "loop_planning_v1",
+            "expected_answer": "(b)",
+            "answer_format": "option_letter",
+        },
+    )
+
+    judge = task.evaluate({"execution": {"agent_message": "<final_answer>(b)</final_answer>"}})
+
+    assert judge.success is True
+    assert task.metadata["expected_answer_match"] is True
+    assert task.metadata["predicted_answer"] == "(b)"
+
+
 def test_generate_run_report_best_effort_writes_index(tmp_path):
     module = load_run_aiden_module()
     run_dir = tmp_path / "run"

--- a/src/agent/internal/agent/benchmark_html.go
+++ b/src/agent/internal/agent/benchmark_html.go
@@ -50,6 +50,11 @@ input[type=text]{width:260px}
 .field-label{display:block;font-size:12px;color:#64748b;margin-bottom:6px}
 .inline-field{display:inline-flex;gap:8px;align-items:center}
 .muted{font-size:12px;color:#888}
+.selected-tags{display:none;flex-wrap:wrap;gap:8px;margin-top:8px;min-height:32px;align-items:center}
+.suite-tag{display:inline-flex;align-items:center;gap:7px;max-width:100%;padding:5px 9px;border:1px solid #cdd8ec;border-radius:999px;background:#eef4ff;color:#1e3a8a;font-size:12px;font-weight:650}
+.suite-tag button{padding:0;border:0;background:transparent;color:#475569;font-size:15px;line-height:1;cursor:pointer}
+.suite-tag button:hover{color:#dc2626;background:transparent}
+.selected-tags-empty{font-size:12px;color:#64748b}
 .err{color:#dc2626;font-size:13px;white-space:pre-wrap;margin-top:8px}
 .ok{color:#16a34a;font-size:13px;margin-top:8px}
 .del{background:#dc2626;font-size:12px;padding:4px 8px}
@@ -71,6 +76,7 @@ input[type=text]{width:260px}
 <div>
 <label class="field-label" for="suiteSelect">Benchmarks</label>
 <select id="suiteSelect"><option value="">Loading...</option></select>
+<div id="selectedSuiteTags" class="selected-tags" aria-live="polite"></div>
 </div>
 <div class="actions">
 <span id="mgConfig" class="inline-field" style="display:none">
@@ -143,6 +149,8 @@ var suiteIndex={};
 var benchmarkSuiteCount=0;
 var unitSuiteCount=0;
 var logPolling=null;
+var lastBenchmarkStatus={status:'idle'};
+var selectedSuiteKeysState=[];
 function benchmarkEndpoint(path){return getMode()==='mobilegym'?MOBILEGYM_LOCAL_BASE+path:path}
 function mobileGymLauncherMessage(e){return 'Start the Mac MobileGym launcher first: '+String(e)}
 function setStartLauncherVisible(visible){document.getElementById('startLauncherBtn').style.display=visible?'inline-block':'none'}
@@ -201,10 +209,23 @@ var els=document.getElementsByName('mode');
 for(var i=0;i<els.length;i++){if(els[i].checked)return els[i].value}
 return 'aiden';
 }
+function selectedSuiteKeys(){
+return selectedSuiteKeysState.slice();
+}
+function selectedBenchmarkSuites(){return selectedSuiteKeys().map(function(key){return {key:key,item:suiteIndex[key]}}).filter(function(x){return x.item})}
+function suiteLabel(key){var item=suiteIndex[key];return item?(item.name+(item.task_count?(' · '+item.task_count):'')):key}
+function syncSelectedSuiteKeys(){selectedSuiteKeysState=selectedSuiteKeysState.filter(function(key){return !!suiteIndex[key]})}
+function renderSelectedSuiteTags(){var wrap=document.getElementById('selectedSuiteTags');if(!wrap)return;wrap.style.display='flex';wrap.innerHTML='';syncSelectedSuiteKeys();if(!selectedSuiteKeysState.length){var empty=document.createElement('span');empty.className='selected-tags-empty';empty.textContent=getMode()==='mobilegym'?'Select one or more suites. Run Aiden and built-in suites separately.':'Select one or more benchmark suites.';wrap.appendChild(empty);return}selectedSuiteKeysState.forEach(function(key){var tag=document.createElement('span');tag.className='suite-tag';var label=document.createElement('span');label.textContent=suiteLabel(key);var btn=document.createElement('button');btn.type='button';btn.setAttribute('aria-label','Remove '+suiteLabel(key));btn.textContent='×';btn.onclick=function(){removeSelectedSuiteKey(key)};tag.appendChild(label);tag.appendChild(btn);wrap.appendChild(tag);});}
+function addSelectedSuiteKey(key){if(!key)return;var item=suiteIndex[key];if(!item)return;var current=selectedBenchmarkSuites();if(selectedSuiteKeysState.indexOf(key)<0){if(getMode()==='mobilegym'&&current.length>0&&current.some(function(x){return x.item.type!==item.type})){alert('Run Aiden and built-in MobileGym suites separately');document.getElementById('suiteSelect').value='';return}selectedSuiteKeysState.push(key)}document.getElementById('suiteSelect').value='';renderSelectedSuiteTags();syncDelBtn();syncRunButtons();}
+function removeSelectedSuiteKey(key){selectedSuiteKeysState=selectedSuiteKeysState.filter(function(item){return item!==key});renderSelectedSuiteTags();syncDelBtn();syncRunButtons();}
+function configureSuiteSelect(){var s=document.getElementById('suiteSelect');s.multiple=false;s.size=1;renderSelectedSuiteTags();}
+function syncRunButtons(status){if(status)lastBenchmarkStatus=status;var running=lastBenchmarkStatus&&lastBenchmarkStatus.status==='running';var hasBench=benchmarkSuiteCount>0&&selectedSuiteKeys().length>0;document.getElementById('runBtn').disabled=(running||!hasBench);document.getElementById('runUnitBtn').disabled=(running||unitSuiteCount===0||getMode()==='mobilegym')}
 function onModeChange(){
 var mg=getMode()==='mobilegym';
 document.getElementById('mgConfig').style.display=mg?'inline-block':'none';
 document.getElementById('unitCard').style.display=mg?'none':'block';
+selectedSuiteKeysState=[];
+configureSuiteSelect();
 setStartLauncherVisible(false);
 loadSuites();
 loadRuns();
@@ -220,7 +241,7 @@ s.innerHTML='';u.innerHTML='';suiteIndex={};benchmarkSuiteCount=0;unitSuiteCount
 if(!d || !d.length){
 var o=document.createElement('option');o.value='';o.textContent='(no suites)';s.appendChild(o);
 var uo=document.createElement('option');uo.value='';uo.textContent='(no unit suites)';u.appendChild(uo);
-syncDelBtn();return;
+configureSuiteSelect();syncDelBtn();syncRunButtons();return;
 }
 var groups={aiden:[],mobilegym_builtin:[]};
 d.forEach(function(x){
@@ -240,6 +261,7 @@ suiteIndex[x.path||x.name]=x;
 });
 s.appendChild(og);
 }
+var add=document.createElement('option');add.value='';add.textContent='Add suite...';s.appendChild(add);
 appendGroup('Aiden Suites',groups.aiden);
 if(mode==='mobilegym')appendGroup('MobileGym Built-in',groups.mobilegym_builtin);
 if(!benchmarkSuiteCount){var bo=document.createElement('option');bo.value='';bo.textContent='(no benchmark suites)';s.appendChild(bo)}
@@ -252,18 +274,18 @@ u.appendChild(o);suiteIndex[x.path||x.name]=x;
 });
 if(!unitSuiteCount){var uo=document.createElement('option');uo.value='';uo.textContent='(no unit suites)';u.appendChild(uo)}
 }
-syncDelBtn();
+configureSuiteSelect();syncDelBtn();syncRunButtons();
 }).catch(function(e){
 var s=document.getElementById('suiteSelect');var u=document.getElementById('unitSelect');s.innerHTML='';u.innerHTML='';suiteIndex={};
 var o=document.createElement('option');o.value='';o.textContent=getMode()==='mobilegym'?'(Start the Mac MobileGym launcher first)':'(failed to load suites)';s.appendChild(o);
 var uo=document.createElement('option');uo.value='';uo.textContent='(failed to load unit suites)';u.appendChild(uo);
-syncDelBtn();
+benchmarkSuiteCount=0;unitSuiteCount=0;configureSuiteSelect();syncDelBtn();syncRunButtons();
 if(getMode()==='mobilegym')showMobileGymLauncherError(e);
 });
 }
 function syncDelBtn(){
-var p=document.getElementById('suiteSelect').value;
-var x=suiteIndex[p];
+var keys=selectedSuiteKeys();
+var x=keys.length===1?suiteIndex[keys[0]]:null;
 document.getElementById('delBtn').style.display=(x&&x.custom)?'inline-block':'none';
 }
 function mobileGymSuiteName(item,key){
@@ -294,7 +316,7 @@ span.textContent='Not ready';
 td.appendChild(span);
 return td;
 }
-var reportHref=benchmarkEndpoint('/benchmark/report/')+encodeURIComponent(r.run_id);
+var reportHref=r.report_path?benchmarkEndpoint(r.report_path):(benchmarkEndpoint('/benchmark/report/')+encodeURIComponent(r.run_id));
 var link=document.createElement('a');
 link.href=reportHref;
 link.textContent='View';
@@ -330,21 +352,15 @@ tb.appendChild(tr);
 })}
 function loadStatus(){
 fetch(benchmarkEndpoint('/benchmark/status')).then(r=>r.json()).then(d=>{
-var btn=document.getElementById('runBtn');
-var unitBtn=document.getElementById('runUnitBtn');
-btn.disabled=(d.status==='running'||benchmarkSuiteCount===0);
-unitBtn.disabled=(d.status==='running'||unitSuiteCount===0||getMode()==='mobilegym');
+syncRunButtons(d);
 updateProgress(d);
 loadLog();
 if(d.status==='running'&&!polling)polling=setInterval(pollStatus,3000);
 if(d.status==='running'&&!logPolling)logPolling=setInterval(loadLog,1000);
-}).catch(function(e){if(getMode()==='mobilegym')showMobileGymLauncherError(e)})}
+}).catch(function(e){syncRunButtons({status:'idle'});if(getMode()==='mobilegym')showMobileGymLauncherError(e)})}
 function pollStatus(){
 fetch(benchmarkEndpoint('/benchmark/status')).then(r=>r.json()).then(d=>{
-var btn=document.getElementById('runBtn');
-var unitBtn=document.getElementById('runUnitBtn');
-btn.disabled=(d.status==='running'||benchmarkSuiteCount===0);
-unitBtn.disabled=(d.status==='running'||unitSuiteCount===0||getMode()==='mobilegym');
+syncRunButtons(d);
 updateProgress(d);
 loadLog();
 if(d.status!=='running'){
@@ -352,7 +368,7 @@ clearInterval(polling);polling=null;
 if(logPolling){clearInterval(logPolling);logPolling=null}
 loadRuns();loadLog()
 }
-}).catch(function(e){if(getMode()==='mobilegym')showMobileGymLauncherError(e)})}
+}).catch(function(e){if(polling){clearInterval(polling);polling=null}if(logPolling){clearInterval(logPolling);logPolling=null}syncRunButtons({status:'idle'});if(getMode()==='mobilegym')showMobileGymLauncherError(e)})}
 function startMobileGymLauncher(){
 var btn=document.getElementById('startLauncherBtn');
 var controller=new AbortController();
@@ -370,18 +386,23 @@ logPanelError('Start launcher failed',e&&e.name==='AbortError'?'request timed ou
 }).finally(function(){clearTimeout(timer)});
 }
 function startRun(){
-var sel=document.getElementById('suiteSelect');
-var key=sel.value;
-if(!key){alert('Select a suite');return}
-var item=suiteIndex[key];
+var selected=selectedBenchmarkSuites();
+if(!selected.length){alert('Select a suite');return}
 var mode=getMode();
 var payload={};
 if(mode==='aiden'){
-payload.suite=item.path||key;
+var key=selected[0].key;var item=selected[0].item;
+if(selected.length>1){payload.suites=selected.map(function(x){return x.item.path||x.key});}
+else{payload.suite=item.path||key;}
 payload.mode='aiden';
 } else {
+if(selected.length>1&&selected.some(function(x){return x.item.type!==selected[0].item.type})){alert('Run Aiden and built-in MobileGym suites separately');return}
+var key=selected[0].key;var item=selected[0].item;
+if(selected.length>1){payload.suites=selected.map(function(x){return mobileGymSuiteName(x.item,x.key)});payload.suite_type=item.type;}
+else{
 payload.suite=mobileGymSuiteName(item,key);
 payload.suite_type=item.type;
+}
 payload.mode='mobilegym';
 payload.board_url=location.origin;
 payload.parallel=Number(document.getElementById('parallelInput').value)||4;
@@ -492,7 +513,7 @@ if(!confirm('Delete suite '+x.name+'?'))return;
 fetch('/benchmark/suites/delete',{method:'POST',headers:{'Content-Type':'application/json'},
 body:JSON.stringify({name:x.name})}).then(function(r){return r.json()}).then(function(){loadSuites()});
 }
-document.getElementById('suiteSelect').addEventListener('change',syncDelBtn);
+document.getElementById('suiteSelect').addEventListener('change',function(){addSelectedSuiteKey(this.value);});
 load();
 </script></body></html>
 `

--- a/src/agent/internal/agent/benchmark_runner.go
+++ b/src/agent/internal/agent/benchmark_runner.go
@@ -13,6 +13,7 @@ import (
 
 type benchmarkLaunchSpec struct {
 	Suite    string
+	Suites   []string
 	SuiteDir string
 	Kind     string
 }
@@ -30,27 +31,46 @@ func (s *Server) launchBenchmarkRunner(spec benchmarkLaunchSpec, judgeModel, ope
 	}
 	statePath := s.benchmarkStateFile()
 	logPath := s.benchmarkLogFile("aiden")
-	runnerArgs := ""
+	runnerCommands := []string{}
 	if spec.Kind == "unit" {
+		runnerArgs := ""
 		if spec.SuiteDir != "" {
 			runnerArgs = "unit --suite-dir " + shellQuote(spec.SuiteDir) + " --agent-url http://127.0.0.1:8080 "
 		} else {
 			runnerArgs = "unit --suite " + shellQuote(spec.Suite) + " --agent-url http://127.0.0.1:8080 "
 		}
+		runnerCommands = append(runnerCommands, `python3 -c 'import sys;sys.path.insert(0,".");from runner.main import cli;sys.exit(cli())' `+runnerArgs+`>> `+shellQuote(logPath)+` 2>&1`)
 	} else {
-		runnerArgs = "run --suite " + shellQuote(spec.Suite) + " --agent-url http://127.0.0.1:8080 --judge-model " + shellQuote(judgeModel) + " --agent-model " + shellQuote(agentModel) + " --state-file " + shellQuote(statePath) + " "
+		suites := spec.Suites
+		if len(suites) == 0 {
+			suites = []string{spec.Suite}
+		}
+		for _, suite := range suites {
+			runnerArgs := "run --suite " + shellQuote(suite) + " --agent-url http://127.0.0.1:8080 --judge-model " + shellQuote(judgeModel) + " --agent-model " + shellQuote(agentModel) + " --state-file " + shellQuote(statePath) + " "
+			runnerCommands = append(runnerCommands, `python3 -c 'import sys;sys.path.insert(0,".");from runner.main import cli;sys.exit(cli())' `+runnerArgs+`>> `+shellQuote(logPath)+` 2>&1`)
+		}
+	}
+	runnerScript := ""
+	for i, command := range runnerCommands {
+		if i > 0 {
+			runnerScript += `if [ "$runner_rc" -eq 0 ]; then `
+		}
+		runnerScript += command + ` || runner_rc=$?; `
+		if i > 0 {
+			runnerScript += `fi; `
+		}
 	}
 	script := fmt.Sprintf(`cd %s && `+
 		`export OPENROUTER_API_KEY=%s && `+
 		`(`+
 		`echo 'Starting benchmark...' > %s; `+
-		`python3 -c 'import sys;sys.path.insert(0,".");from runner.main import cli;sys.exit(cli())' `+
-		`%s`+
-		`>> %s 2>&1 & `+
-		`runner_pid=$!; echo $runner_pid > /tmp/benchmark_runner.pid; `+
-		`wait $runner_pid; rm -f /tmp/benchmark_runner.pid; `+
-		`echo '{"status":"idle"}' > %s) &`,
-		shellQuote(benchmarkDir), shellQuote(openRouterAPIKey), shellQuote(logPath), runnerArgs, shellQuote(logPath), shellQuote(statePath))
+		`runner_rc=0; `+
+		`runner_pid=$$; echo $runner_pid > /tmp/benchmark_runner.pid; `+
+		`%s; `+
+		`rm -f /tmp/benchmark_runner.pid; `+
+		`echo '{"status":"idle"}' > %s; `+
+		`exit $runner_rc) &`,
+		shellQuote(benchmarkDir), shellQuote(openRouterAPIKey), shellQuote(logPath), runnerScript, shellQuote(statePath))
 	return exec.Command("sh", "-c", script).Start()
 }
 
@@ -97,12 +117,13 @@ func (s *Server) handleBenchmarkRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req struct {
-		Suite     string `json:"suite"`
-		SuiteDir  string `json:"suite_dir"`
-		SuiteType string `json:"suite_type"`
-		Mode      string `json:"mode"`
-		Parallel  int    `json:"parallel"`
-		Limit     int    `json:"limit"`
+		Suite     string   `json:"suite"`
+		Suites    []string `json:"suites"`
+		SuiteDir  string   `json:"suite_dir"`
+		SuiteType string   `json:"suite_type"`
+		Mode      string   `json:"mode"`
+		Parallel  int      `json:"parallel"`
+		Limit     int      `json:"limit"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		s.writeBenchmarkRunError(w, "aiden", http.StatusBadRequest, "invalid request")
@@ -115,20 +136,28 @@ func (s *Server) handleBenchmarkRun(w http.ResponseWriter, r *http.Request) {
 
 	switch req.Mode {
 	case "aiden":
-		if req.Suite == "" && req.SuiteDir == "" {
+		suites := req.Suites
+		if len(suites) == 0 && req.Suite != "" {
+			suites = []string{req.Suite}
+		}
+		if len(suites) == 0 && req.SuiteDir == "" {
 			s.writeBenchmarkRunError(w, req.Mode, http.StatusBadRequest, "missing suite or suite_dir field")
 			return
 		}
-		if req.Suite != "" && req.SuiteDir != "" {
+		if len(suites) > 0 && req.SuiteDir != "" {
 			s.writeBenchmarkRunError(w, req.Mode, http.StatusBadRequest, "exactly one of suite or suite_dir is required")
 			return
 		}
-		spec := benchmarkLaunchSpec{Suite: req.Suite, SuiteDir: req.SuiteDir, Kind: "benchmark"}
-		stateSuite := req.Suite
+		spec := benchmarkLaunchSpec{SuiteDir: req.SuiteDir, Kind: "benchmark"}
+		if len(suites) > 0 {
+			spec.Suite = suites[0]
+			spec.Suites = suites
+		}
+		stateSuite := strings.Join(suites, ",")
 		if req.SuiteDir != "" {
 			spec.Kind = "unit"
 			stateSuite = req.SuiteDir
-		} else if benchmarkSuiteKind(req.Suite) == "unit" {
+		} else if len(suites) == 1 && benchmarkSuiteKind(suites[0]) == "unit" {
 			spec.Kind = "unit"
 		}
 
@@ -152,6 +181,7 @@ func (s *Server) handleBenchmarkRun(w http.ResponseWriter, r *http.Request) {
 			"status": "running",
 			"mode":   "aiden",
 			"suite":  stateSuite,
+			"suites": suites,
 			"model":  agentModel,
 		})
 		if err := os.WriteFile(statePath, stateJSON, 0o644); err != nil {
@@ -164,12 +194,30 @@ func (s *Server) handleBenchmarkRun(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case "mobilegym":
-		if req.Suite == "" {
+		suites := req.Suites
+		if len(suites) == 0 && req.Suite != "" {
+			suites = []string{req.Suite}
+		}
+		if len(suites) == 0 {
 			s.writeBenchmarkRunError(w, req.Mode, http.StatusBadRequest, "missing suite field")
 			return
 		}
 		if req.SuiteDir != "" {
 			s.writeBenchmarkRunError(w, req.Mode, http.StatusBadRequest, "suite_dir is not supported for mobilegym mode")
+			return
+		}
+		for _, suite := range suites {
+			if !validSuiteName(suite) {
+				s.writeBenchmarkRunError(w, req.Mode, http.StatusBadRequest, fmt.Sprintf("invalid suite name %q", suite))
+				return
+			}
+		}
+		suiteType := req.SuiteType
+		if suiteType == "" {
+			suiteType = "mobilegym_builtin"
+		}
+		if len(suites) > 1 && suiteType != "mobilegym_builtin" && suiteType != "aiden" {
+			s.writeBenchmarkRunError(w, req.Mode, http.StatusBadRequest, "multiple suites are only supported for mobilegym_builtin or aiden")
 			return
 		}
 		if req.Parallel < 1 {
@@ -179,15 +227,17 @@ func (s *Server) handleBenchmarkRun(w http.ResponseWriter, r *http.Request) {
 		if launch == nil {
 			launch = s.launchMobileGymRunner
 		}
-		if err := launch(req.Suite, req.SuiteType, req.Parallel, req.Limit); err != nil {
+		suiteArg := strings.Join(suites, ",")
+		if err := launch(suiteArg, suiteType, req.Parallel, req.Limit); err != nil {
 			s.writeBenchmarkRunError(w, req.Mode, http.StatusInternalServerError, "mobilegym launch failed: "+err.Error())
 			return
 		}
 		stateJSON, _ := json.Marshal(map[string]any{
 			"status":     "running",
 			"mode":       "mobilegym",
-			"suite":      req.Suite,
-			"suite_type": req.SuiteType,
+			"suite":      suiteArg,
+			"suites":     suites,
+			"suite_type": suiteType,
 			"parallel":   req.Parallel,
 		})
 		if err := os.WriteFile(statePath, stateJSON, 0o644); err != nil {
@@ -217,6 +267,19 @@ func validSuiteName(suite string) bool {
 	return true
 }
 
+func mobileGymSuiteList(suite string) ([]string, error) {
+	parts := strings.Split(suite, ",")
+	suites := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if !validSuiteName(part) {
+			return nil, fmt.Errorf("invalid suite name %q (must be a safe relative path)", part)
+		}
+		suites = append(suites, part)
+	}
+	return suites, nil
+}
+
 func (s *Server) launchMobileGymRunner(suite, suiteType string, parallel, limit int) error {
 	script, err := buildMobileGymLaunchScript(s.benchmarkDir, suite, suiteType, parallel, limit)
 	if err != nil {
@@ -226,16 +289,28 @@ func (s *Server) launchMobileGymRunner(suite, suiteType string, parallel, limit 
 }
 
 func buildMobileGymLaunchScript(benchmarkDir, suite, suiteType string, parallel, limit int) (string, error) {
-	if !validSuiteName(suite) {
-		return "", fmt.Errorf("invalid suite name %q (must be a safe relative path)", suite)
+	suites, err := mobileGymSuiteList(suite)
+	if err != nil {
+		return "", err
+	}
+	if len(suites) > 1 && suiteType != "mobilegym_builtin" && suiteType != "aiden" && suiteType != "" {
+		return "", fmt.Errorf("multiple suites are only supported for mobilegym_builtin or aiden")
 	}
 
 	var suiteFlag string
 	switch suiteType {
 	case "aiden":
-		suiteFlag = fmt.Sprintf("--aiden-suite %s", shellQuote(suite))
+		if len(suites) > 1 {
+			suiteFlag = fmt.Sprintf("--aiden-suites %s", shellQuote(strings.Join(suites, ",")))
+		} else {
+			suiteFlag = fmt.Sprintf("--aiden-suite %s", shellQuote(suites[0]))
+		}
 	case "mobilegym_builtin", "":
-		suiteFlag = fmt.Sprintf("--suite %s", shellQuote(suite))
+		if len(suites) > 1 {
+			suiteFlag = fmt.Sprintf("--suites %s", shellQuote(strings.Join(suites, ",")))
+		} else {
+			suiteFlag = fmt.Sprintf("--suite %s", shellQuote(suites[0]))
+		}
 	default:
 		return "", fmt.Errorf("unknown suite_type %q", suiteType)
 	}

--- a/src/agent/internal/agent/benchmark_test.go
+++ b/src/agent/internal/agent/benchmark_test.go
@@ -410,9 +410,19 @@ func TestHandleBenchmarkIndex_ServesHTMLWithRouterButtons(t *testing.T) {
 		`id="unitSelect"`,
 		`id="runUnitBtn"`,
 		`function startRunUnit()`,
+		`id="selectedSuiteTags"`,
+		`function configureSuiteSelect()`,
+		`function renderSelectedSuiteTags()`,
+		`function addSelectedSuiteKey(key)`,
+		`function removeSelectedSuiteKey(key)`,
+		`function selectedSuiteKeys()`,
+		`function syncRunButtons(status)`,
+		`payload.suites=selected.map(function(x){return x.item.path||x.key});`,
+		`payload.suites=selected.map(function(x){return mobileGymSuiteName(x.item,x.key)});`,
 		`x.kind==='unit'`,
 		`reportCell(r)`,
 		`Not ready`,
+		`r.report_path`,
 		`payload.suite=mobileGymSuiteName(item,key);`,
 		`payload.board_url=location.origin;`,
 		`/benchmark/record`,
@@ -436,6 +446,9 @@ func TestHandleBenchmarkIndex_ServesHTMLWithRouterButtons(t *testing.T) {
 	}
 	if strings.Contains(body, `alert(String(e))`) {
 		t.Errorf("run errors should be rendered into the Live Log, not alert-only")
+	}
+	if strings.Contains(body, `s.multiple=mg;`) {
+		t.Errorf("MobileGym suite picker should use selected tags, not native multiple select")
 	}
 }
 
@@ -875,6 +888,40 @@ func TestHandleBenchmarkRun_AidenModeDefault(t *testing.T) {
 	}
 }
 
+func TestHandleBenchmarkRun_AidenModeSuites(t *testing.T) {
+	root := t.TempDir()
+	statePath := filepath.Join(root, "state.json")
+	captured := struct {
+		called bool
+		suites []string
+	}{}
+	s := &Server{
+		runtime:            &Runtime{config: Config{Benchmark: BenchmarkConfig{APIKey: "sk-judge"}}},
+		benchmarkDir:       root,
+		benchmarkStatePath: statePath,
+		benchmarkLauncher: func(spec benchmarkLaunchSpec, judge, apiKey, agentModel string) error {
+			captured.called = true
+			captured.suites = append([]string(nil), spec.Suites...)
+			return nil
+		},
+	}
+
+	body := `{"suites":["memory_v1.json","perception/perception_v1.json"],"mode":"aiden"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/benchmark/run", strings.NewReader(body))
+	s.handleBenchmarkRun(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body %s", rec.Code, rec.Body.String())
+	}
+	if !captured.called {
+		t.Fatalf("expected aiden launcher invoked")
+	}
+	if strings.Join(captured.suites, ",") != "memory_v1.json,perception/perception_v1.json" {
+		t.Fatalf("unexpected suites: %+v", captured.suites)
+	}
+}
+
 func TestHandleBenchmarkRun_MobileGymMode(t *testing.T) {
 	root := t.TempDir()
 	statePath := filepath.Join(root, "state.json")
@@ -945,6 +992,64 @@ func TestHandleBenchmarkRun_MobileGymBuiltin(t *testing.T) {
 	}
 }
 
+func TestHandleBenchmarkRun_MobileGymBuiltinSuites(t *testing.T) {
+	root := t.TempDir()
+	statePath := filepath.Join(root, "state.json")
+	captured := struct {
+		suite     string
+		suiteType string
+	}{}
+	s := &Server{
+		benchmarkDir:       root,
+		benchmarkStatePath: statePath,
+		benchmarkMobileGymLauncher: func(suite, suiteType string, parallel, limit int) error {
+			captured.suite = suite
+			captured.suiteType = suiteType
+			return nil
+		},
+	}
+
+	body := `{"suites":["clock","phone_control_v1"],"suite_type":"mobilegym_builtin","mode":"mobilegym","parallel":2}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/benchmark/run", strings.NewReader(body))
+	s.handleBenchmarkRun(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body %s", rec.Code, rec.Body.String())
+	}
+	if captured.suite != "clock,phone_control_v1" || captured.suiteType != "mobilegym_builtin" {
+		t.Fatalf("unexpected mobilegym launch args: %+v", captured)
+	}
+}
+
+func TestHandleBenchmarkRun_MobileGymAidenSuites(t *testing.T) {
+	root := t.TempDir()
+	captured := struct {
+		suite     string
+		suiteType string
+	}{}
+	s := &Server{
+		benchmarkDir: root,
+		benchmarkMobileGymLauncher: func(suite, suiteType string, parallel, limit int) error {
+			captured.suite = suite
+			captured.suiteType = suiteType
+			return nil
+		},
+	}
+
+	body := `{"suites":["memory_v1","perception_v1"],"suite_type":"aiden","mode":"mobilegym"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/benchmark/run", strings.NewReader(body))
+	s.handleBenchmarkRun(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body %s", rec.Code, rec.Body.String())
+	}
+	if captured.suite != "memory_v1,perception_v1" || captured.suiteType != "aiden" {
+		t.Fatalf("unexpected mobilegym launch args: %+v", captured)
+	}
+}
+
 func TestHandleBenchmarkLog_MobileGymMode(t *testing.T) {
 	tmp := t.TempDir()
 	logFile := filepath.Join(tmp, "mobilegym_run.log")
@@ -985,6 +1090,19 @@ func TestBuildMobileGymLaunchScript_AidenSuite(t *testing.T) {
 	}
 }
 
+func TestBuildMobileGymLaunchScript_AidenSuites(t *testing.T) {
+	script, err := buildMobileGymLaunchScript("/bench", "memory_v1,perception_v1", "aiden", 4, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(script, "--aiden-suites 'memory_v1,perception_v1'") {
+		t.Errorf("expected --aiden-suites flag, got: %s", script)
+	}
+	if !strings.Contains(script, "--limit 10") {
+		t.Errorf("expected --limit 10, got: %s", script)
+	}
+}
+
 func TestBuildMobileGymLaunchScript_MobileGymBuiltin(t *testing.T) {
 	script, err := buildMobileGymLaunchScript("/bench", "clock", "mobilegym_builtin", 2, 0)
 	if err != nil {
@@ -998,6 +1116,19 @@ func TestBuildMobileGymLaunchScript_MobileGymBuiltin(t *testing.T) {
 	}
 	if strings.Contains(script, "--limit") {
 		t.Errorf("limit=0 should omit --limit flag: %s", script)
+	}
+}
+
+func TestBuildMobileGymLaunchScript_MobileGymBuiltins(t *testing.T) {
+	script, err := buildMobileGymLaunchScript("/bench", "clock,phone_control_v1", "mobilegym_builtin", 2, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(script, "--suites 'clock,phone_control_v1'") {
+		t.Errorf("expected --suites flag, got: %s", script)
+	}
+	if strings.Contains(script, "--suite 'clock,phone_control_v1'") {
+		t.Errorf("multiple builtins should not use singular --suite: %s", script)
 	}
 }
 

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -626,11 +626,15 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 				"key_info": []string{strings.TrimSpace(answer)},
 				"reason":   "executor returned an explicit final answer",
 			})
-			turn := e.handleExecutorMetaTool(state, schema.AgentAction{
+			action := schema.AgentAction{
 				Tool:      toolFinishStep,
 				ToolInput: string(payload),
 				Log:       strings.TrimSpace(answer),
-			})
+			}
+			if e.CallbacksHandler != nil {
+				e.CallbacksHandler.HandleAgentAction(ctx, action)
+			}
+			turn := e.handleExecutorMetaTool(state, action)
 			if turn.InvalidMetaStep != nil {
 				turn.Step = turn.InvalidMetaStep
 			}

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -620,6 +620,22 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 				answer = value
 			}
 		}
+		if extractMarkedFinalAnswer(answer) != "" {
+			payload, _ := json.Marshal(map[string]any{
+				"summary":  strings.TrimSpace(answer),
+				"key_info": []string{strings.TrimSpace(answer)},
+				"reason":   "executor returned an explicit final answer",
+			})
+			turn := e.handleExecutorMetaTool(state, schema.AgentAction{
+				Tool:      toolFinishStep,
+				ToolInput: string(payload),
+				Log:       strings.TrimSpace(answer),
+			})
+			if turn.InvalidMetaStep != nil {
+				turn.Step = turn.InvalidMetaStep
+			}
+			return turn, nil
+		}
 		observation := "Call finish_step when the step is ready for verification or abort_step if blocked."
 		if answer != "" {
 			observation = fmt.Sprintf("%s Plain text output alone does not enter verification: %s", observation, answer)

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -528,6 +528,42 @@ func TestFinishStepEntersVerifierReview(t *testing.T) {
 	}
 }
 
+func TestExecutorMarkedFinalAnswerEntersVerifierReview(t *testing.T) {
+	executor := newRoleCollaborativeExecutor(
+		&scriptedModel{responses: []*llms.ContentResponse{
+			contentResponse("The result matches option (a).\n\n<final_answer>(a)</final_answer>"),
+		}},
+		RoleProfiles{},
+		nil,
+		nil,
+		10,
+		nil,
+		nil,
+		nil,
+		ScreenshotPruningConfig{},
+		nil,
+	)
+	state := &roleLoopState{
+		Phase:               phaseExecution,
+		PlanCommitted:       true,
+		StepExecutionActive: true,
+		NextStep:            "compare result and output final answer",
+	}
+	inputs := map[string]string{"input": "choose the option", "history": ""}
+
+	turn, err := executor.callExecutorTurn(context.Background(), inputs, state, NewToolSpecs(nil))
+	if err != nil {
+		t.Fatalf("executor turn error: %v", err)
+	}
+
+	if turn.Kind != executorTurnFinishStep {
+		t.Fatalf("turn kind = %v, want finish step", turn.Kind)
+	}
+	if state.ExecutorStepOutcome != "finished" || !strings.Contains(state.ExecutorStepSummary, "<final_answer>(a)</final_answer>") {
+		t.Fatalf("state = %#v", state)
+	}
+}
+
 func TestFinishStepStoresKeyInfo(t *testing.T) {
 	executor := newRoleCollaborativeExecutor(
 		&scriptedModel{},

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -529,6 +529,7 @@ func TestFinishStepEntersVerifierReview(t *testing.T) {
 }
 
 func TestExecutorMarkedFinalAnswerEntersVerifierReview(t *testing.T) {
+	handler := &toolExecutionCallbackRecorder{}
 	executor := newRoleCollaborativeExecutor(
 		&scriptedModel{responses: []*llms.ContentResponse{
 			contentResponse("The result matches option (a).\n\n<final_answer>(a)</final_answer>"),
@@ -538,7 +539,7 @@ func TestExecutorMarkedFinalAnswerEntersVerifierReview(t *testing.T) {
 		nil,
 		10,
 		nil,
-		nil,
+		handler,
 		nil,
 		ScreenshotPruningConfig{},
 		nil,
@@ -561,6 +562,9 @@ func TestExecutorMarkedFinalAnswerEntersVerifierReview(t *testing.T) {
 	}
 	if state.ExecutorStepOutcome != "finished" || !strings.Contains(state.ExecutorStepSummary, "<final_answer>(a)</final_answer>") {
 		t.Fatalf("state = %#v", state)
+	}
+	if len(handler.calls) != 1 || handler.calls[0].Action.Tool != toolFinishStep {
+		t.Fatalf("callback calls = %#v, want synthetic finish_step action", handler.calls)
 	}
 }
 

--- a/tests/benchmark/test_mobilegym_local_launcher.py
+++ b/tests/benchmark/test_mobilegym_local_launcher.py
@@ -85,6 +85,50 @@ def test_build_run_command_uses_mobilegym_builtin_suite(launcher_module, tmp_pat
     assert command.env["PARALLEL"] == "2"
 
 
+def test_build_run_command_uses_mobilegym_builtin_suites(launcher_module, tmp_path):
+    docker_dir = tmp_path / "mobilegym" / "docker"
+    docker_dir.mkdir(parents=True)
+    (docker_dir / "parallel_run.sh").write_text("#!/usr/bin/env bash\n")
+
+    command = launcher_module.build_run_command(
+        tmp_path,
+        {"suites": ["clock", "phone_control_v1"], "suite_type": "mobilegym_builtin", "parallel": 2},
+    )
+
+    assert command.cwd == docker_dir
+    assert command.argv == ["./parallel_run.sh", "--suites", "clock,phone_control_v1"]
+    assert command.env["PARALLEL"] == "2"
+
+
+def test_build_run_command_uses_multiple_aiden_suites(launcher_module, tmp_path):
+    docker_dir = tmp_path / "mobilegym" / "docker"
+    docker_dir.mkdir(parents=True)
+    (docker_dir / "parallel_run.sh").write_text("#!/usr/bin/env bash\n")
+
+    command = launcher_module.build_run_command(
+        tmp_path,
+        {"suites": ["memory_v1", "perception_v1"], "suite_type": "aiden", "parallel": 1},
+    )
+
+    assert command.argv == ["./parallel_run.sh", "--aiden-suites", "memory_v1,perception_v1"]
+
+
+def test_build_run_command_adds_common_docker_cli_paths(launcher_module, tmp_path):
+    docker_dir = tmp_path / "mobilegym" / "docker"
+    docker_dir.mkdir(parents=True)
+    (docker_dir / "parallel_run.sh").write_text("#!/usr/bin/env bash\n")
+
+    command = launcher_module.build_run_command(
+        tmp_path,
+        {"suite": "clock", "suite_type": "mobilegym_builtin", "parallel": 1},
+    )
+
+    path_parts = command.env["PATH"].split(os.pathsep)
+    assert "/usr/local/bin" in path_parts
+    assert "/opt/homebrew/bin" in path_parts
+    assert "/Applications/Docker.app/Contents/Resources/bin" in path_parts
+
+
 def test_build_run_command_rejects_path_traversal(launcher_module, tmp_path):
     with pytest.raises(launcher_module.LauncherError, match="invalid suite name"):
         launcher_module.build_run_command(
@@ -199,6 +243,26 @@ def test_handler_serves_mobilegym_report(launcher_module, tmp_path):
         thread.join(timeout=2)
 
 
+def test_handler_serves_mobilegym_suite_report(launcher_module, tmp_path):
+    report_dir = tmp_path / "runs" / "mobilegym" / "batch-20260611-010101" / "perception" / "perception_v1"
+    report_dir.mkdir(parents=True)
+    (report_dir / "index.html").write_text("<html>Perception report</html>")
+    server = HTTPServer(("127.0.0.1", 0), launcher_module.make_handler(tmp_path))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{server.server_port}/benchmark/report/batch-20260611-010101/perception/perception_v1",
+            timeout=2,
+        ) as resp:
+            assert resp.status == 200
+            assert "text/html" in resp.headers["Content-Type"]
+            assert resp.read().decode() == "<html>Perception report</html>"
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
 def test_list_runs_includes_summary_model_and_progress(launcher_module, tmp_path):
     run_dir = tmp_path / "runs" / "mobilegym" / "batch-20260611-120000"
     run_dir.mkdir(parents=True)
@@ -217,6 +281,41 @@ def test_list_runs_includes_summary_model_and_progress(launcher_module, tmp_path
             "model": "google/gemini-3.5-flash",
             "totals": {"tasks": 17, "passed": 12, "failed": 5},
         }
+    ]
+
+
+def test_list_runs_expands_multiple_summary_suites(launcher_module, tmp_path):
+    run_dir = tmp_path / "runs" / "mobilegym" / "batch-20260611-130000"
+    run_dir.mkdir(parents=True)
+    (run_dir / "clock").mkdir()
+    (run_dir / "phone_control_v1").mkdir()
+    (run_dir / "clock" / "index.html").write_text("clock")
+    (run_dir / "phone_control_v1" / "index.html").write_text("phone")
+    (run_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "tasks": 6,
+                "passed": 4,
+                "failed": 2,
+                "model": "qwen3.6-35b",
+                "suites": [
+                    {"suite": "clock", "tasks": 2, "passed": 1, "failed": 1},
+                    {"suite": "phone_control_v1", "tasks": 4, "passed": 3, "failed": 1},
+                ],
+            }
+        ),
+    )
+
+    runs = launcher_module.list_runs(tmp_path)
+
+    assert [run["suite"] for run in runs] == ["clock", "phone_control_v1"]
+    assert [run["progress"] for run in runs] == ["2/2", "4/4"]
+    assert runs[0]["totals"] == {"tasks": 2, "passed": 1, "failed": 1}
+    assert runs[1]["totals"] == {"tasks": 4, "passed": 3, "failed": 1}
+    assert runs[0]["model"] == "qwen3.6-35b"
+    assert [run["report_path"] for run in runs] == [
+        "/benchmark/report/batch-20260611-130000/clock",
+        "/benchmark/report/batch-20260611-130000/phone_control_v1",
     ]
 
 
@@ -374,6 +473,13 @@ def test_parallel_run_passes_limit_to_suite_workers():
     assert "--limit \"$LIMIT\"" in script
 
 
+def test_parallel_run_supports_multiple_aiden_suites():
+    script = PARALLEL_RUN_PATH.read_text()
+
+    assert "--aiden-suites" in script
+    assert "aiden_suite|$suite|$i|$PARALLEL" in script
+
+
 def test_helper_start_invokes_launchctl_for_local_launcher(helper_module, monkeypatch):
     calls = []
 
@@ -498,6 +604,8 @@ def test_local_launcher_installer_registers_launchd_service():
     assert "http://host.docker.internal:7897" not in script
     assert 'if [[ -n "${MOBILEGYM_DOCKER_PROXY:-}" ]]' in script
     assert "MOBILEGYM_PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST" in script
+    assert "<key>PATH</key>" in script
+    assert "/Applications/Docker.app/Contents/Resources/bin" in script
     assert "launchctl bootstrap gui/$UID" in script
 
 


### PR DESCRIPTION
## Summary
- Split MobileGym history/report links per selected suite and add suite-level report endpoints.
- Recover Aiden MobileGym response/history metadata for deterministic judging and report rendering.
- Add compose.log fallback tool-call parsing and let explicit executor final answers enter verifier review.

## Test Plan
- uv run --project benchmark pytest tests/benchmark benchmark/tests/mobilegym -q
- GOTOOLCHAIN=auto go test -count=1 ./cmd/daemon ./internal/agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-suite benchmark selection and sequential execution across modes, including suite tags in the UI and multi-suite run launching.
  * Added suite-aware report routing plus an optional “Artifacts” drawer section in the task HTML.

* **Improvements**
  * Report generation now derives tool-call actions from logs when bridge artifacts are missing.
  * Enhanced action/metadata enrichment for last responses and chat history.
  * Improved execution handling for marked final answers; improved CLI/PATH setup and runner reporting fallback when `uv` isn’t available.

* **Tests**
  * Expanded coverage for multi-suite behavior and reporting fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->