### PR TITLE
feat(agent): rename instruction override to custom_instruction

### DIFF
--- a/docs/03-services/config-web.md
+++ b/docs/03-services/config-web.md
@@ -44,7 +44,7 @@ config_web [--bind=IP] [--port=PORT] [--config=PATH] [--wifi-config=PATH] [--sys
 
 页面字段覆盖以下配置段：
 
-- `agent`：`input_mode`、`trigger_mode`、VAD 参数、`max_iterations`、`instruction`、`additional_prompt`
+- `agent`：`input_mode`、`trigger_mode`、VAD 参数、`max_iterations`、`custom_instruction`、`additional_prompt`
 - `model`: provider, token_env, model, api_key, base_url, temperature, max_response_tokens, context_window, model_max_output_tokens. `context_window = 0` means auto-discover from OpenRouter/Ollama metadata when available.
 - `stt`：provider、api_key、model、base_url、Tencent ASR 字段
 - `tts`：provider、api_key、model、voice_id、emotion、speed

--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -17,7 +17,7 @@ TOML 是当前支持的配置格式；JSON 配置已废弃。
 ## Web UI 最小配置
 
 ```toml
-instruction = "回答要简洁、自然、有帮助。默认用简体中文回答；用户明确使用其他语言时跟随用户语言。Aiden 通常用于控制连接的手机或移动 UI，但必须根据截图、工具结果和用户输入推断当前可见目标，不要假设。"
+custom_instruction = ""
 max_iterations = -1
 screenshot_keep_n = 3
 screenshot_prune_interval = 25
@@ -50,7 +50,7 @@ frame_socket = "/run/frame_service/frame_service.sock"
 ## STT 语音模式最小配置
 
 ```toml
-instruction = "回答要简洁、自然、有帮助。默认用简体中文回答；用户明确使用其他语言时跟随用户语言。Aiden 通常用于控制连接的手机或移动 UI，但必须根据截图、工具结果和用户输入推断当前可见目标，不要假设。"
+custom_instruction = ""
 input_mode = "stt"
 trigger_mode = "manual"
 vad_backend = "rknn"
@@ -104,8 +104,8 @@ frame_socket = "/run/frame_service/frame_service.sock"
 
 | 字段 | 默认/可选值 | 说明 |
 | --- | --- | --- |
-| `instruction` | - | Agent deployment/persona instruction；默认只放简短语气、语言和目标设备软默认。工具边界、环境感知、UI 操作约束和 skill 策略由运行时默认 prompt 提供，避免在配置中重复长规则 |
-| `additional_prompt` | - | 额外 prompt 字段；运行时会追加到 `instruction` 后面 |
+| `custom_instruction` | - | Optional deployment/persona override for the built-in runtime instruction. Leave empty to use the agent binary default; set only for internal testing or deployment-specific behavior. |
+| `additional_prompt` | - | 额外 prompt 字段；运行时会追加到 base instruction 后面 |
 | `max_iterations` | `-1` | 单次运行最大工具调用循环次数；`-1` 表示不限制 |
 | `screenshot_keep_n` | `3` | LLM 上下文中截图裁剪的最近保留数量；未设置或 `0` 使用默认值 |
 | `screenshot_prune_interval` | `25` | 截图超过 `screenshot_keep_n + screenshot_prune_interval` 后，按批次把旧截图替换为占位符；未设置或 `0` 使用默认值 |

--- a/docs/04-agent/context-lifecycle.md
+++ b/docs/04-agent/context-lifecycle.md
@@ -8,7 +8,7 @@ Each run is assembled from several layers. Some layers are persisted memory, whi
 
 | Layer | Source | Visibility | Persistence |
 | --- | --- | --- | --- |
-| Base instruction | `agent.toml` `instruction` and `additional_prompt` | planner, executor, verifier | configuration |
+| Base instruction | built-in runtime instruction, optional `agent.toml` `custom_instruction`, and `additional_prompt` | planner, executor, verifier | configuration |
 | Runtime defaults | built-in prompt rules, current date, host runtime information | planner, executor, verifier | not persisted |
 | Skills | skill index plus active `SKILL.md` content | planner, executor, verifier | skill files and skill state |
 | Runtime context | `RunRequest.RuntimeContext`, for example phone bridge state | planner, executor, verifier | not persisted |

--- a/overlay/userdata/agent/agent.toml
+++ b/overlay/userdata/agent/agent.toml
@@ -1,5 +1,5 @@
 # Agent instruction and behavior
-instruction = ""
+custom_instruction = ""
 additional_prompt = ""
 max_iterations = -1
 force_simple_loop = false

--- a/src/agent/cmd/daemon/config_commands.go
+++ b/src/agent/cmd/daemon/config_commands.go
@@ -123,7 +123,7 @@ type telemetryDTO struct {
 }
 
 type agentDTO struct {
-	Instruction                string  `json:"instruction"`
+	CustomInstruction          string  `json:"custom_instruction"`
 	AdditionalPrompt           string  `json:"additional_prompt"`
 	InputMode                  string  `json:"input_mode"`
 	TriggerMode                string  `json:"trigger_mode"`
@@ -249,7 +249,7 @@ func (d webConfigDTO) toAgentConfig() agent.Config {
 			Tags:              d.Telemetry.Tags,
 			Environment:       d.Telemetry.Environment,
 		},
-		Instruction:                d.Agent.Instruction,
+		Instruction:                d.Agent.CustomInstruction,
 		AdditionalPrompt:           d.Agent.AdditionalPrompt,
 		InputMode:                  d.Agent.InputMode,
 		TriggerMode:                d.Agent.TriggerMode,
@@ -368,7 +368,7 @@ func webConfigDTOFromAgentConfig(cfg agent.Config) webConfigDTO {
 			Environment:       cfg.Telemetry.EnvironmentOrDefault(),
 		},
 		Agent: agentDTO{
-			Instruction:                cfg.Instruction,
+			CustomInstruction:          customInstructionValue(cfg.Instruction),
 			AdditionalPrompt:           cfg.AdditionalPrompt,
 			InputMode:                  cfg.InputModeOrDefault(),
 			TriggerMode:                cfg.TriggerModeOrDefault(),
@@ -398,6 +398,13 @@ func webConfigDTOFromAgentConfig(cfg agent.Config) webConfigDTO {
 			ScreenStableDiffThreshold:  cfg.ScreenStableDiffThreshold,
 		},
 	}
+}
+
+func customInstructionValue(instruction string) string {
+	if strings.TrimSpace(instruction) == agent.DefaultConfig().Instruction {
+		return ""
+	}
+	return instruction
 }
 
 // runConfigCheck implements the `agent config-check` subcommand

--- a/src/agent/cmd/daemon/config_commands_test.go
+++ b/src/agent/cmd/daemon/config_commands_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -74,8 +75,8 @@ func TestResolvedWebConfigDTO_MissingFileUsesDefaults(t *testing.T) {
 		t.Fatalf("HID frame_socket = %q, want %q",
 			dto.HID.FrameSocket, agent.DefaultConfig().HID.FrameSocket)
 	}
-	if dto.Agent.Instruction == "" {
-		t.Fatal("instruction is empty")
+	if dto.Agent.CustomInstruction != "" {
+		t.Fatalf("custom_instruction = %q, want empty wire value for built-in runtime default", dto.Agent.CustomInstruction)
 	}
 
 	data, err := json.Marshal(dto)
@@ -88,6 +89,70 @@ func TestResolvedWebConfigDTO_MissingFileUsesDefaults(t *testing.T) {
 	}
 	if !result.Valid {
 		t.Fatalf("resolved default config is invalid: %+v", result.Errors)
+	}
+}
+
+func TestResolvedWebConfigDTO_PreservesCustomInstruction(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.toml")
+	if err := os.WriteFile(path, []byte(`
+custom_instruction = "Use a deployment-specific persona."
+
+[model]
+provider = "fake"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	dto, err := resolvedWebConfigDTO(path)
+	if err != nil {
+		t.Fatalf("resolvedWebConfigDTO() error = %v", err)
+	}
+	if dto.Agent.CustomInstruction != "Use a deployment-specific persona." {
+		t.Fatalf("custom_instruction = %q, want custom instruction preserved", dto.Agent.CustomInstruction)
+	}
+}
+
+func TestResolvedWebConfigDTO_ElidesConfiguredDefaultCustomInstruction(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.toml")
+	body := `
+custom_instruction = ` + strconv.Quote(agent.DefaultConfig().Instruction) + `
+
+[model]
+provider = "fake"
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	dto, err := resolvedWebConfigDTO(path)
+	if err != nil {
+		t.Fatalf("resolvedWebConfigDTO() error = %v", err)
+	}
+	if dto.Agent.CustomInstruction != "" {
+		t.Fatalf("custom_instruction = %q, want empty wire value when config matches default", dto.Agent.CustomInstruction)
+	}
+}
+
+func TestResolvedWebConfigDTO_IgnoresLegacyInstructionField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.toml")
+	if err := os.WriteFile(path, []byte(`
+instruction = "legacy field should be ignored"
+
+[model]
+provider = "fake"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	dto, err := resolvedWebConfigDTO(path)
+	if err != nil {
+		t.Fatalf("resolvedWebConfigDTO() error = %v", err)
+	}
+	if dto.Agent.CustomInstruction != "" {
+		t.Fatalf("custom_instruction = %q, want empty because legacy instruction is ignored", dto.Agent.CustomInstruction)
 	}
 }
 

--- a/src/agent/cmd/daemon/config_wire_test.go
+++ b/src/agent/cmd/daemon/config_wire_test.go
@@ -144,6 +144,18 @@ func TestConfigCheck_WireForceSimpleLoopMapsToAgentConfig(t *testing.T) {
 	}
 }
 
+func TestConfigCheck_WireCustomInstructionMapsToAgentConfig(t *testing.T) {
+	dto := webConfigDTO{
+		Model:  modelDTO{Provider: "openai", Model: "gpt-4"},
+		Search: searchDTO{Provider: "duckduckgo"},
+		Agent:  agentDTO{CustomInstruction: "Use custom behavior."},
+	}
+	cfg := dto.toAgentConfig()
+	if cfg.Instruction != "Use custom behavior." {
+		t.Fatalf("Instruction = %q, want custom instruction", cfg.Instruction)
+	}
+}
+
 // TestConfigCheck_WireTelemetryNested verifies telemetry validation runs
 // against the nested "telemetry" wire object.
 func TestConfigCheck_WireTelemetryNested(t *testing.T) {

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -104,7 +104,7 @@ type Config struct {
 	Benchmark                  BenchmarkConfig    `toml:"benchmark,omitempty"`
 	Search                     SearchConfig       `toml:"search,omitempty"`
 	LiveActivity               LiveActivityConfig `toml:"live_activity,omitempty"`
-	Instruction                string             `toml:"instruction"`
+	Instruction                string             `toml:"custom_instruction,omitempty"`
 	AdditionalPrompt           string             `toml:"additional_prompt,omitempty"`
 	InputMode                  string             `toml:"input_mode,omitempty"`   // "text", "audio", "stt"
 	TriggerMode                string             `toml:"trigger_mode,omitempty"` // "manual", "wakeup"
@@ -503,6 +503,7 @@ func LoadRuntimeConfig(path string) (Config, error) {
 	}
 
 	applyRuntimeOptionalProviderDefaults(&cfg, metadata)
+	applyRuntimeInstructionDefault(&cfg)
 
 	if err := cfg.Validate(); err != nil {
 		return Config{}, err
@@ -576,6 +577,8 @@ func LoadResolvedConfig(path string) (Config, error) {
 		}
 	}
 
+	applyRuntimeInstructionDefault(&cfg)
+
 	if err := cfg.Validate(); err != nil {
 		return Config{}, err
 	}
@@ -614,6 +617,15 @@ func resolveConfigPath(path string) (string, bool, error) {
 		return path, false, nil
 	}
 	return "", false, fmt.Errorf("read config: %w", err)
+}
+
+func applyRuntimeInstructionDefault(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	if strings.TrimSpace(cfg.Instruction) == "" {
+		cfg.Instruction = defaultInstruction
+	}
 }
 
 func decodeConfigFile(path string, cfg *Config) (toml.MetaData, error) {

--- a/src/agent/internal/agent/config_meta.go
+++ b/src/agent/internal/agent/config_meta.go
@@ -94,9 +94,9 @@ func all(conds ...Condition) *VisibleRule { return &VisibleRule{All: conds} }
 
 // ConfigMeta returns the full field metadata for the config web UI. Defaults
 // here are the canonical defaults for the device's agent.toml. Free-text
-// fields (instruction, additional_prompt) intentionally carry no default: the
-// first-boot seed prompt is product content owned by the provisioning path,
-// not UI metadata.
+// fields (custom_instruction, additional_prompt) intentionally carry no
+// metadata default: the built-in prompt is runtime content, while
+// custom_instruction is only an override.
 func ConfigMeta() ConfigMetadata {
 	defaults := DefaultConfig()
 	return ConfigMetadata{
@@ -315,7 +315,7 @@ func ConfigMeta() ConfigMetadata {
 					{Key: "screen_stable_timeout_ms", Widget: WidgetNumber, Default: defaults.ScreenStableTimeoutMs},
 					{Key: "screen_stable_ms", Widget: WidgetNumber, Default: defaults.ScreenStableMs},
 					{Key: "screen_stable_diff_threshold", Widget: WidgetNumber, Default: defaults.ScreenStableDiffThreshold},
-					{Key: "instruction", Widget: WidgetTextarea},
+					{Key: "custom_instruction", Widget: WidgetTextarea},
 					{Key: "additional_prompt", Widget: WidgetTextarea},
 				},
 			},

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -90,7 +90,7 @@ func TestConfigTodoReminderToolCallsDefaultsAndOverrides(t *testing.T) {
 func TestLoadConfigParsesModelSpecOverrides(t *testing.T) {
 	configDir := t.TempDir()
 	config := `
-instruction = "test"
+custom_instruction = "test"
 
 [model]
 provider = "openrouter"
@@ -121,7 +121,7 @@ model_max_output_tokens = 4096
 func TestLoadConfigParsesLegacyModelMaxTokens(t *testing.T) {
 	configDir := t.TempDir()
 	config := `
-instruction = "test"
+custom_instruction = "test"
 
 [model]
 provider = "openrouter"
@@ -144,7 +144,7 @@ max_tokens = 777
 func TestLoadConfigPrefersMaxResponseTokensOverLegacyMaxTokens(t *testing.T) {
 	configDir := t.TempDir()
 	config := `
-instruction = "test"
+custom_instruction = "test"
 
 [model]
 provider = "openrouter"
@@ -206,6 +206,48 @@ provider = "fake"
 	}
 	if cfg.STT.Provider != "" {
 		t.Fatalf("STT.Provider = %q, want empty when text mode did not configure STT", cfg.STT.Provider)
+	}
+}
+
+func TestLoadRuntimeConfigIgnoresLegacyInstructionField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.toml")
+	if err := os.WriteFile(path, []byte(`
+instruction = "legacy field should be ignored"
+
+[model]
+provider = "fake"
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadRuntimeConfig(path)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfig() error = %v", err)
+	}
+	if cfg.Instruction != defaultInstruction {
+		t.Fatalf("Instruction = %q, want built-in default because legacy instruction is ignored", cfg.Instruction)
+	}
+}
+
+func TestLoadRuntimeConfigEmptyCustomInstructionUsesDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.toml")
+	if err := os.WriteFile(path, []byte(`
+custom_instruction = ""
+
+[model]
+provider = "fake"
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadRuntimeConfig(path)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfig() error = %v", err)
+	}
+	if cfg.Instruction != defaultInstruction {
+		t.Fatalf("Instruction = %q, want built-in default for empty custom_instruction", cfg.Instruction)
 	}
 }
 
@@ -646,7 +688,7 @@ func TestLoadConfigAcceptsMobileGymDeviceBackend(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agent.toml")
 	content := `
-instruction = "test"
+custom_instruction = "test"
 input_mode = "text"
 max_iterations = 20
 force_simple_loop = true
@@ -679,7 +721,7 @@ func TestLoadConfigRejectsUnknownDeviceBackend(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agent.toml")
 	content := `
-instruction = "test"
+custom_instruction = "test"
 
 [model]
 provider = "fake"

--- a/src/agent_toml.cpp
+++ b/src/agent_toml.cpp
@@ -245,8 +245,8 @@ void apply_kv(AgentToml& cfg,
     std::string sub_err;
 
     if (section.empty()) {
-        if (key == "instruction") {
-            if (!assign_string(&cfg.instruction, raw, &sub_err)) fail(sub_err);
+        if (key == "custom_instruction") {
+            if (!assign_string(&cfg.custom_instruction, raw, &sub_err)) fail(sub_err);
         } else if (key == "additional_prompt") {
             if (!assign_string(&cfg.additional_prompt, raw, &sub_err)) fail(sub_err);
         } else if (key == "input_mode") {
@@ -600,7 +600,7 @@ bool save_agent_toml(const char* path, const AgentToml& cfg, std::string* error)
     }
 
     std::ostringstream out;
-    if (!cfg.instruction.empty()) emit_string(out, "instruction", cfg.instruction);
+    if (!cfg.custom_instruction.empty()) emit_string(out, "custom_instruction", cfg.custom_instruction);
     if (!cfg.additional_prompt.empty()) emit_string(out, "additional_prompt", cfg.additional_prompt);
     if (!cfg.input_mode.empty()) emit_string(out, "input_mode", cfg.input_mode);
     if (!cfg.trigger_mode.empty()) emit_string(out, "trigger_mode", cfg.trigger_mode);

--- a/src/agent_toml.h
+++ b/src/agent_toml.h
@@ -95,7 +95,7 @@ struct AgentToml {
     SearchToml search;
     TelemetryToml telemetry;
 
-    std::string instruction;
+    std::string custom_instruction;
     std::string additional_prompt;
     std::string input_mode;
     std::string trigger_mode;

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -532,7 +532,7 @@ bool validate_known_config_field_types(cJSON* root, std::string* error) {
         {"telemetry", "max_retry", CONFIG_FIELD_NUMBER},
         {"telemetry", "tags", CONFIG_FIELD_ARRAY},
         {"telemetry", "environment", CONFIG_FIELD_STRING},
-        {"agent", "instruction", CONFIG_FIELD_STRING},
+        {"agent", "custom_instruction", CONFIG_FIELD_STRING},
         {"agent", "additional_prompt", CONFIG_FIELD_STRING},
         {"agent", "input_mode", CONFIG_FIELD_STRING},
         {"agent", "trigger_mode", CONFIG_FIELD_STRING},
@@ -1418,7 +1418,7 @@ cJSON* config_to_json(const aiden::AgentToml& config, bool include_secrets = fal
     cJSON_AddStringToObject(telemetry, "environment", config.telemetry.environment.c_str());
 
     cJSON* agent = add_object(root, "agent");
-    cJSON_AddStringToObject(agent, "instruction", config.instruction.c_str());
+    cJSON_AddStringToObject(agent, "custom_instruction", config.custom_instruction.c_str());
     cJSON_AddStringToObject(agent, "additional_prompt", config.additional_prompt.c_str());
     cJSON_AddStringToObject(agent, "input_mode", config.input_mode.c_str());
     cJSON_AddStringToObject(agent, "trigger_mode", config.trigger_mode.c_str());
@@ -1675,7 +1675,7 @@ void update_config_from_json(cJSON* root, aiden::AgentToml* config) {
 
     cJSON* agent = cJSON_GetObjectItem(root, "agent");
     if (json_is_object(agent)) {
-        set_json_str(&config->instruction, agent, "instruction");
+        set_json_str(&config->custom_instruction, agent, "custom_instruction");
         set_json_str(&config->additional_prompt, agent, "additional_prompt");
         set_json_str(&config->input_mode, agent, "input_mode");
         set_json_str(&config->trigger_mode, agent, "trigger_mode");

--- a/tests/agent_stub_main.cpp
+++ b/tests/agent_stub_main.cpp
@@ -68,7 +68,7 @@ const char* kDefaultConfig =
     "\"telemetry\":{\"enabled\":false,\"provider\":\"langfuse\",\"base_url\":\"\","
     "\"public_key\":\"\",\"secret_key\":\"\",\"upload_screenshots\":true,"
     "\"upload_timeout_sec\":30,\"max_retry\":2,\"tags\":[],\"environment\":\"default\"},"
-    "\"agent\":{\"instruction\":\"stub default instruction\",\"additional_prompt\":\"\","
+    "\"agent\":{\"custom_instruction\":\"stub custom instruction\",\"additional_prompt\":\"\","
     "\"input_mode\":\"text\",\"trigger_mode\":\"manual\",\"vad_backend\":\"rknn\","
     "\"vad_model_path\":\"/oem/usr/model/silero_vad_6_2_encoder_rv1106_w8a8_v1.rknn\","
     "\"vad_helper_path\":\"/oem/usr/bin/rknn_vad\",\"vad_speech_threshold\":0.5,"

--- a/tests/agent_toml_test.cpp
+++ b/tests/agent_toml_test.cpp
@@ -24,7 +24,7 @@ std::string make_temp_path(const char* leaf) {
 
 TEST_CASE("agent_toml round-trip preserves Go-agent schema fields") {
     aiden::AgentToml cfg;
-    cfg.instruction = "Hello \"world\"";
+    cfg.custom_instruction = "Hello \"world\"";
     cfg.input_mode = "stt";
     cfg.trigger_mode = "manual";
     cfg.vad_backend = "cpu";
@@ -109,11 +109,20 @@ TEST_CASE("agent_toml round-trip preserves Go-agent schema fields") {
     REQUIRE(aiden::save_agent_toml(path.c_str(), cfg, &err));
     REQUIRE(err.empty());
 
+    {
+        std::ifstream saved_in(path);
+        REQUIRE(saved_in.good());
+        std::string contents((std::istreambuf_iterator<char>(saved_in)), std::istreambuf_iterator<char>());
+        CHECK(contents.find("custom_instruction = \"Hello \\\"world\\\"\"") != std::string::npos);
+        CHECK(contents.rfind("instruction =", 0) != 0);
+        CHECK(contents.find("\ninstruction =") == std::string::npos);
+    }
+
     aiden::AgentToml loaded;
     REQUIRE(aiden::load_agent_toml(path.c_str(), loaded, &err));
     REQUIRE(err.empty());
 
-    CHECK(loaded.instruction == "Hello \"world\"");
+    CHECK(loaded.custom_instruction == "Hello \"world\"");
     CHECK(loaded.input_mode == "stt");
     CHECK(loaded.trigger_mode == "manual");
     CHECK(loaded.vad_backend == "cpu");
@@ -211,6 +220,25 @@ TEST_CASE("agent_toml no longer writes legacy proxy section") {
     std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
     CHECK(contents.find("[proxy]") == std::string::npos);
     CHECK(contents.find("http_proxy") == std::string::npos);
+
+    std::remove(path.c_str());
+}
+
+TEST_CASE("agent_toml ignores legacy instruction key") {
+    std::string path = make_temp_path("legacy_instruction.toml");
+    {
+        std::ofstream out(path);
+        out << "instruction = \"legacy value\"\n"
+            << "custom_instruction = \"custom value\"\n"
+            << "[model]\n"
+            << "provider = \"fake\"\n";
+    }
+
+    aiden::AgentToml cfg;
+    std::string err;
+    REQUIRE(aiden::load_agent_toml(path.c_str(), cfg, &err));
+    REQUIRE(err.empty());
+    CHECK(cfg.custom_instruction == "custom value");
 
     std::remove(path.c_str());
 }

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -87,6 +87,14 @@ void write_file(const std::string& path, const std::string& content) {
     out << content;
 }
 
+std::string read_file(const std::string& path) {
+    std::ifstream in(path);
+    REQUIRE(in.good());
+    std::ostringstream buf;
+    buf << in.rdbuf();
+    return buf.str();
+}
+
 std::string print_json_unformatted(cJSON* root) {
     char* text = cJSON_PrintUnformatted(root);
     REQUIRE(text != nullptr);
@@ -169,7 +177,7 @@ std::string resolved_config_json(const std::string& search_provider, bool search
         "\"telemetry\":{\"enabled\":false,\"provider\":\"langfuse\",\"base_url\":\"\","
         "\"public_key\":\"\",\"secret_key\":\"\",\"upload_screenshots\":true,"
         "\"upload_timeout_sec\":30,\"max_retry\":2,\"tags\":[],\"environment\":\"default\"},"
-        "\"agent\":{\"instruction\":\"stub default instruction\",\"additional_prompt\":\"\","
+        "\"agent\":{\"custom_instruction\":\"stub custom instruction\",\"additional_prompt\":\"\","
         "\"input_mode\":\"text\",\"trigger_mode\":\"manual\",\"vad_backend\":\"rknn\","
         "\"vad_model_path\":\"/oem/usr/model/silero_vad_6_2_encoder_rv1106_w8a8_v1.rknn\","
         "\"vad_helper_path\":\"/oem/usr/bin/rknn_vad\",\"vad_speech_threshold\":0.5,"
@@ -453,6 +461,14 @@ TEST_CASE("config_web: GET /api/config reads resolved config from agent") {
     cJSON* enabled = cJSON_GetObjectItem(audio_archive, "enabled");
     REQUIRE(enabled != nullptr);
     CHECK((enabled->type & 0xff) == cJSON_True);
+
+    cJSON* agent = cJSON_GetObjectItem(config, "agent");
+    REQUIRE(agent != nullptr);
+    cJSON* custom_instruction = cJSON_GetObjectItem(agent, "custom_instruction");
+    REQUIRE(custom_instruction != nullptr);
+    REQUIRE(custom_instruction->valuestring != nullptr);
+    CHECK(std::string(custom_instruction->valuestring) == "stub custom instruction");
+    CHECK(cJSON_GetObjectItem(agent, "instruction") == nullptr);
     cJSON_Delete(parsed);
 }
 
@@ -559,6 +575,49 @@ TEST_CASE("config_web: POST /api/config accepts empty audio_archive storage_path
         "\"search\":{\"provider\":\"duckduckgo\"},\"agent\":{}},\"apply_wifi\":false}";
     HttpResponse resp = http_request(handle->port, "POST", "/api/config", body);
     CHECK(resp.status == 200);
+}
+
+TEST_CASE("config_web: POST /api/config writes custom_instruction") {
+    StubEnv env;
+    auto handle = start_server(env);
+
+    const std::string body =
+        "{\"config\":{\"model\":{\"provider\":\"openai\",\"model\":\"x\",\"api_key\":\"k\"},"
+        "\"hid\":{\"pointer_mode\":\"absolute\"},"
+        "\"search\":{\"provider\":\"duckduckgo\"},"
+        "\"agent\":{\"custom_instruction\":\"Use custom behavior.\"}},\"apply_wifi\":false}";
+    HttpResponse resp = http_request(handle->port, "POST", "/api/config", body);
+    CHECK(resp.status == 200);
+
+    const std::string saved = read_file(handle->tmp_dir + "/agent.toml");
+    CHECK(saved.find("custom_instruction = \"Use custom behavior.\"") != std::string::npos);
+    CHECK(saved.rfind("instruction =", 0) != 0);
+    CHECK(saved.find("\ninstruction =") == std::string::npos);
+}
+
+TEST_CASE("config_web: POST /api/config ignores legacy instruction") {
+    auto tmp = make_temp_dir();
+    auto cleanup = std::unique_ptr<void, void(*)(void*)>(
+        const_cast<char*>(tmp.c_str()),
+        [](void* p) { std::string cmd = std::string("rm -rf '") + (char*)p + "'"; (void)std::system(cmd.c_str()); }
+    );
+    write_file(tmp + "/config.json", resolved_config_json("duckduckgo", false));
+    StubEnv env;
+    env.set("AIDEN_AGENT_STUB_CONFIG_FILE", tmp + "/config.json");
+    auto handle = start_server(env);
+
+    const std::string body =
+        "{\"config\":{\"model\":{\"provider\":\"openai\",\"model\":\"x\",\"api_key\":\"k\"},"
+        "\"hid\":{\"pointer_mode\":\"absolute\"},"
+        "\"search\":{\"provider\":\"duckduckgo\"},"
+        "\"agent\":{\"custom_instruction\":\"\",\"instruction\":\"legacy value\"}},\"apply_wifi\":false}";
+    HttpResponse resp = http_request(handle->port, "POST", "/api/config", body);
+    CHECK(resp.status == 200);
+
+    const std::string saved = read_file(handle->tmp_dir + "/agent.toml");
+    CHECK(saved.find("custom_instruction") == std::string::npos);
+    CHECK(saved.rfind("instruction =", 0) != 0);
+    CHECK(saved.find("\ninstruction =") == std::string::npos);
 }
 
 TEST_CASE("config_web: GET /api/config tolerates resolved config without force_simple_loop") {


### PR DESCRIPTION
## Summary
- Rename the configurable agent instruction override from `instruction` to `custom_instruction` across Go config, config_web JSON, C++ TOML parsing/writing, overlay, and docs
- Treat empty `custom_instruction` as using the agent binary's built-in default at runtime/resolved-config time
- Do not read the legacy `instruction` field; old configs with that key are ignored rather than treated as overrides

## Tests
- `go test ./internal/agent ./cmd/daemon`
- `go test ./...`
- `cmake -S . -B /tmp/aiden-hardware-demo-cmake-test-aiden-tests -DAIDEN_TESTS=ON -DCMAKE_BUILD_TYPE=Debug && cmake --build /tmp/aiden-hardware-demo-cmake-test-aiden-tests --target aiden_tests -j4`
- `/tmp/aiden-hardware-demo-cmake-test-aiden-tests/bin/aiden_tests`
- `scripts/test_build_scripts.sh`
