### PR TITLE
fix(agent): stop sleep requests from looping

### DIFF
--- a/docs/04-agent/audio-features.md
+++ b/docs/04-agent/audio-features.md
@@ -61,7 +61,7 @@ Go Agent 支持设备侧语音交互，主要由 `internal/agent/audio_client.go
 
 ### `trigger_mode = "wakeup"`
 
-等待 GPIO 33 或 GPIO 32 falling edge 触发后录音，两路触发进入同一套 wakeup 流程。`input_mode = "stt"` 且 `voice_followup_enabled = true` 时，wakeup 打开一个连续语音 session：首轮仍需要 GPIO，Agent 回复后会在 `voice_followup_timeout_ms` 窗口内继续听追问，`voice_first_turn_timeout_ms` 控制首轮等待窗口，`voice_max_turns` 控制单个 session 的轮数上限。录音中再次触发 wakeup 会打断当前录音、丢弃已录音频，并重新开始录音计时；session 内再次触发 wakeup 是否取消当前 LLM 请求由 `voice_interrupt_on_wakeup` 控制；TTS 播放期间默认不开麦，播放结束后才继续录音；播放中再次触发 wakeup 会打断当前轮并立即开始录音。需要 Linux GPIO sysfs 可用，并完成硬件连线。
+等待 GPIO 33 或 GPIO 32 falling edge 触发后录音，两路触发进入同一套 wakeup 流程。`input_mode = "stt"` 且 `voice_followup_enabled = true` 时，wakeup 打开一个连续语音 session：首轮仍需要 GPIO，Agent 回复后会在 `voice_followup_timeout_ms` 窗口内继续听追问，`voice_first_turn_timeout_ms` 控制首轮等待窗口，`voice_max_turns` 控制单个 session 的轮数上限。监听或录音阶段重复触发 wakeup 会被合并或忽略，不会重启录音或丢弃已录音频；thinking 阶段再次触发 wakeup 是否取消当前 LLM 请求由 `voice_interrupt_on_wakeup` 控制；TTS 播放期间默认不开麦，播放结束后才继续录音；播放中再次触发 wakeup 会打断当前轮并立即开始录音。需要 Linux GPIO sysfs 可用，并完成硬件连线。
 
 ## 配置片段
 

--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -121,7 +121,7 @@ frame_socket = "/run/frame_service/frame_service.sock"
 | `voice_followup_timeout_ms` | `6000` | Agent 回复后等待用户追问的窗口 |
 | `voice_first_turn_timeout_ms` | `10000` | wakeup 后等待第一句话的窗口 |
 | `voice_max_turns` | `0` | 单个 wakeup session 最大轮数；`0` 表示不限制 |
-| `voice_interrupt_on_wakeup` | `true` | session 内再次收到 wakeup 时取消 thinking/TTS 并重新听音；录音中 wakeup 会直接重启录音并丢弃已录音频 |
+| `voice_interrupt_on_wakeup` | `true` | session 内再次收到 wakeup 时取消 thinking/TTS 并重新听音；监听或录音阶段的重复 wakeup 会被合并或忽略 |
 | `voice_streaming_tts_enabled` | `true` | LLM 流式输出时按句送入 TTS，降低首句播放等待；启用 `voice_speech_summary_enabled` 时，最终播报改为生成完整输出后的摘要 |
 | `voice_tool_call_speech` | `false` | 是否异步朗读 LLM 在工具参数中显式生成的 `speech`；默认关闭。缺少 `speech` 时保持静默，不会从工具 `description` 派生口播 |
 | `voice_progress_speech_enabled` | `true` | 是否在 todo item 进入 `in_progress` 时播报短进度；todo 状态仍会发送给 UI/trace |

--- a/docs/04-agent/tools-http-api.md
+++ b/docs/04-agent/tools-http-api.md
@@ -71,7 +71,7 @@ JSON 对象输入：
 | --- | --- | --- |
 | `audio_volume` | audio | `{}` |
 | `current_time` | system | `{"timezone":"Asia/Shanghai"}` |
-| `enter_sleep` | system | `{"reason":"user asked me to sleep"}` |
+| `wait_for_wakeup` | system | `{"reason":"user asked me to wait for wakeup"}` |
 | `keyboard_tap` | input | `{"keys":["ctrl","c"]}` |
 | `keyboard_text` | input | `{"text":"hello world"}` |
 | `mouse_click` | input | `{"x":500,"y":500,"button":"left","coord_space":"normalized"}` |
@@ -119,7 +119,7 @@ curl -X POST http://127.0.0.1:8080/api/tools/weather \
 `touch_gesture` 的 `back` 会从左物理边缘附近开始滑动，`home` 会从底部物理边缘附近开始上滑；normalized 坐标使用 0-1000 范围，手写 `swipe` 时也应使用贴边起点，例如 `start.x=1` 或 `start.y=999`。
 `current_time` 支持 IANA 时区名（如 `Asia/Shanghai`、`America/New_York`）、`UTC`、`local` 和 UTC offset（如 `+08:00`）。
 `weather` 支持地点名或经纬度，运行时通过 Open-Meteo 获取 geocoding、当前天气和短期预报。
-`enter_sleep` 会让语音连续对话 session 在当前轮结束后关闭，回到等待下一次 wakeup 的模式。
+`wait_for_wakeup` 是终止型运行时工具。工具调用成功后会立即结束本次 Agent run，并让语音交互回到等待下一次 wakeup 的模式；不会再要求模型补一轮普通 final answer。
 
 ## 外部 Agent 使用建议
 
@@ -129,4 +129,4 @@ curl -X POST http://127.0.0.1:8080/api/tools/weather \
 - 鼠标和触控优先使用 `coord_space: "normalized"` 的 0-1000 坐标；
 - 私有 IP 或 USB 网卡访问时注意代理绕过：设置 `NO_PROXY` / `no_proxy`；
 - `shell` 的长任务应按工具说明使用后台 session，并在结束时停止。
-- 用户要求“休眠 / 停止监听 / 等我下次唤醒”时，使用 `enter_sleep`，不要用普通文本回复假装已经休眠。
+- 用户要求“休眠 / 停止监听 / 等我下次唤醒”时，使用 `wait_for_wakeup`，不要用普通文本回复假装已经回到等待唤醒。

--- a/docs/04-agent/tools-http-api.md
+++ b/docs/04-agent/tools-http-api.md
@@ -119,7 +119,7 @@ curl -X POST http://127.0.0.1:8080/api/tools/weather \
 `touch_gesture` 的 `back` 会从左物理边缘附近开始滑动，`home` 会从底部物理边缘附近开始上滑；normalized 坐标使用 0-1000 范围，手写 `swipe` 时也应使用贴边起点，例如 `start.x=1` 或 `start.y=999`。
 `current_time` 支持 IANA 时区名（如 `Asia/Shanghai`、`America/New_York`）、`UTC`、`local` 和 UTC offset（如 `+08:00`）。
 `weather` 支持地点名或经纬度，运行时通过 Open-Meteo 获取 geocoding、当前天气和短期预报。
-`wait_for_wakeup` 是终止型运行时工具。工具调用成功后会立即结束本次 Agent run，并让语音交互回到等待下一次 wakeup 的模式；不会再要求模型补一轮普通 final answer。
+`wait_for_wakeup` 是终止型运行时工具。工具调用成功后会立即结束本次 Agent run，并让语音交互回到等待下一次 wakeup 的模式；不会再要求模型补一轮普通 final answer。运行结果会设置 `wait_for_wakeup_requested` / `wait_for_wakeup_reason`；旧字段 `sleep_requested` / `sleep_reason` 仅作为兼容别名保留。
 
 ## 外部 Agent 使用建议
 

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 	"time"
 
@@ -410,15 +409,13 @@ func runLegacyWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *ag
 	log.Printf("\n[ready] Starting GPIO wakeup listeners on %s...", wakeupGPIOPinsLabel())
 
 	ctx := context.Background()
-	wakeupTriggered := false
-	var wakeupMutex sync.Mutex
+	wakeupEvents := make(chan struct{}, 8)
 
 	watchers, err := startWakeupWatchers(newWatcher, func() {
-		wakeupMutex.Lock()
-		defer wakeupMutex.Unlock()
-		if !wakeupTriggered {
-			log.Println("\n[wakeup] GPIO wakeup triggered, starting to listen...")
-			wakeupTriggered = true
+		select {
+		case wakeupEvents <- struct{}{}:
+		default:
+			log.Println("[wakeup] event queue full, dropping GPIO wakeup event")
 		}
 	})
 	if err != nil {
@@ -429,38 +426,41 @@ func runLegacyWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *ag
 
 	log.Printf("[ready] Waiting for wakeup event (%s)... Ctrl+C to quit", wakeupGPIOPinsLabel())
 
+	pendingWakeup := false
 	for {
-		select {
-		case <-sigChan:
-			if dialog != nil {
-				dialog.StopRecording()
+		if !pendingWakeup {
+			select {
+			case <-sigChan:
+				if dialog != nil {
+					dialog.StopRecording()
+				}
+				log.Println("\n[exit] Stopped.")
+				return
+			case <-wakeupEvents:
+				log.Println("\n[wakeup] GPIO wakeup triggered, starting to listen...")
 			}
-			log.Println("\n[exit] Stopped.")
-			return
-		default:
-		}
-
-		wakeupMutex.Lock()
-		triggered := wakeupTriggered
-		wakeupMutex.Unlock()
-
-		if !triggered {
-			time.Sleep(100 * time.Millisecond)
-			continue
+		} else {
+			pendingWakeup = false
 		}
 
 		// Start recording
 		log.Println("[listen] Recording audio...")
 		if err := dialog.StartRecording(); err != nil {
 			log.Printf("[error] Failed to start recording: %v\n", err)
-			wakeupMutex.Lock()
-			wakeupTriggered = false
-			wakeupMutex.Unlock()
 			continue
 		}
 
 		dialog.ResetVAD()
-		if exit := processAudioUntilUtterance(dialog, runtime, ctx, sigChan); exit {
+		exit, interrupted := processAudioUntilUtteranceWithWakeupInterrupt(
+			dialog,
+			runtime,
+			ctx,
+			sigChan,
+			wakeupEvents,
+			cfg.VoiceInterruptOnWakeupOrDefault(),
+			wakeupListenTimeout,
+		)
+		if exit {
 			dialog.StopRecording()
 			log.Println("\n[exit] Stopped.")
 			return
@@ -469,10 +469,10 @@ func runLegacyWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *ag
 		// Stop recording
 		dialog.StopRecording()
 
-		// Reset wakeup flag
-		wakeupMutex.Lock()
-		wakeupTriggered = false
-		wakeupMutex.Unlock()
+		if interrupted {
+			pendingWakeup = true
+			continue
+		}
 
 		log.Println("[ready] Waiting for next wakeup event...")
 	}
@@ -813,10 +813,23 @@ func processAudioUntilUtterance(dialog audioDialogRunner, runtime *agent.Runtime
 }
 
 func processAudioUntilUtteranceWithTimeout(dialog audioDialogRunner, runtime *agent.Runtime, ctx context.Context, sigChan chan os.Signal, listenTimeout time.Duration) bool {
+	exit, _ := processAudioUntilUtteranceWithWakeupInterrupt(dialog, runtime, ctx, sigChan, nil, false, listenTimeout)
+	return exit
+}
+
+func processAudioUntilUtteranceWithWakeupInterrupt(
+	dialog audioDialogRunner,
+	runtime *agent.Runtime,
+	ctx context.Context,
+	sigChan chan os.Signal,
+	wakeupEvents <-chan struct{},
+	interruptOnWakeup bool,
+	listenTimeout time.Duration,
+) (bool, bool) {
 	frameSamples := dialog.VADFrameSamples()
 	if frameSamples <= 0 {
 		log.Printf("[listen] invalid VAD frame size: %d\n", frameSamples)
-		return false
+		return false, false
 	}
 
 	vadPending := make([]int16, 0, frameSamples*10)
@@ -830,9 +843,10 @@ func processAudioUntilUtteranceWithTimeout(dialog audioDialogRunner, runtime *ag
 		// Read audio chunk
 		select {
 		case <-sigChan:
-			return true
+			return true, false
 		default:
 		}
+		drainWakeupEventsWhileListening(wakeupEvents)
 
 		if listenTimeout > 0 && time.Since(startedAt) >= listenTimeout {
 			log.Printf("[listen] No complete utterance within %s, stopping recording\n", listenTimeout)
@@ -841,17 +855,18 @@ func processAudioUntilUtteranceWithTimeout(dialog audioDialogRunner, runtime *ag
 				if err := dialog.StopRecording(); err != nil {
 					log.Printf("[listen] stop recording before timeout utterance: %v\n", err)
 				}
-				if err := dialog.ProcessUtterance(ctx, captured, runtime); err != nil {
-					log.Printf("[error] %v\n", err)
+				exit, interrupted := processUtteranceWithWakeupInterrupt(dialog, runtime, ctx, captured, sigChan, wakeupEvents, interruptOnWakeup)
+				if exit || interrupted {
+					return exit, interrupted
 				}
 			}
-			return false
+			return false, false
 		}
 
 		chunk, err := dialog.ReadRecordChunk(200)
 		if err != nil {
 			log.Printf("[listen] read_record_chunk error: %v\n", err)
-			return false
+			return false, false
 		}
 
 		if chunk == nil {
@@ -860,7 +875,7 @@ func processAudioUntilUtteranceWithTimeout(dialog audioDialogRunner, runtime *ag
 
 		if chunk.EndOfStream {
 			log.Println("[listen] record session closed by service")
-			return false
+			return false, false
 		}
 
 		if len(chunk.PCM) == 0 {
@@ -881,7 +896,7 @@ func processAudioUntilUtteranceWithTimeout(dialog audioDialogRunner, runtime *ag
 			consumed += frameSamples
 			if err != nil {
 				log.Printf("[vad] RKNN processing failed: %v\n", err)
-				return false
+				return false, false
 			}
 			if reporter, ok := dialog.(vadDebugReporter); ok && time.Now().After(nextVADLogAt) {
 				state := reporter.VADDebugState()
@@ -900,16 +915,88 @@ func processAudioUntilUtteranceWithTimeout(dialog audioDialogRunner, runtime *ag
 				if err := dialog.StopRecording(); err != nil {
 					log.Printf("[listen] stop recording before utterance processing: %v\n", err)
 				}
-				if err := dialog.ProcessUtterance(ctx, utterance, runtime); err != nil {
-					log.Printf("[error] %v\n", err)
-				}
-				return false
+				return processUtteranceWithWakeupInterrupt(dialog, runtime, ctx, utterance, sigChan, wakeupEvents, interruptOnWakeup)
 			}
 		}
 
 		if consumed > 0 {
 			vadPending = vadPending[consumed:]
 		}
+	}
+}
+
+func drainWakeupEventsWhileListening(wakeupEvents <-chan struct{}) {
+	if wakeupEvents == nil {
+		return
+	}
+	drained := false
+	for {
+		select {
+		case <-wakeupEvents:
+			drained = true
+		default:
+			if drained {
+				log.Println("[listen] duplicate wakeup received while listening, ignoring")
+			}
+			return
+		}
+	}
+}
+
+func processUtteranceWithWakeupInterrupt(
+	dialog audioDialogRunner,
+	runtime *agent.Runtime,
+	ctx context.Context,
+	utterance []int16,
+	sigChan chan os.Signal,
+	wakeupEvents <-chan struct{},
+	interruptOnWakeup bool,
+) (bool, bool) {
+	if wakeupEvents == nil {
+		if err := dialog.ProcessUtterance(ctx, utterance, runtime); err != nil {
+			log.Printf("[error] %v\n", err)
+		}
+		return false, false
+	}
+
+	turnCtx, cancel := context.WithCancel(ctx)
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- dialog.ProcessUtterance(turnCtx, utterance, runtime)
+	}()
+
+	for {
+		select {
+		case <-sigChan:
+			cancel()
+			waitForLegacyUtteranceCancel(resultCh)
+			return true, false
+		case <-wakeupEvents:
+			if interruptOnWakeup {
+				log.Println("[interrupt] wakeup received during legacy turn, canceling current turn")
+				cancel()
+				waitForLegacyUtteranceCancel(resultCh)
+				return false, true
+			}
+			log.Println("[interrupt] wakeup received during legacy turn, ignoring because interrupt is disabled")
+		case err := <-resultCh:
+			cancel()
+			if err != nil && !errors.Is(err, context.Canceled) {
+				log.Printf("[error] %v\n", err)
+			}
+			return false, false
+		}
+	}
+}
+
+func waitForLegacyUtteranceCancel(resultCh <-chan error) {
+	select {
+	case err := <-resultCh:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Printf("[error] %v\n", err)
+		}
+	case <-time.After(voiceTurnCancelWaitTimeout):
+		log.Println("[interrupt] legacy turn did not finish after cancellation; continuing")
 	}
 }
 

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -313,9 +313,7 @@ func runManualMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Ru
 			recording = true
 
 			manualStop = make(chan manualStopResult, 1)
-			var loopCtx context.Context
-			loopCtx, cancelRecording = context.WithCancel(ctx)
-			go processAudioLoop(dialog, runtime, loopCtx, manualStop)
+			cancelRecording = startManualAudioLoop(ctx, dialog, runtime, manualStop)
 		} else {
 			if !scanner.Scan() {
 				break
@@ -357,11 +355,18 @@ func runManualMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Ru
 	if recording {
 		if cancelRecording != nil {
 			cancelRecording()
+			cancelRecording = nil
 		}
 		dialog.StopRecording()
 	}
 
 	log.Println("\n[exit] Stopped.")
+}
+
+func startManualAudioLoop(ctx context.Context, dialog audioDialogRunner, runtime *agent.Runtime, manualStop chan<- manualStopResult) context.CancelFunc {
+	loopCtx, cancel := context.WithCancel(ctx)
+	go processAudioLoop(dialog, runtime, loopCtx, manualStop)
+	return cancel
 }
 
 func runWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Runtime, sigChan chan os.Signal, newWatcher wakeupWatcherFactory) {

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -271,9 +271,9 @@ const (
 )
 
 type voiceTurnResult struct {
-	interrupted    bool
-	sleepRequested bool
-	exit           bool
+	interrupted            bool
+	waitForWakeupRequested bool
+	exit                   bool
 }
 
 func runManualMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Runtime, sigChan chan os.Signal) {
@@ -516,8 +516,8 @@ func runVoiceSession(cfg agent.Config, dialog audioDialogRunner, runtime *agent.
 			return true
 		}
 		firstTurn = false
-		if result.sleepRequested {
-			log.Println("[session] agent requested sleep, closing voice session")
+		if result.waitForWakeupRequested {
+			log.Println("[session] agent requested wakeup wait, closing voice session")
 			return false
 		}
 		if result.interrupted {
@@ -589,8 +589,8 @@ thinking:
 
 	dialog.PersistVoiceTurn(input, result, utterance)
 
-	if result.SleepRequested {
-		return voiceTurnResult{sleepRequested: true}
+	if result.WaitForWakeupRequested {
+		return voiceTurnResult{waitForWakeupRequested: true}
 	}
 
 	speechText := result.SpokenTextForConfig(cfg)

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -377,14 +377,10 @@ func runWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Ru
 
 	log.Printf("\n[ready] Starting GPIO wakeup listeners on %s...", wakeupGPIOPinsLabel())
 
-	events := make(chan voiceEvent, 8)
+	events := make(chan voiceEvent, 1)
 
 	watchers, err := startWakeupWatchers(newWatcher, func() {
-		select {
-		case events <- voiceEventWakeup:
-		default:
-			log.Println("[wakeup] event queue full, dropping GPIO wakeup event")
-		}
+		signalVoiceWakeupEvent(events)
 	})
 	if err != nil {
 		log.Printf("[error] Failed to start GPIO wakeup listeners: %v\n", err)
@@ -414,14 +410,10 @@ func runLegacyWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *ag
 	log.Printf("\n[ready] Starting GPIO wakeup listeners on %s...", wakeupGPIOPinsLabel())
 
 	ctx := context.Background()
-	wakeupEvents := make(chan struct{}, 8)
+	wakeupEvents := make(chan struct{}, 1)
 
 	watchers, err := startWakeupWatchers(newWatcher, func() {
-		select {
-		case wakeupEvents <- struct{}{}:
-		default:
-			log.Println("[wakeup] event queue full, dropping GPIO wakeup event")
-		}
+		signalWakeupEvent(wakeupEvents)
 	})
 	if err != nil {
 		log.Printf("[error] Failed to start GPIO wakeup listeners: %v\n", err)
@@ -480,6 +472,22 @@ func runLegacyWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *ag
 		}
 
 		log.Println("[ready] Waiting for next wakeup event...")
+	}
+}
+
+func signalVoiceWakeupEvent(events chan<- voiceEvent) {
+	select {
+	case events <- voiceEventWakeup:
+	default:
+		log.Println("[wakeup] pending wakeup already queued, coalescing duplicate GPIO wakeup event")
+	}
+}
+
+func signalWakeupEvent(wakeupEvents chan<- struct{}) {
+	select {
+	case wakeupEvents <- struct{}{}:
+	default:
+		log.Println("[wakeup] pending wakeup already queued, coalescing duplicate GPIO wakeup event")
 	}
 }
 

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -818,6 +818,7 @@ func processAudioUntilUtterance(dialog audioDialogRunner, runtime *agent.Runtime
 }
 
 func processAudioUntilUtteranceWithTimeout(dialog audioDialogRunner, runtime *agent.Runtime, ctx context.Context, sigChan chan os.Signal, listenTimeout time.Duration) bool {
+	// Wakeup interruption is disabled when wakeupEvents is nil, so interrupted is always false here.
 	exit, _ := processAudioUntilUtteranceWithWakeupInterrupt(dialog, runtime, ctx, sigChan, nil, false, listenTimeout)
 	return exit
 }
@@ -934,14 +935,14 @@ func drainWakeupEventsWhileListening(wakeupEvents <-chan struct{}) {
 	if wakeupEvents == nil {
 		return
 	}
-	drained := false
+	drainedCount := 0
 	for {
 		select {
 		case <-wakeupEvents:
-			drained = true
+			drainedCount++
 		default:
-			if drained {
-				log.Println("[listen] duplicate wakeup received while listening, ignoring")
+			if drainedCount > 0 {
+				log.Printf("[listen] %d duplicate wakeup(s) received while listening, ignoring", drainedCount)
 			}
 			return
 		}

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -20,7 +20,9 @@ type fakeAudioDialog struct {
 	vad                *agent.AudioVAD
 	utterance          []int16
 	utterancesToReturn [][]int16
+	onStart            func(*fakeAudioDialog)
 	onUtterance        func()
+	processUtterance   func(context.Context, []int16, *agent.Runtime) error
 	utterances         [][]int16
 	prepareTurnInput   func([]int16) (agent.TurnInput, error)
 	runTurn            func(context.Context) (agent.RunResult, error)
@@ -51,6 +53,9 @@ func (d *fakeAudioDialog) StartRecording() error {
 	d.ops = append(d.ops, "start")
 	d.starts++
 	d.recordingActive = true
+	if d.onStart != nil {
+		d.onStart(d)
+	}
 	if len(d.chunkBatches) > 0 {
 		d.chunks = d.chunkBatches[0]
 		d.chunkBatches = d.chunkBatches[1:]
@@ -113,6 +118,9 @@ func (d *fakeAudioDialog) ProcessUtterance(ctx context.Context, utterance []int1
 	d.utterances = append(d.utterances, append([]int16(nil), utterance...))
 	if d.onUtterance != nil {
 		d.onUtterance()
+	}
+	if d.processUtterance != nil {
+		return d.processUtterance(ctx, utterance, runtime)
 	}
 	return nil
 }
@@ -719,6 +727,72 @@ func TestRunWakeupModeStartsNewRecordingForNextWakeup(t *testing.T) {
 	}
 	if len(dialog.utterances) != 2 {
 		t.Fatalf("utterances = %d, want 2", len(dialog.utterances))
+	}
+}
+
+func TestRunWakeupModeLegacyWakeupInterruptsProcessing(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	watcher := &fakeWakeupWatcher{fireOnStart: true}
+	processingStarted := make(chan struct{})
+	ctxCanceled := make(chan struct{})
+	secondStart := make(chan struct{})
+	voiceSessionDisabled := false
+	var dialog *fakeAudioDialog
+	dialog = &fakeAudioDialog{
+		frameSamples: 2,
+		chunks: []*agent.AudioChunkResult{
+			{PCM: pcm16BytesFromSamples(100, 200)},
+		},
+		utterance: []int16{100, 200},
+		onStart: func(d *fakeAudioDialog) {
+			if d.starts == 2 {
+				close(secondStart)
+				sigChan <- syscall.SIGTERM
+			}
+		},
+		processUtterance: func(ctx context.Context, utterance []int16, runtime *agent.Runtime) error {
+			close(processingStarted)
+			select {
+			case <-ctx.Done():
+				close(ctxCanceled)
+				return ctx.Err()
+			case <-time.After(150 * time.Millisecond):
+				sigChan <- syscall.SIGTERM
+				return errors.New("legacy wakeup did not cancel utterance processing")
+			}
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		runWakeupMode(agent.Config{InputMode: "stt", VoiceFollowupEnabled: &voiceSessionDisabled}, dialog, nil, sigChan, func(pin int, callback func()) (wakeupWatcher, error) {
+			watcher.callback = callback
+			return watcher, nil
+		})
+		close(done)
+	}()
+
+	select {
+	case <-processingStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("legacy wakeup mode did not start utterance processing")
+	}
+	watcher.callback()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runWakeupMode did not stop after interrupted legacy wakeup")
+	}
+	select {
+	case <-ctxCanceled:
+	default:
+		t.Fatal("legacy utterance context was not canceled by wakeup")
+	}
+	select {
+	case <-secondStart:
+	default:
+		t.Fatal("legacy wakeup interrupt did not trigger the next recording")
 	}
 }
 

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -1005,7 +1005,7 @@ func TestRunVoiceSessionPersistsCompletedTurn(t *testing.T) {
 	}
 }
 
-func TestRunVoiceSessionClosesWhenAgentRequestsSleep(t *testing.T) {
+func TestRunVoiceSessionClosesWhenAgentRequestsWaitForWakeup(t *testing.T) {
 	sigChan := make(chan os.Signal, 1)
 	dialog := &fakeAudioDialog{
 		frameSamples: 2,
@@ -1016,7 +1016,7 @@ func TestRunVoiceSessionClosesWhenAgentRequestsSleep(t *testing.T) {
 			{100, 200},
 		},
 		runTurn: func(ctx context.Context) (agent.RunResult, error) {
-			return agent.RunResult{Output: "我先休眠，等下次唤醒。", SleepRequested: true}, nil
+			return agent.RunResult{Output: "我先待命，等下次唤醒。", WaitForWakeupRequested: true}, nil
 		},
 	}
 
@@ -1028,7 +1028,7 @@ func TestRunVoiceSessionClosesWhenAgentRequestsSleep(t *testing.T) {
 		t.Fatalf("dialog starts = %d, want one recording for the single voice turn", dialog.starts)
 	}
 	if len(dialog.spoken) != 0 {
-		t.Fatalf("spoken = %#v, want no final reply after sleep request", dialog.spoken)
+		t.Fatalf("spoken = %#v, want no final reply after wait-for-wakeup request", dialog.spoken)
 	}
 }
 
@@ -1095,8 +1095,8 @@ func TestRunVoiceTurnSignalWaitsForThinkingGoroutine(t *testing.T) {
 	}()
 
 	result := runVoiceTurn(agent.Config{}, dialog, nil, []int16{1}, sigChan, events)
-	if result.interrupted || result.sleepRequested || !result.exit {
-		t.Fatalf("runVoiceTurn = interrupted:%v sleep:%v exit:%v, want false false true", result.interrupted, result.sleepRequested, result.exit)
+	if result.interrupted || result.waitForWakeupRequested || !result.exit {
+		t.Fatalf("runVoiceTurn = interrupted:%v wait:%v exit:%v, want false false true", result.interrupted, result.waitForWakeupRequested, result.exit)
 	}
 	select {
 	case <-ctxCanceled:
@@ -1128,8 +1128,8 @@ func TestRunVoiceTurnSignalWaitsForSpeakingGoroutine(t *testing.T) {
 	}()
 
 	result := runVoiceTurn(agent.Config{}, dialog, nil, []int16{1}, sigChan, events)
-	if result.interrupted || result.sleepRequested || !result.exit {
-		t.Fatalf("runVoiceTurn = interrupted:%v sleep:%v exit:%v, want false false true", result.interrupted, result.sleepRequested, result.exit)
+	if result.interrupted || result.waitForWakeupRequested || !result.exit {
+		t.Fatalf("runVoiceTurn = interrupted:%v wait:%v exit:%v, want false false true", result.interrupted, result.waitForWakeupRequested, result.exit)
 	}
 	select {
 	case <-ctxCanceled:
@@ -1339,8 +1339,8 @@ func TestRunVoiceTurnPersistsCompletedResultReturnedDuringWakeupInterrupt(t *tes
 	}()
 
 	result := runVoiceTurn(agent.Config{}, dialog, nil, []int16{100, 200}, sigChan, events)
-	if !result.interrupted || result.exit || result.sleepRequested {
-		t.Fatalf("runVoiceTurn = interrupted:%v exit:%v sleep:%v, want true false false", result.interrupted, result.exit, result.sleepRequested)
+	if !result.interrupted || result.exit || result.waitForWakeupRequested {
+		t.Fatalf("runVoiceTurn = interrupted:%v exit:%v wait:%v, want true false false", result.interrupted, result.exit, result.waitForWakeupRequested)
 	}
 	select {
 	case <-ctxCanceled:

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -443,6 +443,33 @@ func TestDrainWakeupEventsWhileListeningLogsDrainedCount(t *testing.T) {
 	}
 }
 
+func TestSignalWakeupEventCoalescesPendingEvents(t *testing.T) {
+	wakeupEvents := make(chan struct{}, 1)
+
+	signalWakeupEvent(wakeupEvents)
+	signalWakeupEvent(wakeupEvents)
+	signalWakeupEvent(wakeupEvents)
+
+	if got := len(wakeupEvents); got != 1 {
+		t.Fatalf("pending wakeup events = %d, want 1", got)
+	}
+}
+
+func TestSignalVoiceWakeupEventCoalescesPendingEvents(t *testing.T) {
+	events := make(chan voiceEvent, 1)
+
+	signalVoiceWakeupEvent(events)
+	signalVoiceWakeupEvent(events)
+	signalVoiceWakeupEvent(events)
+
+	if got := len(events); got != 1 {
+		t.Fatalf("pending voice events = %d, want 1", got)
+	}
+	if got := <-events; got != voiceEventWakeup {
+		t.Fatalf("voice event = %v, want wakeup", got)
+	}
+}
+
 func TestProcessAudioLoopStopsRecordingBeforeProcessingUtterance(t *testing.T) {
 	dialog := &fakeAudioDialog{
 		frameSamples:    2,

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
+	"log"
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -414,6 +417,29 @@ func TestProcessAudioUntilUtteranceSendsBufferedAudioAfterVADTimeout(t *testing.
 	}
 	if dialog.stops != 1 {
 		t.Fatalf("dialog stops = %d, want 1 before timeout utterance processing", dialog.stops)
+	}
+}
+
+func TestDrainWakeupEventsWhileListeningLogsDrainedCount(t *testing.T) {
+	wakeupEvents := make(chan struct{}, 3)
+	wakeupEvents <- struct{}{}
+	wakeupEvents <- struct{}{}
+	wakeupEvents <- struct{}{}
+
+	var logBuf bytes.Buffer
+	originalOutput := log.Writer()
+	originalFlags := log.Flags()
+	log.SetOutput(&logBuf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(originalOutput)
+		log.SetFlags(originalFlags)
+	})
+
+	drainWakeupEventsWhileListening(wakeupEvents)
+
+	if got := logBuf.String(); !strings.Contains(got, "3 duplicate wakeup(s) received while listening, ignoring") {
+		t.Fatalf("drain log = %q, want drained count", got)
 	}
 }
 

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -497,7 +497,7 @@ func (d *AudioDialog) HandleRunEvent(ctx context.Context, event RunEvent) {
 		d.currentProgressSpeaker().Schedule(ctx, text)
 		return
 	}
-	if event.Type != runEventToolCall || !d.config.VoiceToolCallSpeechOrDefault() || event.ToolName == "enter_sleep" {
+	if event.Type != runEventToolCall || !d.config.VoiceToolCallSpeechOrDefault() || event.ToolName == toolWaitForWakeup {
 		return
 	}
 	// Tool-call speech is only the explicit LLM-generated speech field; do not

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -329,7 +329,7 @@ func TestAudioDialogSpeaksToolDescriptionAsynchronously(t *testing.T) {
 	}
 }
 
-func TestAudioDialogDoesNotSpeakEnterSleepToolDescription(t *testing.T) {
+func TestAudioDialogDoesNotSpeakWaitForWakeupToolDescription(t *testing.T) {
 	toolSpeech := true
 	provider := &recordingTTSProvider{name: "dialog-provider"}
 	dialog := &AudioDialog{
@@ -342,8 +342,8 @@ func TestAudioDialogDoesNotSpeakEnterSleepToolDescription(t *testing.T) {
 
 	dialog.HandleRunEvent(context.Background(), RunEvent{
 		Type:        runEventToolCall,
-		ToolName:    "enter_sleep",
-		Description: "用户让我休息，我准备进入睡眠模式。",
+		ToolName:    "wait_for_wakeup",
+		Description: "用户让我休息，我准备回到等待唤醒状态。",
 	})
 
 	assertNoProviderTextWithin(t, provider, 200*time.Millisecond)
@@ -495,11 +495,11 @@ func TestProgressSpeakerCancelDropsPending(t *testing.T) {
 	}
 }
 
-func TestAudioDialogStreamingSpeechErrorDoesNotHideSleepRequest(t *testing.T) {
+func TestAudioDialogStreamingSpeechErrorDoesNotHideWaitForWakeupRequest(t *testing.T) {
 	model := &scriptedModel{
-		responses: roleToolResponses("enter_sleep", `{"__arg1":"{\"reason\":\"user asked\"}"}`, "I will wait for the next wakeup."),
+		responses: roleToolResponses("wait_for_wakeup", `{"__arg1":"{\"reason\":\"user asked\"}"}`, "I will wait for the next wakeup."),
 	}
-	controller := NewSleepController()
+	controller := NewWaitForWakeupController()
 	runtime := NewRuntimeWithDeps(
 		Config{
 			Model:       ModelConfig{Provider: "fake"},
@@ -508,7 +508,7 @@ func TestAudioDialogStreamingSpeechErrorDoesNotHideSleepRequest(t *testing.T) {
 		&testModelResolver{model: model},
 		NewMemoryManager(""),
 		&ToolSet{tools: map[string]langtools.Tool{
-			"enter_sleep": NewEnterSleepTool(controller),
+			"wait_for_wakeup": NewWaitForWakeupTool(controller),
 		}},
 		NewSkillIndex(),
 	)
@@ -525,8 +525,8 @@ func TestAudioDialogStreamingSpeechErrorDoesNotHideSleepRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunAgentTurn() error = %v", err)
 	}
-	if !result.SleepRequested {
-		t.Fatal("SleepRequested = false, want true even when streaming speech fails")
+	if !result.WaitForWakeupRequested {
+		t.Fatal("WaitForWakeupRequested = false, want true even when streaming speech fails")
 	}
 	if result.SpeechStreamed {
 		t.Fatal("SpeechStreamed = true, want false when TTS playback failed before successful speech")

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -342,8 +342,9 @@ func TestAudioDialogDoesNotSpeakWaitForWakeupToolDescription(t *testing.T) {
 
 	dialog.HandleRunEvent(context.Background(), RunEvent{
 		Type:        runEventToolCall,
-		ToolName:    "wait_for_wakeup",
+		ToolName:    toolWaitForWakeup,
 		Description: "用户让我休息，我准备回到等待唤醒状态。",
+		Speech:      "我准备回到等待唤醒状态。",
 	})
 
 	assertNoProviderTextWithin(t, provider, 200*time.Millisecond)

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -303,7 +303,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					state.noteDefaultToolCallAndMaybeTodoReminder()
 				}
 				if turn.Kind == plannerTurnSleep {
-					answer := enterSleepFinalAnswer(turn.Step)
+					answer := waitForWakeupFinalAnswer(turn.Step)
 					if e.Recorder != nil {
 						e.Recorder.RecordDefaultFinish(answer)
 					}
@@ -341,7 +341,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					}
 				}
 				if turn.Kind == executorTurnSleep {
-					answer := enterSleepFinalAnswer(turn.Step)
+					answer := waitForWakeupFinalAnswer(turn.Step)
 					if e.Recorder != nil {
 						e.Recorder.RecordDefaultFinish(answer)
 					}
@@ -644,7 +644,7 @@ func (e *roleCollaborativeExecutor) executePlannerToolAction(
 		e.Recorder.RecordPlannerExecution(execution)
 	}
 	kind := plannerTurnTool
-	if isEnterSleepTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError {
+	if isWaitForWakeupTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError {
 		kind = plannerTurnSleep
 	}
 	return plannerTurnResult{Kind: kind, Step: &toolExecution.Step}, nil
@@ -827,7 +827,7 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 	}
 	actionCopy := toolExecution.Step.Action
 	kind := executorTurnTool
-	if isEnterSleepTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError {
+	if isWaitForWakeupTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError {
 		kind = executorTurnSleep
 	}
 	return executorTurnResult{

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -307,7 +307,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					if e.Recorder != nil {
 						e.Recorder.RecordDefaultFinish(answer)
 					}
-					return e.finishRun(ctx, answer, answer, &state)
+					return e.finishRunWithoutStreaming(ctx, answer, answer, &state)
 				}
 			}
 		case phaseExecution:
@@ -345,7 +345,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					if e.Recorder != nil {
 						e.Recorder.RecordDefaultFinish(answer)
 					}
-					return e.finishRun(ctx, answer, answer, &state)
+					return e.finishRunWithoutStreaming(ctx, answer, answer, &state)
 				}
 			case executorTurnFinishStep, executorTurnAbortStep:
 				if turn.Step != nil {
@@ -651,9 +651,19 @@ func (e *roleCollaborativeExecutor) executePlannerToolAction(
 }
 
 func (e *roleCollaborativeExecutor) finishRun(ctx context.Context, finalAnswer, log string, state *roleLoopState) (map[string]any, error) {
+	return e.finishRunWithStreaming(ctx, finalAnswer, log, state, true)
+}
+
+func (e *roleCollaborativeExecutor) finishRunWithoutStreaming(ctx context.Context, finalAnswer, log string, state *roleLoopState) (map[string]any, error) {
+	return e.finishRunWithStreaming(ctx, finalAnswer, log, state, false)
+}
+
+func (e *roleCollaborativeExecutor) finishRunWithStreaming(ctx context.Context, finalAnswer, log string, state *roleLoopState, stream bool) (map[string]any, error) {
 	finalAnswer = strings.TrimSpace(finalAnswer)
 	if e.CallbacksHandler != nil {
-		e.streamFinalAnswer(ctx, finalAnswer)
+		if stream {
+			e.streamFinalAnswer(ctx, finalAnswer)
+		}
 		e.CallbacksHandler.HandleAgentFinish(ctx, schema.AgentFinish{
 			ReturnValues: map[string]any{e.OutputKey: finalAnswer},
 			Log:          log,

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -291,7 +291,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 				if e.Recorder != nil {
 					e.Recorder.RecordLoopPhase(phaseDefault, "cancel_plan")
 				}
-			case plannerTurnTool, plannerTurnInvalidMeta:
+			case plannerTurnTool, plannerTurnInvalidMeta, plannerTurnSleep:
 				if turn.Step != nil {
 					state.ToolSteps = append(state.ToolSteps, *turn.Step)
 					state.World.UpdateFromStep(*turn.Step, len(state.ToolSteps))
@@ -301,6 +301,13 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 						return nil, err
 					}
 					state.noteDefaultToolCallAndMaybeTodoReminder()
+				}
+				if turn.Kind == plannerTurnSleep {
+					answer := enterSleepFinalAnswer(turn.Step)
+					if e.Recorder != nil {
+						e.Recorder.RecordDefaultFinish(answer)
+					}
+					return e.finishRun(ctx, answer, answer, &state)
 				}
 			}
 		case phaseExecution:
@@ -316,7 +323,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 				return nil, err
 			}
 			switch turn.Kind {
-			case executorTurnTool, executorTurnInvalidMeta:
+			case executorTurnTool, executorTurnInvalidMeta, executorTurnSleep:
 				if turn.Step != nil {
 					state.ToolSteps = append(state.ToolSteps, *turn.Step)
 					state.StepToolSteps = append(state.StepToolSteps, *turn.Step)
@@ -332,6 +339,13 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					if _, err := e.consumePendingSteer(ctx, inputs, &state); err != nil {
 						return nil, err
 					}
+				}
+				if turn.Kind == executorTurnSleep {
+					answer := enterSleepFinalAnswer(turn.Step)
+					if e.Recorder != nil {
+						e.Recorder.RecordDefaultFinish(answer)
+					}
+					return e.finishRun(ctx, answer, answer, &state)
 				}
 			case executorTurnFinishStep, executorTurnAbortStep:
 				if turn.Step != nil {
@@ -629,7 +643,11 @@ func (e *roleCollaborativeExecutor) executePlannerToolAction(
 	if e.Recorder != nil {
 		e.Recorder.RecordPlannerExecution(execution)
 	}
-	return plannerTurnResult{Kind: plannerTurnTool, Step: &toolExecution.Step}, nil
+	kind := plannerTurnTool
+	if isEnterSleepTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError {
+		kind = plannerTurnSleep
+	}
+	return plannerTurnResult{Kind: kind, Step: &toolExecution.Step}, nil
 }
 
 func (e *roleCollaborativeExecutor) finishRun(ctx context.Context, finalAnswer, log string, state *roleLoopState) (map[string]any, error) {
@@ -808,8 +826,12 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 		return executorTurnResult{}, toolExecution.Error
 	}
 	actionCopy := toolExecution.Step.Action
+	kind := executorTurnTool
+	if isEnterSleepTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError {
+		kind = executorTurnSleep
+	}
 	return executorTurnResult{
-		Kind:   executorTurnTool,
+		Kind:   kind,
 		Action: &actionCopy,
 		Step:   &toolExecution.Step,
 	}, nil

--- a/src/agent/internal/agent/role_loop.go
+++ b/src/agent/internal/agent/role_loop.go
@@ -29,6 +29,7 @@ const (
 	plannerTurnSetTodo
 	plannerTurnCancelPlan
 	plannerTurnInvalidMeta
+	plannerTurnSleep
 )
 
 type plannerTurnResult struct {
@@ -65,6 +66,7 @@ const (
 	executorTurnFinishStep
 	executorTurnAbortStep
 	executorTurnInvalidMeta
+	executorTurnSleep
 )
 
 type executorTurnResult struct {
@@ -102,6 +104,39 @@ func plannerPlanModeToolRejectedTurn(action schema.AgentAction) plannerTurnResul
 
 func toolNameEqual(got, want string) bool {
 	return strings.EqualFold(strings.TrimSpace(got), strings.TrimSpace(want))
+}
+
+func isEnterSleepTool(name string) bool {
+	return toolNameEqual(name, toolEnterSleep)
+}
+
+func enterSleepFinalAnswer(step *schema.AgentStep) string {
+	if step != nil {
+		if speech := toolSpeechFromAction(step.Action); speech != "" {
+			return speech
+		}
+		if description := toolDescriptionFromAction(step.Action); description != "" {
+			return description
+		}
+		if message := toolObservationMessage(step.Observation); message != "" {
+			return message
+		}
+	}
+	return "I will wait for the next wakeup."
+}
+
+func toolObservationMessage(observation string) string {
+	observation = strings.TrimSpace(observation)
+	if observation == "" || !strings.HasPrefix(observation, "{") {
+		return ""
+	}
+	var payload struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(observation), &payload); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(payload.Message)
 }
 
 func (s roleLoopState) canAcceptPlannerFinal(answer string) bool {

--- a/src/agent/internal/agent/role_loop.go
+++ b/src/agent/internal/agent/role_loop.go
@@ -118,6 +118,9 @@ func waitForWakeupFinalAnswer(step *schema.AgentStep) string {
 		if description := toolDescriptionFromAction(step.Action); description != "" {
 			return description
 		}
+		if message := toolObservationMessage(step.Observation); message != "" {
+			return message
+		}
 	}
 	return "I will wait for the next wakeup."
 }

--- a/src/agent/internal/agent/role_loop.go
+++ b/src/agent/internal/agent/role_loop.go
@@ -106,20 +106,17 @@ func toolNameEqual(got, want string) bool {
 	return strings.EqualFold(strings.TrimSpace(got), strings.TrimSpace(want))
 }
 
-func isEnterSleepTool(name string) bool {
-	return toolNameEqual(name, toolEnterSleep)
+func isWaitForWakeupTool(name string) bool {
+	return toolNameEqual(name, toolWaitForWakeup)
 }
 
-func enterSleepFinalAnswer(step *schema.AgentStep) string {
+func waitForWakeupFinalAnswer(step *schema.AgentStep) string {
 	if step != nil {
 		if speech := toolSpeechFromAction(step.Action); speech != "" {
 			return speech
 		}
 		if description := toolDescriptionFromAction(step.Action); description != "" {
 			return description
-		}
-		if message := toolObservationMessage(step.Observation); message != "" {
-			return message
 		}
 	}
 	return "I will wait for the next wakeup."

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -114,6 +114,9 @@ func (r RunResult) SpokenText() string {
 }
 
 func (r RunResult) SpokenTextForConfig(cfg Config) string {
+	if r.WaitForWakeupRequested {
+		return ""
+	}
 	if !cfg.VoiceSpeechSummaryEnabledOrDefault() {
 		return strings.TrimSpace(r.Output)
 	}

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -48,7 +48,7 @@ type Runtime struct {
 	mergeWorker        *MergeWorker
 	logger             *Logger
 	profileDebouncer   *ProfileDebouncer
-	sleep              *SleepController
+	waitForWakeup      *WaitForWakeupController
 	memoryPlane        MemoryPlane
 	sessionManager     SessionManager
 	telemetrySessionID string
@@ -78,15 +78,15 @@ type RunRequest struct {
 }
 
 type RunResult struct {
-	Output         string          `json:"output"`
-	SpeechText     string          `json:"-"`
-	Skills         []string        `json:"skills"`
-	EpisodeID      string          `json:"episode_id,omitempty"`
-	Memory         []MessageRecord `json:"memory,omitempty"`
-	Metrics        *RunMetrics     `json:"metrics,omitempty"`
-	SleepRequested bool            `json:"sleep_requested,omitempty"`
-	SleepReason    string          `json:"sleep_reason,omitempty"`
-	SpeechStreamed bool            `json:"-"`
+	Output                 string          `json:"output"`
+	SpeechText             string          `json:"-"`
+	Skills                 []string        `json:"skills"`
+	EpisodeID              string          `json:"episode_id,omitempty"`
+	Memory                 []MessageRecord `json:"memory,omitempty"`
+	Metrics                *RunMetrics     `json:"metrics,omitempty"`
+	WaitForWakeupRequested bool            `json:"wait_for_wakeup_requested,omitempty"`
+	WaitForWakeupReason    string          `json:"wait_for_wakeup_reason,omitempty"`
+	SpeechStreamed         bool            `json:"-"`
 }
 
 func canonicalTurnInputFromRunRequest(req RunRequest) TurnInput {
@@ -270,7 +270,7 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 		memoryDir = filepath.Join(cfg.ConfigDir, "memory")
 	}
 
-	sleepController := NewSleepController()
+	waitForWakeupController := NewWaitForWakeupController()
 	proxy := ProxyConfigFromEnvironment()
 	if err := proxy.Validate(); err != nil {
 		return nil, fmt.Errorf("proxy environment: %w", err)
@@ -280,7 +280,7 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 		cfg,
 		proxy,
 		mobileGymStore,
-		WithSleepController(sleepController),
+		WithWaitForWakeupController(waitForWakeupController),
 		WithScreenStableDefaults(cfg.ScreenStableDefaults()),
 	)
 	extractionCfg := LoadMemoryExtractionConfig(cfg.ConfigDir)
@@ -318,7 +318,7 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 	}
 	rt.logger = logger
 	rt.profileDebouncer = debouncer
-	rt.sleep = sleepController
+	rt.waitForWakeup = waitForWakeupController
 	rt.mobileGym = mobileGymStore
 
 	if len(mergeNeeded) > 0 && cfg.SkillMergeModel != nil {
@@ -338,11 +338,11 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 }
 
 func NewRuntimeWithDeps(cfg Config, models ModelResolver, memories *MemoryManager, tools *ToolSet, skillIndex *SkillIndex) *Runtime {
-	sleepController := NewSleepController()
+	waitForWakeupController := NewWaitForWakeupController()
 	if tools != nil {
-		if tool, ok := tools.Get("enter_sleep"); ok {
-			if sleepTool, ok := tool.(*EnterSleepTool); ok && sleepTool.controller != nil {
-				sleepController = sleepTool.controller
+		if tool, ok := tools.Get(toolWaitForWakeup); ok {
+			if waitTool, ok := tool.(*WaitForWakeupTool); ok && waitTool.controller != nil {
+				waitForWakeupController = waitTool.controller
 			}
 		}
 	}
@@ -357,7 +357,7 @@ func NewRuntimeWithDeps(cfg Config, models ModelResolver, memories *MemoryManage
 		tools:              tools,
 		skills:             skillManager,
 		skillsLoaded:       skillIndex != nil && len(skillIndex.Names()) > 0,
-		sleep:              sleepController,
+		waitForWakeup:      waitForWakeupController,
 		telemetrySessionID: uuid.NewString(),
 		mobileGym:          &mobileGymSessionStore{},
 	}
@@ -474,8 +474,8 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	metrics := &RunMetrics{}
 	turnInput := canonicalTurnInputFromRunRequest(req)
 	normalizedInput := turnInput.InputText
-	if r.sleep != nil {
-		r.sleep.Consume()
+	if r.waitForWakeup != nil {
+		r.waitForWakeup.Consume()
 	}
 
 	if r.logger != nil {
@@ -697,19 +697,19 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, nil, promptCapture, boundaryTelemetry)
 
-	sleepRequested, sleepReason := false, ""
-	if r.sleep != nil {
-		sleepRequested, sleepReason = r.sleep.Consume()
+	waitForWakeupRequested, waitForWakeupReason := false, ""
+	if r.waitForWakeup != nil {
+		waitForWakeupRequested, waitForWakeupReason = r.waitForWakeup.Consume()
 	}
 	return RunResult{
-		Output:         output,
-		SpeechText:     speechText,
-		Skills:         runSkills.GetActivatedSkills(),
-		EpisodeID:      episodeID,
-		Memory:         commitResult.Memory,
-		Metrics:        metrics,
-		SleepRequested: sleepRequested,
-		SleepReason:    sleepReason,
+		Output:                 output,
+		SpeechText:             speechText,
+		Skills:                 runSkills.GetActivatedSkills(),
+		EpisodeID:              episodeID,
+		Memory:                 commitResult.Memory,
+		Metrics:                metrics,
+		WaitForWakeupRequested: waitForWakeupRequested,
+		WaitForWakeupReason:    waitForWakeupReason,
 	}, nil
 }
 

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -86,7 +86,11 @@ type RunResult struct {
 	Metrics                *RunMetrics     `json:"metrics,omitempty"`
 	WaitForWakeupRequested bool            `json:"wait_for_wakeup_requested,omitempty"`
 	WaitForWakeupReason    string          `json:"wait_for_wakeup_reason,omitempty"`
-	SpeechStreamed         bool            `json:"-"`
+	// Deprecated: use WaitForWakeupRequested.
+	SleepRequested bool `json:"sleep_requested,omitempty"`
+	// Deprecated: use WaitForWakeupReason.
+	SleepReason    string `json:"sleep_reason,omitempty"`
+	SpeechStreamed bool   `json:"-"`
 }
 
 func canonicalTurnInputFromRunRequest(req RunRequest) TurnInput {
@@ -713,6 +717,8 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		Metrics:                metrics,
 		WaitForWakeupRequested: waitForWakeupRequested,
 		WaitForWakeupReason:    waitForWakeupReason,
+		SleepRequested:         waitForWakeupRequested,
+		SleepReason:            waitForWakeupReason,
 	}, nil
 }
 

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -79,18 +79,18 @@ func TestRuntimeRun(t *testing.T) {
 	}
 }
 
-func TestRuntimeRunEnterSleepTerminatesRoleLoop(t *testing.T) {
+func TestRuntimeRunWaitForWakeupTerminatesRoleLoop(t *testing.T) {
 	model := &scriptedModel{responses: []*llms.ContentResponse{
-		toolCallResponse("sleep_1", "enter_sleep", `{"reason":"user asked"}`),
-		toolCallResponse("sleep_2", "enter_sleep", `{"reason":"still awake"}`),
+		toolCallResponse("wait_1", "wait_for_wakeup", `{"reason":"user asked"}`),
+		toolCallResponse("wait_2", "wait_for_wakeup", `{"reason":"still awake"}`),
 	}}
-	controller := NewSleepController()
+	controller := NewWaitForWakeupController()
 	runtime := NewRuntimeWithDeps(
 		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Use tools.", MaxIterations: 2},
 		&testModelResolver{model: model},
 		NewMemoryManager(""),
 		&ToolSet{tools: map[string]langtools.Tool{
-			"enter_sleep": NewEnterSleepTool(controller),
+			"wait_for_wakeup": NewWaitForWakeupTool(controller),
 		}},
 		NewSkillIndex(),
 	)
@@ -99,14 +99,17 @@ func TestRuntimeRunEnterSleepTerminatesRoleLoop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if !result.SleepRequested {
-		t.Fatal("SleepRequested = false, want true")
+	if !result.WaitForWakeupRequested {
+		t.Fatal("WaitForWakeupRequested = false, want true")
 	}
-	if result.SleepReason != "user asked" {
-		t.Fatalf("SleepReason = %q, want user asked", result.SleepReason)
+	if result.WaitForWakeupReason != "user asked" {
+		t.Fatalf("WaitForWakeupReason = %q, want user asked", result.WaitForWakeupReason)
+	}
+	if result.Output != "I will wait for the next wakeup." {
+		t.Fatalf("Output = %q, want wait-for-wakeup final answer", result.Output)
 	}
 	if model.callCount != 1 {
-		t.Fatalf("model call count = %d, want role loop to stop after enter_sleep", model.callCount)
+		t.Fatalf("model call count = %d, want role loop to stop after wait_for_wakeup", model.callCount)
 	}
 }
 

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -80,6 +80,7 @@ func TestRuntimeRun(t *testing.T) {
 }
 
 func TestRuntimeRunWaitForWakeupTerminatesRoleLoop(t *testing.T) {
+	const wakeupMessage = "The current agent run is ending now, and the voice interaction will wait for the next wakeup event."
 	model := &scriptedModel{responses: []*llms.ContentResponse{
 		toolCallResponse("wait_1", "wait_for_wakeup", `{"reason":"user asked"}`),
 		toolCallResponse("wait_2", "wait_for_wakeup", `{"reason":"still awake"}`),
@@ -105,8 +106,28 @@ func TestRuntimeRunWaitForWakeupTerminatesRoleLoop(t *testing.T) {
 	if result.WaitForWakeupReason != "user asked" {
 		t.Fatalf("WaitForWakeupReason = %q, want user asked", result.WaitForWakeupReason)
 	}
-	if result.Output != "I will wait for the next wakeup." {
-		t.Fatalf("Output = %q, want wait-for-wakeup final answer", result.Output)
+	if !result.SleepRequested {
+		t.Fatal("SleepRequested = false, want deprecated alias to mirror WaitForWakeupRequested")
+	}
+	if result.SleepReason != "user asked" {
+		t.Fatalf("SleepReason = %q, want deprecated alias to mirror WaitForWakeupReason", result.SleepReason)
+	}
+	if result.Output != wakeupMessage {
+		t.Fatalf("Output = %q, want wait-for-wakeup observation message", result.Output)
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("Marshal RunResult: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatalf("Unmarshal RunResult JSON: %v", err)
+	}
+	if payload["wait_for_wakeup_requested"] != true || payload["sleep_requested"] != true {
+		t.Fatalf("RunResult JSON missing wakeup aliases: %s", encoded)
+	}
+	if payload["wait_for_wakeup_reason"] != "user asked" || payload["sleep_reason"] != "user asked" {
+		t.Fatalf("RunResult JSON missing wakeup reason aliases: %s", encoded)
 	}
 	if model.callCount != 1 {
 		t.Fatalf("model call count = %d, want role loop to stop after wait_for_wakeup", model.callCount)

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -79,6 +79,37 @@ func TestRuntimeRun(t *testing.T) {
 	}
 }
 
+func TestRuntimeRunEnterSleepTerminatesRoleLoop(t *testing.T) {
+	model := &scriptedModel{responses: []*llms.ContentResponse{
+		toolCallResponse("sleep_1", "enter_sleep", `{"reason":"user asked"}`),
+		toolCallResponse("sleep_2", "enter_sleep", `{"reason":"still awake"}`),
+	}}
+	controller := NewSleepController()
+	runtime := NewRuntimeWithDeps(
+		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Use tools.", MaxIterations: 2},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"enter_sleep": NewEnterSleepTool(controller),
+		}},
+		NewSkillIndex(),
+	)
+
+	result, err := runtime.Run(context.Background(), RunRequest{Input: "go to sleep"})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !result.SleepRequested {
+		t.Fatal("SleepRequested = false, want true")
+	}
+	if result.SleepReason != "user asked" {
+		t.Fatalf("SleepReason = %q, want user asked", result.SleepReason)
+	}
+	if model.callCount != 1 {
+		t.Fatalf("model call count = %d, want role loop to stop after enter_sleep", model.callCount)
+	}
+}
+
 func TestRuntimeRunInjectsCurrentDateIntoPlannerPrompt(t *testing.T) {
 	originalNow := promptNow
 	promptNow = func() time.Time {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -113,6 +113,38 @@ func TestRuntimeRunWaitForWakeupTerminatesRoleLoop(t *testing.T) {
 	}
 }
 
+func TestRuntimeRunWaitForWakeupDoesNotStreamFinalAnswer(t *testing.T) {
+	model := &scriptedModel{responses: []*llms.ContentResponse{
+		toolCallResponse("wait_1", "wait_for_wakeup", `{"reason":"user asked"}`),
+	}}
+	controller := NewWaitForWakeupController()
+	runtime := NewRuntimeWithDeps(
+		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Use tools."},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"wait_for_wakeup": NewWaitForWakeupTool(controller),
+		}},
+		NewSkillIndex(),
+	)
+
+	var stream strings.Builder
+	result, err := runtime.Run(context.Background(), RunRequest{
+		Input:             "go to sleep",
+		StreamWriter:      &stream,
+		StreamFinalChunks: true,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !result.WaitForWakeupRequested {
+		t.Fatal("WaitForWakeupRequested = false, want true")
+	}
+	if stream.String() != "" {
+		t.Fatalf("stream = %q, want no spoken final answer for wait_for_wakeup", stream.String())
+	}
+}
+
 func TestRuntimeRunInjectsCurrentDateIntoPlannerPrompt(t *testing.T) {
 	originalNow := promptNow
 	promptNow = func() time.Time {

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -825,7 +825,7 @@ func (s *Server) handleChatAsync(
 				s.liveActivity.UpdateFromRunEvent(requestID, event)
 			}
 
-			if event.Type == runEventToolCall && s.runtime.config.VoiceToolCallSpeechOrDefault() {
+			if s.shouldSpeakToolCall(event) {
 				go s.speakToolDescription(runCtx, event.Speech)
 			}
 			if event.Type == runEventTodoUpdate && s.runtime.config.VoiceProgressSpeechEnabledOrDefault() {
@@ -1091,7 +1091,7 @@ func (s *Server) handleChatSync(
 		StreamFinalChunks: true,
 		EventHandler: func(event RunEvent) {
 			s.appendHistory(messageFromRunEvent(event, episodeID, ""))
-			if event.Type == runEventToolCall && s.runtime.config.VoiceToolCallSpeechOrDefault() {
+			if s.shouldSpeakToolCall(event) {
 				go s.speakToolDescription(r.Context(), event.Speech)
 			}
 			if event.Type == runEventTodoUpdate && s.runtime.config.VoiceProgressSpeechEnabledOrDefault() {
@@ -1270,7 +1270,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 			if req.RequestID != "" && s.liveActivity != nil {
 				s.liveActivity.UpdateFromRunEvent(req.RequestID, event)
 			}
-			if event.Type == runEventToolCall && s.runtime.config.VoiceToolCallSpeechOrDefault() {
+			if s.shouldSpeakToolCall(event) {
 				go s.speakToolDescription(ctx, event.Speech)
 			}
 			if event.Type == runEventTodoUpdate && s.runtime.config.VoiceProgressSpeechEnabledOrDefault() {
@@ -1415,6 +1415,13 @@ func (s *Server) speakToolDescription(ctx context.Context, description string) {
 			s.logger.Error("Tool description TTS playback failed: %v", err)
 		}
 	}
+}
+
+func (s *Server) shouldSpeakToolCall(event RunEvent) bool {
+	if event.Type != runEventToolCall || event.ToolName == toolWaitForWakeup {
+		return false
+	}
+	return s.runtime != nil && s.runtime.config.VoiceToolCallSpeechOrDefault()
 }
 
 func (s *Server) newRunProgressSpeaker() *progressSpeaker {

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -630,6 +630,46 @@ func TestServerHandleChatDoesNotWaitForToolDescriptionTTSWhenEnabled(t *testing.
 	}
 }
 
+func TestServerHandleChatDoesNotSpeakWaitForWakeup(t *testing.T) {
+	toolSpeechEnabled := true
+	streamingDisabled := false
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			toolCallResponse("wait_1", "wait_for_wakeup", `{"reason":"user asked","speech":"我先待命。"}`),
+		},
+	}
+	controller := NewWaitForWakeupController()
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:                    ModelConfig{Provider: "fake"},
+			Instruction:              "Use tools.",
+			VoiceStreamingTTSEnabled: &streamingDisabled,
+			VoiceToolCallSpeech:      &toolSpeechEnabled,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"wait_for_wakeup": NewWaitForWakeupTool(controller),
+		}},
+		NewSkillIndex(),
+	)
+	server := NewServer(runtime, ":0", "")
+	provider := &recordingTTSProvider{name: "server-provider"}
+	server.ttsManager = ttsmodule.NewProviderManager(provider, nil)
+	server.audioClient = NewAudioServiceClient(startTTSPlaybackAudioSocket(t))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"go to sleep"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.handleChat(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	assertNoProviderTextWithin(t, provider, 200*time.Millisecond)
+}
+
 func TestServerHandleChatSkipsToolDescriptionTTSWhenDisabled(t *testing.T) {
 	model := &scriptedModel{
 		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我先读取当前音量。","speech":"读取音量。"}`, "The current audio volume is 42."),

