### PR TITLE
feat(agent): unify coordinate system to active_area                                                                         

### DIFF
--- a/src/agent/internal/agent/coordinate_debug_html.go
+++ b/src/agent/internal/agent/coordinate_debug_html.go
@@ -175,6 +175,19 @@ function imagePixelToSourcePixel(pixelX, pixelY) {
 
 function sourcePixelToNormalized(pixelX, pixelY) {
     const meta = currentScreenshotMeta || defaultScreenshotMeta(canvas.width, canvas.height);
+    const active = normalizeActiveArea(meta);
+    // Normalized coordinates are relative to active_area (0-1000 maps to visible content)
+    if (active) {
+        const activeWidth = Math.max(active.width, 1);
+        const activeHeight = Math.max(active.height, 1);
+        const activePixelX = clamp(pixelX - active.x, 0, active.width - 1);
+        const activePixelY = clamp(pixelY - active.y, 0, active.height - 1);
+        return {
+            x: clamp(Math.round((activePixelX / Math.max(activeWidth - 1, 1)) * 1000), 0, 1000),
+            y: clamp(Math.round((activePixelY / Math.max(activeHeight - 1, 1)) * 1000), 0, 1000)
+        };
+    }
+    // Fallback: no active_area, treat as full frame
     const sourceWidth = Math.max(meta.source_width || canvas.width, 1);
     const sourceHeight = Math.max(meta.source_height || canvas.height, 1);
     const maxPixelX = Math.max(sourceWidth - 1, 1);
@@ -187,6 +200,19 @@ function sourcePixelToNormalized(pixelX, pixelY) {
 
 function normalizedToSourcePixel(x, y) {
     const meta = currentScreenshotMeta || defaultScreenshotMeta(canvas.width, canvas.height);
+    const active = normalizeActiveArea(meta);
+    // Normalized coordinates are relative to active_area (0-1000 maps to visible content)
+    if (active) {
+        const activeWidth = Math.max(active.width, 1);
+        const activeHeight = Math.max(active.height, 1);
+        const activePixelX = clamp(Math.round((x / 1000) * Math.max(activeWidth - 1, 0)), 0, activeWidth - 1);
+        const activePixelY = clamp(Math.round((y / 1000) * Math.max(activeHeight - 1, 0)), 0, activeHeight - 1);
+        return {
+            pixelX: clamp(activePixelX + active.x, 0, (meta.source_width || canvas.width) - 1),
+            pixelY: clamp(activePixelY + active.y, 0, (meta.source_height || canvas.height) - 1)
+        };
+    }
+    // Fallback: no active_area, treat as full frame
     const sourceWidth = Math.max(meta.source_width || canvas.width, 1);
     const sourceHeight = Math.max(meta.source_height || canvas.height, 1);
     return {

--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -1197,6 +1197,23 @@ func resolvePointerPosition(screen *screenState, x, y float64, coordSpace string
 		}
 		return pixelToAbsolutePoint(x, y, width, height, active)
 	case coordinateSpaceNormalized:
+		// Normalized coordinates are relative to active_area (0-1000 maps to visible content).
+		// Convert to pixel coordinates within active_area, then to absolute HID coordinates.
+		if screen != nil {
+			if width, height, active, age, ok := screen.ActiveAreaWithAge(); ok && age < screenDimensionsStaleAfter && active.Valid {
+				// Step 1: Map normalized (0-1000) to pixel within active_area (0 to active.Width-1)
+				activePixelX := (x / 1000.0) * float64(active.Width-1)
+				activePixelY := (y / 1000.0) * float64(active.Height-1)
+				// Step 2: Add active_area offset to get full-frame pixel coordinates
+				fullFramePixelX := activePixelX + float64(active.X)
+				fullFramePixelY := activePixelY + float64(active.Y)
+				// Step 3: Scale full-frame pixel (0 to width-1) to HID absolute (0 to 32767)
+				absX := int(math.Round((fullFramePixelX / float64(width-1)) * float64(absMouseMaxPos)))
+				absY := int(math.Round((fullFramePixelY / float64(height-1)) * float64(absMouseMaxPos)))
+				return absX, absY, nil
+			}
+		}
+		// Fallback: no active_area available, treat as full-frame normalized
 		absX, absY := normalizedToAbsolutePoint(x, y)
 		return absX, absY, nil
 	case coordinateSpaceAbsolute:

--- a/src/agent/internal/agent/tools_screenshot.go
+++ b/src/agent/internal/agent/tools_screenshot.go
@@ -66,17 +66,25 @@ func (t *ScreenshotTool) Call(_ context.Context, _ string) (string, error) {
 		t.screen.UpdateActiveArea(int(meta.Width), int(meta.Height), active)
 	}
 
-	result := screenshotResult{
-		Width:  int(meta.Width),
-		Height: int(meta.Height),
-		Format: "jpeg",
-		Size:   len(jpegData),
-		Data:   base64.StdEncoding.EncodeToString(jpegData),
+	// Crop to active_area so LLM sees only visible content (normalized coordinates map to this)
+	displayWidth := int(meta.Width)
+	displayHeight := int(meta.Height)
+	displayData := jpegData
+	if active.Valid && (active.X != 0 || active.Y != 0 || active.Width != displayWidth || active.Height != displayHeight) {
+		croppedData, croppedWidth, croppedHeight, err := cropJPEGToActiveArea(jpegData, active, screenshotJPEGQuality)
+		if err == nil {
+			displayWidth = croppedWidth
+			displayHeight = croppedHeight
+			displayData = croppedData
+		}
 	}
-	if active.Valid && (active.X != 0 || active.Y != 0 || active.Width != result.Width || active.Height != result.Height) {
-		result.ActiveArea = &active
-		result.ActiveWidth = active.Width
-		result.ActiveHeight = active.Height
+
+	result := screenshotResult{
+		Width:  displayWidth,
+		Height: displayHeight,
+		Format: "jpeg",
+		Size:   len(displayData),
+		Data:   base64.StdEncoding.EncodeToString(displayData),
 	}
 
 	out, _ := json.Marshal(result)


### PR DESCRIPTION
 ## Summary                                                                                                                  
  Unifies all coordinate systems (LLM, coordinate debug tool, and HID execution layer) to use `active_area` instead of full   
  frame, eliminating coordinate mismatches and black border handling issues.                                                  
                                                                                                                              
  ## Problem                                                                                                                  
  Previously, different components used inconsistent coordinate systems:                                                    
  - **LLM** saw full-frame screenshots (including black borders) and output full-frame coordinates                            
  - **Coordinate debug tool** displayed full-frame coordinates                                                                
  - **HID execution layer** mapped coordinates to `active_area` in some modes but not others                                  
                                                                                                                              
  This caused:                                                                                                                
  - LLM-generated coordinates not matching coordinate tool display                                                            
  - Clicks landing in black borders instead of visible content                                                                
  - Test coordinate selections not matching actual execution positions                                                        
                                                                                                                              
  ## Solution                                                                                                                 
  All components now use **active_area coordinate system (0-1000)**:                                                          
                                                                                                                              
  ### 1. Screenshot Tool (`tools_screenshot.go`)                                                                              
  - Detects `active_area` (visible content region, excluding black borders)                                                   
  - **Crops image** to active_area before returning to LLM                                                                    
  - LLM now only sees visible content, naturally reasons in active_area coordinates                                           
                                                                                                                              
  ### 2. HID Execution Layer (`tools_hid.go`)                                                                                 
  - Normalized coordinates (0-1000) now map to active_area instead of full frame                                              
  - Coordinate mapping flow:                                                                                                  
    normalized (0-1000)                                                                                                       
      → active_area pixel                                                                                                     
      → full-frame pixel (+ offset)                                                                                           
      → HID absolute (0-32767)                                                                                              
  - Fallback to full-frame when no active_area detected                                                                       
                                                                                                                              
  ### 3. Coordinate Debug Tool (`coordinate_debug_html.go`)                                                                   
  - Display: `full-frame pixel → active_area pixel → normalized (0-1000)`                                                     
  - Input: `normalized (0-1000) → active_area pixel → full-frame pixel`                                                       
  - Coordinates shown now match execution coordinates exactly                                                                 
                                                                                                                              
  ## Impact                                                                                                                   
  - ✅ LLM output coordinates match coordinate tool display                                                                   
  - ✅ Clicks land accurately on visible content, never on black borders                                                      
  - ✅ Coordinate tool test selections match actual execution positions                                                       
  - ✅ `quick_action` gestures now target visible content correctly (e.g., home gesture goes to active_area bottom instead of 
  full-frame bottom)                                                                                                          
                                                                                                                              
  ## Test Plan                                                                                                                
  1. Capture screenshot with black borders on device                                                                          
  2. Click center of visible content in coordinate debug tool → verify displays ~(500, 500)                                 
  3. Input (500, 500) and trigger click → verify lands on visible content center                                              
  4. Test LLM-generated coordinates → verify alignment with coordinate tool                                                   
  5. Test iOS quick_action gestures (back, app_switch, control_center)   