### PR TITLE
fix(ota): remove scheduled update daemon

### DIFF
--- a/docs/02-architecture/boot-services.md
+++ b/docs/02-architecture/boot-services.md
@@ -15,7 +15,7 @@
 | `S52frame_service` | 启动并守护 HDMI 帧服务 |
 | `S53audio_service` | 启动并守护音频服务 |
 | `S53agent` | 启动并守护 Go Agent |
-| `S54ota` | 启动并守护 OTA daemon |
+| `S54ota` | 开机运行一次 OTA health 处理 |
 | `S55aiden_usb_dhcp` | USB 网络 DHCP / dnsmasq 相关服务 |
 | `S56config_web` | 启动配置网页 |
 | `S99rtcinit` | 覆盖 SDK 默认 RTC 脚本；RTC 异常且系统时间仍早于基线时写入默认日期 |
@@ -83,7 +83,7 @@ WATCHDOG_PID_FILE=/run/audio_service/audio_service_watchdog.pid
 默认启动命令：
 
 ```bash
-/oem/usr/bin/aiden-env-run /oem/usr/bin/ota daemon
+/oem/usr/bin/aiden-env-run /oem/usr/bin/ota health
 ```
 
 运行时目录：

--- a/docs/03-services/config-web.md
+++ b/docs/03-services/config-web.md
@@ -56,11 +56,10 @@ config_web [--bind=IP] [--port=PORT] [--config=PATH] [--wifi-config=PATH] [--sys
 ## Runtime apply behavior
 
 Config Web writes Agent, Wi-Fi, and system environment files. Saving Agent
-config still schedules an Agent restart. OTA is restarted only when the
-effective `/userdata/system/env` file changes, because OTA reads proxy settings
-from that file at process startup:
+config still schedules an Agent restart. OTA updates read the effective
+`/userdata/system/env` file when `ota update` is run, so saving system
+environment no longer restarts OTA:
 
 ```bash
 /etc/init.d/S53agent restart
-/etc/init.d/S54ota restart  # only when /userdata/system/env changes
 ```

--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -161,7 +161,7 @@ Optional. Place `memory/extraction.yaml` under the config directory to control s
 
 ## System Environment Variables
 
-The Agent no longer reads `[proxy]` from `agent.toml`. Outbound HTTP/WebSocket requests, shell tool subprocesses, the OTA daemon, and SSH login shells all use environment variables from `/userdata/system/env`. The file is loaded with shell syntax, for example:
+The Agent no longer reads `[proxy]` from `agent.toml`. Outbound HTTP/WebSocket requests, shell tool subprocesses, OTA commands launched through `aiden-env-run`, and SSH login shells all use environment variables from `/userdata/system/env`. The file is loaded with shell syntax, for example:
 
 ```sh
 HTTP_PROXY=http://127.0.0.1:7890

--- a/docs/08-reference/paths-and-artifacts.md
+++ b/docs/08-reference/paths-and-artifacts.md
@@ -20,7 +20,7 @@
 | `src/audio_service_main.cpp` | Audio Service 入口 |
 | `src/config_web.cpp` | Config Web 入口 |
 | `src/agent/cmd/daemon` | Go Agent daemon |
-| `src/agent/cmd/ota` | OTA CLI / daemon |
+| `src/agent/cmd/ota` | OTA CLI |
 | `src/agent/cmd/abctl` | A/B metadata 诊断工具 |
 | `src/agent/internal/agent` | Agent runtime 和工具实现 |
 | `src/agent/internal/ota` | OTA manifest、下载、slot、health 和状态机 |
@@ -54,7 +54,7 @@
 | `overlay/etc/init.d/S20oemslot` | Slot-aware `/oem` 挂载脚本 |
 | `overlay/etc/init.d/S49ntp` | ntpd daemon 启动 + `step` 一次性同步子命令 |
 | `overlay/etc/init.d/S50ntp_watchdog` | NTP 同步周期检查，未同步时触发 `S49ntp step` |
-| `overlay/etc/init.d/S54ota` | OTA daemon watchdog |
+| `overlay/etc/init.d/S54ota` | Boot-time OTA health one-shot |
 | `overlay/etc/init.d/S99rtcinit` | RTC invalid-date calibration script replacing the SDK default |
 | `overlay/etc/profile.d/aiden-env.sh` | SSH/login shell environment loader snippet |
 | `overlay/oem/usr/bin/aiden-env-run` | Service environment launcher |

--- a/docs/09-ota/OTA_OPEN_SOURCES.md
+++ b/docs/09-ota/OTA_OPEN_SOURCES.md
@@ -50,18 +50,18 @@ scripts/generate_ota_manifest.sh \
 
 官方仓库的 CI/CD 现在根据分支自动区分发布渠道：
 
-| 分支 | Channel | GitHub Release | 默认 OTA 行为 |
+| 分支 | Channel | GitHub Release | 默认手动 OTA 行为 |
 |------|---------|---------------|--------------|
-| `main` | `stable` | 正常 Release | ✅ 自动升级 |
-| 其他分支 | `dev-{分支名}` | Prerelease | ❌ 不会升级 |
+| `main` | `stable` | 正常 Release | `ota update` 默认可发现 |
+| 其他分支 | `dev-{分支名}` | Prerelease | 默认 `ota update` 不会发现 |
 
 **隔离机制**：
 
-非 main 分支的 Release 被标记为 **Prerelease**，而设备常规更新走 `releases/latest` API，该接口只返回正式 Release，不返回 prerelease。因此 `stable` 设备根本不会在常规检查中发现非 main 分支的固件。
+非 main 分支的 Release 被标记为 **Prerelease**，而不指定 `--manifest-url` 的手动 `ota update` 走 `releases/latest` API，该接口只返回正式 Release，不返回 prerelease。因此默认手动更新不会发现非 main 分支的固件。
 
 注：manifest 里的 `channel` 字段仅作为人类可读标签（CI 会为非 main 分支写入 `dev-{分支名}`），OTA 客户端只校验其字符串格式，并不会拿它和某个期望 channel 做匹配。真正起隔离作用的是上述 prerelease 机制。
 
-这样非 main 分支的固件即使发布也不会影响生产设备的正常 OTA 升级。
+这样非 main 分支的固件即使发布，也不会影响生产设备的默认手动 OTA 更新路径。
 
 **测试非 main 分支固件**：
 

--- a/docs/09-ota/README.md
+++ b/docs/09-ota/README.md
@@ -60,11 +60,11 @@ mount | grep ' /oem '
 
 | 路径 | 说明 |
 | --- | --- |
-| `src/agent/cmd/ota` | OTA CLI / daemon 入口 |
+| `src/agent/cmd/ota` | OTA CLI 入口，包含手动更新和 health 处理 |
 | `src/agent/cmd/abctl` | A/B metadata 诊断工具 |
 | `src/agent/internal/ota` | manifest、下载、状态机、slot、health 等 OTA 核心逻辑 |
 | `overlay/etc/init.d/S20oemslot` | 根据 `aiden.slot_suffix` 挂载 `/oem` |
-| `overlay/etc/init.d/S54ota` | OTA daemon watchdog |
+| `overlay/etc/init.d/S54ota` | 开机一次性 OTA health 处理 |
 | `scripts/generate_ota_manifest.sh` | 生成签名 OTA manifest |
 | `scripts/generate_ota_device_config.sh` | 从 manifest 生成首刷配置 |
 | `scripts/repack_ota_update_image.sh` | 把首刷 OTA 配置重新打入 `userdata.img` 和 `update.img` |

--- a/docs/09-ota/architecture.md
+++ b/docs/09-ota/architecture.md
@@ -1,6 +1,6 @@
 # OTA 架构与运行时
 
-OTA 由三层配合完成：`pico-sdk` 生成 A/B 镜像和 factory `misc.img`，GitHub Actions 发布签名 Release，设备端 `ota` daemon 在运行时完成下载、写入、切换和健康提交。
+OTA 由三层配合完成：`pico-sdk` 生成 A/B 镜像和 factory `misc.img`，GitHub Actions 发布签名 Release，设备端 `ota` 在手动触发时完成下载、写入和切换，开机 one-shot health 处理负责启动后的健康提交。
 
 ## 分区布局
 
@@ -29,7 +29,7 @@ OTA 由三层配合完成：`pico-sdk` 生成 A/B 镜像和 factory `misc.img`�
 4. slot-specific FIT boot image 提供 `root=PARTLABEL=rootfs_a|rootfs_b` 和 `aiden.slot_suffix=_a|_b`。
 5. Linux 挂载匹配的 `rootfs_*`。
 6. `S20oemslot` 根据 `aiden.slot_suffix` 挂载 `/dev/block/by-name/oem_a|oem_b` 到 `/oem`。
-7. `S54ota` 启动 OTA daemon，先处理 pending health，再进行网络检查。
+7. `S54ota` 运行一次 `ota health`，处理 pending health 后退出。
 
 ## 更新流程
 
@@ -59,7 +59,7 @@ OTA 由三层配合完成：`pico-sdk` 生成 A/B 镜像和 factory `misc.img`�
 2. 更新 `/userdata/ota/state.json` 的 committed version/build time 和 per-slot partition hashes。
 3. 删除 `pending_boot.json` 和 `health.ok`。
 
-如果健康窗口超时，`ota` 会主动 reboot，让 SPL 消耗 tries。tries 用尽且目标 slot 未 successful 时，SPL 回退到上一成功 slot。daemon 在旧 slot 观察到已经回滚后，会清理 pending 状态并把 state phase 标记为 `rolled-back`。
+如果健康窗口超时，`ota health` 会主动 reboot，让 SPL 消耗 tries。tries 用尽且目标 slot 未 successful 时，SPL 回退到上一成功 slot。`ota health` 在旧 slot 观察到已经回滚后，会清理 pending 状态并把 state phase 标记为 `rolled-back`。
 
 ## Manifest 约定
 
@@ -87,7 +87,6 @@ For `.img.tar.gz` assets, `size` and `sha256` describe the downloaded archive. T
 
 - `manifest_url` - 直接指定 manifest URL（跳过 GitHub Release API）
 - `public_key_path` - 覆盖默认公钥路径（默认 `/oem/etc/ota_pubkey.pem`）
-- `interval_seconds` - OTA 检查间隔（默认 3600 秒）
 - `github_token_path` - GitHub token 文件路径（私有仓库需要）
 
 Factory baseline 必须 slot-aware，因为 `boot_a.img` 和 `boot_b.img` hash 不同。缺失 baseline 时 OTA 初始化必须失败，不应猜测当前分区版本。

--- a/docs/09-ota/device-acceptance.md
+++ b/docs/09-ota/device-acceptance.md
@@ -9,7 +9,7 @@
 - The `update.img` inside `update.img.tar.gz` has `/userdata/ota/config.json` embedded.
 - 有 UART 时建议同时记录 SPL rollback 日志。
 
-`ota` 在启动时必须先处理 `/userdata/ota/pending_boot.json` health，再做网络或 GitHub update check。不要在 pending health 处理前加入网络等待。
+`S54ota` 在启动时只处理 `/userdata/ota/pending_boot.json` health，不做网络或 GitHub update check。手动更新必须通过 `ota update` 触发。
 
 ## 1. USB 首刷验收
 

--- a/docs/09-ota/ota-external-developers.md
+++ b/docs/09-ota/ota-external-developers.md
@@ -220,16 +220,12 @@ Instead of passing parameters every time, configure the device permanently:
 cat > /userdata/ota/config.json << 'EOF'
 {
   "manifest_url": "https://your-server.com/firmware/latest/manifest.json",
-  "public_key_path": "/userdata/ota/custom_pubkey.pem",
-  "interval_seconds": 3600
+  "public_key_path": "/userdata/ota/custom_pubkey.pem"
 }
 EOF
-
-# Restart OTA daemon
-/etc/init.d/S54ota restart
 ```
 
-Now the device will automatically check your custom source every hour.
+Run `ota update` whenever you want the device to check and install from this source.
 
 ## Security Considerations
 
@@ -278,7 +274,7 @@ To control which firmware a device installs, point it at a specific manifest via
 
 ### Check OTA logs
 ```bash
-# The OTA daemon writes to stderr, which S54ota redirects to a log file
+# The boot-time OTA health pass writes to stderr, which S54ota redirects here
 tail -f /var/log/ota/ota.log
 
 # When running `ota update` manually, logs go to stderr (your terminal)
@@ -360,6 +356,6 @@ echo "  ota update --manifest-url $BASE_URL/manifest.json --public-key /path/to/
 ## Support
 
 For issues or questions:
-- Check the daemon log at `/var/log/ota/ota.log` (S54ota redirects the daemon's stderr there)
+- Check the boot-time OTA health log at `/var/log/ota/ota.log`
 - Use `--dry-run` for testing
 - Join community discussions

--- a/docs/09-ota/ota-quick-examples.md
+++ b/docs/09-ota/ota-quick-examples.md
@@ -106,16 +106,12 @@ To avoid typing parameters every time:
 cat > /userdata/ota/config.json << 'EOF'
 {
   "manifest_url": "https://your-server.com/firmware/latest/manifest.json",
-  "public_key_path": "/userdata/ota/your_pubkey.pem",
-  "interval_seconds": 3600
+  "public_key_path": "/userdata/ota/your_pubkey.pem"
 }
 EOF
-
-# Restart OTA service
-/etc/init.d/S54ota restart
 ```
 
-Now the device will automatically check your custom source every hour!
+Run `ota update` whenever you want the device to check and install from this source.
 
 ## Security Notes
 

--- a/docs/09-ota/ota-release-channels.md
+++ b/docs/09-ota/ota-release-channels.md
@@ -6,10 +6,10 @@ This document explains how the official repository distinguishes releases by bra
 
 The CI/CD pipeline assigns a release channel based on the branch being built:
 
-| Branch | Channel | GitHub Release | Default OTA Behavior |
+| Branch | Channel | GitHub Release | Default Manual OTA Behavior |
 |--------|---------|----------------|----------------------|
-| `main` | `stable` | Normal release | Auto-updates devices |
-| any other branch | `dev-{branch-name}` | Prerelease | Ignored by default OTA |
+| `main` | `stable` | Normal release | Discoverable by `ota update` |
+| any other branch | `dev-{branch-name}` | Prerelease | Ignored by default `ota update` |
 
 For example:
 - `main` → channel `stable`, normal release
@@ -25,11 +25,12 @@ mechanism described below.
 Non-main branch builds are protected from affecting production OTA by their
 **prerelease** status on GitHub.
 
-Non-main branch releases are marked as **prerelease**. A device's normal update
-check uses the `releases/latest` API, which only returns the newest
-non-prerelease release, so `stable` devices never even discover development
-builds. The `dev-*` channel name is just a label that makes the manifest easy to
-identify; it is not what keeps the build off production devices.
+Non-main branch releases are marked as **prerelease**. A manual `ota update`
+without `--manifest-url` uses the `releases/latest` API, which only returns the
+newest non-prerelease release, so the default update path never discovers
+development builds. The `dev-*` channel name is just a label that makes the
+manifest easy to identify; it is not what keeps the build off production
+devices.
 
 This means you can safely push experimental branches and let CI build them,
 without any risk to devices running production firmware.
@@ -59,7 +60,7 @@ Notes:
 Because development releases are published as prereleases, they:
 
 - **Do not** appear as the latest stable release
-- **Do not** auto-update production devices
+- **Do not** get selected by the default `ota update` release lookup
 - **Do** remain available for manual testing via `--manifest-url`
 
 This lets individual developers build and debug firmware on their own branches without coordinating with, or disrupting, anyone else.

--- a/overlay/etc/init.d/S54ota
+++ b/overlay/etc/init.d/S54ota
@@ -7,6 +7,8 @@ LOG_PATH=${LOG_PATH:-/var/log/ota/ota.log}
 USERDATA_DIR=${USERDATA_DIR:-/userdata}
 SLEEP_BIN=${SLEEP_BIN:-sleep}
 WAIT_TIMEOUT=${WAIT_TIMEOUT:-}
+USERDATA_REQUIRE_MOUNT=${USERDATA_REQUIRE_MOUNT:-1}
+MOUNTS_PATH=${MOUNTS_PATH:-/proc/mounts}
 
 wait_for_existing_path() {
     path="$1"
@@ -18,6 +20,32 @@ wait_for_existing_path() {
             return 1
         fi
         echo "[ota] waiting for $path" >> "$LOG_PATH"
+        "$SLEEP_BIN" 1
+        waited=$((waited + 1))
+    done
+    return 0
+}
+
+path_is_mounted() {
+    path="$1"
+    [ -r "$MOUNTS_PATH" ] || return 1
+    awk -v target="$path" '
+        $2 == target { found = 1 }
+        END { exit found ? 0 : 1 }
+    ' "$MOUNTS_PATH"
+}
+
+wait_for_userdata_ready() {
+    wait_for_existing_path "$USERDATA_DIR" "userdata" || return 1
+    [ "$USERDATA_REQUIRE_MOUNT" = "0" ] && return 0
+
+    waited=0
+    while ! path_is_mounted "$USERDATA_DIR"; do
+        if [ -n "$WAIT_TIMEOUT" ] && [ "$waited" -ge "$WAIT_TIMEOUT" ]; then
+            echo "[ota] userdata mount unavailable after ${WAIT_TIMEOUT}s: $USERDATA_DIR" >> "$LOG_PATH"
+            return 1
+        fi
+        echo "[ota] waiting for userdata mount: $USERDATA_DIR" >> "$LOG_PATH"
         "$SLEEP_BIN" 1
         waited=$((waited + 1))
     done
@@ -44,7 +72,7 @@ run_health_once() {
     mkdir -p "$(dirname "$LOG_PATH")"
     chmod 0755 "$(dirname "$LOG_PATH")"
 
-    wait_for_existing_path "$USERDATA_DIR" "userdata" || return 1
+    wait_for_userdata_ready || return 1
     mkdir -p "$USERDATA_DIR/ota"
     chmod 0755 "$USERDATA_DIR/ota"
 

--- a/overlay/etc/init.d/S54ota
+++ b/overlay/etc/init.d/S54ota
@@ -1,125 +1,91 @@
 #!/bin/sh
-# Production OTA daemon watchdog. Runs in the background and never blocks boot.
+# One-shot OTA health processing. Manual updates run through `ota update`.
 
 OTA_BIN=${OTA_BIN:-/oem/usr/bin/ota}
 ENV_RUN_BIN=${ENV_RUN_BIN:-/oem/usr/bin/aiden-env-run}
 LOG_PATH=${LOG_PATH:-/var/log/ota/ota.log}
-PID_FILE=${PID_FILE:-/run/ota/ota.pid}
-WATCHDOG_PID_FILE=${WATCHDOG_PID_FILE:-/run/ota/ota_watchdog.pid}
 USERDATA_DIR=${USERDATA_DIR:-/userdata}
 SLEEP_BIN=${SLEEP_BIN:-sleep}
+WAIT_TIMEOUT=${WAIT_TIMEOUT:-}
 
-is_running() {
-    pid="$1"
-    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
+wait_for_existing_path() {
+    path="$1"
+    description="$2"
+    waited=0
+    while [ ! -e "$path" ]; do
+        if [ -n "$WAIT_TIMEOUT" ] && [ "$waited" -ge "$WAIT_TIMEOUT" ]; then
+            echo "[ota] $description unavailable after ${WAIT_TIMEOUT}s: $path" >> "$LOG_PATH"
+            return 1
+        fi
+        echo "[ota] waiting for $path" >> "$LOG_PATH"
+        "$SLEEP_BIN" 1
+        waited=$((waited + 1))
+    done
+    return 0
 }
 
-pid_matches_service() {
-    pid="$1"
-    [ -n "$pid" ] || return 1
-    [ -r "/proc/$pid/cmdline" ] || return 1
-    cmd=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null)
-    case "$cmd" in
-        *"$OTA_BIN"*"daemon"*|*"ota"*"daemon"*) return 0 ;;
-        *) return 1 ;;
-    esac
+wait_for_executable() {
+    path="$1"
+    description="$2"
+    waited=0
+    while [ ! -x "$path" ]; do
+        if [ -n "$WAIT_TIMEOUT" ] && [ "$waited" -ge "$WAIT_TIMEOUT" ]; then
+            echo "[ota] $description unavailable after ${WAIT_TIMEOUT}s: $path" >> "$LOG_PATH"
+            return 1
+        fi
+        echo "[ota] waiting for $path" >> "$LOG_PATH"
+        "$SLEEP_BIN" 1
+        waited=$((waited + 1))
+    done
+    return 0
 }
 
-pid_matches_watchdog() {
-    pid="$1"
-    [ -n "$pid" ] || return 1
-    [ -r "/proc/$pid/cmdline" ] || return 1
-    cmd=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null)
-    case "$cmd" in
-        *"$0"*|*"S54ota"*) return 0 ;;
-        *) return 1 ;;
-    esac
-}
+run_health_once() {
+    mkdir -p "$(dirname "$LOG_PATH")"
+    chmod 0755 "$(dirname "$LOG_PATH")"
 
-service_pid() {
-    if [ -f "$PID_FILE" ]; then
-        pid=$(cat "$PID_FILE" 2>/dev/null)
-        case "$pid" in ''|*[!0-9]*) return ;; esac
-        if pid_matches_service "$pid"; then echo "$pid"; fi
-    fi
-}
+    wait_for_existing_path "$USERDATA_DIR" "userdata" || return 1
+    mkdir -p "$USERDATA_DIR/ota"
+    chmod 0755 "$USERDATA_DIR/ota"
 
