### PR TITLE
feat: improve voice turn resilience and memory recovery

### DIFF
--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -213,7 +213,11 @@ func wakeupGPIOPinsLabel() string {
 func startWakeupWatchers(newWatcher wakeupWatcherFactory, callback func()) ([]wakeupWatcher, error) {
 	watchers := make([]wakeupWatcher, 0, len(wakeupGPIOPins))
 	for _, pin := range wakeupGPIOPins {
-		watcher, err := newWatcher(pin, callback)
+		pin := pin
+		watcher, err := newWatcher(pin, func() {
+			log.Printf("[wakeup] GPIO %d wakeup event", pin)
+			callback()
+		})
 		if err != nil {
 			stopWakeupWatchers(watchers)
 			return nil, fmt.Errorf("create GPIO %d watcher: %w", pin, err)
@@ -644,41 +648,16 @@ func captureUtteranceWithTimeout(dialog audioDialogRunner, sigChan chan os.Signa
 	nextVADLogAt := startedAt.Add(time.Second)
 	hasVADState := false
 	speechDetected := false
-	resetCapture := func(now time.Time) {
-		vadPending = vadPending[:0]
-		captured = captured[:0]
-		hasPendingByte = false
-		pendingByte = 0
-		startedAt = now
-		nextVADLogAt = now.Add(time.Second)
-		hasVADState = false
-		speechDetected = false
-	}
-	restartRecordingAfterWakeup := func() bool {
-		log.Println("[listen] wakeup received while listening, restarting recording")
-		if dialog.RecordingActive() {
-			if err := dialog.StopRecording(); err != nil {
-				log.Printf("[listen] stop recording before wakeup restart: %v\n", err)
-			}
-		}
-		if err := dialog.StartRecording(); err != nil {
-			log.Printf("[listen] restart recording after wakeup failed: %v\n", err)
-			return false
-		}
-		dialog.ResetVAD()
-		resetCapture(time.Now())
-		return true
+	ignoreWakeupWhileListening := func() {
+		log.Println("[listen] duplicate wakeup received while listening, ignoring")
 	}
 
-captureLoop:
 	for {
 		select {
 		case <-sigChan:
 			return nil, true
 		case <-events:
-			if !restartRecordingAfterWakeup() {
-				return nil, false
-			}
+			ignoreWakeupWhileListening()
 			continue
 		default:
 		}
@@ -705,10 +684,7 @@ captureLoop:
 		case <-sigChan:
 			return nil, true
 		case <-events:
-			if !restartRecordingAfterWakeup() {
-				return nil, false
-			}
-			continue
+			ignoreWakeupWhileListening()
 		default:
 		}
 
@@ -762,10 +738,7 @@ captureLoop:
 				case <-sigChan:
 					return nil, true
 				case <-events:
-					if !restartRecordingAfterWakeup() {
-						return nil, false
-					}
-					continue captureLoop
+					ignoreWakeupWhileListening()
 				default:
 				}
 				log.Println("[utterance] VAD detected end of speech")

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -630,7 +630,25 @@ func listenOneUtterance(dialog audioDialogRunner, sigChan chan os.Signal, events
 	}()
 	dialog.ResetVAD()
 	utterance, exit := captureUtteranceWithTimeout(dialog, sigChan, events, listenTimeout)
+	if !exit {
+		drainWakeupsWhileListening(events)
+	}
 	return utterance, exit
+}
+
+func drainWakeupsWhileListening(events <-chan voiceEvent) {
+	for {
+		select {
+		case <-events:
+			ignoreWakeupWhileListening()
+		default:
+			return
+		}
+	}
+}
+
+func ignoreWakeupWhileListening() {
+	log.Println("[listen] duplicate wakeup received while listening, ignoring")
 }
 
 func captureUtteranceWithTimeout(dialog audioDialogRunner, sigChan chan os.Signal, events <-chan voiceEvent, listenTimeout time.Duration) ([]int16, bool) {
@@ -648,9 +666,6 @@ func captureUtteranceWithTimeout(dialog audioDialogRunner, sigChan chan os.Signa
 	nextVADLogAt := startedAt.Add(time.Second)
 	hasVADState := false
 	speechDetected := false
-	ignoreWakeupWhileListening := func() {
-		log.Println("[listen] duplicate wakeup received while listening, ignoring")
-	}
 
 	for {
 		select {

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -1111,6 +1111,56 @@ func TestListenOneUtteranceIgnoresWakeupWhileAlreadyListening(t *testing.T) {
 	}
 }
 
+func TestRunVoiceSessionDrainsBurstWakeupsWhileAlreadyListening(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	events := make(chan voiceEvent, 8)
+	firstRead := true
+	turnStarted := make(chan struct{})
+	allowTurnResult := make(chan struct{})
+	dialog := &fakeAudioDialog{
+		frameSamples: 2,
+		chunkBatches: [][]*agent.AudioChunkResult{
+			{{PCM: pcm16BytesFromSamples(100, 200)}},
+			{},
+		},
+		utterancesToReturn: [][]int16{
+			{100, 200},
+		},
+		repeatEmpty: true,
+		readDelay:   time.Millisecond,
+		onRead: func(d *fakeAudioDialog, chunk *agent.AudioChunkResult) {
+			if firstRead {
+				firstRead = false
+				for i := 0; i < 4; i++ {
+					events <- voiceEventWakeup
+				}
+			}
+		},
+		runTurn: func(ctx context.Context) (agent.RunResult, error) {
+			close(turnStarted)
+			select {
+			case <-ctx.Done():
+				return agent.RunResult{}, ctx.Err()
+			case <-allowTurnResult:
+				return agent.RunResult{Output: "reply"}, nil
+			}
+		},
+	}
+	go func() {
+		<-turnStarted
+		time.Sleep(10 * time.Millisecond)
+		close(allowTurnResult)
+	}()
+
+	exit := runVoiceSession(agent.Config{VoiceFollowupTimeoutMs: 5}, dialog, nil, sigChan, events)
+	if exit {
+		t.Fatal("runVoiceSession returned exit=true")
+	}
+	if len(dialog.spoken) != 1 || dialog.spoken[0] != "reply" {
+		t.Fatalf("spoken texts = %#v, want reply after draining listen-time wakeups", dialog.spoken)
+	}
+}
+
 func TestRunVoiceSessionWakeupInterruptsThinking(t *testing.T) {
 	sigChan := make(chan os.Signal, 1)
 	events := make(chan voiceEvent, 2)

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -1070,7 +1070,7 @@ func TestCaptureUtteranceTimeoutReturnsBufferedSpeechWhenVADStarted(t *testing.T
 	}
 }
 
-func TestListenOneUtteranceWakeupRestartsRecordingAndDiscardsBufferedAudio(t *testing.T) {
+func TestListenOneUtteranceIgnoresWakeupWhileAlreadyListening(t *testing.T) {
 	sigChan := make(chan os.Signal, 1)
 	events := make(chan voiceEvent, 1)
 	firstRead := true
@@ -1078,10 +1078,9 @@ func TestListenOneUtteranceWakeupRestartsRecordingAndDiscardsBufferedAudio(t *te
 		frameSamples: 2,
 		chunkBatches: [][]*agent.AudioChunkResult{
 			{{PCM: pcm16BytesFromSamples(100, 200)}},
-			{{PCM: pcm16BytesFromSamples(300, 400)}},
 		},
 		utterancesToReturn: [][]int16{
-			{300, 400},
+			{100, 200},
 		},
 		onRead: func(d *fakeAudioDialog, chunk *agent.AudioChunkResult) {
 			if firstRead {
@@ -1095,13 +1094,13 @@ func TestListenOneUtteranceWakeupRestartsRecordingAndDiscardsBufferedAudio(t *te
 	if exit {
 		t.Fatal("listenOneUtterance returned exit=true")
 	}
-	if got, want := utterance, []int16{300, 400}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
-		t.Fatalf("utterance = %#v, want only restarted recording samples %#v", got, want)
+	if got, want := utterance, []int16{100, 200}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("utterance = %#v, want original recording samples %#v", got, want)
 	}
-	if len(dialog.frames) != 1 || dialog.frames[0][0] != 300 || dialog.frames[0][1] != 400 {
-		t.Fatalf("VAD frames = %#v, want only restarted recording samples", dialog.frames)
+	if len(dialog.frames) != 1 || dialog.frames[0][0] != 100 || dialog.frames[0][1] != 200 {
+		t.Fatalf("VAD frames = %#v, want original recording samples", dialog.frames)
 	}
-	wantOps := []string{"start", "reset", "stop", "start", "reset", "stop"}
+	wantOps := []string{"start", "reset", "stop"}
 	if len(dialog.ops) != len(wantOps) {
 		t.Fatalf("dialog ops = %#v, want %#v", dialog.ops, wantOps)
 	}

--- a/src/agent/internal/agent/audio_client.go
+++ b/src/agent/internal/agent/audio_client.go
@@ -33,6 +33,15 @@ type PlaybackStartResult struct {
 	SessionID uint64 `json:"session_id"`
 }
 
+type audioStatusError struct {
+	op     string
+	status string
+}
+
+func (e *audioStatusError) Error() string {
+	return fmt.Sprintf("%s failed: %s", e.op, e.status)
+}
+
 // AudioHealthResult contains audio service health status
 type AudioHealthResult struct {
 	RecordingActive  bool   `json:"recording_active"`
@@ -370,7 +379,7 @@ func (c *AudioServiceClient) StartPlayback(format AudioFormat) (*PlaybackStartRe
 	}
 
 	if resp.Status != "OK" {
-		return nil, fmt.Errorf("start_playback failed: %s", resp.Status)
+		return nil, &audioStatusError{op: "start_playback", status: resp.Status}
 	}
 
 	return &PlaybackStartResult{SessionID: uint64(resp.SessionID)}, nil

--- a/src/agent/internal/agent/long_term_memory.go
+++ b/src/agent/internal/agent/long_term_memory.go
@@ -194,7 +194,7 @@ func (s *LongTermMemoryStore) Search(ctx context.Context, query MemoryQuery) ([]
 		path := filepath.Join(s.rootDir, entry.File)
 		parsed, err := readMemoryMarkdown(path)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		if memoryItemExpired(parsed.Item, time.Now().UTC()) {
 			continue
@@ -531,7 +531,7 @@ func (s *LongTermMemoryStore) RebuildIndex(ctx context.Context) error {
 		path := filepath.Join(s.memoriesDir(), entry.Name())
 		parsed, err := readMemoryMarkdown(path)
 		if err != nil {
-			return err
+			continue
 		}
 		index.Memories = append(index.Memories, memoryIndexEntry{
 			ID:         parsed.Item.ID,

--- a/src/agent/internal/agent/long_term_memory_test.go
+++ b/src/agent/internal/agent/long_term_memory_test.go
@@ -221,6 +221,87 @@ func TestLongTermMemorySearchTreatsWhitespaceOnlyTagsAsEmptyQuery(t *testing.T) 
 	}
 }
 
+func TestLongTermMemorySearchSkipsCorruptIndexedMarkdown(t *testing.T) {
+	ctx := context.Background()
+	store := NewLongTermMemoryStore(filepath.Join(t.TempDir(), "long_term"))
+	if _, err := store.AddMemory(ctx, MemoryItem{
+		ID:         "mem_valid",
+		Type:       "preference",
+		Priority:   80,
+		Confidence: 0.9,
+		Tags:       []string{"general"},
+		Title:      "Valid memory",
+		Content:    "The user prefers concise replies.",
+		EvidenceExcerpts: []string{
+			"The user asked for concise replies.",
+		},
+	}); err != nil {
+		t.Fatalf("AddMemory() error = %v", err)
+	}
+
+	corruptPath := filepath.Join(store.RootDir(), "memories", "mem_corrupt.md")
+	if err := os.WriteFile(corruptPath, nil, 0o644); err != nil {
+		t.Fatalf("write corrupt memory: %v", err)
+	}
+	index, err := store.loadIndex(ctx)
+	if err != nil {
+		t.Fatalf("loadIndex() error = %v", err)
+	}
+	index.Memories = append(index.Memories, memoryIndexEntry{
+		ID:         "mem_corrupt",
+		File:       filepath.ToSlash(filepath.Join("memories", "mem_corrupt.md")),
+		Type:       "preference",
+		Status:     "active",
+		Priority:   100,
+		Confidence: 1,
+		Tags:       []string{"general"},
+	})
+	if err := store.writeIndex(index); err != nil {
+		t.Fatalf("writeIndex() error = %v", err)
+	}
+
+	results, err := store.Search(ctx, MemoryQuery{Tags: []string{"general"}, Limit: 5})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "mem_valid" {
+		t.Fatalf("expected valid memory only, got %#v", results)
+	}
+}
+
+func TestLongTermMemoryRebuildIndexSkipsCorruptMarkdown(t *testing.T) {
+	ctx := context.Background()
+	store := NewLongTermMemoryStore(filepath.Join(t.TempDir(), "long_term"))
+	if _, err := store.AddMemory(ctx, MemoryItem{
+		ID:         "mem_valid",
+		Type:       "preference",
+		Priority:   80,
+		Confidence: 0.9,
+		Tags:       []string{"general"},
+		Title:      "Valid memory",
+		Content:    "The user prefers concise replies.",
+		EvidenceExcerpts: []string{
+			"The user asked for concise replies.",
+		},
+	}); err != nil {
+		t.Fatalf("AddMemory() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(store.RootDir(), "memories", "mem_corrupt.md"), nil, 0o644); err != nil {
+		t.Fatalf("write corrupt memory: %v", err)
+	}
+
+	if err := store.RebuildIndex(ctx); err != nil {
+		t.Fatalf("RebuildIndex() error = %v", err)
+	}
+	index, err := store.loadIndex(ctx)
+	if err != nil {
+		t.Fatalf("loadIndex() error = %v", err)
+	}
+	if len(index.Memories) != 1 || index.Memories[0].ID != "mem_valid" {
+		t.Fatalf("expected valid memory only in rebuilt index, got %#v", index.Memories)
+	}
+}
+
 func TestLongTermMemoryForgetExcludesMemoryFromSearch(t *testing.T) {
 	ctx := context.Background()
 	store := NewLongTermMemoryStore(filepath.Join(t.TempDir(), "long_term"))

--- a/src/agent/internal/agent/prompt_sound.go
+++ b/src/agent/internal/agent/prompt_sound.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -41,16 +42,20 @@ func playPromptSound(ctx context.Context, audio *AudioServiceClient, kind prompt
 		BitWidth:   promptSoundBitWidth,
 	}
 	playback, err := audio.StartPlayback(format)
-	if err != nil && ctx.Err() == nil {
+	if err != nil && ctx.Err() == nil && retryablePromptStartPlaybackError(err) {
 		timer := time.NewTimer(promptSoundRetryDelay)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
+			return ctx.Err()
 		case <-timer.C:
 			playback, err = audio.StartPlayback(format)
 		}
 	}
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return fmt.Errorf("start prompt playback: %w", err)
 	}
 
@@ -75,6 +80,11 @@ func playPromptSound(ctx context.Context, audio *AudioServiceClient, kind prompt
 	}
 	stopPlayback = false
 	return nil
+}
+
+func retryablePromptStartPlaybackError(err error) bool {
+	var statusErr *audioStatusError
+	return errors.As(err, &statusErr) && statusErr.op == "start_playback" && statusErr.status == "SERVICE_RECOVERING"
 }
 
 func waitPromptPlayback(ctx context.Context, audio *AudioServiceClient) error {

--- a/src/agent/internal/agent/prompt_sound.go
+++ b/src/agent/internal/agent/prompt_sound.go
@@ -20,6 +20,7 @@ const (
 
 	promptSoundDrainTimeout = 2 * time.Second
 	promptSoundSettleDelay  = 450 * time.Millisecond
+	promptSoundRetryDelay   = 150 * time.Millisecond
 )
 
 func playPromptSound(ctx context.Context, audio *AudioServiceClient, kind promptSoundKind, wait bool) error {
@@ -34,11 +35,21 @@ func playPromptSound(ctx context.Context, audio *AudioServiceClient, kind prompt
 	}
 
 	pcm := promptSoundPCM(kind)
-	playback, err := audio.StartPlayback(AudioFormat{
+	format := AudioFormat{
 		SampleRate: promptSoundSampleRate,
 		Channels:   promptSoundChannels,
 		BitWidth:   promptSoundBitWidth,
-	})
+	}
+	playback, err := audio.StartPlayback(format)
+	if err != nil && ctx.Err() == nil {
+		timer := time.NewTimer(promptSoundRetryDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+		case <-timer.C:
+			playback, err = audio.StartPlayback(format)
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("start prompt playback: %w", err)
 	}

--- a/src/agent/internal/agent/tts_test.go
+++ b/src/agent/internal/agent/tts_test.go
@@ -49,12 +49,26 @@ func TestWaitForPlaybackDrainRetriesTransientHealthFailure(t *testing.T) {
 	}
 }
 
+func TestPlayPromptSoundRetriesBusyStartPlayback(t *testing.T) {
+	audioServer := newTestAudioService(t)
+	audioServer.startPlaybackStatuses = []string{"INTERNAL_ERROR", "OK"}
+	audioServer.healthPlaybackSessions = []uint32{0}
+
+	if err := playPromptSound(context.Background(), NewAudioServiceClient(audioServer.socketPath), promptSoundRecordingStart, true); err != nil {
+		t.Fatalf("playPromptSound() error = %v", err)
+	}
+	if got := audioServer.countOp("start_playback"); got != 2 {
+		t.Fatalf("start_playback count = %d, want retry after busy failure", got)
+	}
+}
+
 type testAudioService struct {
 	socketPath               string
 	listener                 net.Listener
 	mu                       sync.Mutex
 	ops                      []string
 	stopStatus               string
+	startPlaybackStatuses    []string
 	healthConnectionDrops    int
 	healthPlaybackSessions   []uint32
 	lastHealthPlaybackStatus uint32
@@ -123,6 +137,7 @@ func (s *testAudioService) handleConn(conn net.Conn) {
 	status := "OK"
 	extra := map[string]interface{}{}
 	if req.Op == "start_playback" {
+		status = s.nextStartPlaybackStatus()
 		extra["session_id"] = uint64(77)
 	}
 	if req.Op == "start_recording" {
@@ -143,6 +158,17 @@ func (s *testAudioService) handleConn(conn net.Conn) {
 	}
 	data, _ := json.Marshal(resp)
 	_ = writeUdsMessage(conn, udsMessage{HeaderJSON: string(data)})
+}
+
+func (s *testAudioService) nextStartPlaybackStatus() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.startPlaybackStatuses) == 0 {
+		return "OK"
+	}
+	status := s.startPlaybackStatuses[0]
+	s.startPlaybackStatuses = s.startPlaybackStatuses[1:]
+	return status
 }
 
 func (s *testAudioService) nextHealthPlaybackSessionsLocked() uint32 {

--- a/src/agent/internal/agent/tts_test.go
+++ b/src/agent/internal/agent/tts_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -51,7 +52,7 @@ func TestWaitForPlaybackDrainRetriesTransientHealthFailure(t *testing.T) {
 
 func TestPlayPromptSoundRetriesBusyStartPlayback(t *testing.T) {
 	audioServer := newTestAudioService(t)
-	audioServer.startPlaybackStatuses = []string{"INTERNAL_ERROR", "OK"}
+	audioServer.startPlaybackStatuses = []string{"SERVICE_RECOVERING", "OK"}
 	audioServer.healthPlaybackSessions = []uint32{0}
 
 	if err := playPromptSound(context.Background(), NewAudioServiceClient(audioServer.socketPath), promptSoundRecordingStart, true); err != nil {
@@ -62,6 +63,45 @@ func TestPlayPromptSoundRetriesBusyStartPlayback(t *testing.T) {
 	}
 }
 
+func TestPlayPromptSoundDoesNotRetryNonRetryableStartPlaybackFailure(t *testing.T) {
+	audioServer := newTestAudioService(t)
+	audioServer.startPlaybackStatuses = []string{"INTERNAL_ERROR", "OK"}
+
+	if err := playPromptSound(context.Background(), NewAudioServiceClient(audioServer.socketPath), promptSoundRecordingStart, true); err == nil {
+		t.Fatal("playPromptSound() error = nil, want start playback failure")
+	}
+	if got := audioServer.countOp("start_playback"); got != 1 {
+		t.Fatalf("start_playback count = %d, want no retry for non-retryable failure", got)
+	}
+}
+
+func TestPlayPromptSoundReturnsContextErrorWhenCanceledBeforeRetry(t *testing.T) {
+	audioServer := newTestAudioService(t)
+	audioServer.startPlaybackStatuses = []string{"SERVICE_RECOVERING", "OK"}
+	firstStart := make(chan struct{})
+	var once sync.Once
+	audioServer.onStartPlayback = func() {
+		once.Do(func() {
+			close(firstStart)
+		})
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-firstStart
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	err := playPromptSound(ctx, NewAudioServiceClient(audioServer.socketPath), promptSoundRecordingStart, true)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("playPromptSound() error = %v, want context.Canceled", err)
+	}
+	if got := audioServer.countOp("start_playback"); got != 1 {
+		t.Fatalf("start_playback count = %d, want no retry after cancellation", got)
+	}
+}
+
 type testAudioService struct {
 	socketPath               string
 	listener                 net.Listener
@@ -69,6 +109,7 @@ type testAudioService struct {
 	ops                      []string
 	stopStatus               string
 	startPlaybackStatuses    []string
+	onStartPlayback          func()
 	healthConnectionDrops    int
 	healthPlaybackSessions   []uint32
 	lastHealthPlaybackStatus uint32
@@ -138,6 +179,9 @@ func (s *testAudioService) handleConn(conn net.Conn) {
 	extra := map[string]interface{}{}
 	if req.Op == "start_playback" {
 		status = s.nextStartPlaybackStatus()
+		if s.onStartPlayback != nil {
+			s.onStartPlayback()
+		}
 		extra["session_id"] = uint64(77)
 	}
 	if req.Op == "start_recording" {


### PR DESCRIPTION
## Summary
- ignore duplicate wakeup events while already listening, while logging the GPIO source
- retry prompt cue playback once after transient start_playback failures
- skip corrupt long-term memory markdown during search and index rebuilds

## Tests
- GOTOOLCHAIN=auto go test ./cmd/daemon ./internal/agent -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved wakeup handling during active listening by draining queued wakeups and ignoring wakeup events that arrive mid-utterance, preventing recording interruptions.
  * Improved resilience of long-term memory operations by skipping corrupted entries during search and index rebuilds.
  * Enhanced prompt audio playback reliability by retrying once when the audio service is temporarily busy/recovering.

* **Tests**
  * Added/updated coverage for in-progress wakeup ignoring and queued wakeup draining.
  * Added tests for skipping corrupted memory markdown during search and index rebuild.
  * Added tests for audio playback retry and context cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->