### PR TITLE
fix(agent): stream web chat assistant replies

### DIFF
--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -191,8 +191,7 @@ type audioDialogRunner interface {
 	ProcessVADFrame(samples []int16) ([]int16, error)
 	ProcessUtterance(ctx context.Context, utterance []int16, runtime *agent.Runtime) error
 	PrepareTurnInput(utterance []int16) (agent.TurnInput, error)
-	RunAgentTurn(ctx context.Context, input agent.TurnInput, runtime *agent.Runtime) (agent.RunResult, error)
-	PersistVoiceTurn(input agent.TurnInput, result agent.RunResult, utterance []int16)
+	RunVoiceTurn(ctx context.Context, input agent.TurnInput, utterance []int16, runtime *agent.Runtime) (agent.RunResult, error)
 	Speak(ctx context.Context, text string, interrupt <-chan struct{}) error
 	FlushVAD() []int16
 	FinishManualUtterance(pending []int16) []int16
@@ -543,7 +542,7 @@ func runVoiceTurnWithInput(cfg agent.Config, dialog audioDialogRunner, runtime *
 		err    error
 	}, 1)
 	go func() {
-		result, err := dialog.RunAgentTurn(turnCtx, input, runtime)
+		result, err := dialog.RunVoiceTurn(turnCtx, input, utterance, runtime)
 		resultCh <- struct {
 			result agent.RunResult
 			err    error
@@ -568,8 +567,6 @@ thinking:
 						if !errors.Is(turnResult.err, context.Canceled) {
 							log.Printf("[error] %v\n", turnResult.err)
 						}
-					} else {
-						dialog.PersistVoiceTurn(input, turnResult.result, utterance)
 					}
 				case <-time.After(2 * time.Second):
 					log.Println("[interrupt] current turn did not finish after cancellation; continuing session")
@@ -586,8 +583,6 @@ thinking:
 			break thinking
 		}
 	}