-watchdog_pid() {
-    if [ -f "$WATCHDOG_PID_FILE" ]; then
-        pid=$(cat "$WATCHDOG_PID_FILE" 2>/dev/null)
-        case "$pid" in ''|*[!0-9]*) return ;; esac
-        if pid_matches_watchdog "$pid"; then echo "$pid"; fi
-    fi
+    wait_for_executable "$ENV_RUN_BIN" "environment launcher" || return 1
+    wait_for_executable "$OTA_BIN" "ota binary" || return 1
+
+    echo "[ota] processing pending health" >> "$LOG_PATH"
+    "$ENV_RUN_BIN" "$OTA_BIN" health >> "$LOG_PATH" 2>&1
+    status="$?"
+    echo "[ota] health processing exited with status $status" >> "$LOG_PATH"
+    return "$status"
 }
 
 start() {
-    wpid=$(watchdog_pid)
-    if is_running "$wpid"; then
-        echo "ota watchdog already running (pid $wpid)"
-        return 0
-    fi
-
-    mkdir -p "$(dirname "$PID_FILE")" "$(dirname "$LOG_PATH")"
-    chmod 0755 "$(dirname "$PID_FILE")" "$(dirname "$LOG_PATH")"
-
     (
-        trap 'exit 0' INT TERM
-        while true; do
-            if [ ! -d "$USERDATA_DIR" ]; then
-                echo "[ota] waiting for $USERDATA_DIR" >> "$LOG_PATH"
-                "$SLEEP_BIN" 2
-                continue
-            fi
-            mkdir -p "$USERDATA_DIR/ota"
-            chmod 0755 "$USERDATA_DIR/ota"
-            if [ ! -x "$OTA_BIN" ]; then
-                echo "[ota] waiting for $OTA_BIN" >> "$LOG_PATH"
-                "$SLEEP_BIN" 5
-                continue
-            fi
-
-            echo "[ota] starting $OTA_BIN daemon" >> "$LOG_PATH"
-            "$ENV_RUN_BIN" "$OTA_BIN" daemon >> "$LOG_PATH" 2>&1 &
-            child="$!"
-            echo "$child" > "$PID_FILE"
-            wait "$child"
+        if run_health_once; then
+            echo "[ota] one-shot health complete" >> "$LOG_PATH"
+        else
             status="$?"
-            rm -f "$PID_FILE"
-            echo "[ota] exited with status $status; restarting in 2s" >> "$LOG_PATH"
-            "$SLEEP_BIN" 2
-        done
+            echo "[ota] one-shot health failed with status $status" >> "$LOG_PATH"
+            exit "$status"
+        fi
     ) &
-    echo "$!" > "$WATCHDOG_PID_FILE"
-    echo "Started ota"
+    echo "Started ota health"
+    return 0
 }
 
 stop() {
-    wpid=$(watchdog_pid)
-    if is_running "$wpid"; then kill "$wpid" 2>/dev/null || true; fi
-    rm -f "$WATCHDOG_PID_FILE"
-
-    spid=$(service_pid)
-    if is_running "$spid"; then
-        kill "$spid" 2>/dev/null || true
-        i=0
-        while is_running "$spid" && [ "$i" -lt 5 ]; do sleep 1; i=$((i + 1)); done
-        if is_running "$spid"; then kill -9 "$spid" 2>/dev/null || true; fi
-    fi
-    rm -f "$PID_FILE"
-    echo "Stopped ota"
+    echo "ota health is one-shot"
 }
 
 status() {
-    wpid=$(watchdog_pid)
-    spid=$(service_pid)
-    if is_running "$wpid"; then echo "watchdog=running pid=$wpid"; else echo "watchdog=stopped"; fi
-    if is_running "$spid"; then echo "ota=running pid=$spid"; else echo "ota=stopped"; fi
+    echo "ota=one-shot"
+    if [ -f "$LOG_PATH" ]; then
+        tail -n 20 "$LOG_PATH"
+    fi
 }
 
 case "${1:-}" in
