### PR TITLE
fix: use llm-generated tool call speech

### DIFF
--- a/docs/04-agent/audio-features.md
+++ b/docs/04-agent/audio-features.md
@@ -109,6 +109,12 @@ emotion = "happy"
 speed = 1.0
 ```
 
+### 工具调用口播
+
+`voice_tool_call_speech = true` 时，运行时会把工具 schema 中可选的 `speech` 参数暴露给 LLM，并在工具调用事件到达时异步 TTS 播放该字段。`speech` 是运行时元字段，不会传给真实工具。
+
+如果 LLM 没有生成 `speech`，该工具调用保持静默。运行时不会从工具 `description`、assistant text 或其他上下文字段派生短口播；`description` 只用于 UI、trace、memory 和调试上下文。
+
 ## TTS provider 使用方式
 
 `[tts]` 的通用字段是 `provider`、`api_key`、`model`、`voice_id`、`emotion`、`speed` 和 `reference_id`。不同 provider 对字段的解释不同，完整说明见 [Agent 配置参考](configuration.md#stt-和-tts)。以下示例省略 `api_key`，只展示 adapter 行为相关配置。

--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -123,7 +123,7 @@ frame_socket = "/run/frame_service/frame_service.sock"
 | `voice_max_turns` | `0` | 单个 wakeup session 最大轮数；`0` 表示不限制 |
 | `voice_interrupt_on_wakeup` | `true` | session 内再次收到 wakeup 时取消 thinking/TTS 并重新听音；录音中 wakeup 会直接重启录音并丢弃已录音频 |
 | `voice_streaming_tts_enabled` | `true` | LLM 流式输出时按句送入 TTS，降低首句播放等待；启用 `voice_speech_summary_enabled` 时，最终播报改为生成完整输出后的摘要 |
-| `voice_tool_call_speech` | `false` | 是否异步朗读工具调用说明；默认关闭，避免快动作已经执行后才播报预告 |
+| `voice_tool_call_speech` | `false` | 是否异步朗读 LLM 在工具参数中显式生成的 `speech`；默认关闭。缺少 `speech` 时保持静默，不会从工具 `description` 派生口播 |
 | `voice_progress_speech_enabled` | `true` | 是否在 todo item 进入 `in_progress` 时播报短进度；todo 状态仍会发送给 UI/trace |
 | `voice_speech_summary_enabled` | `true` | 是否将完整 assistant 输出转换成更短的口播文本；不影响 Web UI、history 和 memory 中的完整 `result.Output` |
 | `voice_speech_max_runes` | `120` | 口播摘要最大 rune 数；设为 `0` 使用默认值 |

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -436,6 +436,8 @@ func (d *AudioDialog) HandleRunEvent(ctx context.Context, event RunEvent) {
 	if event.Type != runEventToolCall || !d.config.VoiceToolCallSpeechOrDefault() || event.ToolName == "enter_sleep" {
 		return
 	}
+	// Tool-call speech is only the explicit LLM-generated speech field; do not
+	// synthesize speech from the description when it is missing.
 	go d.SpeakToolDescription(event.Speech)
 }
 

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -283,7 +283,7 @@ func TestProcessUtteranceSpeaksSpeechTextWithoutChangingHistoryOutput(t *testing
 func TestAudioDialogSpeaksToolDescriptionAsynchronously(t *testing.T) {
 	toolSpeech := true
 	model := &scriptedModel{
-		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我先检查当前音量。"}`, "当前音量是 42。"),
+		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我会检查当前音量。","speech":"检查音量。"}`, "当前音量是 42。"),
 	}
 	runtime := NewRuntimeWithDeps(
 		Config{
@@ -324,7 +324,7 @@ func TestAudioDialogSpeaksToolDescriptionAsynchronously(t *testing.T) {
 	if len(texts) != 2 {
 		t.Fatalf("expected tool description and final answer TTS, got %#v", texts)
 	}
-	if !containsString(texts, "我先检查当前音量。") || !containsString(texts, "当前音量是 42。") {
+	if !containsString(texts, "检查音量。") || !containsString(texts, "当前音量是 42。") {
 		t.Fatalf("unexpected TTS texts: %#v", texts)
 	}
 }

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -409,6 +409,7 @@ type AgentConfig struct {
 	RuntimeContext            string
 	ForceSimpleLoop           bool
 	VoiceSpeechSummaryEnabled *bool
+	VoiceToolCallSpeech       *bool
 }
 
 // MemoryConfig is used internally by the memory manager.

--- a/src/agent/internal/agent/device_memory_review_fixes_test.go
+++ b/src/agent/internal/agent/device_memory_review_fixes_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"testing"
+
+	"github.com/tmc/langchaingo/schema"
 )
 
 // TestEpisodeRecorderFinishRespectsVerifierRejection ensures a clean run whose
@@ -41,6 +43,38 @@ func TestEpisodeRecorderFinishAcceptsVerifierApproval(t *testing.T) {
 	if episode.Outcome.FinalAnswer != "done" {
 		t.Errorf("final answer = %q, want verifier final answer", episode.Outcome.FinalAnswer)
 	}
+}
+
+func TestEpisodeRecorderPersistsToolSpeechOnlyWhenEnabled(t *testing.T) {
+	action := schema.AgentAction{
+		Tool:      "echo",
+		ToolInput: "hello",
+		Log:       formatToolActionLog("echo", `{"input":"hello","speech":"Saying hi."}`, "I will echo.", "Saying hi.", "\n"),
+	}
+
+	disabled := NewEpisodeRecorder(MemoryRetrieveRequest{Input: "test"}, MemoryContext{})
+	disabled.RecordExecution(roleExecutionResult{Action: &action})
+	disabledEpisode := disabled.Finish("", nil, nil, nil, nil)
+	if got := firstToolCallEventSpeech(disabledEpisode.Events); got != "" {
+		t.Fatalf("disabled recorder speech = %q, want empty", got)
+	}
+
+	enabled := NewEpisodeRecorder(MemoryRetrieveRequest{Input: "test"}, MemoryContext{})
+	enabled.ToolCallSpeech = true
+	enabled.RecordExecution(roleExecutionResult{Action: &action})
+	enabledEpisode := enabled.Finish("", nil, nil, nil, nil)
+	if got := firstToolCallEventSpeech(enabledEpisode.Events); got != "Saying hi." {
+		t.Fatalf("enabled recorder speech = %q", got)
+	}
+}
+
+func firstToolCallEventSpeech(events []TaskEpisodeEvent) string {
+	for _, event := range events {
+		if event.Type == runEventToolCall {
+			return event.Speech
+		}
+	}
+	return ""
 }
 
 // TestDeviceMemoryConflictTypeFiltering ensures conflicted records are matched

--- a/src/agent/internal/agent/episode_exporter.go
+++ b/src/agent/internal/agent/episode_exporter.go
@@ -470,6 +470,7 @@ func (e *EpisodeExporter) buildLangfuseBatch(ctx context.Context, episode TaskEp
 				"event_id":         event.EventID,
 				"tool_name":        event.ToolName,
 				"tool_description": event.ToolDescription,
+				"speech":           event.Speech,
 				"has_tool_result":  paired && pair.HasResult,
 				"role":             event.Role,
 				"phase":            currentPhase,
@@ -1373,6 +1374,9 @@ func toolCallInput(event TaskEpisodeEvent) map[string]interface{} {
 	}
 	if strings.TrimSpace(event.ToolDescription) != "" {
 		input["description"] = event.ToolDescription
+	}
+	if strings.TrimSpace(event.Speech) != "" {
+		input["speech"] = event.Speech
 	}
 	return input
 }

--- a/src/agent/internal/agent/episode_exporter_test.go
+++ b/src/agent/internal/agent/episode_exporter_test.go
@@ -122,6 +122,7 @@ func TestBuildLangfuseBatchMapsPlannerToolVerifier(t *testing.T) {
 				Type:      runEventToolCall,
 				ToolName:  "mouse_click",
 				ToolInput: `{"x":100,"y":200}`,
+				Speech:    "点击设置。",
 			},
 			{
 				EventID:       "evt3",
@@ -179,6 +180,7 @@ func TestBuildLangfuseBatchMapsPlannerToolVerifier(t *testing.T) {
 	types := map[string]int{}
 	names := map[string]int{}
 	var usageBody map[string]interface{}
+	var toolBody map[string]interface{}
 	for _, event := range batch {
 		types[event.Type]++
 		var body map[string]interface{}
@@ -190,6 +192,9 @@ func TestBuildLangfuseBatchMapsPlannerToolVerifier(t *testing.T) {
 		}
 		if name, _ := body["name"].(string); name != "" {
 			names[name]++
+			if name == "tool/mouse_click" {
+				toolBody = body
+			}
 		}
 	}
 	if types["trace-create"] != 1 {
@@ -222,6 +227,20 @@ func TestBuildLangfuseBatchMapsPlannerToolVerifier(t *testing.T) {
 	}
 	if names["tool/mouse_click"] != 1 {
 		t.Fatalf("tool span count = %d, want 1", names["tool/mouse_click"])
+	}
+	toolInput, ok := toolBody["input"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("tool span input missing: %#v", toolBody["input"])
+	}
+	if toolInput["speech"] != "点击设置。" {
+		t.Fatalf("tool span speech input = %#v", toolInput["speech"])
+	}
+	toolMetadata, ok := toolBody["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("tool span metadata missing: %#v", toolBody["metadata"])
+	}
+	if toolMetadata["speech"] != "点击设置。" {
+		t.Fatalf("tool span speech metadata = %#v", toolMetadata["speech"])
 	}
 	if names["verifier"] != 1 {
 		t.Fatalf("verifier span count = %d, want 1", names["verifier"])

--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -15,6 +15,7 @@ type FunctionAgent struct {
 	Tools             []langtools.Tool
 	OutputKey         string
 	ScreenshotPruning ScreenshotPruningConfig
+	ToolCallSpeech    bool
 }
 
 type visualObservationTool interface {
@@ -27,7 +28,8 @@ type structuredInputTool interface {
 
 const toolActionLogVersion = 1
 const maxToolObservationRunes = 4000
-const toolCallSpeechMaxRunes = 40
+const toolCallSpeechField = "speech"
+const toolCallDescriptionField = "description"
 
 type ScreenshotPruningConfig struct {
 	KeepN    int
@@ -60,11 +62,13 @@ type toolActionLog struct {
 	Version         int    `json:"aiden_action_log_version"`
 	Message         string `json:"message"`
 	ToolDescription string `json:"tool_description,omitempty"`
+	ToolSpeech      string `json:"tool_speech,omitempty"`
 }
 
 type toolInvocation struct {
 	Input       string
 	Description string
+	Speech      string
 }
 
 func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema.AgentAction, *schema.AgentFinish, error) {
@@ -82,7 +86,7 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 			functionName := toolCall.FunctionCall.Name
 			toolInputStr := toolCall.FunctionCall.Arguments
 			invocation := extractToolInvocation(toolInputStr)
-			invocation.Description = toolCallSpeechText(choice.Content, invocation.Description)
+			invocation.Description = toolCallDescriptionText(choice.Content, invocation.Description)
 
 			contentMsg := "\n"
 			if choice.Content != "" {
@@ -92,7 +96,7 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 			actions = append(actions, schema.AgentAction{
 				Tool:      functionName,
 				ToolInput: invocation.Input,
-				Log:       formatToolActionLog(functionName, toolInputStr, invocation.Description, contentMsg),
+				Log:       formatToolActionLog(functionName, toolInputStr, invocation.Description, invocation.Speech, contentMsg),
 				ToolID:    ensureToolCallID(toolCall.ID, len(actions)),
 			})
 		}
@@ -103,7 +107,7 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 		functionName := choice.FuncCall.Name
 		toolInputStr := choice.FuncCall.Arguments
 		invocation := extractToolInvocation(toolInputStr)
-		invocation.Description = toolCallSpeechText(choice.Content, invocation.Description)
+		invocation.Description = toolCallDescriptionText(choice.Content, invocation.Description)
 
 		contentMsg := "\n"
 		if choice.Content != "" {
@@ -113,7 +117,7 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 		return []schema.AgentAction{{
 			Tool:      functionName,
 			ToolInput: invocation.Input,
-			Log:       formatToolActionLog(functionName, toolInputStr, invocation.Description, contentMsg),
+			Log:       formatToolActionLog(functionName, toolInputStr, invocation.Description, invocation.Speech, contentMsg),
 			ToolID:    ensureToolCallID("", 0),
 		}}, nil, nil
 	}
@@ -132,13 +136,13 @@ func (a *FunctionAgent) toolsAsLLM() []llms.Tool {
 		if tool == nil {
 			continue
 		}
-		result = append(result, NewToolSpec(tool).LLMTool())
+		result = append(result, NewToolSpec(tool).LLMToolWithSpeech(a.ToolCallSpeech))
 	}
 	return result
 }
 
-func genericToolParameters() map[string]any {
-	return map[string]any{
+func genericToolParameters(includeSpeech bool) map[string]any {
+	return addToolSpeechParameter(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"input": map[string]string{
@@ -148,15 +152,38 @@ func genericToolParameters() map[string]any {
 			},
 		},
 		"required": []string{"input"},
-	}
+	}, includeSpeech)
 }
 
-func toolParametersSchema(schema map[string]any) map[string]any {
+func toolParametersSchema(schema map[string]any, includeSpeech bool) map[string]any {
 	parameters := make(map[string]any, len(schema))
 	for key, value := range schema {
 		parameters[key] = value
 	}
 	parameters["type"] = "object"
+	return addToolSpeechParameter(parameters, includeSpeech)
+}
+
+func addToolSpeechParameter(parameters map[string]any, includeSpeech bool) map[string]any {
+	if parameters == nil {
+		parameters = map[string]any{}
+	}
+	if !includeSpeech {
+		return parameters
+	}
+	properties, _ := parameters["properties"].(map[string]any)
+	copiedProperties := make(map[string]any, len(properties)+1)
+	for key, value := range properties {
+		copiedProperties[key] = value
+	}
+	if _, exists := copiedProperties[toolCallSpeechField]; !exists {
+		copiedProperties[toolCallSpeechField] = map[string]string{
+			"title":       "speech",
+			"type":        "string",
+			"description": "Optional short spoken status before this tool call. Write natural TTS text directly; use the user's language, avoid implementation details, and keep it under 20 Chinese characters or 8 English words.",
+		}
+	}
+	parameters["properties"] = copiedProperties
 	return parameters
 }
 
@@ -422,35 +449,40 @@ func extractToolInvocation(raw string) toolInvocation {
 	invocation := toolInvocation{Input: raw}
 	_, hasLegacyArg := toolInputMap["__arg1"]
 	hasGenericInput := false
+	if speech, ok := toolInputMap[toolCallSpeechField].(string); ok {
+		invocation.Speech = strings.TrimSpace(speech)
+	}
 	if arg1, ok := toolInputMap["__arg1"].(string); ok {
 		invocation.Input = arg1
 	} else if input, ok := toolInputMap["input"].(string); ok && isGenericStringInputWrapper(toolInputMap) {
 		invocation.Input = input
 		hasGenericInput = true
 	}
-	if description, ok := toolInputMap["description"].(string); ok {
+	if description, ok := toolInputMap[toolCallDescriptionField].(string); ok {
 		invocation.Description = strings.TrimSpace(description)
-		if !hasLegacyArg && !hasGenericInput {
-			delete(toolInputMap, "description")
-			if encoded, err := json.Marshal(toolInputMap); err == nil {
-				invocation.Input = string(encoded)
-			}
+	}
+	if !hasLegacyArg && !hasGenericInput {
+		delete(toolInputMap, toolCallDescriptionField)
+		delete(toolInputMap, toolCallSpeechField)
+		if encoded, err := json.Marshal(toolInputMap); err == nil {
+			invocation.Input = string(encoded)
 		}
 	}
 	return invocation
 }
 
 func isGenericStringInputWrapper(fields map[string]any) bool {
-	if len(fields) == 1 {
-		_, ok := fields["input"]
-		return ok
+	if _, ok := fields["input"]; !ok {
+		return false
 	}
-	if len(fields) == 2 {
-		_, hasInput := fields["input"]
-		_, hasDescription := fields["description"]
-		return hasInput && hasDescription
+	for key := range fields {
+		switch key {
+		case "input", toolCallDescriptionField, toolCallSpeechField:
+		default:
+			return false
+		}
 	}
-	return false
+	return true
 }
 
 func extractToolInput(raw string) string {
@@ -478,12 +510,13 @@ func encodeToolArguments(input string) string {
 	return string(encoded)
 }
 
-func formatToolActionLog(name, arguments, description, contentMsg string) string {
+func formatToolActionLog(name, arguments, description, speech, contentMsg string) string {
 	message := fmt.Sprintf("Invoking: %s with %s %s", name, arguments, contentMsg)
 	metadata := toolActionLog{
 		Version:         toolActionLogVersion,
 		Message:         message,
 		ToolDescription: strings.TrimSpace(description),
+		ToolSpeech:      strings.TrimSpace(speech),
 	}
 	encoded, err := json.Marshal(metadata)
 	if err != nil {
@@ -503,27 +536,22 @@ func toolDescriptionFromAction(action schema.AgentAction) string {
 	return strings.TrimSpace(metadata.ToolDescription)
 }
 
-func toolCallSpeechText(content, legacyDescription string) string {
+func toolSpeechFromAction(action schema.AgentAction) string {
+	var metadata toolActionLog
+	if err := json.Unmarshal([]byte(action.Log), &metadata); err != nil {
+		return ""
+	}
+	if metadata.Version != toolActionLogVersion {
+		return ""
+	}
+	return strings.TrimSpace(metadata.ToolSpeech)
+}
+
+func toolCallDescriptionText(content, legacyDescription string) string {
 	if content = strings.TrimSpace(content); content != "" {
 		return content
 	}
 	return strings.TrimSpace(legacyDescription)
-}
-
-func deriveToolCallSpeech(description string) string {
-	description = strings.TrimSpace(description)
-	if description == "" {
-		return ""
-	}
-	text := stripSpeechUnfriendlyMarkdown(description)
-	text = strings.Join(strings.Fields(text), " ")
-	if text == "" {
-		text = strings.Join(strings.Fields(description), " ")
-	}
-	if sentence := firstSpeechSentence(text); sentence != "" {
-		text = sentence
-	}
-	return truncateSpeechRunes(text, toolCallSpeechMaxRunes)
 }
 
 func extractFinalAnswer(content string) string {

--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -85,7 +85,7 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 			}
 			functionName := toolCall.FunctionCall.Name
 			toolInputStr := toolCall.FunctionCall.Arguments
-			invocation := extractToolInvocation(toolInputStr)
+			invocation := extractToolInvocation(toolInputStr, a.ToolCallSpeech)
 			invocation.Description = toolCallDescriptionText(choice.Content, invocation.Description)
 
 			contentMsg := "\n"
@@ -106,7 +106,7 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 	if choice.FuncCall != nil {
 		functionName := choice.FuncCall.Name
 		toolInputStr := choice.FuncCall.Arguments
-		invocation := extractToolInvocation(toolInputStr)
+		invocation := extractToolInvocation(toolInputStr, a.ToolCallSpeech)
 		invocation.Description = toolCallDescriptionText(choice.Content, invocation.Description)
 
 		contentMsg := "\n"
@@ -441,7 +441,7 @@ func attachmentAwarePrompt(text string, attachments []InputAttachment, descripti
 	return text + "\n\nAttached content:\n- " + strings.Join(descriptions, "\n- ")
 }
 
-func extractToolInvocation(raw string) toolInvocation {
+func extractToolInvocation(raw string, includeSpeech bool) toolInvocation {
 	var toolInputMap map[string]any
 	if err := json.Unmarshal([]byte(raw), &toolInputMap); err != nil {
 		return toolInvocation{Input: raw}
@@ -449,12 +449,14 @@ func extractToolInvocation(raw string) toolInvocation {
 	invocation := toolInvocation{Input: raw}
 	_, hasLegacyArg := toolInputMap["__arg1"]
 	hasGenericInput := false
-	if speech, ok := toolInputMap[toolCallSpeechField].(string); ok {
-		invocation.Speech = strings.TrimSpace(speech)
+	if includeSpeech {
+		if speech, ok := toolInputMap[toolCallSpeechField].(string); ok {
+			invocation.Speech = strings.TrimSpace(speech)
+		}
 	}
 	if arg1, ok := toolInputMap["__arg1"].(string); ok {
 		invocation.Input = arg1
-	} else if input, ok := toolInputMap["input"].(string); ok && isGenericStringInputWrapper(toolInputMap) {
+	} else if input, ok := toolInputMap["input"].(string); ok && isGenericStringInputWrapper(toolInputMap, includeSpeech) {
 		invocation.Input = input
 		hasGenericInput = true
 	}
@@ -463,7 +465,9 @@ func extractToolInvocation(raw string) toolInvocation {
 	}
 	if !hasLegacyArg && !hasGenericInput {
 		delete(toolInputMap, toolCallDescriptionField)
-		delete(toolInputMap, toolCallSpeechField)
+		if includeSpeech {
+			delete(toolInputMap, toolCallSpeechField)
+		}
 		if encoded, err := json.Marshal(toolInputMap); err == nil {
 			invocation.Input = string(encoded)
 		}
@@ -471,13 +475,17 @@ func extractToolInvocation(raw string) toolInvocation {
 	return invocation
 }
 
-func isGenericStringInputWrapper(fields map[string]any) bool {
+func isGenericStringInputWrapper(fields map[string]any, includeSpeech bool) bool {
 	if _, ok := fields["input"]; !ok {
 		return false
 	}
 	for key := range fields {
 		switch key {
-		case "input", toolCallDescriptionField, toolCallSpeechField:
+		case "input", toolCallDescriptionField:
+		case toolCallSpeechField:
+			if !includeSpeech {
+				return false
+			}
 		default:
 			return false
 		}
@@ -486,7 +494,7 @@ func isGenericStringInputWrapper(fields map[string]any) bool {
 }
 
 func extractToolInput(raw string) string {
-	return extractToolInvocation(raw).Input
+	return extractToolInvocation(raw, false).Input
 }
 
 func encodeToolArguments(input string) string {

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -45,18 +45,18 @@ func TestFunctionAgentParseOutputSkipsNilToolCalls(t *testing.T) {
 	}
 }
 
-func TestFunctionAgentParseOutputUsesAssistantContentForToolSpeech(t *testing.T) {
+func TestFunctionAgentParseOutputUsesLLMToolSpeechArgument(t *testing.T) {
 	agent := &FunctionAgent{OutputKey: "output"}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
-			Content: "我先发送一段测试文本。",
+			Content: "我会发送一段测试文本。",
 			ToolCalls: []llms.ToolCall{{
 				ID:   "call_1",
 				Type: "function",
 				FunctionCall: &llms.FunctionCall{
 					Name:      "echo",
-					Arguments: `{"input":"hello"}`,
+					Arguments: `{"input":"hello","speech":"发送测试文本。"}`,
 				},
 			}},
 		}},
@@ -73,15 +73,18 @@ func TestFunctionAgentParseOutputUsesAssistantContentForToolSpeech(t *testing.T)
 	if actions[0].ToolInput != "hello" {
 		t.Fatalf("ToolInput = %q, want stripped tool input", actions[0].ToolInput)
 	}
-	if got := toolDescriptionFromAction(actions[0]); got != "我先发送一段测试文本。" {
+	if got := toolDescriptionFromAction(actions[0]); got != "我会发送一段测试文本。" {
 		t.Fatalf("tool description = %q", got)
+	}
+	if got := toolSpeechFromAction(actions[0]); got != "发送测试文本。" {
+		t.Fatalf("tool speech = %q", got)
 	}
 
 	var log toolActionLog
 	if err := json.Unmarshal([]byte(actions[0].Log), &log); err != nil {
 		t.Fatalf("action log should be structured JSON: %v", err)
 	}
-	if log.Version != toolActionLogVersion || log.ToolDescription != "我先发送一段测试文本。" {
+	if log.Version != toolActionLogVersion || log.ToolDescription != "我会发送一段测试文本。" || log.ToolSpeech != "发送测试文本。" {
 		t.Fatalf("unexpected action log metadata: %#v", log)
 	}
 }
@@ -91,13 +94,12 @@ func TestFunctionAgentParseOutputExtractsGenericInputWrapper(t *testing.T) {
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
-			Content: "I will echo text.",
 			ToolCalls: []llms.ToolCall{{
 				ID:   "call_1",
 				Type: "function",
 				FunctionCall: &llms.FunctionCall{
 					Name:      "echo",
-					Arguments: `{"input":"hello"}`,
+					Arguments: `{"input":"hello","speech":"Echoing text."}`,
 				},
 			}},
 		}},
@@ -114,8 +116,11 @@ func TestFunctionAgentParseOutputExtractsGenericInputWrapper(t *testing.T) {
 	if actions[0].ToolInput != "hello" {
 		t.Fatalf("ToolInput = %q, want generic input wrapper", actions[0].ToolInput)
 	}
-	if got := toolDescriptionFromAction(actions[0]); got != "I will echo text." {
-		t.Fatalf("tool description = %q", got)
+	if got := toolDescriptionFromAction(actions[0]); got != "" {
+		t.Fatalf("tool description = %q, want empty", got)
+	}
+	if got := toolSpeechFromAction(actions[0]); got != "Echoing text." {
+		t.Fatalf("tool speech = %q", got)
 	}
 }
 
@@ -130,7 +135,7 @@ func TestFunctionAgentParseOutputPassesStructuredToolArguments(t *testing.T) {
 				Type: "function",
 				FunctionCall: &llms.FunctionCall{
 					Name:      "keyboard_tap",
-					Arguments: `{"keys":["enter"]}`,
+					Arguments: `{"keys":["enter"],"speech":"按回车。"}`,
 				},
 			}},
 		}},
@@ -150,6 +155,9 @@ func TestFunctionAgentParseOutputPassesStructuredToolArguments(t *testing.T) {
 	if got := toolDescriptionFromAction(actions[0]); got != "我会按下回车键。" {
 		t.Fatalf("tool description = %q", got)
 	}
+	if got := toolSpeechFromAction(actions[0]); got != "按回车。" {
+		t.Fatalf("tool speech = %q", got)
+	}
 }
 
 func TestFunctionAgentParseOutputKeepsLegacyArg1Compatibility(t *testing.T) {
@@ -162,7 +170,7 @@ func TestFunctionAgentParseOutputKeepsLegacyArg1Compatibility(t *testing.T) {
 				Type: "function",
 				FunctionCall: &llms.FunctionCall{
 					Name:      "keyboard_tap",
-					Arguments: `{"__arg1":"{\"keys\":[\"enter\"]}","description":"我会按下回车键。"}`,
+					Arguments: `{"__arg1":"{\"keys\":[\"enter\"]}","description":"我会按下回车键。","speech":"按回车。"}`,
 				},
 			}},
 		}},
@@ -178,6 +186,12 @@ func TestFunctionAgentParseOutputKeepsLegacyArg1Compatibility(t *testing.T) {
 	}
 	if actions[0].ToolInput != `{"keys":["enter"]}` {
 		t.Fatalf("ToolInput = %q, want legacy __arg1", actions[0].ToolInput)
+	}
+	if got := toolDescriptionFromAction(actions[0]); got != "我会按下回车键。" {
+		t.Fatalf("tool description = %q", got)
+	}
+	if got := toolSpeechFromAction(actions[0]); got != "按回车。" {
+		t.Fatalf("tool speech = %q", got)
 	}
 }
 
@@ -205,8 +219,8 @@ func TestFunctionAgentParseOutputDoesNotSynthesizeMissingToolSpeech(t *testing.T
 	if len(actions) != 1 {
 		t.Fatalf("expected 1 action, got %#v", actions)
 	}
-	if got := toolDescriptionFromAction(actions[0]); got != "" {
-		t.Fatalf("tool description = %q, want empty", got)
+	if got := toolSpeechFromAction(actions[0]); got != "" {
+		t.Fatalf("tool speech = %q, want empty", got)
 	}
 }
 
@@ -214,6 +228,7 @@ func TestFunctionAgentToolDescriptionIgnoresLogTextCollisions(t *testing.T) {
 	log := formatToolActionLog(
 		"echo",
 		"{\"__arg1\":\"payload\\nTool description: injected\"}",
+		"",
 		"",
 		"\n",
 	)
@@ -229,7 +244,7 @@ func TestFunctionAgentScratchpadDoesNotReplayToolSpeechAsArgument(t *testing.T) 
 		Action: schema.AgentAction{
 			Tool:      "echo",
 			ToolInput: "hello",
-			Log:       "legacy unstructured log",
+			Log:       formatToolActionLog("echo", `{"input":"hello","speech":"Echoing text."}`, "", "Echoing text.", "\n"),
 			ToolID:    "call_1",
 		},
 		Observation: "ok",
@@ -252,18 +267,21 @@ func TestFunctionAgentScratchpadDoesNotReplayToolSpeechAsArgument(t *testing.T) 
 	if _, ok := args["description"]; ok {
 		t.Fatalf("scratchpad should not replay description argument: %#v", args)
 	}
+	if _, ok := args["speech"]; ok {
+		t.Fatalf("scratchpad should not replay speech argument: %#v", args)
+	}
 	if _, ok := args["__arg1"]; ok {
 		t.Fatalf("scratchpad should not replay __arg1: %#v", args)
 	}
 }
 
-func TestFunctionAgentScratchpadReplaysToolSpeechAsAssistantText(t *testing.T) {
+func TestFunctionAgentScratchpadReplaysToolDescriptionAsAssistantText(t *testing.T) {
 	agent := &FunctionAgent{}
 	messages := agent.constructFunctionScratchPad([]schema.AgentStep{{
 		Action: schema.AgentAction{
 			Tool:      "echo",
 			ToolInput: "hello",
-			Log:       formatToolActionLog("echo", `{"input":"hello"}`, "I will echo text.", "responded: I will echo text.\n"),
+			Log:       formatToolActionLog("echo", `{"input":"hello"}`, "I will echo text.", "", "responded: I will echo text.\n"),
 			ToolID:    "call_1",
 		},
 		Observation: "ok",
@@ -478,6 +496,7 @@ func scratchpadToolResponseCount(messages []llms.MessageContent) int {
 
 func TestFunctionAgentToolsAsLLMUsesGenericInputFallback(t *testing.T) {
 	agent := &FunctionAgent{
+		ToolCallSpeech: true,
 		Tools: []langtools.Tool{&stubTool{
 			name:        "echo",
 			description: "Echo text.",
@@ -505,6 +524,13 @@ func TestFunctionAgentToolsAsLLMUsesGenericInputFallback(t *testing.T) {
 	if _, ok := props["__arg1"]; ok {
 		t.Fatalf("generic fallback schema should not expose __arg1: %#v", props)
 	}
+	speech, ok := props["speech"].(map[string]string)
+	if !ok {
+		t.Fatalf("generic fallback schema missing speech property: %#v", props)
+	}
+	if !strings.Contains(speech["description"], "spoken") {
+		t.Fatalf("speech description does not explain spoken text: %q", speech["description"])
+	}
 	input, ok := props["input"].(map[string]string)
 	if !ok {
 		t.Fatalf("unexpected input schema: %#v", props["input"])
@@ -519,6 +545,34 @@ func TestFunctionAgentToolsAsLLMUsesGenericInputFallback(t *testing.T) {
 	if len(required) != 1 || required[0] != "input" {
 		t.Fatalf("required = %#v, want input", required)
 	}
+	for _, field := range required {
+		if field == "speech" {
+			t.Fatalf("speech should be optional, required = %#v", required)
+		}
+	}
+}
+
+func TestFunctionAgentToolsAsLLMOmitsSpeechWhenToolCallSpeechDisabled(t *testing.T) {
+	agent := &FunctionAgent{
+		Tools: []langtools.Tool{&stubTool{
+			name:        "echo",
+			description: "Echo text.",
+			output:      "ok",
+		}},
+	}
+
+	tools := agent.toolsAsLLM()
+	params, ok := tools[0].Function.Parameters.(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected parameters type: %T", tools[0].Function.Parameters)
+	}
+	props, ok := params["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected properties: %#v", params["properties"])
+	}
+	if _, ok := props["speech"]; ok {
+		t.Fatalf("schema should not expose speech when tool-call speech is disabled: %#v", props)
+	}
 }
 
 type structuredStubTool struct {
@@ -530,6 +584,7 @@ func (t *structuredStubTool) ArgsSchema() map[string]any { return t.schema }
 
 func TestFunctionAgentToolsAsLLMUsesStructuredSchema(t *testing.T) {
 	agent := &FunctionAgent{
+		ToolCallSpeech: true,
 		Tools: []langtools.Tool{&structuredStubTool{
 			stubTool: stubTool{name: "structured", description: "Structured input."},
 			schema: map[string]any{
@@ -559,6 +614,9 @@ func TestFunctionAgentToolsAsLLMUsesStructuredSchema(t *testing.T) {
 	}
 	if _, ok := props["description"]; ok {
 		t.Fatalf("structured schema should not expose description property: %#v", props)
+	}
+	if _, ok := props["speech"]; !ok {
+		t.Fatalf("structured schema missing speech property: %#v", props)
 	}
 }
 

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -46,7 +46,7 @@ func TestFunctionAgentParseOutputSkipsNilToolCalls(t *testing.T) {
 }
 
 func TestFunctionAgentParseOutputUsesLLMToolSpeechArgument(t *testing.T) {
-	agent := &FunctionAgent{OutputKey: "output"}
+	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
@@ -90,7 +90,7 @@ func TestFunctionAgentParseOutputUsesLLMToolSpeechArgument(t *testing.T) {
 }
 
 func TestFunctionAgentParseOutputExtractsGenericInputWrapper(t *testing.T) {
-	agent := &FunctionAgent{OutputKey: "output"}
+	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
@@ -125,7 +125,7 @@ func TestFunctionAgentParseOutputExtractsGenericInputWrapper(t *testing.T) {
 }
 
 func TestFunctionAgentParseOutputPassesStructuredToolArguments(t *testing.T) {
-	agent := &FunctionAgent{OutputKey: "output"}
+	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
@@ -161,7 +161,7 @@ func TestFunctionAgentParseOutputPassesStructuredToolArguments(t *testing.T) {
 }
 
 func TestFunctionAgentParseOutputKeepsLegacyArg1Compatibility(t *testing.T) {
-	agent := &FunctionAgent{OutputKey: "output"}
+	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
@@ -196,7 +196,7 @@ func TestFunctionAgentParseOutputKeepsLegacyArg1Compatibility(t *testing.T) {
 }
 
 func TestFunctionAgentParseOutputDoesNotSynthesizeMissingToolSpeech(t *testing.T) {
-	agent := &FunctionAgent{OutputKey: "output"}
+	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
@@ -221,6 +221,42 @@ func TestFunctionAgentParseOutputDoesNotSynthesizeMissingToolSpeech(t *testing.T
 	}
 	if got := toolSpeechFromAction(actions[0]); got != "" {
 		t.Fatalf("tool speech = %q, want empty", got)
+	}
+}
+
+func TestFunctionAgentParseOutputPreservesSpeechArgumentWhenDisabled(t *testing.T) {
+	agent := &FunctionAgent{OutputKey: "output"}
+
+	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
+		Choices: []*llms.ContentChoice{{
+			ToolCalls: []llms.ToolCall{{
+				ID:   "call_1",
+				Type: "function",
+				FunctionCall: &llms.FunctionCall{
+					Name:      "say",
+					Arguments: `{"speech":"hello","volume":1}`,
+				},
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ParseOutput() error = %v", err)
+	}
+	if finish != nil {
+		t.Fatalf("expected no finish, got %#v", finish)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %#v", actions)
+	}
+	var input map[string]any
+	if err := json.Unmarshal([]byte(actions[0].ToolInput), &input); err != nil {
+		t.Fatalf("ToolInput is not JSON: %q err=%v", actions[0].ToolInput, err)
+	}
+	if input["speech"] != "hello" || input["volume"] != float64(1) {
+		t.Fatalf("ToolInput lost real speech argument: %#v", input)
+	}
+	if got := toolSpeechFromAction(actions[0]); got != "" {
+		t.Fatalf("tool speech metadata = %q, want empty", got)
 	}
 }
 

--- a/src/agent/internal/agent/prompt.go
+++ b/src/agent/internal/agent/prompt.go
@@ -95,7 +95,7 @@ func combinedAgentInstruction(cfg AgentConfig) string {
 func defaultAgentBehavior(cfg AgentConfig) string {
 	toolCallSpeechRule := "- When calling a tool, do not add speech or description arguments to tool inputs."
 	if cfg.VoiceToolCallSpeechOrDefault() {
-		toolCallSpeechRule = "- When calling a tool and a short spoken preface is useful, set the optional tool argument speech to concise natural TTS text in the user's language. Do not put spoken prefaces in assistant text and do not add a description argument; speech is consumed by the runtime and is not passed to the real tool."
+		toolCallSpeechRule = "- When calling a user-visible tool, set the optional tool argument speech to concise natural TTS text in the user's language. Keep speech under 20 Chinese characters or 8 English words. Do not put spoken prefaces in assistant text and do not add a description argument; speech is consumed by the runtime and is not passed to the real tool."
 	}
 	return strings.Join([]string{
 		"### Environment",

--- a/src/agent/internal/agent/prompt.go
+++ b/src/agent/internal/agent/prompt.go
@@ -92,7 +92,11 @@ func combinedAgentInstruction(cfg AgentConfig) string {
 	return strings.Join(parts, "\n\n")
 }
 
-func defaultAgentBehavior() string {
+func defaultAgentBehavior(cfg AgentConfig) string {
+	toolCallSpeechRule := "- When calling a tool, do not add speech or description arguments to tool inputs."
+	if cfg.VoiceToolCallSpeechOrDefault() {
+		toolCallSpeechRule = "- When calling a tool and a short spoken preface is useful, set the optional tool argument speech to concise natural TTS text in the user's language. Do not put spoken prefaces in assistant text and do not add a description argument; speech is consumed by the runtime and is not passed to the real tool."
+	}
 	return strings.Join([]string{
 		"### Environment",
 		"- You run on the Aiden hardware controller (" + hostRuntimeInfoContext() + "); you are not the device shown in screenshots.",
@@ -120,6 +124,6 @@ func defaultAgentBehavior() string {
 		"- List scrolling: prefer search to locate targets; avoid blind scroll. Without search, probe with strength=\"medium\"; use small/tiny when the target is near, items are dense, or precise stopping is needed. Use image_diff to confirm scrolling; low diff_ratio or changed=false may mean boundary, gesture not consumed, or distance too small—stop, reverse, or adjust contact points. Do not repeat the same distance indefinitely. For locally scrollable regions (pickers, modal lists, embedded ScrollView, partial dialogs), start/end coordinates must fall inside the control's visible bounds or the outer container captures the gesture; adjust endpoints before increasing distance. For older chat/message history above the current viewport, use swipe_down from inside the message pane, not swipe_up.",
 		"- Horizontal carousels/tab switches: use swipe_left/swipe_right, prefer strength=\"medium\" or \"large\". If the control snaps back or does not switch, try large or explicit distance; use small/tiny near precise positions. Do not treat one fixed distance as the only solution.",
 		"- Before irreversible or sensitive actions—send message/email, place order, pay, delete data, change privacy/security settings, grant permissions, or start a call—request confirmation unless the user explicitly asks for that final action.",
-		"- When calling a tool, put any short spoken preface in the assistant text that accompanies the tool call; do not add a description argument to tool inputs.",
+		toolCallSpeechRule,
 	}, "\n")
 }

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -33,6 +33,7 @@ type roleCollaborativeExecutor struct {
 	ScreenshotPruning     ScreenshotPruningConfig
 	InitialWorldState     worldState
 	ForceSimpleLoop       bool
+	ToolCallSpeech        bool
 	SteerProvider         func(context.Context) (RunSteerMessage, bool)
 }
 
@@ -418,8 +419,9 @@ func (e *roleCollaborativeExecutor) callPlannerTurn(
 		}
 	}
 	parser := &FunctionAgent{
-		Tools:     plannerTools,
-		OutputKey: e.OutputKey,
+		Tools:          plannerTools,
+		OutputKey:      e.OutputKey,
+		ToolCallSpeech: e.ToolCallSpeech,
 	}
 	baseOptions := append(chains.GetLLMCallOptions(options...), llms.WithTools(parser.toolsAsLLM()))
 	finalStreaming := state.Phase == phaseDefault || e.ForceSimpleLoop
@@ -535,7 +537,7 @@ func (e *roleCollaborativeExecutor) callRouteTurn(
 	}
 	e.emitRoleOutput(ctx, RolePlanner, roleResponseDebugText(res))
 
-	parser := &FunctionAgent{Tools: appendLoopMetaTools(e.Tools), OutputKey: e.OutputKey}
+	parser := &FunctionAgent{Tools: appendLoopMetaTools(e.Tools), OutputKey: e.OutputKey, ToolCallSpeech: e.ToolCallSpeech}
 	actions, _, parseErr := parser.ParseOutput(res)
 	if parseErr != nil && !errors.Is(parseErr, agents.ErrUnableToParseOutput) {
 		return plannerTurnResult{}, parseErr
@@ -704,8 +706,9 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 	messages := e.roleMessages(e.Profiles.Executor, inputs, *state, "Executor task: work on the current next_step across multiple tool calls if needed, then call finish_step when the step is ready for verification or abort_step if blocked.")
 	executorTools := appendExecutorMetaTools(e.Tools)
 	parser := &FunctionAgent{
-		Tools:     executorTools,
-		OutputKey: e.OutputKey,
+		Tools:          executorTools,
+		OutputKey:      e.OutputKey,
+		ToolCallSpeech: e.ToolCallSpeech,
 	}
 	callOptions := append(chains.GetLLMCallOptions(options...), llms.WithTools(parser.toolsAsLLM()))
 	res, err := e.generateRoleContent(ctx, RoleExecutor, messages, callOptions...)

--- a/src/agent/internal/agent/role_profile.go
+++ b/src/agent/internal/agent/role_profile.go
@@ -92,6 +92,13 @@ func (cfg AgentConfig) VoiceSpeechSummaryEnabledOrDefault() bool {
 	return true
 }
 
+func (cfg AgentConfig) VoiceToolCallSpeechOrDefault() bool {
+	if cfg.VoiceToolCallSpeech != nil {
+		return *cfg.VoiceToolCallSpeech
+	}
+	return false
+}
+
 func verifierRoleRules(cfg AgentConfig, openAppAvailable bool) []string {
 	finalAnswerRule := "When returning can_finish=true, also include speech and text as top-level JSON fields. Put speech before text in the JSON object. speech is a concise spoken summary; text is the complete user-facing answer. Keep final_answer equal to text for compatibility."
 	formatRule := "Return only JSON: {\"can_finish\":true|false,\"speech\":\"short spoken answer when can_finish is true\",\"text\":\"complete answer when can_finish is true\",\"final_answer\":\"same as text when can_finish is true\",\"needs_replan\":true|false,\"reason\":\"brief reason\",\"observed_state\":{\"app_name\":\"\",\"page_name\":\"\",\"platform\":\"\",\"visible_text\":[],\"dialogs\":[],\"confidence\":0}}."
@@ -214,7 +221,7 @@ func buildRoleProfile(
 		combinedAgentInstruction(cfg),
 		"",
 		"## Default behavior",
-		defaultAgentBehavior(),
+		defaultAgentBehavior(cfg),
 		"",
 		"## Available skills",
 		skills.CatalogSummary(),

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1478,6 +1478,8 @@ func (h *runtimeCallbackHandler) toolCallSpeech(speech string) string {
 	if h == nil || !h.toolCallSpeechEnabled {
 		return ""
 	}
+	// Intentionally do not derive speech from the tool description. Missing
+	// LLM-generated tool-call speech means this tool call stays silent.
 	return strings.TrimSpace(speech)
 }
 

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -548,6 +548,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if r.memoryPlane != nil {
 		episodeRecorder = r.memoryPlane.NewEpisodeRecorder(retrieveReq, memoryContext)
 		if episodeRecorder != nil {
+			episodeRecorder.ToolCallSpeech = r.config.VoiceToolCallSpeechOrDefault()
 			retrieveReq.EpisodeID = episodeRecorder.ID()
 			if err := episodeRecorder.Start(ctx); err != nil && r.logger != nil {
 				r.logger.Warn("[memory] start episode failed: %v", err)
@@ -596,6 +597,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	executor := newRoleCollaborativeExecutor(model, profiles, availableTools, plannerMemory, maxIterations, req.Attachments, executorHandler, episodeRecorder, r.config.ScreenshotPruningOrDefault(), req.DeviceEnvironment, req.SteerProvider)
 	executor.TodoReminderToolCalls = r.config.TodoReminderToolCallsOrDefault()
+	executor.ToolCallSpeech = r.config.VoiceToolCallSpeechOrDefault()
 
 	output, err := chains.Run(ctx, executor, normalizedInput, callOptions...)
 	if err != nil {
@@ -999,6 +1001,7 @@ func (r *Runtime) buildRoleProfiles(skills ResolvedSkills, availableTools []lang
 			RuntimeContext:            runtimeContext,
 			ForceSimpleLoop:           r.config.ForceSimpleLoop,
 			VoiceSpeechSummaryEnabled: r.config.VoiceSpeechSummaryEnabled,
+			VoiceToolCallSpeech:       r.config.VoiceToolCallSpeech,
 		},
 		skills,
 		availableTools,
@@ -1189,10 +1192,17 @@ func (h *runtimeCallbackHandler) HandleNamedToolError(ctx context.Context, name,
 
 func (h *runtimeCallbackHandler) HandleToolCallStart(ctx context.Context, call ToolCall) {
 	description := call.Description
+	speech := call.Speech
 	if h.logger != nil {
-		if description != "" {
+		if description != "" && speech != "" {
+			h.logger.Info("Tool call: name=%s input=%s description=%s speech=%s",
+				call.Spec.Name, truncateForLog(call.Input, 240), truncateForLog(description, 240), truncateForLog(speech, 120))
+		} else if description != "" {
 			h.logger.Info("Tool call: name=%s input=%s description=%s",
 				call.Spec.Name, truncateForLog(call.Input, 240), truncateForLog(description, 240))
+		} else if speech != "" {
+			h.logger.Info("Tool call: name=%s input=%s speech=%s",
+				call.Spec.Name, truncateForLog(call.Input, 240), truncateForLog(speech, 120))
 		} else {
 			h.logger.Info("Tool call: name=%s input=%s",
 				call.Spec.Name, truncateForLog(call.Input, 240))
@@ -1205,7 +1215,7 @@ func (h *runtimeCallbackHandler) HandleToolCallStart(ctx context.Context, call T
 			ToolName:    call.Spec.Name,
 			ToolInput:   call.Input,
 			Description: description,
-			Speech:      h.toolCallSpeech(description),
+			Speech:      h.toolCallSpeech(speech),
 			Content:     description,
 			Timestamp:   time.Now(),
 		})
@@ -1244,10 +1254,17 @@ func (h *runtimeCallbackHandler) HandleToolCallResult(ctx context.Context, call 
 
 func (h *runtimeCallbackHandler) HandleAgentAction(ctx context.Context, action schema.AgentAction) {
 	description := toolDescriptionFromAction(action)
+	speech := toolSpeechFromAction(action)
 	if h.logger != nil {
-		if description != "" {
+		if description != "" && speech != "" {
+			h.logger.Info("Tool call: name=%s input=%s description=%s speech=%s",
+				action.Tool, truncateForLog(action.ToolInput, 240), truncateForLog(description, 240), truncateForLog(speech, 120))
+		} else if description != "" {
 			h.logger.Info("Tool call: name=%s input=%s description=%s",
 				action.Tool, truncateForLog(action.ToolInput, 240), truncateForLog(description, 240))
+		} else if speech != "" {
+			h.logger.Info("Tool call: name=%s input=%s speech=%s",
+				action.Tool, truncateForLog(action.ToolInput, 240), truncateForLog(speech, 120))
 		} else {
 			h.logger.Info("Tool call: name=%s input=%s",
 				action.Tool, truncateForLog(action.ToolInput, 240))
@@ -1261,7 +1278,7 @@ func (h *runtimeCallbackHandler) HandleAgentAction(ctx context.Context, action s
 			ToolName:    action.Tool,
 			ToolInput:   action.ToolInput,
 			Description: description,
-			Speech:      h.toolCallSpeech(description),
+			Speech:      h.toolCallSpeech(speech),
 			Content:     description,
 			Timestamp:   time.Now(),
 		})
@@ -1457,11 +1474,11 @@ func (h *runtimeCallbackHandler) recordFinalStreamError(err error) {
 
 var _ callbacks.Handler = (*runtimeCallbackHandler)(nil)
 
-func (h *runtimeCallbackHandler) toolCallSpeech(description string) string {
+func (h *runtimeCallbackHandler) toolCallSpeech(speech string) string {
 	if h == nil || !h.toolCallSpeechEnabled {
 		return ""
 	}
-	return deriveToolCallSpeech(description)
+	return strings.TrimSpace(speech)
 }
 
 func (h *runtimeCallbackHandler) pushPendingAction(action schema.AgentAction) {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1484,6 +1484,53 @@ func TestRuntimeRunEmitsToolSpeechOnlyWhenToolCallSpeechEnabled(t *testing.T) {
 	}
 }
 
+func TestRuntimeRunDoesNotDeriveToolSpeechWhenMissing(t *testing.T) {
+	description := "我先读取当前音量并检查当前播放设备、音量状态、静音状态、输出通道以及系统返回结果是否一致。然后继续回答。"
+	model := &scriptedModel{
+		responses: roleToolResponses("audio_volume", fmt.Sprintf(`{"__arg1":"{}","description":%q}`, description), "The current audio volume is 42."),
+	}
+	tool := &stubTool{
+		name:        "audio_volume",
+		description: "Get the current audio playback volume.",
+		output:      `{"volume":42}`,
+	}
+	toolSpeechEnabled := true
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:               ModelConfig{Provider: "fake"},
+			Instruction:         "Use tools when external state is requested.",
+			VoiceToolCallSpeech: &toolSpeechEnabled,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"audio_volume": tool,
+		}},
+		NewSkillIndex(),
+	)
+
+	var events []RunEvent
+	if _, err := runtime.Run(context.Background(), RunRequest{
+		Input: "当前音量是多少？",
+		EventHandler: func(event RunEvent) {
+			events = append(events, event)
+		},
+	}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	toolCall, ok := firstRunEventOfType(events, runEventToolCall)
+	if !ok {
+		t.Fatalf("expected tool_call event, got %#v", events)
+	}
+	if toolCall.Description != description {
+		t.Fatalf("tool_call description changed: %q", toolCall.Description)
+	}
+	if toolCall.Speech != "" {
+		t.Fatalf("tool_call speech = %q, want empty when LLM omitted speech", toolCall.Speech)
+	}
+}
+
 func TestRuntimePlannedTodoLifecycleEvents(t *testing.T) {
 	model := &scriptedModel{
 		responses: roleCommittedExecutionResponses(

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1378,7 +1378,7 @@ func TestRuntimeAllowsRepeatedKeyboardText(t *testing.T) {
 
 func TestRuntimeRunEmitsToolDescriptionEventAndStripsToolInput(t *testing.T) {
 	model := &scriptedModel{
-		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我先读取当前音量。"}`, "The current audio volume is 42."),
+		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我先读取当前音量。","speech":"读取音量。"}`, "The current audio volume is 42."),
 	}
 	tool := &stubTool{
 		name:        "audio_volume",
@@ -1432,8 +1432,9 @@ func TestRuntimeRunEmitsToolDescriptionEventAndStripsToolInput(t *testing.T) {
 
 func TestRuntimeRunEmitsToolSpeechOnlyWhenToolCallSpeechEnabled(t *testing.T) {
 	description := "我先读取当前音量并检查当前播放设备、音量状态、静音状态、输出通道以及系统返回结果是否一致。然后继续回答。"
+	speech := "读取音量。"
 	model := &scriptedModel{
-		responses: roleToolResponses("audio_volume", fmt.Sprintf(`{"__arg1":"{}","description":%q}`, description), "The current audio volume is 42."),
+		responses: roleToolResponses("audio_volume", fmt.Sprintf(`{"__arg1":"{}","description":%q,"speech":%q}`, description, speech), "The current audio volume is 42."),
 	}
 	tool := &stubTool{
 		name:        "audio_volume",
@@ -1478,11 +1479,8 @@ func TestRuntimeRunEmitsToolSpeechOnlyWhenToolCallSpeechEnabled(t *testing.T) {
 	if toolCall.Speech == "" {
 		t.Fatal("tool_call speech is empty when voice_tool_call_speech is enabled")
 	}
-	if toolCall.Speech == description {
-		t.Fatalf("tool_call speech was not shortened: %q", toolCall.Speech)
-	}
-	if len([]rune(toolCall.Speech)) > toolCallSpeechMaxRunes {
-		t.Fatalf("tool_call speech has %d runes, want <= %d: %q", len([]rune(toolCall.Speech)), toolCallSpeechMaxRunes, toolCall.Speech)
+	if toolCall.Speech != speech {
+		t.Fatalf("tool_call speech = %q, want LLM speech %q", toolCall.Speech, speech)
 	}
 }
 

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -46,7 +46,7 @@ func firstMessageOfType(messages []Message, messageType string) (Message, bool) 
 
 func TestServerHandleChatReturnsToolHistory(t *testing.T) {
 	model := &scriptedModel{
-		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我先读取当前音量。"}`, "The current audio volume is 42."),
+		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我先读取当前音量。","speech":"读取音量。"}`, "The current audio volume is 42."),
 	}
 	tool := &stubTool{
 		name:        "audio_volume",
@@ -572,8 +572,9 @@ func TestServerSpeakToolDescriptionUsesTTS(t *testing.T) {
 
 func TestServerHandleChatDoesNotWaitForToolDescriptionTTSWhenEnabled(t *testing.T) {
 	description := "我先读取当前音量并检查当前播放设备、音量状态、静音状态、输出通道以及系统返回结果是否一致。然后继续回答。"
+	speech := "读取音量。"
 	model := &scriptedModel{
-		responses: roleToolResponses("audio_volume", fmt.Sprintf(`{"__arg1":"{}","description":%q}`, description), "The current audio volume is 42."),
+		responses: roleToolResponses("audio_volume", fmt.Sprintf(`{"__arg1":"{}","description":%q,"speech":%q}`, description, speech), "The current audio volume is 42."),
 	}
 	streamingDisabled := false
 	toolSpeechEnabled := true
@@ -596,7 +597,7 @@ func TestServerHandleChatDoesNotWaitForToolDescriptionTTSWhenEnabled(t *testing.
 		NewSkillIndex(),
 	)
 	server := NewServer(runtime, ":0", "")
-	provider := &blockingTTSProvider{started: make(chan struct{}), blockText: deriveToolCallSpeech(description)}
+	provider := &blockingTTSProvider{started: make(chan struct{}), blockText: speech}
 	server.ttsManager = ttsmodule.NewProviderManager(provider, nil)
 	server.audioClient = NewAudioServiceClient("/tmp/audio.sock")
 
@@ -631,7 +632,7 @@ func TestServerHandleChatDoesNotWaitForToolDescriptionTTSWhenEnabled(t *testing.
 
 func TestServerHandleChatSkipsToolDescriptionTTSWhenDisabled(t *testing.T) {
 	model := &scriptedModel{
-		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我先读取当前音量。"}`, "The current audio volume is 42."),
+		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我先读取当前音量。","speech":"读取音量。"}`, "The current audio volume is 42."),
 	}
 	streamingDisabled := false
 	toolSpeechDisabled := false

--- a/src/agent/internal/agent/task_episode.go
+++ b/src/agent/internal/agent/task_episode.go
@@ -311,6 +311,8 @@ func (r *EpisodeRecorder) recordExecutionForRole(result roleExecutionResult, rol
 			ToolDescription: description,
 		}
 		if r.ToolCallSpeech {
+			// Persist only explicit LLM-generated tool-call speech. Missing
+			// speech is intentionally left empty rather than derived.
 			event.Speech = toolSpeechFromAction(*result.Action)
 		}
 		r.append(event)

--- a/src/agent/internal/agent/task_episode.go
+++ b/src/agent/internal/agent/task_episode.go
@@ -70,6 +70,7 @@ type TaskEpisodeEvent struct {
 	ToolName           string              `json:"tool_name,omitempty" yaml:"tool_name,omitempty"`
 	ToolInput          string              `json:"tool_input,omitempty" yaml:"tool_input,omitempty"`
 	ToolDescription    string              `json:"tool_description,omitempty" yaml:"tool_description,omitempty"`
+	Speech             string              `json:"speech,omitempty" yaml:"speech,omitempty"`
 	Content            string              `json:"content,omitempty" yaml:"content,omitempty"`
 	Todo               *TodoState          `json:"todo,omitempty" yaml:"todo,omitempty"`
 	SpeechEligible     bool                `json:"speech_eligible,omitempty" yaml:"speech_eligible,omitempty"`
@@ -125,6 +126,8 @@ type EpisodeRecorder struct {
 	store     *TaskEpisodeStore
 	started   bool
 	startErr  error
+	// ToolCallSpeech gates persistence of LLM-generated tool-call speech.
+	ToolCallSpeech bool
 }
 
 func NewTaskEpisodeStore(rootDir string) *TaskEpisodeStore {
@@ -296,13 +299,21 @@ func (r *EpisodeRecorder) recordExecutionForRole(result roleExecutionResult, rol
 	}
 	if result.Action != nil {
 		input := normalizeToolInput(result.Action.ToolInput)
-		r.append(TaskEpisodeEvent{
+		description := toolDescriptionFromAction(*result.Action)
+		if description == "" {
+			description = extractToolCallDescription(input)
+		}
+		event := TaskEpisodeEvent{
 			Type:            runEventToolCall,
 			Role:            string(role),
 			ToolName:        result.Action.Tool,
 			ToolInput:       input,
-			ToolDescription: extractToolCallDescription(input),
-		})
+			ToolDescription: description,
+		}
+		if r.ToolCallSpeech {
+			event.Speech = toolSpeechFromAction(*result.Action)
+		}
+		r.append(event)
 	}
 	if result.Step != nil {
 		event := TaskEpisodeEvent{

--- a/src/agent/internal/agent/tool_execution.go
+++ b/src/agent/internal/agent/tool_execution.go
@@ -17,6 +17,7 @@ type ToolCall struct {
 	Action      schema.AgentAction
 	Input       string
 	Description string
+	Speech      string
 	StartedAt   time.Time
 }
 
@@ -80,6 +81,7 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 		Action:      action,
 		Input:       input,
 		Description: toolDescriptionFromAction(action),
+		Speech:      toolSpeechFromAction(action),
 		StartedAt:   startedAt,
 	}
 
@@ -133,6 +135,7 @@ func invalidToolCall(action schema.AgentAction, startedAt time.Time) ToolCall {
 		Action:      action,
 		Input:       action.ToolInput,
 		Description: toolDescriptionFromAction(action),
+		Speech:      toolSpeechFromAction(action),
 		StartedAt:   startedAt,
 	}
 }

--- a/src/agent/internal/agent/tool_schema_test.go
+++ b/src/agent/internal/agent/tool_schema_test.go
@@ -47,6 +47,17 @@ func TestAgentExposedToolsDoNotExposeLegacyArg1Schema(t *testing.T) {
 			if _, ok := props["description"]; ok {
 				t.Fatalf("schema exposes tool-call speech description property: %#v", schema)
 			}
+			if _, ok := props["speech"]; ok {
+				t.Fatalf("schema exposes speech while tool-call speech is disabled: %#v", schema)
+			}
+			enabledSchema := NewToolSpec(tool).LLMSchemaWithSpeech(true)
+			enabledProps, ok := enabledSchema["properties"].(map[string]any)
+			if !ok {
+				t.Fatalf("enabled schema missing properties: %#v", enabledSchema)
+			}
+			if _, ok := enabledProps["speech"]; !ok {
+				t.Fatalf("enabled schema missing speech property: %#v", enabledSchema)
+			}
 		})
 	}
 }

--- a/src/agent/internal/agent/tool_spec.go
+++ b/src/agent/internal/agent/tool_spec.go
@@ -349,23 +349,31 @@ func (spec ToolSpec) Descriptor() ToolDescriptor {
 }
 
 func (spec ToolSpec) LLMTool() llms.Tool {
+	return spec.LLMToolWithSpeech(false)
+}
+
+func (spec ToolSpec) LLMToolWithSpeech(includeSpeech bool) llms.Tool {
 	return llms.Tool{
 		Type: "function",
 		Function: &llms.FunctionDefinition{
 			Name:        spec.Name,
 			Description: strings.TrimSpace(spec.Description),
-			Parameters:  spec.LLMSchema(),
+			Parameters:  spec.LLMSchemaWithSpeech(includeSpeech),
 		},
 	}
 }
 
 func (spec ToolSpec) LLMSchema() map[string]any {
+	return spec.LLMSchemaWithSpeech(false)
+}
+
+func (spec ToolSpec) LLMSchemaWithSpeech(includeSpeech bool) map[string]any {
 	if structured, ok := spec.Tool.(structuredInputTool); ok {
 		if schema := structured.ArgsSchema(); len(schema) > 0 {
-			return toolParametersSchema(schema)
+			return toolParametersSchema(schema, includeSpeech)
 		}
 	}
-	return genericToolParameters()
+	return genericToolParameters(includeSpeech)
 }
 
 func (spec ToolSpec) NormalizeInput(input string) string {


### PR DESCRIPTION
## Summary
- Gate the tool-call speech schema and prompt behind voice_tool_call_speech
- Parse LLM-generated speech from tool arguments and strip it from real tool inputs
- Emit, persist, and export tool-call speech only when the feature is enabled
- Remove description-derived tool speech from the runtime path

## Tests
- go test ./internal/agent
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for tool-call speech synthesis: When enabled via `voice_tool_call_speech`, the LLM can generate explicit spoken output for individual tool invocations, played asynchronously via TTS. Speech is generated only when explicitly provided by the LLM, not synthesized from other sources.

## Documentation
* Updated configuration and feature documentation for tool-call speech synthesis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->