### PR TITLE
fix(agent): guard oversized tool results before model calls

### DIFF
--- a/src/agent/internal/agent/context_budget.go
+++ b/src/agent/internal/agent/context_budget.go
@@ -24,6 +24,18 @@ type toolResponseBudgetCandidate struct {
 	EstimatedPromptTokensSingle int
 }
 
+type toolResponseBudgetCandidateKey struct {
+	MessageIndex int
+	PartIndex    int
+}
+
+func (c toolResponseBudgetCandidate) key() toolResponseBudgetCandidateKey {
+	return toolResponseBudgetCandidateKey{
+		MessageIndex: c.MessageIndex,
+		PartIndex:    c.PartIndex,
+	}
+}
+
 func (e *roleCollaborativeExecutor) guardMessagesWithinContextWindow(messages []llms.MessageContent, options []llms.CallOption) []llms.MessageContent {
 	if e == nil || e.Model == nil {
 		return messages
@@ -57,7 +69,7 @@ func (e *roleCollaborativeExecutor) guardMessagesWithinContextWindow(messages []
 	}
 
 	sanitized := cloneMessageContents(messages)
-	changed := false
+	omitted := make(map[toolResponseBudgetCandidateKey]struct{})
 	for _, candidate := range candidates {
 		singlePromptTokens := estimateSingleToolResponsePromptTokens(messages, candidate) + toolSchemaTokens
 		if singlePromptTokens <= inputBudget {
@@ -65,11 +77,7 @@ func (e *roleCollaborativeExecutor) guardMessagesWithinContextWindow(messages []
 		}
 		candidate.EstimatedPromptTokensSingle = singlePromptTokens
 		replaceToolResponsePart(sanitized, candidate, omittedToolResultMessage(candidate, contextWindow, inputBudget, callOptions.MaxTokens))
-		changed = true
-	}
-
-	if !changed {
-		return messages
+		omitted[candidate.key()] = struct{}{}
 	}
 
 	if estimateMessagesTokens(sanitized)+toolSchemaTokens <= inputBudget {
@@ -80,11 +88,12 @@ func (e *roleCollaborativeExecutor) guardMessagesWithinContextWindow(messages []
 		return candidates[i].ContentTokens > candidates[j].ContentTokens
 	})
 	for _, candidate := range candidates {
-		if isToolResponseAlreadyOmitted(sanitized, candidate) {
+		if isToolResponseAlreadyOmitted(omitted, candidate) {
 			continue
 		}
 		candidate.EstimatedPromptTokensSingle = estimateSingleToolResponsePromptTokens(messages, candidate) + toolSchemaTokens
 		replaceToolResponsePart(sanitized, candidate, omittedToolResultMessage(candidate, contextWindow, inputBudget, callOptions.MaxTokens))
+		omitted[candidate.key()] = struct{}{}
 		if estimateMessagesTokens(sanitized)+toolSchemaTokens <= inputBudget {
 			break
 		}
@@ -185,16 +194,9 @@ func replaceToolResponsePart(messages []llms.MessageContent, candidate toolRespo
 	parts[candidate.PartIndex] = response
 }
 
-func isToolResponseAlreadyOmitted(messages []llms.MessageContent, candidate toolResponseBudgetCandidate) bool {
-	if candidate.MessageIndex < 0 || candidate.MessageIndex >= len(messages) {
-		return true
-	}
-	parts := messages[candidate.MessageIndex].Parts
-	if candidate.PartIndex < 0 || candidate.PartIndex >= len(parts) {
-		return true
-	}
-	response, ok := parts[candidate.PartIndex].(llms.ToolCallResponse)
-	return ok && strings.Contains(response.Content, "tool result omitted")
+func isToolResponseAlreadyOmitted(omitted map[toolResponseBudgetCandidateKey]struct{}, candidate toolResponseBudgetCandidate) bool {
+	_, ok := omitted[candidate.key()]
+	return ok
 }
 
 func omittedToolResultMessage(candidate toolResponseBudgetCandidate, contextWindow, inputBudget, maxResponseTokens int) string {

--- a/src/agent/internal/agent/context_budget.go
+++ b/src/agent/internal/agent/context_budget.go
@@ -1,0 +1,293 @@
+package agent
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+type contextWindowModel interface {
+	contextWindow() int
+}
+
+type toolResponseBudgetCandidate struct {
+	MessageIndex                int
+	PartIndex                   int
+	ToolCallID                  string
+	ToolName                    string
+	Content                     string
+	ContentTokens               int
+	EstimatedPromptTokensSingle int
+}
+
+func (e *roleCollaborativeExecutor) guardMessagesWithinContextWindow(messages []llms.MessageContent, options []llms.CallOption) []llms.MessageContent {
+	if e == nil || e.Model == nil {
+		return messages
+	}
+	windowProvider, ok := e.Model.(contextWindowModel)
+	if !ok {
+		return messages
+	}
+	contextWindow := windowProvider.contextWindow()
+	if contextWindow <= 0 {
+		return messages
+	}
+
+	var callOptions llms.CallOptions
+	for _, option := range options {
+		option(&callOptions)
+	}
+	inputBudget := inputContextBudget(contextWindow, callOptions.MaxTokens)
+	if inputBudget <= 0 {
+		return messages
+	}
+
+	toolSchemaTokens := estimateToolSchemaTokens(callOptions)
+	if estimateMessagesTokens(messages)+toolSchemaTokens <= inputBudget {
+		return messages
+	}
+
+	candidates := collectToolResponseBudgetCandidates(messages)
+	if len(candidates) == 0 {
+		return messages
+	}
+
+	sanitized := cloneMessageContents(messages)
+	changed := false
+	for _, candidate := range candidates {
+		singlePromptTokens := estimateSingleToolResponsePromptTokens(messages, candidate) + toolSchemaTokens
+		if singlePromptTokens <= inputBudget {
+			continue
+		}
+		candidate.EstimatedPromptTokensSingle = singlePromptTokens
+		replaceToolResponsePart(sanitized, candidate, omittedToolResultMessage(candidate, contextWindow, inputBudget, callOptions.MaxTokens))
+		changed = true
+	}
+
+	if !changed {
+		return messages
+	}
+
+	if estimateMessagesTokens(sanitized)+toolSchemaTokens <= inputBudget {
+		return sanitized
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ContentTokens > candidates[j].ContentTokens
+	})
+	for _, candidate := range candidates {
+		if isToolResponseAlreadyOmitted(sanitized, candidate) {
+			continue
+		}
+		candidate.EstimatedPromptTokensSingle = estimateSingleToolResponsePromptTokens(messages, candidate) + toolSchemaTokens
+		replaceToolResponsePart(sanitized, candidate, omittedToolResultMessage(candidate, contextWindow, inputBudget, callOptions.MaxTokens))
+		if estimateMessagesTokens(sanitized)+toolSchemaTokens <= inputBudget {
+			break
+		}
+	}
+	return sanitized
+}
+
+func inputContextBudget(contextWindow, maxResponseTokens int) int {
+	if contextWindow <= 0 {
+		return 0
+	}
+	if maxResponseTokens <= 0 {
+		return contextWindow
+	}
+	if maxResponseTokens >= contextWindow {
+		return 1
+	}
+	return contextWindow - maxResponseTokens
+}
+
+func collectToolResponseBudgetCandidates(messages []llms.MessageContent) []toolResponseBudgetCandidate {
+	var candidates []toolResponseBudgetCandidate
+	for messageIndex, message := range messages {
+		for partIndex, part := range message.Parts {
+			response, ok := part.(llms.ToolCallResponse)
+			if !ok {
+				continue
+			}
+			content := strings.TrimSpace(response.Content)
+			candidates = append(candidates, toolResponseBudgetCandidate{
+				MessageIndex:  messageIndex,
+				PartIndex:     partIndex,
+				ToolCallID:    response.ToolCallID,
+				ToolName:      response.Name,
+				Content:       response.Content,
+				ContentTokens: estimateTextTokens(content),
+			})
+		}
+	}
+	return candidates
+}
+
+func estimateSingleToolResponsePromptTokens(messages []llms.MessageContent, candidate toolResponseBudgetCandidate) int {
+	matchingCallIndex := findMatchingToolCallMessageIndex(messages, candidate.ToolCallID, candidate.MessageIndex)
+	total := 0
+	for i, message := range messages {
+		switch {
+		case i == candidate.MessageIndex:
+			total += estimateMessageTokens(llms.MessageContent{
+				Role:  message.Role,
+				Parts: []llms.ContentPart{message.Parts[candidate.PartIndex]},
+			})
+		case i == matchingCallIndex:
+			total += estimateMessageTokens(message)
+		case message.Role == llms.ChatMessageTypeSystem || message.Role == llms.ChatMessageTypeHuman:
+			total += estimateMessageTokens(message)
+		}
+	}
+	return total
+}
+
+func findMatchingToolCallMessageIndex(messages []llms.MessageContent, toolCallID string, before int) int {
+	if strings.TrimSpace(toolCallID) == "" {
+		return -1
+	}
+	for i := before - 1; i >= 0; i-- {
+		for _, part := range messages[i].Parts {
+			call, ok := part.(llms.ToolCall)
+			if ok && call.ID == toolCallID {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func cloneMessageContents(messages []llms.MessageContent) []llms.MessageContent {
+	cloned := append([]llms.MessageContent(nil), messages...)
+	for i := range cloned {
+		cloned[i].Parts = append([]llms.ContentPart(nil), messages[i].Parts...)
+	}
+	return cloned
+}
+
+func replaceToolResponsePart(messages []llms.MessageContent, candidate toolResponseBudgetCandidate, content string) {
+	if candidate.MessageIndex < 0 || candidate.MessageIndex >= len(messages) {
+		return
+	}
+	parts := messages[candidate.MessageIndex].Parts
+	if candidate.PartIndex < 0 || candidate.PartIndex >= len(parts) {
+		return
+	}
+	response, ok := parts[candidate.PartIndex].(llms.ToolCallResponse)
+	if !ok {
+		return
+	}
+	response.Content = content
+	parts[candidate.PartIndex] = response
+}
+
+func isToolResponseAlreadyOmitted(messages []llms.MessageContent, candidate toolResponseBudgetCandidate) bool {
+	if candidate.MessageIndex < 0 || candidate.MessageIndex >= len(messages) {
+		return true
+	}
+	parts := messages[candidate.MessageIndex].Parts
+	if candidate.PartIndex < 0 || candidate.PartIndex >= len(parts) {
+		return true
+	}
+	response, ok := parts[candidate.PartIndex].(llms.ToolCallResponse)
+	return ok && strings.Contains(response.Content, "tool result omitted")
+}
+
+func omittedToolResultMessage(candidate toolResponseBudgetCandidate, contextWindow, inputBudget, maxResponseTokens int) string {
+	toolName := strings.TrimSpace(candidate.ToolName)
+	if toolName == "" {
+		toolName = "tool"
+	}
+	return fmt.Sprintf(
+		"error: %s tool result omitted before the next model call because the result is too large for the model context window. context_window=%d available_input_tokens=%d max_response_tokens=%d estimated_prompt_tokens_with_this_result=%d tool_result_estimated_tokens=%d. The original tool call completed, but its raw output was not inserted. Use a narrower query, request a smaller range, or call a tool that returns a concise summary.",
+		toolName,
+		contextWindow,
+		inputBudget,
+		maxResponseTokens,
+		candidate.EstimatedPromptTokensSingle,
+		candidate.ContentTokens,
+	)
+}
+
+func estimateMessagesTokens(messages []llms.MessageContent) int {
+	total := 0
+	for _, message := range messages {
+		total += estimateMessageTokens(message)
+	}
+	return total
+}
+
+func estimateMessageTokens(message llms.MessageContent) int {
+	total := 4 + estimateTextTokens(string(message.Role))
+	for _, part := range message.Parts {
+		total += estimateContentPartTokens(part)
+	}
+	return total
+}
+
+func estimateContentPartTokens(part llms.ContentPart) int {
+	switch p := part.(type) {
+	case llms.TextContent:
+		return estimateTextTokens(p.Text)
+	case llms.ToolCallResponse:
+		return 8 + estimateTextTokens(p.ToolCallID) + estimateTextTokens(p.Name) + estimateTextTokens(p.Content)
+	case llms.ToolCall:
+		name := ""
+		arguments := ""
+		if p.FunctionCall != nil {
+			name = p.FunctionCall.Name
+			arguments = p.FunctionCall.Arguments
+		}
+		return 8 + estimateTextTokens(p.ID) + estimateTextTokens(name) + estimateTextTokens(arguments)
+	case llms.ImageURLContent:
+		return estimateImageURLTokens(p.URL)
+	case llms.BinaryContent:
+		return estimateBinaryTokens(p.Data)
+	default:
+		return estimateTextTokens(fmt.Sprint(part))
+	}
+}
+
+func estimateImageURLTokens(url string) int {
+	if strings.HasPrefix(url, "data:image/") {
+		return 1024
+	}
+	return estimateTextTokens(url)
+}
+
+func estimateBinaryTokens(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+	encodedLen := base64.StdEncoding.EncodedLen(len(data))
+	return (encodedLen + 3) / 4
+}
+
+func estimateToolSchemaTokens(options llms.CallOptions) int {
+	total := 0
+	if len(options.Tools) > 0 {
+		total += estimateJSONTokens(options.Tools)
+	}
+	if len(options.Functions) > 0 {
+		total += estimateJSONTokens(options.Functions)
+	}
+	if options.ToolChoice != nil {
+		total += estimateJSONTokens(options.ToolChoice)
+	}
+	if options.FunctionCallBehavior != "" {
+		total += estimateTextTokens(string(options.FunctionCallBehavior))
+	}
+	return total
+}
+
+func estimateJSONTokens(value any) int {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return estimateTextTokens(fmt.Sprint(value))
+	}
+	return estimateTextTokens(string(data))
+}

--- a/src/agent/internal/agent/context_budget_test.go
+++ b/src/agent/internal/agent/context_budget_test.go
@@ -1,0 +1,144 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+func TestGuardMessagesWithinContextWindowFallbackOmitsCombinedToolResults(t *testing.T) {
+	messages := contextBudgetToolMessages(
+		strings.Repeat("alpha ", 240),
+		strings.Repeat("bravo ", 240),
+	)
+	inputBudget := maxSingleToolResponsePromptTokens(t, messages) + 12
+	if got := estimateMessagesTokens(messages); got <= inputBudget {
+		t.Fatalf("test setup total tokens = %d, want > %d", got, inputBudget)
+	}
+
+	executor := &roleCollaborativeExecutor{
+		Model: contextBudgetWindowModel{window: inputBudget},
+	}
+
+	sanitized := executor.guardMessagesWithinContextWindow(messages, nil)
+	if got := estimateMessagesTokens(sanitized); got > inputBudget {
+		t.Fatalf("sanitized tokens = %d, want <= %d", got, inputBudget)
+	}
+	contents := toolResponseContents(t, sanitized)
+	if !strings.Contains(contents[0], "tool result omitted") || !strings.Contains(contents[1], "tool result omitted") {
+		t.Fatalf("combined tool responses should be omitted by fallback pass: %#v", contents)
+	}
+}
+
+func TestGuardMessagesWithinContextWindowDoesNotTreatRawOmissionTextAsAlreadyOmitted(t *testing.T) {
+	oversizedOutput := strings.Repeat("oversized ", 720)
+	rawOmissionTextOutput := "raw diagnostic says tool result omitted by the remote process\n" + strings.Repeat("secondary ", 160)
+	messages := contextBudgetToolMessages(oversizedOutput, rawOmissionTextOutput)
+	candidates := collectToolResponseBudgetCandidates(messages)
+	if len(candidates) != 2 {
+		t.Fatalf("test setup candidates = %d, want 2", len(candidates))
+	}
+	inputBudget := estimateSingleToolResponsePromptTokens(messages, candidates[1]) + 12
+	if got := estimateSingleToolResponsePromptTokens(messages, candidates[0]); got <= inputBudget {
+		t.Fatalf("oversized single prompt tokens = %d, want > %d", got, inputBudget)
+	}
+	if got := estimateMessagesTokens(messages); got <= inputBudget {
+		t.Fatalf("test setup total tokens = %d, want > %d", got, inputBudget)
+	}
+
+	executor := &roleCollaborativeExecutor{
+		Model: contextBudgetWindowModel{window: inputBudget},
+	}
+
+	sanitized := executor.guardMessagesWithinContextWindow(messages, nil)
+	contents := toolResponseContents(t, sanitized)
+	if contents[1] == rawOmissionTextOutput {
+		t.Fatalf("raw tool output containing omission text should not be treated as already omitted")
+	}
+	if !strings.Contains(contents[1], "context_window=") {
+		t.Fatalf("second tool response should be replaced with omission metadata, got: %q", contents[1])
+	}
+}
+
+func contextBudgetToolMessages(outputs ...string) []llms.MessageContent {
+	messages := []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeSystem, "system prompt"),
+		llms.TextParts(llms.ChatMessageTypeHuman, "summarize tool output"),
+	}
+	for i, output := range outputs {
+		id := fmt.Sprintf("call_%d", i+1)
+		messages = append(messages,
+			llms.MessageContent{
+				Role: llms.ChatMessageTypeAI,
+				Parts: []llms.ContentPart{llms.ToolCall{
+					ID:   id,
+					Type: "function",
+					FunctionCall: &llms.FunctionCall{
+						Name:      "dump",
+						Arguments: "{}",
+					},
+				}},
+			},
+			llms.MessageContent{
+				Role: llms.ChatMessageTypeTool,
+				Parts: []llms.ContentPart{llms.ToolCallResponse{
+					ToolCallID: id,
+					Name:       "dump",
+					Content:    output,
+				}},
+			},
+		)
+	}
+	return messages
+}
+
+func maxSingleToolResponsePromptTokens(t *testing.T, messages []llms.MessageContent) int {
+	t.Helper()
+	candidates := collectToolResponseBudgetCandidates(messages)
+	if len(candidates) == 0 {
+		t.Fatal("no tool response candidates")
+	}
+	maxTokens := 0
+	for _, candidate := range candidates {
+		tokens := estimateSingleToolResponsePromptTokens(messages, candidate)
+		if tokens > maxTokens {
+			maxTokens = tokens
+		}
+	}
+	return maxTokens
+}
+
+func toolResponseContents(t *testing.T, messages []llms.MessageContent) []string {
+	t.Helper()
+	var contents []string
+	for _, message := range messages {
+		for _, part := range message.Parts {
+			if response, ok := part.(llms.ToolCallResponse); ok {
+				contents = append(contents, response.Content)
+			}
+		}
+	}
+	if len(contents) == 0 {
+		t.Fatalf("no tool responses found in messages: %#v", messages)
+	}
+	return contents
+}
+
+type contextBudgetWindowModel struct {
+	window int
+}
+
+func (m contextBudgetWindowModel) contextWindow() int {
+	return m.window
+}
+
+func (m contextBudgetWindowModel) GenerateContent(context.Context, []llms.MessageContent, ...llms.CallOption) (*llms.ContentResponse, error) {
+	panic("unexpected GenerateContent invocation")
+}
+
+func (m contextBudgetWindowModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	panic("unexpected Call invocation")
+}

--- a/src/agent/internal/agent/memory_cutpoint.go
+++ b/src/agent/internal/agent/memory_cutpoint.go
@@ -25,12 +25,16 @@ import (
 // the budget. The split estimate intentionally overestimates slightly so the
 // window stays within budget rather than creeping over it.
 func estimateSessionEventTokens(event SessionEvent) int {
-	if len(event.Content) == 0 {
+	return estimateTextTokens(event.Content)
+}
+
+func estimateTextTokens(content string) int {
+	if len(content) == 0 {
 		return 0
 	}
 	cjkTokens := 0
 	nonCJKBytes := 0
-	for _, r := range event.Content {
+	for _, r := range content {
 		if isCJK(r) {
 			cjkTokens++
 		} else {

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -821,6 +821,7 @@ func (e *roleCollaborativeExecutor) generateRoleContent(ctx context.Context, rol
 	callCtx, cancel := context.WithTimeout(ctx, roleModelCallTimeout)
 	defer cancel()
 	callCtx = contextWithTelemetryRole(callCtx, role)
+	messages = e.guardMessagesWithinContextWindow(messages, options)
 	res, err := e.Model.GenerateContent(callCtx, messages, options...)
 	if errors.Is(err, context.DeadlineExceeded) {
 		return nil, fmt.Errorf("%s role model call timed out after %s", role, roleModelCallTimeout)

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -614,6 +614,66 @@ func TestExecutorMarkedFinalAnswerEntersVerifierReview(t *testing.T) {
 	}
 }
 
+func TestCallExecutorTurnOmitOversizedToolResultBeforeModelCall(t *testing.T) {
+	hugeObservation := strings.Repeat("超", 2000)
+	model := &contextWindowScriptedModel{
+		scriptedModel: scriptedModel{responses: []*llms.ContentResponse{
+			finishStepToolCall("handled oversized tool result"),
+		}},
+		window: 300,
+	}
+	executor := newRoleCollaborativeExecutor(
+		model,
+		RoleProfiles{
+			Executor: RoleProfile{
+				Name:         RoleExecutor,
+				SystemPrompt: strings.Repeat("executor system prompt ", 20),
+			},
+		},
+		[]langtools.Tool{&stubTool{name: "dump", description: "Return a dump."}},
+		nil,
+		10,
+		nil,
+		nil,
+		nil,
+		ScreenshotPruningConfig{},
+		nil,
+	)
+	state := &roleLoopState{
+		Phase:               phaseExecution,
+		PlanCommitted:       true,
+		StepExecutionActive: true,
+		NextStep:            "inspect dump",
+		StepToolSteps: []schema.AgentStep{{
+			Action: schema.AgentAction{
+				Tool:      "dump",
+				ToolInput: "{}",
+				ToolID:    "dump_1",
+			},
+			Observation: hugeObservation,
+		}},
+	}
+	inputs := map[string]string{"input": "summarize the dump", "history": ""}
+
+	turn, err := executor.callExecutorTurn(context.Background(), inputs, state, NewToolSpecs(executor.Tools))
+	if err != nil {
+		t.Fatalf("executor turn error: %v", err)
+	}
+	if turn.Kind != executorTurnFinishStep {
+		t.Fatalf("turn kind = %v, want finish step", turn.Kind)
+	}
+	if model.callCount != 1 {
+		t.Fatalf("model call count = %d, want 1", model.callCount)
+	}
+	content := firstToolResponseContent(t, model.messages[0])
+	if strings.Contains(content, strings.Repeat("超", 20)) {
+		t.Fatalf("oversized raw observation leaked into model prompt: %q", content)
+	}
+	if !strings.Contains(content, "tool result omitted") || !strings.Contains(content, "context_window=300") {
+		t.Fatalf("tool response should explain the context-window rejection, got: %q", content)
+	}
+}
+
 func TestFinishStepStoresKeyInfo(t *testing.T) {
 	executor := newRoleCollaborativeExecutor(
 		&scriptedModel{},
@@ -648,6 +708,28 @@ func TestFinishStepStoresKeyInfo(t *testing.T) {
 	if !strings.Contains(turn.Step.Observation, "account_id=abc123") {
 		t.Fatalf("observation should include key_info: %s", turn.Step.Observation)
 	}
+}
+
+type contextWindowScriptedModel struct {
+	scriptedModel
+	window int
+}
+
+func (m *contextWindowScriptedModel) contextWindow() int {
+	return m.window
+}
+
+func firstToolResponseContent(t *testing.T, messages []llms.MessageContent) string {
+	t.Helper()
+	for _, message := range messages {
+		for _, part := range message.Parts {
+			if response, ok := part.(llms.ToolCallResponse); ok {
+				return response.Content
+			}
+		}
+	}
+	t.Fatalf("no tool response found in messages: %#v", messages)
+	return ""
 }
 
 func TestAbortStepEntersVerifierReview(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a preflight context-window guard before role model calls
- replace oversized tool responses with an explicit model-visible error instead of sending the raw payload
- reuse the existing CJK-aware token estimate for prompt budgeting and cover the oversized tool-result path with a regression test

## Tests
- go test ./internal/agent -run TestCallExecutorTurnOmitOversizedToolResultBeforeModelCall -count=1
- go test ./internal/agent -run 'TestFunctionAgentScratchpad|TestRoleCollaborativeExecutor|TestExecutorMarkedFinalAnswer|TestFinishStepStoresKeyInfo' -count=1
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent now gracefully handles tool responses that exceed available context window by omitting them from model prompts with appropriate error messaging

* **Refactor**
  * Optimized token counting and context window budgeting logic for more efficient agent operation

* **Tests**
  * Added test coverage verifying correct handling of oversized tool responses in agent execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->