-    start) start ;;
+    start|restart|reload) start ;;
     stop) stop ;;
-    restart|reload) stop; start ;;
     status) status ;;
     *) echo "Usage: $0 {start|stop|restart|reload|status}" >&2; exit 1 ;;
 esac

--- a/scripts/test_ota_init.sh
+++ b/scripts/test_ota_init.sh
@@ -10,66 +10,120 @@ if [ ! -f "$SCRIPT" ]; then
 fi
 
 TMP_DIR=$(mktemp -d)
-trap 'if [ -f "$TMP_DIR/watchdog.pid" ]; then kill "$(cat "$TMP_DIR/watchdog.pid")" 2>/dev/null || true; fi; if [ -f "$TMP_DIR/ota.pid" ]; then kill "$(cat "$TMP_DIR/ota.pid")" 2>/dev/null || true; fi; rm -rf "$TMP_DIR"' EXIT INT TERM
+LATE_TMP_DIR=
+trap 'rm -rf "$TMP_DIR" "$LATE_TMP_DIR"' EXIT INT TERM
 
 OTA_BIN="$TMP_DIR/ota"
 LOG_PATH="$TMP_DIR/ota.log"
-PID_FILE="$TMP_DIR/ota.pid"
-WATCHDOG_PID_FILE="$TMP_DIR/watchdog.pid"
 USERDATA_DIR="$TMP_DIR/userdata"