--- a/src/agent/internal/agent/tool_http_catalog_test.go
+++ b/src/agent/internal/agent/tool_http_catalog_test.go
@@ -14,6 +14,15 @@ func TestQuickActionExposedToAgentAndToolLab(t *testing.T) {
 	}
 }
 
+func TestWaitForWakeupExposedToAgentAndToolLab(t *testing.T) {
+	if !isHTTPToolExposed("wait_for_wakeup") {
+		t.Fatal("expected wait_for_wakeup in Tool Lab HTTP catalog")
+	}
+	if !isAgentToolExposed("wait_for_wakeup") {
+		t.Fatal("expected wait_for_wakeup available to conversational agent")
+	}
+}
+
 func TestPhoneBridgeToolsExposedToAgentOnly(t *testing.T) {
 	for _, name := range []string{"open_app", "clipboard", "calendar", "contacts", "notification"} {
 		if isHTTPToolExposed(name) {

--- a/src/agent/internal/agent/tool_spec.go
+++ b/src/agent/internal/agent/tool_spec.go
@@ -71,6 +71,11 @@ var builtInToolSpecMetadata = map[string]toolSpecMetadata{
 		InputMode:    toolInputModeText,
 		ExampleInput: `{"timezone":"Asia/Shanghai"}`,
 	},
+	toolWaitForWakeup: {
+		Category:     "system",
+		InputMode:    toolInputModeJSON,
+		ExampleInput: `{"reason":"user asked me to wait for wakeup"}`,
+	},
 	"inspect_episode": {
 		Category:     "memory",
 		InputMode:    toolInputModeJSON,

--- a/src/agent/internal/agent/tools.go
+++ b/src/agent/internal/agent/tools.go
@@ -20,13 +20,13 @@ type ToolSet struct {
 type BuiltinToolSetOption func(*builtinToolSetOptions)
 
 type builtinToolSetOptions struct {
-	sleepController *SleepController
-	screenStable    ScreenStableDefaults
+	waitForWakeupController *WaitForWakeupController
+	screenStable            ScreenStableDefaults
 }
 
-func WithSleepController(controller *SleepController) BuiltinToolSetOption {
+func WithWaitForWakeupController(controller *WaitForWakeupController) BuiltinToolSetOption {
 	return func(options *builtinToolSetOptions) {
-		options.sleepController = controller
+		options.waitForWakeupController = controller
 	}
 }
 
@@ -85,8 +85,8 @@ func newHardwareToolSet(hidCfg HIDConfig, audioCfg AudioConfig, searchCfg Search
 		"calculator":             NewCalculatorTool(),
 		"web_scraper":            NewWebScraperTool(proxyCfg),
 	}
-	if toolOptions.sleepController != nil {
-		tools["enter_sleep"] = NewEnterSleepTool(toolOptions.sleepController)
+	if toolOptions.waitForWakeupController != nil {
+		tools[toolWaitForWakeup] = NewWaitForWakeupTool(toolOptions.waitForWakeupController)
 	}
 	// Always register human handoff tool - no callback needed for non-blocking version
 	tools["request_human_handoff"] = NewHumanHandoffTool()

--- a/src/agent/internal/agent/tools_mobilegym.go
+++ b/src/agent/internal/agent/tools_mobilegym.go
@@ -129,8 +129,8 @@ func newMobileGymToolSet(cfg Config, proxyCfg ProxyConfig, mobileGym *mobileGymS
 		"current_time":  NewCurrentTimeTool(),
 		"calculator":    NewCalculatorTool(),
 	}
-	if toolOptions.sleepController != nil {
-		tools["enter_sleep"] = NewEnterSleepTool(toolOptions.sleepController)
+	if toolOptions.waitForWakeupController != nil {
+		tools[toolWaitForWakeup] = NewWaitForWakeupTool(toolOptions.waitForWakeupController)
 	}
 	return &ToolSet{tools: tools, screen: screen}
 }

--- a/src/agent/internal/agent/tools_system.go
+++ b/src/agent/internal/agent/tools_system.go
@@ -20,7 +20,7 @@ const (
 	defaultWeatherGeocodingURL = "https://geocoding-api.open-meteo.com/v1/search"
 	defaultWeatherForecastURL  = "https://api.open-meteo.com/v1/forecast"
 	defaultWeatherForecastDays = 3
-	toolEnterSleep             = "enter_sleep"
+	toolWaitForWakeup          = "wait_for_wakeup"
 )
 
 type CurrentTimeTool struct {
@@ -511,17 +511,17 @@ func weatherCodeDescription(code int) string {
 	}
 }
 
-type SleepController struct {
+type WaitForWakeupController struct {
 	mu        sync.Mutex
 	requested bool
 	reason    string
 }
 
-func NewSleepController() *SleepController {
-	return &SleepController{}
+func NewWaitForWakeupController() *WaitForWakeupController {
+	return &WaitForWakeupController{}
 }
 
-func (c *SleepController) Request(reason string) {
+func (c *WaitForWakeupController) Request(reason string) {
 	if c == nil {
 		return
 	}
@@ -531,7 +531,7 @@ func (c *SleepController) Request(reason string) {
 	c.reason = strings.TrimSpace(reason)
 }
 
-func (c *SleepController) Consume() (bool, string) {
+func (c *WaitForWakeupController) Consume() (bool, string) {
 	if c == nil {
 		return false, ""
 	}
@@ -544,39 +544,39 @@ func (c *SleepController) Consume() (bool, string) {
 	return requested, reason
 }
 
-type EnterSleepTool struct {
-	controller *SleepController
+type WaitForWakeupTool struct {
+	controller *WaitForWakeupController
 }
 
-func NewEnterSleepTool(controller *SleepController) *EnterSleepTool {
-	return &EnterSleepTool{controller: controller}
+func NewWaitForWakeupTool(controller *WaitForWakeupController) *WaitForWakeupTool {
+	return &WaitForWakeupTool{controller: controller}
 }
 
-func (t *EnterSleepTool) Name() string { return toolEnterSleep }
+func (t *WaitForWakeupTool) Name() string { return toolWaitForWakeup }
 
-func (t *EnterSleepTool) Description() string {
-	return `Ask the runtime to close the active voice session and return to wakeup-waiting sleep mode. ` +
-		`Use this when the user says to stop listening, go to sleep, standby, or wait for the next wakeup. ` +
-		`Input JSON is optional: {"reason":"user asked me to sleep"}.`
+func (t *WaitForWakeupTool) Description() string {
+	return `End the current agent run and return the voice interaction to wakeup-waiting mode. ` +
+		`Use this when the user asks Aiden to stop listening, go idle, or wait for the next wakeup. ` +
+		`Input JSON is optional: {"reason":"user asked me to wait for wakeup"}.`
 }
 
-func (t *EnterSleepTool) ArgsSchema() map[string]any {
+func (t *WaitForWakeupTool) ArgsSchema() map[string]any {
 	return objectArgsSchema(map[string]any{
 		"reason": map[string]any{
 			"type":        "string",
-			"description": "Optional reason for entering sleep mode.",
+			"description": "Optional reason for returning to wakeup-waiting mode.",
 		},
 	})
 }
 
-func (t *EnterSleepTool) Call(ctx context.Context, input string) (string, error) {
+func (t *WaitForWakeupTool) Call(ctx context.Context, input string) (string, error) {
 	reason := strings.TrimSpace(input)
 	if strings.HasPrefix(reason, "{") {
 		var args struct {
 			Reason string `json:"reason"`
 		}
 		if err := json.Unmarshal([]byte(reason), &args); err != nil {
-			return fmt.Sprintf("error: invalid input: %v. Expected JSON format: {\"reason\": \"task completed\"} or a bare string describing the reason for entering sleep mode", err), nil
+			return fmt.Sprintf("error: invalid input: %v. Expected JSON format: {\"reason\": \"task completed\"} or a bare string describing why Aiden should wait for wakeup", err), nil
 		}
 		reason = strings.TrimSpace(args.Reason)
 	}
@@ -584,10 +584,10 @@ func (t *EnterSleepTool) Call(ctx context.Context, input string) (string, error)
 		t.controller.Request(reason)
 	}
 	return jsonString(map[string]interface{}{
-		"status":  "sleep_requested",
+		"status":  "wait_for_wakeup_requested",
 		"mode":    "wakeup",
 		"reason":  reason,
-		"message": "The active voice session will close after this turn, and the agent will wait for the next wakeup event.",
+		"message": "The current agent run is ending now, and the voice interaction will wait for the next wakeup event.",
 	}), nil
 }
 

--- a/src/agent/internal/agent/tools_system.go
+++ b/src/agent/internal/agent/tools_system.go
@@ -20,6 +20,7 @@ const (
 	defaultWeatherGeocodingURL = "https://geocoding-api.open-meteo.com/v1/search"
 	defaultWeatherForecastURL  = "https://api.open-meteo.com/v1/forecast"
 	defaultWeatherForecastDays = 3
+	toolEnterSleep             = "enter_sleep"
 )
 
 type CurrentTimeTool struct {
@@ -551,7 +552,7 @@ func NewEnterSleepTool(controller *SleepController) *EnterSleepTool {
 	return &EnterSleepTool{controller: controller}
 }
 
-func (t *EnterSleepTool) Name() string { return "enter_sleep" }
+func (t *EnterSleepTool) Name() string { return toolEnterSleep }
 
 func (t *EnterSleepTool) Description() string {
 	return `Ask the runtime to close the active voice session and return to wakeup-waiting sleep mode. ` +

--- a/src/agent/internal/agent/tools_system_test.go
+++ b/src/agent/internal/agent/tools_system_test.go
@@ -40,8 +40,8 @@ func TestBuiltinToolSetRegistersSystemTools(t *testing.T) {
 			t.Fatalf("builtin tool %q was not registered", name)
 		}
 	}
-	if _, ok := tools.Get("enter_sleep"); ok {
-		t.Fatal("enter_sleep should not be registered")
+	if _, ok := tools.Get("wait_for_wakeup"); ok {
+		t.Fatal("wait_for_wakeup should not be registered")
 	}
 }
 


### PR DESCRIPTION
## Summary
- terminate the role loop immediately after a successful enter_sleep tool call
- keep Runtime.Run session commit and SleepController consumption intact
- allow legacy wakeup mode to cancel in-flight utterance processing on a new wake event

## Tests
- git diff --check
- go test ./... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `wait_for_wakeup` as the agent’s “end run and wait” control, replacing the prior sleep workflow; the agent run now terminates and returns to wakeup-waiting voice mode.
  * Exposed `wait_for_wakeup` in the Tool Lab and Tool catalog, and updated server behavior to suppress related tool-call speech.
* **Bug Fixes**
  * Improved wakeup-aware interrupt handling during audio/utterance processing, including legacy wakeups interrupting in-progress utterances.
* **Documentation**
  * Updated wakeup-trigger and configuration guidance to match the new wakeup-wait behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->