### PR TITLE
fix: harden OTA binary staging verification

### DIFF
--- a/_build_image.sh
+++ b/_build_image.sh
@@ -67,6 +67,7 @@ AIDEN_GENERATED_BINARIES=(
     rknn_vad
     trigger
 )
+GENERATED_BINARY_MANIFEST="$SCRIPT_DIR/build/aiden-generated-binaries.sha256"
 
 clean_generated_binaries() {
     local bin_dir="$1"
@@ -238,6 +239,9 @@ log_binary_fingerprint() {
     sha="$(sha256_file "$path")"
     echo "  binary-fingerprint stage=$stage name=$binary size=$size allocated=$allocated sha256=$sha"
 
+    if stat -c 'mode=%A uid=%u gid=%g inode=%i links=%h mtime=%y ctime=%z' "$path" >/dev/null 2>&1; then
+        echo "    stat: $(stat -c 'mode=%A uid=%u gid=%g inode=%i links=%h mtime=%y ctime=%z' "$path")"
+    fi
     if command -v file >/dev/null 2>&1; then
         echo "    file: $(file -b "$path")"
     fi
@@ -259,6 +263,202 @@ log_generated_binaries_in_dir() {
     for binary in "${AIDEN_GENERATED_BINARIES[@]}"; do
         log_binary_fingerprint "$stage" "$binary" "$bin_dir/$binary"
     done
+}
+
+manifest_sha_for_binary() {
+    local manifest="$1"
+    local binary="$2"
+
+    awk -v binary="$binary" '$2 == binary { print $1; found = 1; exit } END { if (!found) exit 1 }' "$manifest"
+}
+
+write_generated_binary_manifest() {
+    local bin_dir="$1"
+    local manifest="$2"
+    local binary path sha tmp_manifest
+
+    mkdir -p "$(dirname "$manifest")"
+    tmp_manifest="$(mktemp "${manifest}.tmp.XXXXXX")"
+    for binary in "${AIDEN_GENERATED_BINARIES[@]}"; do
+        path="$bin_dir/$binary"
+        if [ ! -f "$path" ]; then
+            rm -f "$tmp_manifest"
+            echo "  ✗ Error: missing generated binary for manifest: $path" >&2
+            exit 1
+        fi
+        sha="$(sha256_file "$path")"
+        printf '%s  %s\n' "$sha" "$binary" >> "$tmp_manifest"
+    done
+    mv "$tmp_manifest" "$manifest"
+    echo "  ✓ Generated binary manifest written: $manifest"
+}
+
+log_binary_storage_details() {
+    local label="$1"
+    local path="$2"
+
+    if [ ! -e "$path" ]; then
+        return 0
+    fi
+    if command -v filefrag >/dev/null 2>&1; then
+        filefrag -v "$path" 2>/dev/null | sed "s/^/    filefrag-$label: /" || true
+    fi
+}
+
+log_binary_diff_summary() {
+    local expected_path="$1"
+    local actual_path="$2"
+
+    if [ ! -f "$expected_path" ] || [ ! -f "$actual_path" ] || ! command -v python3 >/dev/null 2>&1; then
+        return 0
+    fi
+
+    python3 - "$expected_path" "$actual_path" <<'PY' || true
+from pathlib import Path
+import sys
+
+expected = Path(sys.argv[1]).read_bytes()
+actual = Path(sys.argv[2]).read_bytes()
+limit = min(len(expected), len(actual))
+diffs = [i for i in range(limit) if expected[i] != actual[i]]
+if len(expected) != len(actual):
+    diffs.extend(range(limit, max(len(expected), len(actual))))
+if not diffs:
+    print("    diff-summary: files are byte-identical")
+    raise SystemExit
+
+first = diffs[0]
+last = diffs[-1]
+print(f"    diff-summary: count={len(diffs)} first=0x{first:x} last=0x{last:x} expected_size={len(expected)} actual_size={len(actual)}")
+
+page_size = 4096
+start_page = first // page_size
+end_page = last // page_size
+zeroed_pages = []
+for page in range(start_page, end_page + 1):
+    start = page * page_size
+    end = min(start + page_size, limit)
+    if start >= end:
+        continue
+    expected_nonzero = sum(1 for byte in expected[start:end] if byte != 0)
+    actual_nonzero = sum(1 for byte in actual[start:end] if byte != 0)
+    if expected_nonzero > 0 and actual_nonzero == 0:
+        zeroed_pages.append((start, end - 1))
+
+if zeroed_pages:
+    ranges = []
+    range_start, range_end = zeroed_pages[0]
+    for start, end in zeroed_pages[1:]:
+        if start == range_end + 1:
+            range_end = end
+        else:
+            ranges.append((range_start, range_end))
+            range_start, range_end = start, end
+    ranges.append((range_start, range_end))
+    rendered = " ".join(f"0x{start:x}-0x{end:x}" for start, end in ranges[:8])
+    suffix = " ..." if len(ranges) > 8 else ""
+    print(f"    diff-summary: zeroed-page-ranges={rendered}{suffix}")
+PY
+}
+
+log_generated_binary_mismatch() {
+    local stage="$1"
+    local binary="$2"
+    local expected_sha="$3"
+    local actual_sha="$4"
+    local expected_path="$5"
+    local actual_path="$6"
+
+    echo "  ✗ Generated binary mismatch stage=$stage name=$binary expected_sha256=$expected_sha actual_sha256=$actual_sha path=$actual_path" >&2
+    log_binary_fingerprint "$stage-expected" "$binary" "$expected_path" >&2 || true
+    log_binary_fingerprint "$stage-actual" "$binary" "$actual_path" >&2 || true
+    log_binary_diff_summary "$expected_path" "$actual_path" >&2 || true
+    log_binary_storage_details "expected" "$expected_path" >&2 || true
+    log_binary_storage_details "actual" "$actual_path" >&2 || true
+}
+
+check_generated_binaries_against_manifest() {
+    local stage="$1"
+    local bin_dir="$2"
+    local manifest="$3"
+    local expected_bin_dir="${4:-}"
+    local binary expected_sha actual_sha path expected_path mismatch checked
+
+    if [ ! -f "$manifest" ]; then
+        echo "  ✗ Error: missing generated binary manifest for $stage: $manifest" >&2
+        exit 1
+    fi
+
+    mismatch=0
+    checked=0
+    for binary in "${AIDEN_GENERATED_BINARIES[@]}"; do
+        expected_sha="$(manifest_sha_for_binary "$manifest" "$binary")" || {
+            echo "  ✗ Error: manifest missing generated binary: $binary" >&2
+            exit 1
+        }
+        path="$bin_dir/$binary"
+        expected_path="${expected_bin_dir:-$bin_dir}/$binary"
+        if [ ! -f "$path" ]; then
+            echo "  ✗ Generated binary missing stage=$stage name=$binary path=$path expected_sha256=$expected_sha" >&2
+            mismatch=1
+            continue
+        fi
+        actual_sha="$(sha256_file "$path")"
+        if [ "$actual_sha" != "$expected_sha" ]; then
+            mismatch=1
+            log_generated_binary_mismatch "$stage" "$binary" "$expected_sha" "$actual_sha" "$expected_path" "$path"
+            continue
+        fi
+        checked=$((checked + 1))
+    done
+
+    if [ "$mismatch" -eq 0 ]; then
+        echo "  ✓ Generated binary manifest check passed stage=$stage count=$checked"
+        return 0
+    fi
+    return 1
+}
+
+sync_generated_binaries_from_source() {
+    local source_bin_dir="$1"
+    local dest_bin_dir="$2"
+    local binary source_path
+
+    mkdir -p "$dest_bin_dir"
+    clean_generated_binaries "$dest_bin_dir"
+    for binary in "${AIDEN_GENERATED_BINARIES[@]}"; do
+        source_path="$source_bin_dir/$binary"
+        if [ ! -f "$source_path" ]; then
+            echo "  ✗ Error: missing generated binary source: $source_path" >&2
+            exit 1
+        fi
+        rsync -a "$source_path" "$dest_bin_dir/$binary"
+    done
+}
+
+repair_generated_binaries_from_manifest() {
+    local stage="$1"
+    local source_bin_dir="$2"
+    local dest_bin_dir="$3"
+    local manifest="$4"
+
+    log_generated_binaries_in_dir "$stage" "$dest_bin_dir"
+    if check_generated_binaries_against_manifest "$stage" "$dest_bin_dir" "$manifest" "$source_bin_dir"; then
+        return 0
+    fi
+
+    echo "  ⚠ Generated binary mismatch detected stage=$stage; restoring from $source_bin_dir" >&2
+    if ! check_generated_binaries_against_manifest "$stage-source" "$source_bin_dir" "$manifest" "$source_bin_dir"; then
+        echo "  ✗ Error: generated binary source is not trustworthy: $source_bin_dir" >&2
+        exit 1
+    fi
+
+    sync_generated_binaries_from_source "$source_bin_dir" "$dest_bin_dir"
+    log_generated_binaries_in_dir "$stage-after-repair" "$dest_bin_dir"
+    if ! check_generated_binaries_against_manifest "$stage-after-repair" "$dest_bin_dir" "$manifest" "$source_bin_dir"; then
+        echo "  ✗ Error: generated binary repair failed stage=$stage dest=$dest_bin_dir" >&2
+        exit 1
+    fi
 }
 
 verify_ext4_image_file_matches() {
@@ -361,7 +561,7 @@ rebuild_ext4_image() {
     }
 
     if [ "$name" = "oem" ]; then
-        log_generated_binaries_in_dir "sdk-oem-before-strip" "$src_dir/usr/bin"
+        repair_generated_binaries_from_manifest "sdk-oem-before-strip" "$SCRIPT_DIR/build/bin" "$src_dir/usr/bin" "$GENERATED_BINARY_MANIFEST"
     fi
     strip_release_files "$src_dir"
     if [ "$name" = "oem" ]; then
@@ -384,14 +584,15 @@ echo "[1/6] Building applications..."
 cd "$SCRIPT_DIR"
 ./_build.sh
 log_generated_binaries_in_dir "build-bin" "$SCRIPT_DIR/build/bin"
+write_generated_binary_manifest "$SCRIPT_DIR/build/bin" "$GENERATED_BINARY_MANIFEST"
+check_generated_binaries_against_manifest "build-bin" "$SCRIPT_DIR/build/bin" "$GENERATED_BINARY_MANIFEST" "$SCRIPT_DIR/build/bin"
 
 # Step 2: 准备 overlay 目录
 echo "[2/6] Preparing overlay directories..."
 mkdir -p "$OVERLAY/oem/usr/bin" "$OVERLAY/oem/usr/lib" "$OVERLAY/oem/etc"
-clean_generated_binaries "$OVERLAY/oem/usr/bin"
-rsync -a "$SCRIPT_DIR/build/bin/" "$OVERLAY/oem/usr/bin/"
+sync_generated_binaries_from_source "$SCRIPT_DIR/build/bin" "$OVERLAY/oem/usr/bin"
 echo "  ✓ Binaries copied to overlay/oem/usr/bin"
-log_generated_binaries_in_dir "overlay-oem-usr-bin" "$OVERLAY/oem/usr/bin"
+repair_generated_binaries_from_manifest "overlay-oem-usr-bin" "$SCRIPT_DIR/build/bin" "$OVERLAY/oem/usr/bin" "$GENERATED_BINARY_MANIFEST"
 
 BENCHMARK_SRC="$SCRIPT_DIR/benchmark"
 BENCHMARK_DEST="$OVERLAY/userdata/agent/benchmark"
@@ -496,9 +697,13 @@ fi
 # Step 4: Run pico-sdk build stages and base firmware packaging.
 echo "[4/6] Running pico-sdk build stages..."
 cd "$PICO_SDK"
+repair_generated_binaries_from_manifest "overlay-before-sdk-sysdrv" "$SCRIPT_DIR/build/bin" "$OVERLAY/oem/usr/bin" "$GENERATED_BINARY_MANIFEST"
 ./build.sh sysdrv "$@"
+repair_generated_binaries_from_manifest "overlay-after-sdk-sysdrv" "$SCRIPT_DIR/build/bin" "$OVERLAY/oem/usr/bin" "$GENERATED_BINARY_MANIFEST"
 ./build.sh media "$@"
+repair_generated_binaries_from_manifest "overlay-after-sdk-media" "$SCRIPT_DIR/build/bin" "$OVERLAY/oem/usr/bin" "$GENERATED_BINARY_MANIFEST"
 ./build.sh app "$@"
+repair_generated_binaries_from_manifest "overlay-after-sdk-app" "$SCRIPT_DIR/build/bin" "$OVERLAY/oem/usr/bin" "$GENERATED_BINARY_MANIFEST"
 
 # Step 5: 获取输出路径并复制 oem/userdata 内容
 echo "[5/6] Injecting oem and userdata content..."
@@ -523,6 +728,7 @@ firmware_log="$(mktemp)"
 grep -E "(oem|userdata|update)" "$firmware_log" || true
 rm -f "$firmware_log"
 echo "  ✓ Base images packaged"
+repair_generated_binaries_from_manifest "overlay-after-sdk-firmware" "$SCRIPT_DIR/build/bin" "$OVERLAY/oem/usr/bin" "$GENERATED_BINARY_MANIFEST"
 
 # 复制 oem 内容
 if [ -d "$OVERLAY/oem" ]; then
@@ -533,9 +739,9 @@ if [ -d "$OVERLAY/oem" ]; then
         "usr/lib/librknnmrt.so" \
         "usr/model"
     clean_generated_binaries "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin"
-    # Keep Aiden-managed /oem/usr/bin exact when pico-sdk/output/out is reused.
-    rsync -a --delete "$OVERLAY/oem/usr/bin/" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin/"
     rsync -a "$OVERLAY/oem/" "$RK_PROJECT_PACKAGE_OEM_DIR/"
+    # Keep generated binaries anchored to build/bin; overlay/oem/usr/bin is only an intermediate staging copy.
+    repair_generated_binaries_from_manifest "sdk-oem-usr-bin" "$SCRIPT_DIR/build/bin" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin" "$GENERATED_BINARY_MANIFEST"
     echo "  ✓ OEM content copied"
     log_generated_binaries_in_dir "sdk-oem-usr-bin" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin"
 fi

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -121,16 +121,20 @@ if ! grep -Fq 'scripts/clean_rootfs_overlay_staging.sh" --dest-overlay "$DEST_OV
 fi
 
 if grep -Fq 'cp -a "$SCRIPT_DIR/build/bin"/. "$OVERLAY/oem/usr/bin/"' "$ROOT_DIR/_build_image.sh" || \
-   ! grep -Fq 'clean_generated_binaries "$OVERLAY/oem/usr/bin"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'sync_generated_binaries_from_source "$SCRIPT_DIR/build/bin" "$OVERLAY/oem/usr/bin"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq 'clean_generated_binaries "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin"' "$ROOT_DIR/_build_image.sh"; then
     echo "_build_image.sh must remove stale generated binaries from overlay and SDK OEM staging" >&2
     exit 1
 fi
 
-oem_bin_sync_line=$(grep -nF 'rsync -a --delete "$OVERLAY/oem/usr/bin/" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin/"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
 oem_full_sync_line=$(grep -nF 'rsync -a "$OVERLAY/oem/" "$RK_PROJECT_PACKAGE_OEM_DIR/"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
-if [ -z "$oem_bin_sync_line" ] || [ -z "$oem_full_sync_line" ] || [ "$oem_bin_sync_line" -ge "$oem_full_sync_line" ]; then
-    echo "_build_image.sh must sync OEM usr/bin with delete semantics before full OEM overlay sync" >&2
+oem_repair_line=$(grep -nF 'repair_generated_binaries_from_manifest "sdk-oem-usr-bin" "$SCRIPT_DIR/build/bin" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin" "$GENERATED_BINARY_MANIFEST"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
+if [ -z "$oem_full_sync_line" ] || [ -z "$oem_repair_line" ] || [ "$oem_full_sync_line" -ge "$oem_repair_line" ]; then
+    echo "_build_image.sh must sync OEM overlay first, then restore generated usr/bin files from the build manifest source" >&2
+    exit 1
+fi
+if grep -Fq 'rsync -a --delete "$OVERLAY/oem/usr/bin/" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin/"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must not trust overlay/oem/usr/bin as the final generated binary source" >&2
     exit 1
 fi
 firmware_count=$(grep -cF './build.sh firmware "$@"' "$ROOT_DIR/_build_image.sh")
@@ -164,10 +168,16 @@ fi
 
 if ! grep -Fq 'log_generated_binaries_in_dir' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq 'binary-fingerprint stage=' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'write_generated_binary_manifest "$SCRIPT_DIR/build/bin" "$GENERATED_BINARY_MANIFEST"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'repair_generated_binaries_from_manifest "overlay-after-sdk-sysdrv"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'repair_generated_binaries_from_manifest "overlay-after-sdk-media"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'repair_generated_binaries_from_manifest "overlay-after-sdk-app"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'repair_generated_binaries_from_manifest "overlay-after-sdk-firmware"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'log_binary_diff_summary' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq 'log_generated_binaries_in_dir "build-bin"' "$ROOT_DIR/_build_image.sh" || \
-   ! grep -Fq 'log_generated_binaries_in_dir "overlay-oem-usr-bin"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'repair_generated_binaries_from_manifest "overlay-oem-usr-bin"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq 'log_generated_binaries_in_dir "sdk-oem-usr-bin"' "$ROOT_DIR/_build_image.sh" || \
-   ! grep -Fq 'log_generated_binaries_in_dir "sdk-oem-before-strip"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'repair_generated_binaries_from_manifest "sdk-oem-before-strip"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq 'log_generated_binaries_in_dir "sdk-oem-after-strip"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq 'image-file-verified rel=/$rel_path' "$ROOT_DIR/_build_image.sh"; then
     echo "_build_image.sh must log staged, stripped, and image-readback binary fingerprints for OTA forensics" >&2

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -175,10 +175,14 @@ if ! grep -q 'Compress OTA manifest images' "$WORKFLOW" || \
     exit 1
 fi
 
-oem_bin_sync_line=$(grep -nF 'rsync -a --delete "$OVERLAY/oem/usr/bin/" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin/"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
 oem_full_sync_line=$(grep -nF 'rsync -a "$OVERLAY/oem/" "$RK_PROJECT_PACKAGE_OEM_DIR/"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
-if [ -z "$oem_bin_sync_line" ] || [ -z "$oem_full_sync_line" ] || [ "$oem_bin_sync_line" -ge "$oem_full_sync_line" ]; then
-    echo "_build_image.sh must sync OEM usr/bin with delete semantics before full OEM overlay sync" >&2
+oem_repair_line=$(grep -nF 'repair_generated_binaries_from_manifest "sdk-oem-usr-bin" "$SCRIPT_DIR/build/bin" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin" "$GENERATED_BINARY_MANIFEST"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
+if [ -z "$oem_full_sync_line" ] || [ -z "$oem_repair_line" ] || [ "$oem_full_sync_line" -ge "$oem_repair_line" ]; then
+    echo "_build_image.sh must sync OEM overlay first, then restore generated usr/bin files from the build manifest source" >&2
+    exit 1
+fi
+if grep -Fq 'rsync -a --delete "$OVERLAY/oem/usr/bin/" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin/"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must not trust overlay/oem/usr/bin as the final generated binary source" >&2
     exit 1
 fi
 firmware_count=$(grep -cF './build.sh firmware "$@"' "$ROOT_DIR/_build_image.sh")


### PR DESCRIPTION
## Summary
- add a generated binary manifest anchored to build/bin
- verify and repair generated OEM binaries across overlay, SDK stage, firmware, and image rebuild boundaries
- expand OTA binary forensic logging for mismatch diagnosis

## Tests
- bash -n _build_image.sh
- bash scripts/test_build_scripts.sh
- bash scripts/test_release_ci_scripts.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added binary integrity verification system using SHA256 manifests to track and validate generated binaries throughout the build process.
  * Implemented automated repair mechanisms that restore binaries from trusted sources when integrity checks detect mismatches.

* **Chores**
  * Enhanced build system validation and test scripts to enforce manifest-based integrity verification across all build stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->