-RUN_DIR="$TMP_DIR/run"
 
 cat > "$OTA_BIN" <<'EOF'
 #!/bin/sh
 echo "$@" >> "$OTA_DAEMON_LOG"
-while :; do sleep 1; done
+exit 0
 EOF
 chmod +x "$OTA_BIN"
 
-mkdir -p "$USERDATA_DIR" "$RUN_DIR"
+mkdir -p "$USERDATA_DIR"
 
 OTA_BIN="$OTA_BIN" \
 ENV_RUN_BIN="$ROOT_DIR/overlay/oem/usr/bin/aiden-env-run" \
 LOG_PATH="$LOG_PATH" \
-PID_FILE="$PID_FILE" \
-WATCHDOG_PID_FILE="$WATCHDOG_PID_FILE" \
 USERDATA_DIR="$USERDATA_DIR" \
 OTA_DAEMON_LOG="$TMP_DIR/daemon.args" \
 SLEEP_BIN=":" \
+WAIT_TIMEOUT=1 \
 "$SCRIPT" start >/dev/null
 
 deadline=$(( $(date +%s) + 5 ))
-while [ ! -s "$PID_FILE" ] || [ ! -s "$WATCHDOG_PID_FILE" ] || [ ! -s "$TMP_DIR/daemon.args" ]; do
+while [ ! -s "$TMP_DIR/daemon.args" ]; do
     if [ "$(date +%s)" -ge "$deadline" ]; then
-        echo "ota daemon did not start promptly without network carrier" >&2
+        echo "ota health did not run promptly" >&2
         [ -f "$LOG_PATH" ] && cat "$LOG_PATH" >&2
         exit 1
     fi
     sleep 1
 done
 
-if ! grep -qx 'daemon' "$TMP_DIR/daemon.args"; then
-    echo "ota daemon was not started with daemon subcommand" >&2
+if ! grep -qx 'health' "$TMP_DIR/daemon.args"; then
+    echo "ota health was not processed through the health subcommand" >&2
     cat "$TMP_DIR/daemon.args" >&2
     exit 1
 fi
 
-if ! grep -q 'starting' "$LOG_PATH"; then
-    echo "ota startup log missing" >&2
+if ! grep -q 'processing pending health' "$LOG_PATH"; then
+    echo "ota health startup log missing" >&2
     cat "$LOG_PATH" >&2
     exit 1
 fi
 
-service_pid=$(cat "$PID_FILE")
-watchdog_pid=$(cat "$WATCHDOG_PID_FILE")
+deadline=$(( $(date +%s) + 5 ))
+while ! grep -q 'health processing exited with status 0' "$LOG_PATH"; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+        echo "ota health did not finish promptly" >&2
+        cat "$LOG_PATH" >&2
+        exit 1
+    fi
+    sleep 1
+done
 
-OTA_BIN="$OTA_BIN" \
+if ! grep -q 'health processing exited with status 0' "$LOG_PATH"; then
+    echo "ota health completion log missing" >&2
+    cat "$LOG_PATH" >&2
+    exit 1
+fi
+
+status_output=$(
+    LOG_PATH="$LOG_PATH" "$SCRIPT" status
+)
+if ! printf '%s\n' "$status_output" | grep -q '^ota=one-shot$'; then
+    echo "ota status must report one-shot mode" >&2
+    printf '%s\n' "$status_output" >&2
+    exit 1
+fi
+
+LATE_TMP_DIR=$(mktemp -d)
+LATE_OTA_BIN="$LATE_TMP_DIR/ota"
+LATE_LOG_PATH="$LATE_TMP_DIR/ota.log"
+LATE_USERDATA_DIR="$LATE_TMP_DIR/userdata"
+mkdir -p "$LATE_USERDATA_DIR"
+
+OTA_BIN="$LATE_OTA_BIN" \
 ENV_RUN_BIN="$ROOT_DIR/overlay/oem/usr/bin/aiden-env-run" \
-LOG_PATH="$LOG_PATH" \
-PID_FILE="$PID_FILE" \
-WATCHDOG_PID_FILE="$WATCHDOG_PID_FILE" \
-USERDATA_DIR="$USERDATA_DIR" \
-"$SCRIPT" stop >/dev/null
+LOG_PATH="$LATE_LOG_PATH" \
+USERDATA_DIR="$LATE_USERDATA_DIR" \
+OTA_DAEMON_LOG="$LATE_TMP_DIR/daemon.args" \
+SLEEP_BIN="sleep" \
+"$SCRIPT" start >/dev/null
 
