### PR TITLE
fix(config-web): persist progress speech toggle

### DIFF
--- a/src/agent_toml.cpp
+++ b/src/agent_toml.cpp
@@ -279,6 +279,8 @@ void apply_kv(AgentToml& cfg,
             if (!assign_bool(&cfg.voice_streaming_tts_enabled, raw, &sub_err)) fail(sub_err);
         } else if (key == "voice_tool_call_speech") {
             if (!assign_bool(&cfg.voice_tool_call_speech, raw, &sub_err)) fail(sub_err);
+        } else if (key == "voice_progress_speech_enabled") {
+            if (!assign_bool(&cfg.voice_progress_speech_enabled, raw, &sub_err)) fail(sub_err);
         } else if (key == "voice_speech_summary_enabled") {
             if (!assign_bool(&cfg.voice_speech_summary_enabled, raw, &sub_err)) fail(sub_err);
         } else if (key == "voice_speech_max_runes") {
@@ -617,6 +619,7 @@ bool save_agent_toml(const char* path, const AgentToml& cfg, std::string* error)
     emit_bool(out, "voice_interrupt_on_wakeup", cfg.voice_interrupt_on_wakeup);
     emit_bool(out, "voice_streaming_tts_enabled", cfg.voice_streaming_tts_enabled);
     emit_bool(out, "voice_tool_call_speech", cfg.voice_tool_call_speech);
+    emit_bool(out, "voice_progress_speech_enabled", cfg.voice_progress_speech_enabled);
     emit_bool(out, "voice_speech_summary_enabled", cfg.voice_speech_summary_enabled);
     if (cfg.voice_speech_max_runes != 0) emit_int(out, "voice_speech_max_runes", cfg.voice_speech_max_runes);
     if (cfg.voice_max_response_tokens != 0) emit_int(out, "voice_max_response_tokens", cfg.voice_max_response_tokens);

--- a/src/agent_toml.h
+++ b/src/agent_toml.h
@@ -112,6 +112,7 @@ struct AgentToml {
     bool voice_interrupt_on_wakeup = true;
     bool voice_streaming_tts_enabled = true;
     bool voice_tool_call_speech = false;
+    bool voice_progress_speech_enabled = true;
     bool voice_speech_summary_enabled = true;
     int voice_speech_max_runes = 120;
     int voice_max_response_tokens = 400;

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -549,6 +549,7 @@ bool validate_known_config_field_types(cJSON* root, std::string* error) {
         {"agent", "voice_interrupt_on_wakeup", CONFIG_FIELD_BOOL},
         {"agent", "voice_streaming_tts_enabled", CONFIG_FIELD_BOOL},
         {"agent", "voice_tool_call_speech", CONFIG_FIELD_BOOL},
+        {"agent", "voice_progress_speech_enabled", CONFIG_FIELD_BOOL},
         {"agent", "voice_speech_summary_enabled", CONFIG_FIELD_BOOL},
         {"agent", "voice_speech_max_runes", CONFIG_FIELD_NUMBER},
         {"agent", "voice_max_response_tokens", CONFIG_FIELD_NUMBER},
@@ -1435,6 +1436,7 @@ cJSON* config_to_json(const aiden::AgentToml& config, bool include_secrets = fal
     cJSON_AddBoolToObject(agent, "voice_interrupt_on_wakeup", config.voice_interrupt_on_wakeup ? 1 : 0);
     cJSON_AddBoolToObject(agent, "voice_streaming_tts_enabled", config.voice_streaming_tts_enabled ? 1 : 0);
     cJSON_AddBoolToObject(agent, "voice_tool_call_speech", config.voice_tool_call_speech ? 1 : 0);
+    cJSON_AddBoolToObject(agent, "voice_progress_speech_enabled", config.voice_progress_speech_enabled ? 1 : 0);
     cJSON_AddBoolToObject(agent, "voice_speech_summary_enabled", config.voice_speech_summary_enabled ? 1 : 0);
     cJSON_AddNumberToObject(agent, "voice_speech_max_runes", config.voice_speech_max_runes);
     cJSON_AddNumberToObject(agent, "voice_max_response_tokens", config.voice_max_response_tokens);
@@ -1692,6 +1694,7 @@ void update_config_from_json(cJSON* root, aiden::AgentToml* config) {
         set_json_bool(&config->voice_interrupt_on_wakeup, agent, "voice_interrupt_on_wakeup");
         set_json_bool(&config->voice_streaming_tts_enabled, agent, "voice_streaming_tts_enabled");
         set_json_bool(&config->voice_tool_call_speech, agent, "voice_tool_call_speech");
+        set_json_bool(&config->voice_progress_speech_enabled, agent, "voice_progress_speech_enabled");
         set_json_bool(&config->voice_speech_summary_enabled, agent, "voice_speech_summary_enabled");
         set_json_int(&config->voice_speech_max_runes, agent, "voice_speech_max_runes");
         set_json_int(&config->voice_max_response_tokens, agent, "voice_max_response_tokens");

--- a/tests/agent_toml_test.cpp
+++ b/tests/agent_toml_test.cpp
@@ -40,6 +40,7 @@ TEST_CASE("agent_toml round-trip preserves Go-agent schema fields") {
     cfg.voice_interrupt_on_wakeup = false;
     cfg.voice_streaming_tts_enabled = false;
     cfg.voice_tool_call_speech = false;
+    cfg.voice_progress_speech_enabled = false;
     cfg.voice_speech_summary_enabled = false;
     cfg.voice_speech_max_runes = 80;
     cfg.voice_max_response_tokens = 240;
@@ -129,6 +130,7 @@ TEST_CASE("agent_toml round-trip preserves Go-agent schema fields") {
     CHECK(loaded.voice_interrupt_on_wakeup == false);
 	CHECK(loaded.voice_streaming_tts_enabled == false);
 	CHECK(loaded.voice_tool_call_speech == false);
+	CHECK(loaded.voice_progress_speech_enabled == false);
 	CHECK(loaded.voice_speech_summary_enabled == false);
 	CHECK(loaded.voice_speech_max_runes == 80);
 	CHECK(loaded.voice_max_response_tokens == 240);

--- a/tests/config_web_source_test.cpp
+++ b/tests/config_web_source_test.cpp
@@ -1,6 +1,7 @@
 #include <doctest.h>
 
 #include <fstream>
+#include <set>
 #include <sstream>
 #include <string>
 
@@ -870,6 +871,71 @@ TEST_CASE("config web resolved config validation keeps required fields and type 
     CHECK(source.find("validate_search_secret_presence") != std::string::npos);
     CHECK(source.find("validate_required_string(model, \"model\", \"provider\", false") != std::string::npos);
     CHECK(source.find("\"search\", \"has_api_key\", CONFIG_FIELD_BOOL") != std::string::npos);
+    CHECK(source.find("\"voice_progress_speech_enabled\", CONFIG_FIELD_BOOL") != std::string::npos);
     CHECK(source.find("\"voice_speech_summary_enabled\", CONFIG_FIELD_BOOL") != std::string::npos);
     CHECK(source.find("\"voice_speech_max_runes\", CONFIG_FIELD_NUMBER") != std::string::npos);
+}
+
+TEST_CASE("config web rendered config controls are registered in field type guards") {
+    const std::string source_path = std::string(AIDEN_SOURCE_DIR) + "/src/config_web.cpp";
+    std::ifstream source_in(source_path.c_str());
+    REQUIRE(source_in.good());
+
+    std::ostringstream source_buffer;
+    source_buffer << source_in.rdbuf();
+    const std::string source = source_buffer.str();
+
+    const std::string html_path = std::string(AIDEN_SOURCE_DIR) + "/src/config_web_html.h";
+    std::ifstream html_in(html_path.c_str());
+    REQUIRE(html_in.good());
+
+    std::ostringstream html_buffer;
+    html_buffer << html_in.rdbuf();
+    const std::string html = html_buffer.str();
+
+    std::set<std::string> rendered_fields;
+    const std::string section_marker = "data-section=\\\"";
+    size_t pos = 0;
+    while ((pos = html.find(section_marker, pos)) != std::string::npos) {
+        const size_t section_start = pos + section_marker.size();
+        const size_t section_end = html.find("\\\"", section_start);
+        REQUIRE(section_end != std::string::npos);
+        const std::string section = html.substr(section_start, section_end - section_start);
+        pos = section_end + 2;
+
+        if (section == "system_env") {
+            continue;
+        }
+
+        size_t line_start = html.rfind('\n', section_start);
+        line_start = line_start == std::string::npos ? 0 : line_start + 1;
+        size_t line_end = html.find('\n', section_start);
+        line_end = line_end == std::string::npos ? html.size() : line_end;
+        const std::string line = html.substr(line_start, line_end - line_start);
+
+        const std::string id_marker = "id=\\\"";
+        const size_t id_pos = line.find(id_marker);
+        REQUIRE(id_pos != std::string::npos);
+        const size_t id_start = id_pos + id_marker.size();
+        const size_t id_end = line.find("\\\"", id_start);
+        REQUIRE(id_end != std::string::npos);
+        const std::string id = line.substr(id_start, id_end - id_start);
+        const std::string prefix = section + "_";
+
+        REQUIRE_MESSAGE(id.find(prefix) == 0, "config control id must be section_key: " << id);
+        rendered_fields.insert(section + "." + id.substr(prefix.size()));
+    }
+
+    REQUIRE(!rendered_fields.empty());
+    for (std::set<std::string>::const_iterator it = rendered_fields.begin(); it != rendered_fields.end(); ++it) {
+        const std::string& field = *it;
+        const size_t dot = field.find('.');
+        REQUIRE(dot != std::string::npos);
+        const std::string section = field.substr(0, dot);
+        const std::string key = field.substr(dot + 1);
+        const std::string guard = "{\"" + section + "\", \"" + key + "\", CONFIG_FIELD_";
+
+        CHECK_MESSAGE(source.find(guard) != std::string::npos,
+                      "rendered config field is missing from validate_known_config_field_types: " << field);
+    }
 }


### PR DESCRIPTION
## Summary
- persist voice_progress_speech_enabled through config_web TOML and JSON mappings
- return the toggle in /api/config and accept it on save
- add regression coverage for TOML round-trip and rendered web controls missing backend field guards

## Tests
- make test
- go test ./cmd/daemon
- git diff --check