-
-	dialog.PersistVoiceTurn(input, result, utterance)
 
 	if result.SleepRequested {
 		return voiceTurnResult{sleepRequested: true}

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -24,7 +24,9 @@ type fakeAudioDialog struct {
 	utterances         [][]int16
 	prepareTurnInput   func([]int16) (agent.TurnInput, error)
 	runTurn            func(context.Context) (agent.RunResult, error)
+	runVoiceTurn       func(context.Context, agent.TurnInput, []int16) (agent.RunResult, error)
 	speak              func(context.Context) error
+	persistVoiceTurn   func(agent.TurnInput, agent.RunResult, []int16)
 	persistedTurns     []persistedVoiceTurn
 	vadErr             error
 	onRead             func(*fakeAudioDialog, *agent.AudioChunkResult)
@@ -135,12 +137,37 @@ func (d *fakeAudioDialog) RunAgentTurn(ctx context.Context, input agent.TurnInpu
 	return agent.RunResult{Output: "reply"}, nil
 }
 
+func (d *fakeAudioDialog) RunVoiceTurn(ctx context.Context, input agent.TurnInput, utterance []int16, runtime *agent.Runtime) (agent.RunResult, error) {
+	if d.runVoiceTurn != nil {
+		return d.runVoiceTurn(ctx, input, utterance)
+	}
+	if d.persistVoiceTurn != nil {
+		d.persistVoiceTurn(input, agent.RunResult{}, utterance)
+	}
+	result, err := d.RunAgentTurn(ctx, input, runtime)
+	if err != nil {
+		return result, err
+	}
+	d.persistedTurns = append(d.persistedTurns, persistedVoiceTurn{
+		input:     input,
+		result:    result,
+		utterance: append([]int16(nil), utterance...),
+	})
+	if d.persistVoiceTurn != nil {
+		d.persistVoiceTurn(agent.TurnInput{}, result, nil)
+	}
+	return result, nil
+}
+
 func (d *fakeAudioDialog) PersistVoiceTurn(input agent.TurnInput, result agent.RunResult, utterance []int16) {
 	d.persistedTurns = append(d.persistedTurns, persistedVoiceTurn{
 		input:     input,
 		result:    result,
 		utterance: append([]int16(nil), utterance...),
 	})
+	if d.persistVoiceTurn != nil {
+		d.persistVoiceTurn(input, result, utterance)
+	}
 }
 
 func (d *fakeAudioDialog) Speak(ctx context.Context, text string, interrupt <-chan struct{}) error {
@@ -1027,7 +1054,50 @@ func TestRunVoiceTurnSignalWaitsForThinkingGoroutine(t *testing.T) {
 	select {
 	case <-ctxCanceled:
 	default:
-		t.Fatal("RunAgentTurn goroutine was not finished before signal return")
+		t.Fatal("RunVoiceTurn goroutine was not finished before signal return")
+	}
+}
+
+func TestRunVoiceTurnPersistsUserBeforeRunEvents(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	events := make(chan voiceEvent, 1)
+	historyOrder := make([]string, 0, 3)
+	dialog := &fakeAudioDialog{
+		runTurn: func(ctx context.Context) (agent.RunResult, error) {
+			historyOrder = append(historyOrder, "role_output")
+			return agent.RunResult{EpisodeID: "ep-voice", Output: "reply"}, nil
+		},
+		persistVoiceTurn: func(input agent.TurnInput, result agent.RunResult, utterance []int16) {
+			if input.InputText != "" || input.Transcript != "" {
+				historyOrder = append(historyOrder, "user")
+			}
+			if result.Output != "" {
+				historyOrder = append(historyOrder, "assistant")
+			}
+		},
+	}
+
+	result := runVoiceTurnWithInput(
+		agent.Config{},
+		dialog,
+		nil,
+		agent.TurnInput{InputText: "voice command"},
+		[]int16{1, 2, 3},
+		sigChan,
+		events,
+	)
+
+	if result.interrupted || result.sleepRequested || result.exit {
+		t.Fatalf("runVoiceTurnWithInput = interrupted:%v sleep:%v exit:%v, want false false false", result.interrupted, result.sleepRequested, result.exit)
+	}
+	want := []string{"user", "role_output", "assistant"}
+	if len(historyOrder) != len(want) {
+		t.Fatalf("history order = %#v, want %#v", historyOrder, want)
+	}
+	for i := range want {
+		if historyOrder[i] != want[i] {
+			t.Fatalf("history order = %#v, want %#v", historyOrder, want)
+		}
 	}
 }
 

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -352,6 +352,18 @@ func (d *AudioDialog) PersistVoiceAssistantOutput(result RunResult) {
 	}
 }
 
+func (d *AudioDialog) appendVoiceRunEvent(event RunEvent) {
+	if d.historyAppend == nil && d.historyStore == nil {
+		return
+	}
+	message := messageFromRunEvent(event, event.EpisodeID, "")
+	if message.Type == "" {
+		return
+	}
+	message.Source = "voice"
+	d.appendVoiceHistory(message)
+}
+
 func (d *AudioDialog) appendVoiceHistory(message Message) {
 	if d.historyAppend != nil {
 		d.historyAppend(message)
@@ -429,7 +441,11 @@ func (d *AudioDialog) ensureVoiceInputAudioArtifact(input TurnInput, utterance [
 }
 
 func (d *AudioDialog) RunAgentTurn(ctx context.Context, input TurnInput, runtime *Runtime) (RunResult, error) {
-	return d.runAgentTurnWithEpisode(ctx, input, runtime, "")
+	episodeID := ""
+	if runtime != nil {
+		episodeID = runtime.NewEpisodeID()
+	}
+	return d.runAgentTurnWithEpisode(ctx, input, runtime, episodeID)
 }
 
 func (d *AudioDialog) runAgentTurnWithEpisode(ctx context.Context, input TurnInput, runtime *Runtime, episodeID string) (RunResult, error) {
@@ -452,6 +468,7 @@ func (d *AudioDialog) runAgentTurnWithEpisode(ctx context.Context, input TurnInp
 		Turn:        input,
 		MaxTokens:   d.config.VoiceMaxResponseTokensOrDefault(),
 		EventHandler: func(event RunEvent) {
+			d.appendVoiceRunEvent(event)
 			d.HandleRunEvent(ctx, event)
 		},
 		StreamFinalChunks: true,
@@ -630,6 +647,7 @@ func (d *AudioDialog) ProcessTextInput(ctx context.Context, text string, runtime
 		Input: text,
 		Turn:  NewTextTurnInput(text, nil),
 		EventHandler: func(event RunEvent) {
+			d.appendVoiceRunEvent(event)
 			d.HandleRunEvent(ctx, event)
 		},
 		StreamFinalChunks: true,

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -265,25 +265,18 @@ func (d *AudioDialog) ProcessUtterance(ctx context.Context, utterance []int16, r
 	if err != nil {
 		return err
 	}
-	episodeID := ""
-	if runtime != nil {
-		episodeID = runtime.NewEpisodeID()
-	}
-	d.persistVoiceUserInput(input, utterance, episodeID, "")
-	result, err := d.runAgentTurnWithEpisode(ctx, input, runtime, episodeID)
+	result, err := d.RunVoiceTurn(ctx, input, utterance, runtime)
 	if err != nil {
 		return err
 	}
-	d.PersistVoiceAssistantOutput(result)
 	if result.SpeechStreamed {
 		return nil
 	}
 	return d.Speak(ctx, result.SpokenTextForConfig(d.config), nil)
 }
 
-// SetHistoryStore wires the chat history store. When non-nil, voice user and
-// assistant messages produced during ProcessUtterance are appended with
-// Source="voice".
+// SetHistoryStore wires the chat history store. When non-nil, voice messages
+// produced during RunVoiceTurn are appended with Source="voice".
 func (d *AudioDialog) SetHistoryStore(store *ChatHistoryStore) {
 	d.historyStore = store
 }
@@ -446,6 +439,20 @@ func (d *AudioDialog) RunAgentTurn(ctx context.Context, input TurnInput, runtime
 		episodeID = runtime.NewEpisodeID()
 	}
 	return d.runAgentTurnWithEpisode(ctx, input, runtime, episodeID)
+}
+
+func (d *AudioDialog) RunVoiceTurn(ctx context.Context, input TurnInput, utterance []int16, runtime *Runtime) (RunResult, error) {
+	episodeID := ""
+	if runtime != nil {
+		episodeID = runtime.NewEpisodeID()
+	}
+	d.persistVoiceUserInput(input, utterance, episodeID, "")
+	result, err := d.runAgentTurnWithEpisode(ctx, input, runtime, episodeID)
+	if err != nil {
+		return RunResult{}, err
+	}
+	d.PersistVoiceAssistantOutput(result)
+	return result, nil
 }
 
 func (d *AudioDialog) runAgentTurnWithEpisode(ctx context.Context, input TurnInput, runtime *Runtime, episodeID string) (RunResult, error) {

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -748,6 +748,75 @@ func TestAudioDialogRunAgentTurnAppendsRunEventsToVoiceHistory(t *testing.T) {
 	}
 }
 
+func TestAudioDialogRunVoiceTurnPersistsUserBeforeRunEvents(t *testing.T) {
+	configDir := t.TempDir()
+	model := &scriptedModel{
+		responses: roleToolResponses("echo", `{"__arg1":"{}"}`, "voice tool reply"),
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			ConfigDir:       configDir,
+			Model:           ModelConfig{Provider: "fake"},
+			Instruction:     "Use tools when requested.",
+			ForceSimpleLoop: true,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(filepath.Join(configDir, "memory")),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"echo": &staticTool{name: "echo", output: `{"ok":true}`},
+		}},
+		NewSkillIndex(),
+	)
+	dialog := &AudioDialog{
+		config: Config{
+			Model:        ModelConfig{Provider: "fake"},
+			Audio:        AudioConfig{SampleRate: 16000},
+			AudioArchive: AudioArchiveConfig{Enabled: false},
+		},
+		audioArchive: NewAudioArchiveManager(AudioArchiveConfig{Enabled: false}),
+	}
+	var messages []Message
+	dialog.SetHistoryAppender(func(message Message) {
+		messages = append(messages, message)
+	})
+
+	_, err := dialog.RunVoiceTurn(
+		context.Background(),
+		TurnInput{InputText: "use echo", Transcript: "use echo"},
+		[]int16{100, -100, 200, -200},
+		runtime,
+	)
+	if err != nil {
+		t.Fatalf("RunVoiceTurn() error = %v", err)
+	}
+	if len(messages) < 5 {
+		t.Fatalf("expected user, run events, and assistant messages, got %#v", messages)
+	}
+	if messages[0].Type != "user" {
+		t.Fatalf("first message type = %q, want user in %#v", messages[0].Type, messages)
+	}
+	if messages[len(messages)-1].Type != "assistant" {
+		t.Fatalf("last message type = %q, want assistant in %#v", messages[len(messages)-1].Type, messages)
+	}
+	for _, wantType := range []string{runEventToolCall, "tool_result", "role_output"} {
+		if _, ok := firstAudioDialogTestMessageOfType(messages, wantType); !ok {
+			t.Fatalf("missing voice history message type %q: %#v", wantType, messages)
+		}
+	}
+	episodeID := messages[0].EpisodeID
+	if episodeID == "" {
+		t.Fatalf("user message missing episode id: %#v", messages[0])
+	}
+	for _, message := range messages {
+		if message.Source != "voice" {
+			t.Fatalf("message source = %q, want voice: %#v", message.Source, message)
+		}
+		if message.EpisodeID != episodeID {
+			t.Fatalf("message episode id = %q, want %q in %#v", message.EpisodeID, episodeID, messages)
+		}
+	}
+}
+
 func TestAudioDialogProcessUtteranceSavesAudioFile(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -16,6 +16,15 @@ import (
 	ttsmodule "aiden-agent/internal/agent/tts"
 )
 
+func firstAudioDialogTestMessageOfType(messages []Message, messageType string) (Message, bool) {
+	for _, message := range messages {
+		if message.Type == messageType {
+			return message, true
+		}
+	}
+	return Message{}, false
+}
+
 func TestAudioDialogFinishManualUtterancePreservesTail(t *testing.T) {
 	vad, err := NewAudioVADWithScorer(AudioVADConfig{
 		SampleRate:      16000,
@@ -681,17 +690,61 @@ func TestAudioDialogProcessUtteranceAppendsToHistoryStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-	if len(messages) != 2 {
-		t.Fatalf("expected user and assistant messages, got %d: %#v", len(messages), messages)
+	userMessage, ok := firstAudioDialogTestMessageOfType(messages, "user")
+	if !ok || userMessage.Source != "voice" || userMessage.Modality != "audio" || userMessage.Content != voiceAudioInputPlaceholder {
+		t.Fatalf("user audio message = %#v in %#v", userMessage, messages)
 	}
-	if messages[0].Type != "user" || messages[0].Source != "voice" || messages[0].Modality != "audio" || messages[0].Content != voiceAudioInputPlaceholder {
-		t.Fatalf("user audio message = %#v", messages[0])
+	if len(userMessage.Attachments) != 1 || userMessage.Attachments[0].Kind != AttachmentKindAudio || userMessage.Attachments[0].Data != "" {
+		t.Fatalf("user audio attachment should be metadata-only: %#v", userMessage.Attachments)
 	}
-	if len(messages[0].Attachments) != 1 || messages[0].Attachments[0].Kind != AttachmentKindAudio || messages[0].Attachments[0].Data != "" {
-		t.Fatalf("user audio attachment should be metadata-only: %#v", messages[0].Attachments)
+	roleOutput, ok := firstAudioDialogTestMessageOfType(messages, "role_output")
+	if !ok || roleOutput.Source != "voice" || roleOutput.Content != "voice reply" {
+		t.Fatalf("role_output message = %#v in %#v", roleOutput, messages)
 	}
-	if messages[1].Type != "assistant" || messages[1].Source != "voice" || messages[1].Content != "voice reply" {
-		t.Fatalf("assistant message = %#v", messages[1])
+	assistantMessage, ok := firstAudioDialogTestMessageOfType(messages, "assistant")
+	if !ok || assistantMessage.Source != "voice" || assistantMessage.Content != "voice reply" {
+		t.Fatalf("assistant message = %#v in %#v", assistantMessage, messages)
+	}
+}
+
+func TestAudioDialogRunAgentTurnAppendsRunEventsToVoiceHistory(t *testing.T) {
+	model := &scriptedModel{
+		responses: roleToolResponses("echo", `{"__arg1":"{}"}`, "voice tool reply"),
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:       ModelConfig{Provider: "fake"},
+			Instruction: "Use tools when requested.",
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"echo": &staticTool{name: "echo", output: `{"ok":true}`},
+		}},
+		NewSkillIndex(),
+	)
+	dialog := &AudioDialog{
+		config: Config{
+			Model: ModelConfig{Provider: "fake"},
+		},
+	}
+	var messages []Message
+	dialog.SetHistoryAppender(func(message Message) {
+		messages = append(messages, message)
+	})
+
+	if _, err := dialog.RunAgentTurn(context.Background(), TurnInput{InputText: "use echo"}, runtime); err != nil {
+		t.Fatalf("RunAgentTurn() error = %v", err)
+	}
+
+	for _, wantType := range []string{"role_output", runEventToolCall, "tool_result"} {
+		message, ok := firstAudioDialogTestMessageOfType(messages, wantType)
+		if !ok {
+			t.Fatalf("missing voice history message type %q: %#v", wantType, messages)
+		}
+		if message.Source != "voice" {
+			t.Fatalf("%s Source = %q, want voice", wantType, message.Source)
+		}
 	}
 }
 

--- a/src/agent/internal/agent/progress_speaker.go
+++ b/src/agent/internal/agent/progress_speaker.go
@@ -153,6 +153,9 @@ type cancelOnFirstWriteWriter struct {
 	inner  io.Writer
 	cancel func()
 	once   sync.Once
+
+	mu      sync.Mutex
+	emitted bool
 }
 
 func newCancelOnFirstWriteWriter(inner io.Writer, cancel func()) io.Writer {
@@ -166,5 +169,35 @@ func (w *cancelOnFirstWriteWriter) Write(p []byte) (int, error) {
 	if len(p) > 0 {
 		w.once.Do(w.cancel)
 	}
-	return w.inner.Write(p)
+	n, err := w.inner.Write(p)
+	if n > 0 {
+		w.mu.Lock()
+		w.emitted = true
+		w.mu.Unlock()
+	}
+	return n, err
+}
+
+func (w *cancelOnFirstWriteWriter) ResetStreamState() {
+	if w == nil {
+		return
+	}
+	if resetter, ok := w.inner.(streamStateResetter); ok {
+		resetter.ResetStreamState()
+	}
+	w.mu.Lock()
+	w.emitted = false
+	w.mu.Unlock()
+}
+
+func (w *cancelOnFirstWriteWriter) StreamEmitted() bool {
+	if w == nil {
+		return false
+	}
+	if tracker, ok := w.inner.(streamOutputTracker); ok {
+		return tracker.StreamEmitted()
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.emitted
 }

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -1458,6 +1458,8 @@ func (w *chatAssistantDeltaWriter) StreamEmitted() bool {
 
 type finalStreamFanoutWriter struct {
 	writers []io.Writer
+	mu      sync.Mutex
+	emitted bool
 }
 
 func newFinalStreamFanoutWriter(writers ...io.Writer) io.Writer {
@@ -1477,6 +1479,7 @@ func (w *finalStreamFanoutWriter) Write(p []byte) (int, error) {
 	if w == nil || len(p) == 0 {
 		return len(p), nil
 	}
+	emitted := false
 	for _, writer := range w.writers {
 		if writer == nil {
 			continue
@@ -1484,6 +1487,14 @@ func (w *finalStreamFanoutWriter) Write(p []byte) (int, error) {
 		if _, err := writer.Write(p); err != nil {
 			return 0, err
 		}
+		if streamWriterEmitted(writer) {
+			emitted = true
+		}
+	}
+	if emitted {
+		w.mu.Lock()
+		w.emitted = true
+		w.mu.Unlock()
 	}
 	return len(p), nil
 }
@@ -1497,14 +1508,25 @@ func (w *finalStreamFanoutWriter) ResetStreamState() {
 			resetter.ResetStreamState()
 		}
 	}
+	w.mu.Lock()
+	w.emitted = false
+	w.mu.Unlock()
 }
 
 func (w *finalStreamFanoutWriter) StreamEmitted() bool {
-	if w == nil || len(w.writers) == 0 {
+	if w == nil {
 		return false
 	}
-	if tracker, ok := w.writers[0].(streamOutputTracker); ok {
-		return tracker.StreamEmitted()
+	w.mu.Lock()
+	emitted := w.emitted
+	w.mu.Unlock()
+	if emitted {
+		return true
+	}
+	for _, writer := range w.writers {
+		if streamWriterEmitted(writer) {
+			return true
+		}
 	}
 	return false
 }

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -1480,15 +1480,28 @@ func (w *finalStreamFanoutWriter) Write(p []byte) (int, error) {
 		return len(p), nil
 	}
 	emitted := false
+	delivered := false
 	for _, writer := range w.writers {
 		if writer == nil {
 			continue
 		}
-		if _, err := writer.Write(p); err != nil {
-			return 0, err
-		}
+		n, err := writer.Write(p)
 		if streamWriterEmitted(writer) {
 			emitted = true
+		}
+		if err != nil {
+			if emitted {
+				w.mu.Lock()
+				w.emitted = true
+				w.mu.Unlock()
+			}
+			if delivered {
+				return len(p), err
+			}
+			return n, err
+		}
+		if n == len(p) {
+			delivered = true
 		}
 	}
 	if emitted {

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -1287,7 +1287,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 	var newStream *streamSessionWriter
 	ttsManager := s.currentTTSManager()
 	finalStreamWriters := []io.Writer{
-		NewJSONFieldOrPlainStreamWriter(newChatAssistantDeltaWriter(stream, episodeID, req.RequestID), "text"),
+		newChatAssistantFinalStreamWriter(stream, episodeID, req.RequestID),
 	}
 	if s.runtime.config.VoiceStreamingTTSEnabledOrDefault() && s.audioClient != nil {
 		if ttsManager != nil {
@@ -1443,8 +1443,16 @@ func (w *chatAssistantDeltaWriter) ResetStreamState() {
 		return
 	}
 	w.mu.Lock()
+	emitted := w.emitted
 	w.emitted = false
 	w.mu.Unlock()
+	if emitted && w.stream != nil {
+		w.stream.Write(ChatStreamEvent{
+			Type:      "assistant_delta_reset",
+			RequestID: w.requestID,
+			EpisodeID: w.episodeID,
+		})
+	}
 }
 
 func (w *chatAssistantDeltaWriter) StreamEmitted() bool {
@@ -1454,6 +1462,45 @@ func (w *chatAssistantDeltaWriter) StreamEmitted() bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.emitted
+}
+
+type chatAssistantFinalStreamWriter struct {
+	delta     *chatAssistantDeltaWriter
+	extractor io.Writer
+}
+
+func newChatAssistantFinalStreamWriter(stream *chatStreamWriter, episodeID, requestID string) io.Writer {
+	delta := newChatAssistantDeltaWriter(stream, episodeID, requestID)
+	return &chatAssistantFinalStreamWriter{
+		delta:     delta,
+		extractor: NewJSONFieldOrPlainStreamWriter(delta, "text"),
+	}
+}
+
+func (w *chatAssistantFinalStreamWriter) Write(p []byte) (int, error) {
+	if w == nil || w.extractor == nil {
+		return len(p), nil
+	}
+	return w.extractor.Write(p)
+}
+
+func (w *chatAssistantFinalStreamWriter) ResetStreamState() {
+	if w == nil {
+		return
+	}
+	if w.delta != nil {
+		w.delta.ResetStreamState()
+	}
+	if resetter, ok := w.extractor.(streamStateResetter); ok {
+		resetter.ResetStreamState()
+	}
+}
+
+func (w *chatAssistantFinalStreamWriter) StreamEmitted() bool {
+	if w == nil || w.delta == nil {
+		return false
+	}
+	return w.delta.StreamEmitted()
 }
 
 type finalStreamFanoutWriter struct {
@@ -4455,6 +4502,10 @@ const webUI = `<!DOCTYPE html>
                 appendAssistantDelta(event);
                 return false;
             }
+            if (event.type === 'assistant_delta_reset') {
+                resetAssistantDelta(event);
+                return false;
+            }
             if (event.type === 'message' && event.message) {
                 if (event.message.type === 'steer') {
                     pendingSteer = null;
@@ -4492,6 +4543,26 @@ const webUI = `<!DOCTYPE html>
             }
             msg.content += event.delta || '';
             addMessage(msg);
+        }
+
+        function resetAssistantDelta(event) {
+            const key = assistantStreamKey(event);
+            if (!key) return;
+            const msg = streamingAssistantDrafts[key] || {
+                type: 'assistant',
+                request_id: event.request_id || '',
+                episode_id: event.episode_id || ''
+            };
+            delete streamingAssistantDrafts[key];
+            const messageKey = messageIdentity(msg);
+            const existing = renderedMessageNodes.get(messageKey);
+            renderedMessageKeys.delete(messageKey);
+            renderedMessageNodes.delete(messageKey);
+            if (existing) {
+                existing.remove();
+                updateEmptyState();
+                scrollToBottom();
+            }
         }
 
         function finalizeAssistantMessage(msg) {

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -1713,8 +1713,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			// Only send user and assistant messages
-			if msg.Type != "user" && msg.Type != "assistant" {
+			if !shouldStreamEventMessage(msg) {
 				continue
 			}
 
@@ -1730,6 +1729,10 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			flusher.Flush()
 		}
 	}
+}
+
+func shouldStreamEventMessage(msg Message) bool {
+	return strings.TrimSpace(msg.Type) != ""
 }
 
 func (s *Server) handleEpisodes(w http.ResponseWriter, r *http.Request) {
@@ -2383,6 +2386,8 @@ func (s *Server) appendHistory(message Message) {
 		if err := s.historyStore.Append(context.Background(), message); err != nil && s.logger != nil {
 			s.logger.Warn("Persist chat history failed: %v", err)
 		}
+	} else if s.eventBroadcaster != nil {
+		s.eventBroadcaster.Broadcast(message)
 	}
 }
 
@@ -3940,7 +3945,7 @@ const webUI = `<!DOCTYPE html>
                         return;
                     }
 
-                    if (data.type === 'user' || data.type === 'assistant') {
+                    if (data.type) {
                         addMessage(data);
                     }
                 } catch (err) {

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -287,11 +287,14 @@ type ChatResultResponse struct {
 }
 
 type ChatStreamEvent struct {
-	Type     string    `json:"type"`
-	Message  *Message  `json:"message,omitempty"`
-	Response string    `json:"response,omitempty"`
-	History  []Message `json:"history,omitempty"`
-	Error    string    `json:"error,omitempty"`
+	Type      string    `json:"type"`
+	Message   *Message  `json:"message,omitempty"`
+	RequestID string    `json:"request_id,omitempty"`
+	EpisodeID string    `json:"episode_id,omitempty"`
+	Delta     string    `json:"delta,omitempty"`
+	Response  string    `json:"response,omitempty"`
+	History   []Message `json:"history,omitempty"`
+	Error     string    `json:"error,omitempty"`
 }
 
 type EpisodeResponse struct {
@@ -1283,6 +1286,9 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 
 	var newStream *streamSessionWriter
 	ttsManager := s.currentTTSManager()
+	finalStreamWriters := []io.Writer{
+		NewJSONFieldOrPlainStreamWriter(newChatAssistantDeltaWriter(stream, episodeID, req.RequestID), "text"),
+	}
 	if s.runtime.config.VoiceStreamingTTSEnabledOrDefault() && s.audioClient != nil {
 		if ttsManager != nil {
 			streamSession, err := beginManagedTTSStream(ctx, ttsManager, s.audioClient, s.runtime.config)
@@ -1292,10 +1298,11 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 				}
 			} else {
 				newStream = streamSession
-				runReq.StreamWriter = newCancelOnFirstWriteWriter(speechStreamWriterForConfig(newStream, s.runtime.config), progress.Cancel)
+				finalStreamWriters = append(finalStreamWriters, newCancelOnFirstWriteWriter(speechStreamWriterForConfig(newStream, s.runtime.config), progress.Cancel))
 			}
 		}
 	}
+	runReq.StreamWriter = newFinalStreamFanoutWriter(finalStreamWriters...)
 
 	result, err := s.runtime.Run(ctx, runReq)
 	progress.Cancel()
@@ -1395,6 +1402,111 @@ func (w *chatStreamWriter) Write(event ChatStreamEvent) {
 	if err := w.encoder.Encode(event); err == nil {
 		w.flusher.Flush()
 	}
+}
+
+type chatAssistantDeltaWriter struct {
+	stream    *chatStreamWriter
+	episodeID string
+	requestID string
+
+	mu      sync.Mutex
+	emitted bool
+}
+
+func newChatAssistantDeltaWriter(stream *chatStreamWriter, episodeID, requestID string) *chatAssistantDeltaWriter {
+	return &chatAssistantDeltaWriter{
+		stream:    stream,
+		episodeID: episodeID,
+		requestID: requestID,
+	}
+}
+
+func (w *chatAssistantDeltaWriter) Write(p []byte) (int, error) {
+	if w == nil || w.stream == nil || len(p) == 0 {
+		return len(p), nil
+	}
+	delta := string(p)
+	w.mu.Lock()
+	w.emitted = true
+	w.mu.Unlock()
+	w.stream.Write(ChatStreamEvent{
+		Type:      "assistant_delta",
+		RequestID: w.requestID,
+		EpisodeID: w.episodeID,
+		Delta:     delta,
+	})
+	return len(p), nil
+}
+
+func (w *chatAssistantDeltaWriter) ResetStreamState() {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	w.emitted = false
+	w.mu.Unlock()
+}
+
+func (w *chatAssistantDeltaWriter) StreamEmitted() bool {
+	if w == nil {
+		return false
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.emitted
+}
+
+type finalStreamFanoutWriter struct {
+	writers []io.Writer
+}
+
+func newFinalStreamFanoutWriter(writers ...io.Writer) io.Writer {
+	filtered := make([]io.Writer, 0, len(writers))
+	for _, writer := range writers {
+		if writer != nil {
+			filtered = append(filtered, writer)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return &finalStreamFanoutWriter{writers: filtered}
+}
+
+func (w *finalStreamFanoutWriter) Write(p []byte) (int, error) {
+	if w == nil || len(p) == 0 {
+		return len(p), nil
+	}
+	for _, writer := range w.writers {
+		if writer == nil {
+			continue
+		}
+		if _, err := writer.Write(p); err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
+}
+
+func (w *finalStreamFanoutWriter) ResetStreamState() {
+	if w == nil {
+		return
+	}
+	for _, writer := range w.writers {
+		if resetter, ok := writer.(streamStateResetter); ok {
+			resetter.ResetStreamState()
+		}
+	}
+}
+
+func (w *finalStreamFanoutWriter) StreamEmitted() bool {
+	if w == nil || len(w.writers) == 0 {
+		return false
+	}
+	if tracker, ok := w.writers[0].(streamOutputTracker); ok {
+		return tracker.StreamEmitted()
+	}
+	return false
 }
 
 func (s *Server) speakToolDescription(ctx context.Context, description string) {
@@ -3695,6 +3807,8 @@ const webUI = `<!DOCTYPE html>
         let episodeCache = {};
         let eventSource = null;
         let renderedMessageKeys = new Set();
+        let renderedMessageNodes = new Map();
+        let streamingAssistantDrafts = {};
 
         loadHistory();
         refreshCurrentLiveActivity();
@@ -4302,12 +4416,20 @@ const webUI = `<!DOCTYPE html>
         }
 
         function handleChatStreamEvent(event) {
+            if (event.type === 'assistant_delta') {
+                appendAssistantDelta(event);
+                return false;
+            }
             if (event.type === 'message' && event.message) {
                 if (event.message.type === 'steer') {
                     pendingSteer = null;
                     renderPendingSteer();
                 }
-                addMessage(event.message);
+                if (event.message.type === 'assistant') {
+                    finalizeAssistantMessage(event.message);
+                } else {
+                    addMessage(event.message);
+                }
                 return false;
             }
             if (event.type === 'done') {
@@ -4317,6 +4439,37 @@ const webUI = `<!DOCTYPE html>
                 throw new Error(event.error || 'Agent error');
             }
             return false;
+        }
+
+        function appendAssistantDelta(event) {
+            const key = assistantStreamKey(event);
+            if (!key) return;
+            let msg = streamingAssistantDrafts[key];
+            if (!msg) {
+                msg = {
+                    type: 'assistant',
+                    request_id: event.request_id || '',
+                    episode_id: event.episode_id || '',
+                    content: '',
+                    timestamp: new Date().toISOString()
+                };
+                streamingAssistantDrafts[key] = msg;
+            }
+            msg.content += event.delta || '';
+            addMessage(msg);
+        }
+
+        function finalizeAssistantMessage(msg) {
+            const key = assistantStreamKey(msg);
+            if (key) {
+                delete streamingAssistantDrafts[key];
+            }
+            addMessage(msg);
+        }
+
+        function assistantStreamKey(value) {
+            value = value || {};
+            return value.request_id || value.episode_id || currentChatRequestId || '';
         }
 
         async function clearHistory() {
@@ -4349,6 +4502,8 @@ const webUI = `<!DOCTYPE html>
         function renderHistory(history) {
             messagesDiv.innerHTML = '';
             renderedMessageKeys = new Set();
+            renderedMessageNodes = new Map();
+            streamingAssistantDrafts = {};
 
             const fragment = document.createDocumentFragment();
             history.forEach(function(msg) {
@@ -4356,7 +4511,9 @@ const webUI = `<!DOCTYPE html>
                 const key = messageIdentity(msg);
                 if (renderedMessageKeys.has(key)) return;
                 renderedMessageKeys.add(key);
-                fragment.appendChild(createMessageNode(msg));
+                const node = createMessageNode(msg);
+                renderedMessageNodes.set(key, node);
+                fragment.appendChild(node);
             });
 
             messagesDiv.appendChild(fragment);
@@ -4367,9 +4524,26 @@ const webUI = `<!DOCTYPE html>
         function addMessage(msg) {
             if (isControlMessage(msg)) return;
             const key = messageIdentity(msg);
-            if (renderedMessageKeys.has(key)) return;
+            if (renderedMessageKeys.has(key)) {
+                if (normalizeType((msg || {}).type) === 'assistant') {
+                    updateMessageNode(key, msg);
+                }
+                return;
+            }
             renderedMessageKeys.add(key);
-            messagesDiv.appendChild(createMessageNode(msg));
+            const node = createMessageNode(msg);
+            renderedMessageNodes.set(key, node);
+            messagesDiv.appendChild(node);
+            updateEmptyState();
+            scrollToBottom();
+        }
+
+        function updateMessageNode(key, msg) {
+            const existing = renderedMessageNodes.get(key);
+            if (!existing) return;
+            const replacement = createMessageNode(msg);
+            renderedMessageNodes.set(key, replacement);
+            existing.replaceWith(replacement);
             updateEmptyState();
             scrollToBottom();
         }
@@ -4383,11 +4557,17 @@ const webUI = `<!DOCTYPE html>
             const type = normalizeType(msg.type);
             const content = msg.content || '';
             const requestId = msg.request_id || '';
-            if (requestId && (type === 'user' || type === 'assistant')) {
+            if (requestId && type === 'assistant') {
+                return ['request', requestId, type].join('\u001f');
+            }
+            if (requestId && type === 'user') {
                 return ['request', requestId, type, content].join('\u001f');
             }
 
             const episodeId = msg.episode_id || '';
+            if (episodeId && type === 'assistant') {
+                return ['episode', episodeId, type].join('\u001f');
+            }
             if (episodeId) {
                 return ['episode', episodeId, type, msg.role || '', msg.tool_name || '', msg.tool_input || '', content, msg.timestamp || ''].join('\u001f');
             }

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -385,6 +385,72 @@ func TestFinalStreamFanoutWriterReturnsInputLengthWhenLaterWriterFails(t *testin
 	}
 }
 
+func TestFinalStreamFanoutWriterResetsAssistantDeltaDraftBeforeFallback(t *testing.T) {
+	writeErr := errors.New("fanout write failed")
+	rec := httptest.NewRecorder()
+	stream, ok := newChatStreamWriter(rec)
+	if !ok {
+		t.Fatal("httptest recorder must support streaming")
+	}
+	fanout := newFinalStreamFanoutWriter(
+		newChatAssistantFinalStreamWriter(stream, "episode-reset", "request-reset"),
+		failingStreamWriter{err: writeErr},
+	)
+
+	if _, err := fanout.Write([]byte(`{"text":"Partial`)); !errors.Is(err, writeErr) {
+		t.Fatalf("first Write() error = %v, want %v", err, writeErr)
+	}
+	resetStreamWriterState(fanout)
+	if _, err := fanout.Write([]byte("Complete answer.")); !errors.Is(err, writeErr) {
+		t.Fatalf("fallback Write() error = %v, want %v", err, writeErr)
+	}
+
+	var events []ChatStreamEvent
+	scanner := bufio.NewScanner(strings.NewReader(rec.Body.String()))
+	for scanner.Scan() {
+		var event ChatStreamEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			t.Fatalf("decode stream event %q: %v", scanner.Text(), err)
+		}
+		events = append(events, event)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan stream: %v", err)
+	}
+
+	resetIndex := -1
+	for i, event := range events {
+		if event.Type == "assistant_delta_reset" {
+			if resetIndex >= 0 {
+				t.Fatalf("expected one assistant_delta_reset, events=%#v", events)
+			}
+			resetIndex = i
+		}
+	}
+	if resetIndex <= 0 || resetIndex >= len(events)-1 {
+		t.Fatalf("assistant_delta_reset index = %d, want between deltas: %#v", resetIndex, events)
+	}
+
+	var beforeReset strings.Builder
+	var afterReset strings.Builder
+	for i, event := range events {
+		if event.Type != "assistant_delta" {
+			continue
+		}
+		if i < resetIndex {
+			beforeReset.WriteString(event.Delta)
+		} else {
+			afterReset.WriteString(event.Delta)
+		}
+	}
+	if beforeReset.String() != "Partial" {
+		t.Fatalf("delta before reset = %q, want Partial", beforeReset.String())
+	}
+	if afterReset.String() != "Complete answer." {
+		t.Fatalf("delta after reset = %q, want Complete answer.", afterReset.String())
+	}
+}
+
 func TestFinalStreamFanoutWriterReportsAnyChildEmission(t *testing.T) {
 	var webDelta strings.Builder
 	var speech strings.Builder

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -479,6 +479,22 @@ func TestFinalStreamFanoutWriterReportsAnyChildEmission(t *testing.T) {
 	}
 }
 
+func TestServerEventStreamAllowsRunEventMessages(t *testing.T) {
+	for _, messageType := range []string{
+		"user",
+		"assistant",
+		"role_output",
+		runEventToolCall,
+		"tool_result",
+		runEventTodoUpdate,
+		runEventTodoClosed,
+	} {
+		if !shouldStreamEventMessage(Message{Type: messageType}) {
+			t.Fatalf("message type %q should be streamed to web clients", messageType)
+		}
+	}
+}
+
 func TestHandleCoordinateDebugTap(t *testing.T) {
 	frameSocket := startFakeFrameServiceSocket(t, func(req map[string]any) (string, []byte) {
 		header := `{"type":"response","method":"latest_frame","status":"OK","frame":{"seq":1,"width":2,"height":1,"pixel_format":"uyvy","stride":4,"bytes":4,"stale":false}}`

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -268,6 +268,89 @@ func TestServerHandleChatStreamsRoleToolAndAssistantMessages(t *testing.T) {
 	}
 }
 
+func TestServerHandleChatStreamEmitsAssistantDeltasBeforeDone(t *testing.T) {
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			contentResponse(`{"mode":"direct_answer","speech":"Short answer.","text":"Complete answer.","final_answer":"Complete answer.","reason":"direct"}`),
+		},
+		streamChunks: [][]string{
+			{
+				`{"mode":"direct_answer","speech":"Short answer.","text":"Complete`,
+				` answer.","final_answer":"Complete answer.","reason":"direct"}`,
+			},
+		},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:       ModelConfig{Provider: "fake"},
+			Instruction: "Answer directly.",
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+	server := NewServer(runtime, ":0", "")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"hello","request_id":"web-req-stream"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/x-ndjson")
+	req.Header.Set("X-Aiden-Stream", "ndjson")
+	rec := httptest.NewRecorder()
+
+	server.handleChat(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var (
+		deltaText              strings.Builder
+		sawDeltaBeforeDone     bool
+		sawAssistantBeforeDone bool
+		sawDone                bool
+		events                 []ChatStreamEvent
+	)
+	scanner := bufio.NewScanner(strings.NewReader(rec.Body.String()))
+	for scanner.Scan() {
+		var event ChatStreamEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			t.Fatalf("decode stream event %q: %v", scanner.Text(), err)
+		}
+		events = append(events, event)
+		switch event.Type {
+		case "assistant_delta":
+			if sawDone {
+				t.Fatalf("assistant_delta arrived after done: %#v", events)
+			}
+			sawDeltaBeforeDone = true
+			deltaText.WriteString(event.Delta)
+		case "message":
+			if event.Message != nil && event.Message.Type == "assistant" && !sawDone {
+				sawAssistantBeforeDone = true
+			}
+		case "done":
+			sawDone = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan stream: %v", err)
+	}
+
+	if !sawDeltaBeforeDone {
+		t.Fatalf("expected assistant_delta before done, events=%#v", events)
+	}
+	if !sawAssistantBeforeDone || !sawDone {
+		t.Fatalf("expected final assistant message and done, assistant=%v done=%v events=%#v", sawAssistantBeforeDone, sawDone, events)
+	}
+	if got := deltaText.String(); got != "Complete answer." {
+		t.Fatalf("assistant deltas = %q, want Complete answer.", got)
+	}
+	if len(model.sawStreaming) != 1 || !model.sawStreaming[0] {
+		t.Fatalf("expected web chat stream to enable provider streaming, got %#v", model.sawStreaming)
+	}
+}
+
 func TestHandleCoordinateDebugTap(t *testing.T) {
 	frameSocket := startFakeFrameServiceSocket(t, func(req map[string]any) (string, []byte) {
 		header := `{"type":"response","method":"latest_frame","status":"OK","frame":{"seq":1,"width":2,"height":1,"pixel_format":"uyvy","stride":4,"bytes":4,"stale":false}}`

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"image/jpeg"
 	"net"
@@ -269,6 +270,8 @@ func TestServerHandleChatStreamsRoleToolAndAssistantMessages(t *testing.T) {
 }
 
 func TestServerHandleChatStreamEmitsAssistantDeltasBeforeDone(t *testing.T) {
+	const expectedAnswer = "Complete answer."
+
 	model := &scriptedModel{
 		responses: []*llms.ContentResponse{
 			contentResponse(`{"mode":"direct_answer","speech":"Short answer.","text":"Complete answer.","final_answer":"Complete answer.","reason":"direct"}`),
@@ -308,6 +311,7 @@ func TestServerHandleChatStreamEmitsAssistantDeltasBeforeDone(t *testing.T) {
 		deltaText              strings.Builder
 		sawDeltaBeforeDone     bool
 		sawAssistantBeforeDone bool
+		assistantContent       string
 		sawDone                bool
 		events                 []ChatStreamEvent
 	)
@@ -328,6 +332,7 @@ func TestServerHandleChatStreamEmitsAssistantDeltasBeforeDone(t *testing.T) {
 		case "message":
 			if event.Message != nil && event.Message.Type == "assistant" && !sawDone {
 				sawAssistantBeforeDone = true
+				assistantContent = event.Message.Content
 			}
 		case "done":
 			sawDone = true
@@ -343,11 +348,40 @@ func TestServerHandleChatStreamEmitsAssistantDeltasBeforeDone(t *testing.T) {
 	if !sawAssistantBeforeDone || !sawDone {
 		t.Fatalf("expected final assistant message and done, assistant=%v done=%v events=%#v", sawAssistantBeforeDone, sawDone, events)
 	}
-	if got := deltaText.String(); got != "Complete answer." {
-		t.Fatalf("assistant deltas = %q, want Complete answer.", got)
+	if got := deltaText.String(); got != expectedAnswer {
+		t.Fatalf("assistant deltas = %q, want %q", got, expectedAnswer)
+	}
+	if assistantContent != expectedAnswer {
+		t.Fatalf("assistant message content = %q, want %q", assistantContent, expectedAnswer)
 	}
 	if len(model.sawStreaming) != 1 || !model.sawStreaming[0] {
 		t.Fatalf("expected web chat stream to enable provider streaming, got %#v", model.sawStreaming)
+	}
+}
+
+type failingStreamWriter struct {
+	err error
+}
+
+func (w failingStreamWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+func TestFinalStreamFanoutWriterReturnsInputLengthWhenLaterWriterFails(t *testing.T) {
+	writeErr := errors.New("fanout write failed")
+	var first strings.Builder
+	fanout := newFinalStreamFanoutWriter(&first, failingStreamWriter{err: writeErr})
+
+	n, err := fanout.Write([]byte("chunk"))
+
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("Write() error = %v, want %v", err, writeErr)
+	}
+	if n != len("chunk") {
+		t.Fatalf("Write() bytes = %d, want %d", n, len("chunk"))
+	}
+	if first.String() != "chunk" {
+		t.Fatalf("first writer received %q, want chunk", first.String())
 	}
 }
 

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -351,6 +351,34 @@ func TestServerHandleChatStreamEmitsAssistantDeltasBeforeDone(t *testing.T) {
 	}
 }
 
+func TestFinalStreamFanoutWriterReportsAnyChildEmission(t *testing.T) {
+	var webDelta strings.Builder
+	var speech strings.Builder
+
+	fanout := newFinalStreamFanoutWriter(
+		NewJSONFieldOrPlainStreamWriter(&webDelta, "text"),
+		NewSpeechStreamWriter(&speech),
+	)
+	tracker, ok := fanout.(streamOutputTracker)
+	if !ok {
+		t.Fatal("fanout writer must track stream emission")
+	}
+
+	if _, err := fanout.Write([]byte(`{"speech":"Short answer.","final_answer":"Complete answer."}`)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	if webDelta.String() != "" {
+		t.Fatalf("web delta stream = %q, want empty when text field is absent", webDelta.String())
+	}
+	if speech.String() != "Short answer." {
+		t.Fatalf("speech stream = %q, want Short answer.", speech.String())
+	}
+	if !tracker.StreamEmitted() {
+		t.Fatal("fanout should report emitted when any child stream emitted")
+	}
+}
+
 func TestHandleCoordinateDebugTap(t *testing.T) {
 	frameSocket := startFakeFrameServiceSocket(t, func(req map[string]any) (string, []byte) {
 		header := `{"type":"response","method":"latest_frame","status":"OK","frame":{"seq":1,"width":2,"height":1,"pixel_format":"uyvy","stride":4,"bytes":4,"stale":false}}`


### PR DESCRIPTION
## Summary
- emit assistant_delta NDJSON events while final answers are streaming
- update the web UI to render assistant deltas into the active assistant bubble
- preserve final-stream writer state for fallback handling

## Tests
- go test ./internal/agent -run 'TestServerHandleChat|TestRuntimeRun.*Streaming|TestJSONField' -count=1
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant messages now update incrementally during generation, displaying response text in real-time instead of waiting for completion, enhancing the chat experience.

* **Tests**
  * Added test coverage for incremental assistant message streaming in chat endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->