-kill "$service_pid" "$watchdog_pid" 2>/dev/null || true
+sleep 1
+if [ -e "$LATE_TMP_DIR/daemon.args" ]; then
+    echo "ota health ran before ota binary became available" >&2
+    cat "$LATE_TMP_DIR/daemon.args" >&2
+    exit 1
+fi
+
+cat > "$LATE_OTA_BIN" <<'EOF'
+#!/bin/sh
+echo "$@" >> "$OTA_DAEMON_LOG"
+exit 0
+EOF
+chmod +x "$LATE_OTA_BIN"
+
+deadline=$(( $(date +%s) + 5 ))
+while [ ! -s "$LATE_TMP_DIR/daemon.args" ]; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+        echo "ota health did not run after late ota binary appeared" >&2
+        [ -f "$LATE_LOG_PATH" ] && cat "$LATE_LOG_PATH" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+if ! grep -qx 'health' "$LATE_TMP_DIR/daemon.args"; then
+    echo "late ota health was not processed through the health subcommand" >&2
+    cat "$LATE_TMP_DIR/daemon.args" >&2
+    exit 1
+fi
+
 echo "S54ota tests passed"

--- a/scripts/test_ota_init.sh
+++ b/scripts/test_ota_init.sh
@@ -11,7 +11,8 @@ fi
 
 TMP_DIR=$(mktemp -d)
 LATE_TMP_DIR=
-trap 'rm -rf "$TMP_DIR" "$LATE_TMP_DIR"' EXIT INT TERM
+MOUNT_TMP_DIR=
+trap 'rm -rf "$TMP_DIR" "$LATE_TMP_DIR" "$MOUNT_TMP_DIR"' EXIT INT TERM
 
 OTA_BIN="$TMP_DIR/ota"
 LOG_PATH="$TMP_DIR/ota.log"
@@ -30,6 +31,7 @@ OTA_BIN="$OTA_BIN" \
 ENV_RUN_BIN="$ROOT_DIR/overlay/oem/usr/bin/aiden-env-run" \
 LOG_PATH="$LOG_PATH" \
 USERDATA_DIR="$USERDATA_DIR" \
+USERDATA_REQUIRE_MOUNT=0 \
 OTA_DAEMON_LOG="$TMP_DIR/daemon.args" \
 SLEEP_BIN=":" \
 WAIT_TIMEOUT=1 \
@@ -88,12 +90,54 @@ LATE_LOG_PATH="$LATE_TMP_DIR/ota.log"
 LATE_USERDATA_DIR="$LATE_TMP_DIR/userdata"
 mkdir -p "$LATE_USERDATA_DIR"
 
+MOUNT_TMP_DIR=$(mktemp -d)
+MOUNT_OTA_BIN="$MOUNT_TMP_DIR/ota"
+MOUNT_LOG_PATH="$MOUNT_TMP_DIR/ota.log"
+MOUNT_USERDATA_DIR="$MOUNT_TMP_DIR/userdata"
+MOUNT_MOUNTS_PATH="$MOUNT_TMP_DIR/mounts"
+cat > "$MOUNT_OTA_BIN" <<'EOF'
+#!/bin/sh
+echo "$@" >> "$OTA_DAEMON_LOG"
+exit 0
+EOF
+chmod +x "$MOUNT_OTA_BIN"
+mkdir -p "$MOUNT_USERDATA_DIR"
+: > "$MOUNT_MOUNTS_PATH"
+
+OTA_BIN="$MOUNT_OTA_BIN" \
+ENV_RUN_BIN="$ROOT_DIR/overlay/oem/usr/bin/aiden-env-run" \
+LOG_PATH="$MOUNT_LOG_PATH" \
+USERDATA_DIR="$MOUNT_USERDATA_DIR" \
+MOUNTS_PATH="$MOUNT_MOUNTS_PATH" \
+OTA_DAEMON_LOG="$MOUNT_TMP_DIR/daemon.args" \
+SLEEP_BIN=":" \
+WAIT_TIMEOUT=1 \
+"$SCRIPT" start >/dev/null
+
+deadline=$(( $(date +%s) + 5 ))
+while ! { [ -f "$MOUNT_LOG_PATH" ] && grep -q 'userdata mount unavailable after 1s' "$MOUNT_LOG_PATH"; }; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+        echo "ota health did not wait for mounted userdata" >&2
+        [ -f "$MOUNT_LOG_PATH" ] && cat "$MOUNT_LOG_PATH" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+if [ -e "$MOUNT_TMP_DIR/daemon.args" ]; then
+    echo "ota health ran before userdata was mounted" >&2
+    cat "$MOUNT_TMP_DIR/daemon.args" >&2
+    exit 1
+fi
+
 OTA_BIN="$LATE_OTA_BIN" \
 ENV_RUN_BIN="$ROOT_DIR/overlay/oem/usr/bin/aiden-env-run" \
 LOG_PATH="$LATE_LOG_PATH" \
 USERDATA_DIR="$LATE_USERDATA_DIR" \
+USERDATA_REQUIRE_MOUNT=0 \
 OTA_DAEMON_LOG="$LATE_TMP_DIR/daemon.args" \
 SLEEP_BIN="sleep" \
+WAIT_TIMEOUT=5 \
 "$SCRIPT" start >/dev/null
 
 sleep 1
@@ -125,5 +169,15 @@ if ! grep -qx 'health' "$LATE_TMP_DIR/daemon.args"; then
     cat "$LATE_TMP_DIR/daemon.args" >&2
     exit 1
 fi
+
+deadline=$(( $(date +%s) + 5 ))
+while ! { [ -f "$LATE_LOG_PATH" ] && grep -q 'health processing exited with status 0' "$LATE_LOG_PATH"; }; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+        echo "late ota health did not finish promptly" >&2
+        [ -f "$LATE_LOG_PATH" ] && cat "$LATE_LOG_PATH" >&2
+        exit 1
+    fi
+    sleep 1
+done
 
 echo "S54ota tests passed"

--- a/src/agent/cmd/ota/main.go
+++ b/src/agent/cmd/ota/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -16,13 +15,6 @@ import (
 	"aiden-agent/internal/ota"
 )
 
-const otaInitScriptPath = "/etc/init.d/S54ota"
-
-var (
-	stopRunningDaemon  = stopRunningDaemonWithInitScript
-	startRunningDaemon = startRunningDaemonWithInitScript
-)
-
 func main() {
 	if err := run(os.Args[1:], os.Stdout); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -33,7 +25,7 @@ func main() {
 func run(args []string, out io.Writer) error {
 	command, args := splitCommandAndFlags(args)
 	positional := flagArgs(args)
-	if (command == "daemon" || command == "update" || command == "check-now" || command == "status") && len(positional) != 0 {
+	if (command == "health" || command == "update" || command == "check-now" || command == "status") && len(positional) != 0 {
 		return usage()
 	}
 	config, err := parseConfigFlags(args)
@@ -47,21 +39,10 @@ func run(args []string, out io.Writer) error {
 	ctx := context.Background()
 
 	switch command {
-	case "daemon":
-		return updater.RunDaemon(ctx)
+	case "health":
+		return updater.ProcessPendingHealthOnce(ctx)
 	case "update", "check-now":
-		if err := stopRunningDaemon(); err != nil {
-			return err
-		}
 		result, err := updater.CheckOnce(ctx)
-		if shouldRestartDaemonAfterUpdate(config, result, err) {
-			if restartErr := startRunningDaemon(); restartErr != nil {
-				if err != nil {
-					return fmt.Errorf("%w; restart ota daemon: %v", err, restartErr)
-				}
-				return fmt.Errorf("restart ota daemon after unsuccessful update: %w", restartErr)
-			}
-		}
 		if err != nil {
 			return err
 		}
@@ -110,43 +91,9 @@ func platformReboot() error {
 	return fmt.Errorf("reboot binary not found in trusted paths")
 }
 
-func shouldRestartDaemonAfterUpdate(config ota.UpdaterConfig, result ota.UpdateResult, err error) bool {
-	if errors.Is(err, ota.ErrUpdateAlreadyRunning) {
-		return false
-	}
-	if err != nil {
-		return true
-	}
-	if config.DryRun {
-		return true
-	}
-	return !result.Updated
-}
-
-func stopRunningDaemonWithInitScript() error {
-	return runOtaInitScriptIfExists("stop")
-}
-
-func startRunningDaemonWithInitScript() error {
-	return runOtaInitScriptIfExists("start")
-}
-
-func runOtaInitScriptIfExists(action string) error {
-	if _, err := os.Stat(otaInitScriptPath); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	if err := exec.Command(otaInitScriptPath, action).Run(); err != nil {
-		return fmt.Errorf("%s ota daemon: %w", action, err)
-	}
-	return nil
-}
-
 func splitCommandAndFlags(args []string) (string, []string) {
 	commands := map[string]bool{
-		"daemon":          true,
+		"health":          true,
 		"update":          true,
 		"check-now":       true,
 		"status":          true,
@@ -167,9 +114,9 @@ func splitCommandAndFlags(args []string) (string, []string) {
 			rest = append(rest, args[i+1:]...)
 			return arg, rest
 		}
-		return "daemon", args
+		return "health", args
 	}
-	return "daemon", args
+	return "health", args
 }
 
 func parseConfigFlags(args []string) (ota.UpdaterConfig, error) {
@@ -182,9 +129,7 @@ func parseConfigFlags(args []string) (ota.UpdaterConfig, error) {
 	manifestURL := fs.String("manifest-url", "", "direct manifest URL (skips release API)")
 	publicKeyPath := fs.String("public-key", "", "Ed25519 public key PEM path")
 	dryRun := fs.Bool("dry-run", false, "download and verify without switching misc or rebooting")
-	testMode := fs.Bool("test", false, "use test-friendly short intervals")
-	interval := fs.Duration("interval", 0, "daemon check interval")
-	jitter := fs.Duration("jitter", 0, "daemon check jitter")
+	testMode := fs.Bool("test", false, "use test-friendly short health timeout")
 	healthTimeout := fs.Duration("health-timeout", 0, "pending health timeout")
 	httpTimeout := fs.Duration("http-timeout", 0, "HTTP request timeout")
 	switchTries := fs.Uint("switch-tries", 0, "tries remaining when switching slots")
@@ -214,12 +159,6 @@ func parseConfigFlags(args []string) (ota.UpdaterConfig, error) {
 	if *publicKeyPath != "" {
 		config.PublicKeyPath = *publicKeyPath
 	}
-	if *interval != 0 {
-		config.Interval = *interval
-	}
-	if *jitter != 0 {
-		config.Jitter = *jitter
-	}
 	if *healthTimeout != 0 {
 		config.HealthTimeout = *healthTimeout
 	}
@@ -237,8 +176,6 @@ func parseConfigFlags(args []string) (ota.UpdaterConfig, error) {
 	}
 	config.DryRun = config.DryRun || *dryRun
 	if *testMode {
-		config.Interval = time.Second
-		config.Jitter = 0
 		config.HealthTimeout = time.Second
 	}
 	config.Logger = log.New(os.Stderr, "ota: ", log.LstdFlags)
@@ -291,7 +228,7 @@ func flagIsBool(name string) bool {
 
 func flagTakesValue(name string) bool {
 	switch name {
-	case "config", "state-dir", "misc", "block-dir", "manifest-url", "public-key", "interval", "jitter", "health-timeout", "target-slot", "http-timeout", "switch-tries":
+	case "config", "state-dir", "misc", "block-dir", "manifest-url", "public-key", "health-timeout", "target-slot", "http-timeout", "switch-tries":
 		return true
 	default:
 		return false
@@ -299,5 +236,5 @@ func flagTakesValue(name string) bool {
 }
 
 func usage() error {
-	return fmt.Errorf("usage: ota [flags] [daemon|update|check-now|status|verify-manifest <manifest>]")
+	return fmt.Errorf("usage: ota [flags] [health|update|check-now|status|verify-manifest <manifest>]")
 }

--- a/src/agent/cmd/ota/main_test.go
+++ b/src/agent/cmd/ota/main_test.go
@@ -34,10 +34,10 @@ func TestSplitCommandAndFlagsAllowsGlobalFlagsBeforeCommand(t *testing.T) {
 	}
 }
 
-func TestSplitCommandAndFlagsDefaultsToDaemon(t *testing.T) {
+func TestSplitCommandAndFlagsDefaultsToHealth(t *testing.T) {
 	command, rest := splitCommandAndFlags([]string{"--config", "test.json"})
-	if command != "daemon" {
-		t.Fatalf("command = %q, want daemon", command)
+	if command != "health" {
+		t.Fatalf("command = %q, want health", command)
 	}
 	if len(rest) != 2 || rest[0] != "--config" || rest[1] != "test.json" {
 		t.Fatalf("rest = %#v", rest)
@@ -73,9 +73,20 @@ func TestSplitCommandAndFlagsKeepsCheckNowAlias(t *testing.T) {
 	}
 }
 
+func TestSplitCommandAndFlagsSupportsHealthCommand(t *testing.T) {
+	command, rest := splitCommandAndFlags([]string{"--state-dir", "state", "health"})
+	if command != "health" {
+		t.Fatalf("command = %q, want health", command)
+	}
+	want := []string{"--state-dir", "state"}
+	if len(rest) != len(want) || rest[0] != want[0] || rest[1] != want[1] {
+		t.Fatalf("rest = %#v, want %#v", rest, want)
+	}
+}
+
 func TestRunRejectsExtraPositionalsForNonManifestCommands(t *testing.T) {
 	for _, args := range [][]string{
-		{"daemon", "extra"},
+		{"health", "extra"},
 		{"update", "extra", "--dry-run"},
 		{"check-now", "extra", "--dry-run"},
 		{"status", "extra"},
@@ -101,55 +112,8 @@ func TestDefaultRebootIsRealUnlessDryRun(t *testing.T) {
 	}
 }
 
-func TestShouldRestartDaemonAfterUpdate(t *testing.T) {
-	tests := []struct {
-		name   string
-		config ota.UpdaterConfig
-		result ota.UpdateResult
-		err    error
-		want   bool
-	}{
-		{name: "check failure", err: errForcedUpdateCheckFailure, want: true},
-		{name: "already running", err: ota.ErrUpdateAlreadyRunning, want: false},
-		{name: "no update", result: ota.UpdateResult{NoUpdate: true}, want: true},
-		{name: "dry run", config: ota.UpdaterConfig{DryRun: true}, result: ota.UpdateResult{Updated: true}, want: true},
-		{name: "real update success", result: ota.UpdateResult{Updated: true}, want: false},
-	}
-
-	for _, tt := range tests {
-		if got := shouldRestartDaemonAfterUpdate(tt.config, tt.result, tt.err); got != tt.want {
-			t.Fatalf("%s: shouldRestartDaemonAfterUpdate() = %v, want %v", tt.name, got, tt.want)
-		}
-	}
-}
-
-var errForcedUpdateCheckFailure = &forcedUpdateCheckFailureError{}
-
-type forcedUpdateCheckFailureError struct{}
-
-func (*forcedUpdateCheckFailureError) Error() string {
-	return "forced update check failure"
-}
-
-func TestUpdateRestartsRunningDaemonWhenNoUpdate(t *testing.T) {
+func TestUpdateRunsManualCheckWhenNoUpdate(t *testing.T) {
 	fixture := newNoUpdateFixture(t)
-
-	stopCalls := 0
-	startCalls := 0
-	oldStop := stopRunningDaemon
-	oldStart := startRunningDaemon
-	stopRunningDaemon = func() error {
-		stopCalls++
-		return nil
-	}
-	startRunningDaemon = func() error {
-		startCalls++
-		return nil
-	}
-	t.Cleanup(func() {
-		stopRunningDaemon = oldStop
-		startRunningDaemon = oldStart
-	})
 
 	var out bytes.Buffer
 	err := run([]string{
@@ -162,40 +126,17 @@ func TestUpdateRestartsRunningDaemonWhenNoUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run(update) error = %v", err)
 	}
-	if stopCalls != 1 {
-		t.Fatalf("stopCalls = %d, want 1", stopCalls)
-	}
-	if startCalls != 1 {
-		t.Fatalf("startCalls = %d, want 1", startCalls)
-	}
 	if !strings.Contains(out.String(), `"NoUpdate":true`) {
 		t.Fatalf("output = %q, want no update", out.String())
 	}
 }
 
-func TestUpdateRestartsRunningDaemonAfterCheckFailure(t *testing.T) {
+func TestUpdateReturnsManualCheckFailure(t *testing.T) {
 	fixture := newNoUpdateFixture(t)
 	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("not a manifest"))
 	}))
 	t.Cleanup(badServer.Close)
-
-	stopCalls := 0
-	startCalls := 0
-	oldStop := stopRunningDaemon
-	oldStart := startRunningDaemon
-	stopRunningDaemon = func() error {
-		stopCalls++
-		return nil
-	}
-	startRunningDaemon = func() error {
-		startCalls++
-		return nil
-	}
-	t.Cleanup(func() {
-		stopRunningDaemon = oldStop
-		startRunningDaemon = oldStart
-	})
 
 	err := run([]string{
 		"update",
@@ -206,12 +147,6 @@ func TestUpdateRestartsRunningDaemonAfterCheckFailure(t *testing.T) {
 	}, &bytes.Buffer{})
 	if err == nil {
 		t.Fatalf("run(update) error = nil, want manifest failure")
-	}
-	if stopCalls != 1 {
-		t.Fatalf("stopCalls = %d, want 1", stopCalls)
-	}
-	if startCalls != 1 {
-		t.Fatalf("startCalls = %d, want 1", startCalls)
 	}
 }
 

--- a/src/agent/internal/ota/updater.go
+++ b/src/agent/internal/ota/updater.go
@@ -50,10 +50,6 @@ type UpdaterConfig struct {
 	PartitionSizes         map[string]int64             `json:"partition_sizes,omitempty"`
 	GitHubToken            string                       `json:"github_token,omitempty"`
 	GitHubTokenPath        string                       `json:"github_token_path,omitempty"`
-	Interval               time.Duration                `json:"-"`
-	Jitter                 time.Duration                `json:"-"`
-	IntervalSeconds        int                          `json:"interval_seconds,omitempty"`
-	JitterSeconds          int                          `json:"jitter_seconds,omitempty"`
 	SwitchTries            uint8                        `json:"switch_tries,omitempty"`
 	HealthTimeout          time.Duration                `json:"-"`
 	HealthTimeoutSecs      int                          `json:"health_timeout_seconds,omitempty"`
@@ -125,16 +121,6 @@ func normalizeUpdaterConfig(config UpdaterConfig) (UpdaterConfig, error) {
 	}
 	if config.GitHubTokenPath == "" {
 		config.GitHubTokenPath = filepath.Join(config.StateDir, "gh_token")
-	}
-	if config.Interval == 0 {
-		if config.IntervalSeconds > 0 {
-			config.Interval = time.Duration(config.IntervalSeconds) * time.Second
-		} else {
-			config.Interval = time.Hour
-		}
-	}
-	if config.Jitter == 0 && config.JitterSeconds > 0 {
-		config.Jitter = time.Duration(config.JitterSeconds) * time.Second
 	}
 	if config.SwitchTries == 0 {
 		config.SwitchTries = 3
@@ -644,31 +630,17 @@ func (u *Updater) commitPendingHealth(pending PendingBoot) error {
 	return os.Remove(u.pendingPath())
 }
 
-func (u *Updater) RunDaemon(ctx context.Context) error {
-	u.logf("ota daemon: started interval=%s jitter=%s", u.config.Interval, u.config.Jitter)
+func (u *Updater) ProcessPendingHealthOnce(ctx context.Context) error {
+	u.logf("ota health: processing pending boot")
 	if err := u.processPendingHealthWithLock(ctx); err != nil {
 		u.logf("ota health: %v", err)
 		if !errors.Is(err, ErrUpdateAlreadyRunning) {
 			u.recordError("health", err)
 		}
+		return err
 	}
-	for {
-		if _, err := u.CheckOnce(ctx); err != nil {
-			u.logf("ota check: %v", err)
-			if !errors.Is(err, ErrUpdateAlreadyRunning) {
-				u.recordError("check", err)
-			}
-		}
-		wait := u.config.Interval + randomJitter(u.config.Jitter)
-		u.logf("ota daemon: next check in %s", wait)
-		timer := time.NewTimer(wait)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return ctx.Err()
-		case <-timer.C:
-		}
-	}
+	u.logf("ota health: complete")
+	return nil
 }
 
 func (u *Updater) processPendingHealthWithLock(ctx context.Context) error {
@@ -1158,15 +1130,4 @@ func currentBootID() string {
 		return ""
 	}
 	return strings.TrimSpace(string(data))
-}
-
-func randomJitter(max time.Duration) time.Duration {
-	if max <= 0 {
-		return 0
-	}
-	buf := make([]byte, 1)
-	if _, err := rand.Read(buf); err != nil {
-		return 0
-	}
-	return time.Duration(int64(buf[0]) * int64(max) / 255)
 }

--- a/src/agent/internal/ota/updater_test.go
+++ b/src/agent/internal/ota/updater_test.go
@@ -315,7 +315,7 @@ func TestProcessPendingHealthOnceDoesNotCheckForUpdates(t *testing.T) {
 		}
 	case path := <-requests:
 		t.Fatalf("ProcessPendingHealthOnce made automatic OTA request to %s", path)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Fatal("ProcessPendingHealthOnce did not exit after one health pass")
 	}
 }

--- a/src/agent/internal/ota/updater_test.go
+++ b/src/agent/internal/ota/updater_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -291,6 +292,56 @@ func TestUpdaterCheckOnceRejectsConcurrentUpdateLock(t *testing.T) {
 	_, err = env.updater().CheckOnce(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "ota update already running") {
 		t.Fatalf("CheckOnce() error = %v, want ota update already running", err)
+	}
+}
+
+func TestProcessPendingHealthOnceDoesNotCheckForUpdates(t *testing.T) {
+	env := newUpdaterTestEnv(t)
+	requests := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case requests <- r.URL.Path:
+		default:
+		}
+		http.Error(w, "unexpected automatic OTA check", http.StatusTeapot)
+	}))
+	t.Cleanup(server.Close)
+	env.config.ReleaseURL = server.URL + "/repos/AidenAI-IO/aiden-hardware-demo/releases/latest"
+
+	select {
+	case err := <-processPendingHealthOnceAsync(env.updater(), context.Background()):
+		if err != nil {
+			t.Fatalf("ProcessPendingHealthOnce() error = %v", err)
+		}
+	case path := <-requests:
+		t.Fatalf("ProcessPendingHealthOnce made automatic OTA request to %s", path)
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("ProcessPendingHealthOnce did not exit after one health pass")
+	}
+}
+
+func processPendingHealthOnceAsync(updater *Updater, ctx context.Context) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		done <- updater.ProcessPendingHealthOnce(ctx)
+	}()
+	return done
+}
+
+func TestProcessPendingHealthOnceReturnsContextErrorWhenHealthWaitIsCanceled(t *testing.T) {
+	env := newUpdaterTestEnv(t)
+	pending := PendingBoot{TargetSlot: "a", TargetVersion: "v2", TargetBuildTime: "2026-05-21T12:00:00Z", Nonce: "nonce"}
+	if err := WritePendingBoot(filepath.Join(env.stateDir, "pending_boot.json"), pending); err != nil {
+		t.Fatalf("WritePendingBoot() error = %v", err)
+	}
+	env.config.HealthTimeout = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := processPendingHealthOnceAsync(env.updater(), ctx)
+	cancel()
+
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("ProcessPendingHealthOnce() error = %v, want context canceled", err)
 	}
 }
 

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -111,7 +111,6 @@ const char* kAnyBindAddress = "0.0.0.0";
 const char* kUsbBindAddress = "192.168.42.1";
 const char* kLoopbackBindAddress = "127.0.0.1";
 const char* kAgentInitScript = "/etc/init.d/S53agent";
-const char* kOtaInitScript = "/etc/init.d/S54ota";
 const char* kAgentLogPath = "/var/log/agent/agent.log";
 // Default path to the agent binary on device. Tests override this via the
 // AIDEN_AGENT_BIN environment variable, resolved once on first use to keep
@@ -1877,10 +1876,6 @@ void schedule_agent_restart() {
     schedule_init_script_restart(kAgentInitScript);
 }
 
-void schedule_ota_restart() {
-    schedule_init_script_restart(kOtaInitScript);
-}
-
 int acquire_ota_update_launch_lock(std::string* error) {
     std::string lock_path = ota_update_lock_path();
     int lock_fd = open(lock_path.c_str(), O_CREAT | O_RDWR, 0600);
@@ -1957,7 +1952,7 @@ bool launch_ota_update_supervisor(int lock_fd, const std::string& log_path, std:
         setsid();
         set_fd_cloexec(lock_fd, NULL);
         // Keep the launch lock in this supervisor while `ota update` runs,
-        // but keep it out of the ota/update-daemon exec tree.
+        // but keep it out of the ota update exec tree.
         std::string cmd = build_ota_update_command(log_path);
         int rc = system(cmd.c_str());
         (void)rc;
@@ -2855,26 +2850,18 @@ ApiResponse handle_post_system_env(const Options& options, const std::string& bo
     std::string system_env = env_item->valuestring;
     cJSON_Delete(root);
 
-    std::string original_system_env = read_file_contents(options.system_env_path.c_str(), kMaxSystemEnvSize);
     std::string save_error;
     if (!save_system_env_content(options.system_env_path, system_env, &save_error)) {
         return make_json_error(400, save_error);
     }
 
-    std::string updated_system_env = read_file_contents(options.system_env_path.c_str(), kMaxSystemEnvSize);
-    bool system_env_changed = original_system_env != updated_system_env;
     schedule_agent_restart();
-    if (system_env_changed) {
-        schedule_ota_restart();
-    }
 
     cJSON* response = cJSON_CreateObject();
     cJSON_AddBoolToObject(response, "ok", 1);
-    cJSON_AddStringToObject(response, "message",
-                            system_env_changed ? "system env saved; services restarting"
-                                               : "system env saved; agent restarting");
+    cJSON_AddStringToObject(response, "message", "system env saved; agent restarting");
     cJSON_AddBoolToObject(response, "agent_restart_scheduled", 1);
-    cJSON_AddBoolToObject(response, "ota_restart_scheduled", system_env_changed ? 1 : 0);
+    cJSON_AddBoolToObject(response, "ota_restart_scheduled", 0);
     cJSON_AddStringToObject(response, "system_env",
                             read_file_contents(options.system_env_path.c_str(), kMaxSystemEnvSize).c_str());
     cJSON* paths = add_object(response, "paths");

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -401,6 +401,36 @@ TEST_CASE("config_web: GET /api/config reads resolved config from agent") {
     cJSON_Delete(parsed);
 }
 
+TEST_CASE("config_web: POST /api/system/env saves env without OTA restart") {
+    StubEnv env;
+    auto handle = start_server(env);
+
+    const std::string env_body = "HTTP_PROXY=http://proxy.example:18080\\n";
+    const std::string body = "{\"system_env\":\"" + env_body + "\"}";
+    HttpResponse resp = http_request(handle->port, "POST", "/api/system/env", body);
+    REQUIRE(resp.status == 200);
+
+    cJSON* parsed = cJSON_Parse(resp.body.c_str());
+    REQUIRE(parsed != nullptr);
+    cJSON* agent_restart = cJSON_GetObjectItem(parsed, "agent_restart_scheduled");
+    REQUIRE(agent_restart != nullptr);
+    CHECK((agent_restart->type & 0xff) == cJSON_True);
+    cJSON* ota_restart = cJSON_GetObjectItem(parsed, "ota_restart_scheduled");
+    REQUIRE(ota_restart != nullptr);
+    CHECK((ota_restart->type & 0xff) == cJSON_False);
+    cJSON* saved_env = cJSON_GetObjectItem(parsed, "system_env");
+    REQUIRE(saved_env != nullptr);
+    REQUIRE(saved_env->valuestring != nullptr);
+    CHECK(std::string(saved_env->valuestring) == "HTTP_PROXY=http://proxy.example:18080\n");
+    cJSON_Delete(parsed);
+
+    std::ifstream saved_in((handle->tmp_dir + "/system_env").c_str());
+    REQUIRE(saved_in.good());
+    std::ostringstream saved_buffer;
+    saved_buffer << saved_in.rdbuf();
+    CHECK(saved_buffer.str() == "HTTP_PROXY=http://proxy.example:18080\n");
+}
+
 TEST_CASE("config_web: POST /api/config writes audio_archive section") {
     StubEnv env;
     auto handle = start_server(env);
@@ -757,7 +787,7 @@ TEST_CASE("config_web: both endpoints fail closed with 503 when AIDEN_AGENT_BIN 
     CHECK(save.body.find("agent binary not found") != std::string::npos);
 }
 
-TEST_CASE("config_web: failed manual OTA update releases launch lock even if a daemon keeps running") {
+TEST_CASE("config_web: failed manual OTA update releases launch lock even if a child keeps running") {
     auto tmp = make_temp_dir();
     auto cleanup = std::unique_ptr<void, void(*)(void*)>(
         const_cast<char*>(tmp.c_str()),

--- a/tests/config_web_source_test.cpp
+++ b/tests/config_web_source_test.cpp
@@ -683,7 +683,7 @@ TEST_CASE("config web exposes benchmark settings section") {
     CHECK(html.find("enterEditSection('benchmark')") != std::string::npos);
 }
 
-TEST_CASE("config web restarts ota only when system env changes") {
+TEST_CASE("config web does not restart ota for system env changes") {
     const std::string source_path = std::string(AIDEN_SOURCE_DIR) + "/src/config_web.cpp";
     std::ifstream source_in(source_path.c_str());
     REQUIRE(source_in.good());
@@ -693,12 +693,12 @@ TEST_CASE("config web restarts ota only when system env changes") {
     const std::string source = source_buffer.str();
 
     CHECK(source.find("kAgentInitScript") != std::string::npos);
-    CHECK(source.find("kOtaInitScript") != std::string::npos);
+    CHECK(source.find("kOtaInitScript") == std::string::npos);
     CHECK(source.find("schedule_agent_restart") != std::string::npos);
-    CHECK(source.find("schedule_ota_restart") != std::string::npos);
-    CHECK(source.find("bool system_env_changed = original_system_env != updated_system_env;") != std::string::npos);
-    CHECK(source.find("if (system_env_changed)") != std::string::npos);
-    CHECK(source.find("system env saved; services restarting") != std::string::npos);
+    CHECK(source.find("schedule_ota_restart") == std::string::npos);
+    CHECK(source.find("bool system_env_changed = original_system_env != updated_system_env;") == std::string::npos);
+    CHECK(source.find("system env saved; services restarting") == std::string::npos);
+    CHECK(source.find("system env saved; agent restarting") != std::string::npos);
     CHECK(source.find("config saved; agent restarting") != std::string::npos);
     CHECK(source.find("config saved; agent and ota restarting") == std::string::npos);
 }


### PR DESCRIPTION
## Summary
- replace the long-running OTA daemon/watchdog with a boot-time one-shot health pass
- keep OTA updates manual through `ota update` / `check-now`
- remove stale scheduled-update configuration, Config Web OTA restarts, and auto-update docs

## Tests
- `cd src/agent && go test ./internal/ota ./cmd/ota -count=1`
- `scripts/test_ota_init.sh`
- `scripts/test_system_env.sh`
- `cmake --build build-host-tests --target aiden_tests config_web_for_tests`
- `./build-host-tests/bin/aiden_tests --test-case='config_web: POST /api/system/env saves env without OTA restart'`
- `./build-host-tests/bin/aiden_tests --test-case='config web does not restart ota for system env changes'`
- `./build-host-tests/bin/aiden_tests --test-case='config_web: failed manual OTA update releases launch lock even if a child keeps running'`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * OTA refactored from continuous daemon to one-shot health verification at boot
  * Manual updates now require explicit `ota update` command trigger
  * System environment configuration changes no longer trigger OTA restarts
  * Updated OTA architecture documentation, examples, and release channel guidance

* **Chores**
  * Removed daemon interval and jitter configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->