### PR TITLE
fix(agent): remove runtime memory window cap

### DIFF
--- a/src/agent/internal/agent/chat_history_memory_test.go
+++ b/src/agent/internal/agent/chat_history_memory_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	langtools "github.com/tmc/langchaingo/tools"
 )
@@ -269,5 +270,89 @@ func TestRuntimeRunIncludesFullActivePlannerHistoryAndSessionRootContext(t *test
 		if !strings.Contains(plannerTaskPrompt, want) {
 			t.Fatalf("planner task prompt missing %q:\n%s", want, plannerTaskPrompt)
 		}
+	}
+}
+
+func TestRuntimeRunBudgetsActivePlannerHistoryBeforeModelCall(t *testing.T) {
+	ctx := context.Background()
+	configDir := t.TempDir()
+	memoryDir := filepath.Join(configDir, "memory")
+	cfg := DefaultMemoryExtractionConfig()
+	cfg.ContextWindow = 800
+	cfg.ReserveTokens = 200
+	cfg.KeepRecentTokens = 220
+	manager := NewMemoryManager(memoryDir, WithExtractionConfig(cfg), WithSessionBoundaryEnabled(false))
+
+	if err := manager.AppendSessionEvent(ctx, "default", SessionEvent{
+		Type:    "user_input",
+		Role:    "user",
+		Source:  EventSourcePinnedRoot,
+		Content: "PINNED_ROOT_REQUEST",
+	}, SessionEventMetadata{}); err != nil {
+		t.Fatalf("AppendSessionEvent(pinned root) error = %v", err)
+	}
+	if err := manager.AppendSessionEvent(ctx, "default", SessionEvent{
+		Type:    "system_event",
+		Role:    "system",
+		Source:  EventSourceCompactionPrefix,
+		Content: "SPLIT_SYNTHETIC_CONTEXT",
+	}, SessionEventMetadata{}); err != nil {
+		t.Fatalf("AppendSessionEvent(synthetic context) error = %v", err)
+	}
+	for i := 0; i < 8; i++ {
+		if err := manager.AppendExchange(ctx, "default",
+			fmt.Sprintf("DROP_OLD_USER_%02d %s", i, strings.Repeat("old ", 160)),
+			fmt.Sprintf("DROP_OLD_ASSISTANT_%02d %s", i, strings.Repeat("old ", 160)),
+		); err != nil {
+			t.Fatalf("AppendExchange(old %d) error = %v", i, err)
+		}
+	}
+	if err := manager.AppendExchange(ctx, "default",
+		"KEEP_RECENT_USER "+strings.Repeat("recent ", 28),
+		"KEEP_RECENT_ASSISTANT "+strings.Repeat("recent ", 28),
+	); err != nil {
+		t.Fatalf("AppendExchange(recent) error = %v", err)
+	}
+
+	model := &scriptedModel{responses: roleDirectResponses("继续完成")}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			ConfigDir:     configDir,
+			Model:         ModelConfig{Provider: "fake"},
+			Instruction:   "Answer directly.",
+			MaxIterations: 1,
+		},
+		&testModelResolver{model: model, spec: ModelSpec{ContextWindow: 800}},
+		manager,
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+
+	if _, err := runtime.Run(ctx, RunRequest{Input: "CURRENT_REQUEST_MARKER 继续"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(model.messages) == 0 || len(model.messages[0]) < 3 {
+		t.Fatalf("expected planner system, history, and state prompt messages, got %#v", model.messages)
+	}
+
+	plannerMessages := model.messages[0]
+	historyText := messageText(plannerMessages[1 : len(plannerMessages)-1])
+	for _, want := range []string{"PINNED_ROOT_REQUEST", "SPLIT_SYNTHETIC_CONTEXT", "KEEP_RECENT_USER", "KEEP_RECENT_ASSISTANT"} {
+		if !strings.Contains(historyText, want) {
+			t.Fatalf("budgeted planner history missing %q:\n%s", want, historyText)
+		}
+	}
+	for _, unwanted := range []string{"DROP_OLD_USER_00", "DROP_OLD_ASSISTANT_00", "CURRENT_REQUEST_MARKER"} {
+		if strings.Contains(historyText, unwanted) {
+			t.Fatalf("budgeted planner history should not contain %q:\n%s", unwanted, historyText)
+		}
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := manager.WaitMaintenance(waitCtx); err != nil {
+		t.Fatalf("WaitMaintenance() error = %v", err)
+	}
+	if !manager.HasCompressedHistory() {
+		t.Fatal("over-budget active history should preserve a compression signal for maintenance")
 	}
 }

--- a/src/agent/internal/agent/chat_history_memory_test.go
+++ b/src/agent/internal/agent/chat_history_memory_test.go
@@ -224,7 +224,7 @@ func TestRuntimeRunKeepsCurrentRequestOutOfCompressedHistoryBlock(t *testing.T) 
 	}
 }
 
-func TestRuntimeRunIncludesActivePlannerWindowAndSessionRootContext(t *testing.T) {
+func TestRuntimeRunIncludesFullActivePlannerHistoryAndSessionRootContext(t *testing.T) {
 	ctx := context.Background()
 	configDir := t.TempDir()
 	memoryDir := filepath.Join(configDir, "memory")
@@ -258,6 +258,8 @@ func TestRuntimeRunIncludesActivePlannerWindowAndSessionRootContext(t *testing.T
 
 	plannerTaskPrompt := messageText(model.messages[0][1:])
 	for _, want := range []string{
+		"prior user 00",
+		"prior assistant 00",
 		"prior user 02",
 		"prior assistant 02",
 		"prior user 11",
@@ -267,8 +269,5 @@ func TestRuntimeRunIncludesActivePlannerWindowAndSessionRootContext(t *testing.T
 		if !strings.Contains(plannerTaskPrompt, want) {
 			t.Fatalf("planner task prompt missing %q:\n%s", want, plannerTaskPrompt)
 		}
-	}
-	if strings.Contains(plannerTaskPrompt, "prior assistant 00") {
-		t.Fatalf("planner conversation history should stay within the active message window:\n%s", plannerTaskPrompt)
 	}
 }

--- a/src/agent/internal/agent/conversation_history_messages.go
+++ b/src/agent/internal/agent/conversation_history_messages.go
@@ -52,6 +52,32 @@ func (m *conversationMessagePlannerMemory) Clear(ctx context.Context) error {
 	return m.inner.Clear(ctx)
 }
 
+type conversationHistorySelectionEntry struct {
+	message   llms.MessageContent
+	tokens    int
+	protected bool
+}
+
+func runtimeConversationHistoryMessageContents(ctx context.Context, history *langmemory.ChatMessageHistory, manager *MemoryManager, currentRunID string, maxTokens int) ([]llms.MessageContent, error) {
+	if manager != nil && strings.TrimSpace(manager.storageDir) != "" {
+		events, err := manager.LoadActiveSessionEvents(ctx, 0)
+		if err != nil {
+			return nil, err
+		}
+		if len(events) > 0 {
+			if activeTokens := sumSessionEventTokensExcludingRun(events, currentRunID); maxTokens > 0 && activeTokens > maxTokens {
+				manager.RaisePromptTokenFloor(activeTokens)
+			}
+			return conversationHistoryMessageContentsFromEvents(events, currentRunID, maxTokens), nil
+		}
+	}
+	messages, err := conversationHistoryMessageContents(ctx, history)
+	if err != nil {
+		return nil, err
+	}
+	return selectConversationHistoryWithinBudget(messageSelectionEntries(messages), maxTokens), nil
+}
+
 func conversationHistoryMessageContents(ctx context.Context, history *langmemory.ChatMessageHistory) ([]llms.MessageContent, error) {
 	if history == nil {
 		return nil, nil
@@ -71,6 +97,231 @@ func conversationHistoryMessageContents(ctx context.Context, history *langmemory
 		}
 	}
 	return result, nil
+}
+
+func conversationHistoryMessageContentsFromEvents(events []SessionEvent, currentRunID string, maxTokens int) []llms.MessageContent {
+	entries := make([]conversationHistorySelectionEntry, 0, len(events))
+	firstUserInputIndex := firstSelectableUserInputIndex(events, currentRunID)
+	for i, event := range events {
+		if eventBelongsToRun(event, currentRunID) {
+			continue
+		}
+		record, ok := messageRecordFromSessionEvent(event)
+		if !ok {
+			continue
+		}
+		content := strings.TrimSpace(record.Content)
+		if content == "" {
+			continue
+		}
+		message, ok := messageContentFromChatMessage(llms.ChatMessageType(record.Role), content)
+		if !ok {
+			continue
+		}
+		entries = append(entries, conversationHistorySelectionEntry{
+			message:   message,
+			tokens:    estimateMessageTokens(message),
+			protected: isProtectedConversationHistoryEvent(event, i, firstUserInputIndex),
+		})
+	}
+	return selectConversationHistoryWithinBudget(entries, maxTokens)
+}
+
+func firstSelectableUserInputIndex(events []SessionEvent, currentRunID string) int {
+	for i, event := range events {
+		if eventBelongsToRun(event, currentRunID) {
+			continue
+		}
+		if event.Type == "user_input" && strings.TrimSpace(event.Content) != "" {
+			return i
+		}
+	}
+	return -1
+}
+
+func eventBelongsToRun(event SessionEvent, runID string) bool {
+	return strings.TrimSpace(runID) != "" && event.RunID == runID
+}
+
+func sumSessionEventTokensExcludingRun(events []SessionEvent, runID string) int {
+	total := 0
+	for _, event := range events {
+		if eventBelongsToRun(event, runID) {
+			continue
+		}
+		total += estimateSessionEventTokens(event)
+	}
+	return total
+}
+
+func isProtectedConversationHistoryEvent(event SessionEvent, index int, firstUserInputIndex int) bool {
+	switch event.Source {
+	case EventSourcePinnedRoot, EventSourceCompactionPrefix:
+		return true
+	}
+	return index == firstUserInputIndex
+}
+
+func messageSelectionEntries(messages []llms.MessageContent) []conversationHistorySelectionEntry {
+	entries := make([]conversationHistorySelectionEntry, 0, len(messages))
+	firstUserIndex := -1
+	for i, message := range messages {
+		if firstUserIndex < 0 && message.Role == llms.ChatMessageTypeHuman {
+			firstUserIndex = i
+		}
+	}
+	for i, message := range messages {
+		entries = append(entries, conversationHistorySelectionEntry{
+			message:   message,
+			tokens:    estimateMessageTokens(message),
+			protected: i == firstUserIndex || message.Role == llms.ChatMessageTypeSystem,
+		})
+	}
+	return entries
+}
+
+func selectConversationHistoryWithinBudget(entries []conversationHistorySelectionEntry, maxTokens int) []llms.MessageContent {
+	if len(entries) == 0 {
+		return nil
+	}
+	if maxTokens <= 0 {
+		result := make([]llms.MessageContent, 0, len(entries))
+		for _, entry := range entries {
+			result = append(result, entry.message)
+		}
+		return result
+	}
+	total := 0
+	for _, entry := range entries {
+		total += entry.tokens
+	}
+	if total <= maxTokens {
+		result := make([]llms.MessageContent, 0, len(entries))
+		for _, entry := range entries {
+			result = append(result, entry.message)
+		}
+		return result
+	}
+
+	selected := make(map[int]llms.MessageContent)
+	usedTokens := 0
+	for i, entry := range entries {
+		if !entry.protected {
+			continue
+		}
+		message, tokens, ok := fitConversationHistoryMessage(entry.message, entry.tokens, maxTokens-usedTokens)
+		if !ok {
+			continue
+		}
+		selected[i] = message
+		usedTokens += tokens
+	}
+
+	trimmedRecent := false
+	for i := len(entries) - 1; i >= 0; i-- {
+		if _, ok := selected[i]; ok {
+			continue
+		}
+		remaining := maxTokens - usedTokens
+		if remaining <= 0 {
+			break
+		}
+		entry := entries[i]
+		if entry.tokens <= remaining {
+			selected[i] = entry.message
+			usedTokens += entry.tokens
+			continue
+		}
+		if trimmedRecent {
+			continue
+		}
+		message, tokens, ok := fitConversationHistoryMessage(entry.message, entry.tokens, remaining)
+		if !ok {
+			continue
+		}
+		selected[i] = message
+		usedTokens += tokens
+		trimmedRecent = true
+	}
+
+	result := make([]llms.MessageContent, 0, len(selected))
+	for i, entry := range entries {
+		message, ok := selected[i]
+		if !ok {
+			continue
+		}
+		if len(message.Parts) == 0 {
+			message = entry.message
+		}
+		result = append(result, message)
+	}
+	return result
+}
+
+func fitConversationHistoryMessage(message llms.MessageContent, tokens int, budget int) (llms.MessageContent, int, bool) {
+	if budget <= 0 {
+		return llms.MessageContent{}, 0, false
+	}
+	if tokens <= budget {
+		return message, tokens, true
+	}
+	trimmed, ok := trimTextMessageContentToTokenBudget(message, budget)
+	if !ok {
+		return llms.MessageContent{}, 0, false
+	}
+	return trimmed, estimateMessageTokens(trimmed), true
+}
+
+func trimTextMessageContentToTokenBudget(message llms.MessageContent, budget int) (llms.MessageContent, bool) {
+	if len(message.Parts) != 1 {
+		return llms.MessageContent{}, false
+	}
+	text, ok := message.Parts[0].(llms.TextContent)
+	if !ok {
+		return llms.MessageContent{}, false
+	}
+	roleOverhead := 4 + estimateTextTokens(string(message.Role))
+	available := budget - roleOverhead
+	if available <= 0 {
+		return llms.MessageContent{}, false
+	}
+	trimmed := trimTextToTokenBudget(text.Text, available)
+	if strings.TrimSpace(trimmed) == "" {
+		return llms.MessageContent{}, false
+	}
+	return llms.TextParts(message.Role, trimmed), true
+}
+
+func trimTextToTokenBudget(text string, budget int) string {
+	text = strings.TrimSpace(text)
+	if budget <= 0 || text == "" {
+		return ""
+	}
+	if estimateTextTokens(text) <= budget {
+		return text
+	}
+	const marker = "\n[history truncated to fit context budget]"
+	markerTokens := estimateTextTokens(marker)
+	if budget <= markerTokens {
+		return ""
+	}
+	limit := budget - markerTokens
+	runes := []rune(text)
+	lo, hi := 0, len(runes)
+	best := 0
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		if estimateTextTokens(string(runes[:mid])) <= limit {
+			best = mid
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	if best <= 0 {
+		return ""
+	}
+	return strings.TrimSpace(string(runes[:best])) + marker
 }
 
 func messageContentFromChatMessage(role llms.ChatMessageType, content string) (llms.MessageContent, bool) {

--- a/src/agent/internal/agent/conversation_history_messages.go
+++ b/src/agent/internal/agent/conversation_history_messages.go
@@ -52,16 +52,13 @@ func (m *conversationMessagePlannerMemory) Clear(ctx context.Context) error {
 	return m.inner.Clear(ctx)
 }
 
-func conversationHistoryMessageContents(ctx context.Context, history *langmemory.ChatMessageHistory, maxMessages int) ([]llms.MessageContent, error) {
+func conversationHistoryMessageContents(ctx context.Context, history *langmemory.ChatMessageHistory) ([]llms.MessageContent, error) {
 	if history == nil {
 		return nil, nil
 	}
 	messages, err := history.Messages(ctx)
 	if err != nil {
 		return nil, err
-	}
-	if maxMessages > 0 && len(messages) > maxMessages {
-		messages = messages[len(messages)-maxMessages:]
 	}
 	result := make([]llms.MessageContent, 0, len(messages))
 	for _, message := range messages {

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -51,6 +51,7 @@ type MemoryManager struct {
 	storageDir                     string
 	extraction                     MemoryExtractionConfig
 	lastPromptTokens               int
+	pendingPromptTokenFloor        int
 	summarizeFn                    SummarizeFn
 	structuredSummarizeFn          StructuredSummarizeFn
 	profileFn                      ProfileFn
@@ -211,6 +212,28 @@ func (m *MemoryManager) LastPromptTokens() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.lastPromptTokens
+}
+
+func (m *MemoryManager) RaisePromptTokenFloor(tokens int) {
+	if m == nil || tokens <= 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if tokens > m.pendingPromptTokenFloor {
+		m.pendingPromptTokenFloor = tokens
+	}
+}
+
+func (m *MemoryManager) ConsumePromptTokenFloor() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	tokens := m.pendingPromptTokenFloor
+	m.pendingPromptTokenFloor = 0
+	return tokens
 }
 
 // Get retrieves or creates a memory handle for the specified agent.
@@ -578,6 +601,7 @@ func (m *MemoryManager) RotateSessionEvents() (string, error) {
 			m.eventCount[agentName] = 0
 		}
 		m.lastPromptTokens = 0
+		m.pendingPromptTokenFloor = 0
 		for _, handle := range m.handles {
 			if handle != nil && handle.Memory != nil {
 				_ = handle.Memory.Clear(context.Background())
@@ -835,6 +859,8 @@ func (m *MemoryManager) removeSessionPersisted(agentName string) error {
 		return fmt.Errorf("remove session memory for %q: %w", agentName, err)
 	}
 	m.eventCount[agentName] = 0
+	m.lastPromptTokens = 0
+	m.pendingPromptTokenFloor = 0
 	return nil
 }
 
@@ -867,6 +893,8 @@ func (m *MemoryManager) removeAllPersisted(agentName string) error {
 		}
 	}
 	m.eventCount[agentName] = 0
+	m.lastPromptTokens = 0
+	m.pendingPromptTokenFloor = 0
 	return nil
 }
 
@@ -1068,6 +1096,7 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 	// Without this, eventCount and handle.History remain at pre-compression size,
 	// causing appendSessionEvents() to skip writes or use stale indices.
 	m.lastPromptTokens = cutMeta.KeptTokensEstimate
+	m.pendingPromptTokenFloor = 0
 	for agentName := range m.eventCount {
 		m.eventCount[agentName] = len(hotEvents)
 	}

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -633,7 +633,13 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		executorHandler = streamCallbackHandler
 	}
 	profiles := r.buildRoleProfiles(resolvedSkills, availableTools, memoryContext, req.RuntimeContext)
-	conversationHistory, err := conversationHistoryMessageContents(ctx, memoryHandle.History)
+	conversationHistory, err := runtimeConversationHistoryMessageContents(
+		ctx,
+		memoryHandle.History,
+		r.memories,
+		runID,
+		r.activeConversationHistoryTokenBudget(contextWindow),
+	)
 	if err != nil {
 		return RunResult{}, err
 	}
@@ -795,6 +801,20 @@ func (r *Runtime) effectiveContextWindow() int {
 		return r.memories.effectiveContextWindow()
 	}
 	return 0
+}
+
+func (r *Runtime) activeConversationHistoryTokenBudget(contextWindow int) int {
+	if contextWindow <= 0 {
+		return 0
+	}
+	reserveTokens := defaultReserveTokens
+	keepRecentTokens := defaultKeepRecentTokens
+	if r != nil && r.memories != nil {
+		reserveTokens = r.memories.reserveTokens()
+		keepRecentTokens = r.memories.keepRecentTokens()
+	}
+	_, keepRecent := clampTokenBudgets(reserveTokens, keepRecentTokens, contextWindow)
+	return keepRecent
 }
 
 func (r *Runtime) ClearMemory(ctx context.Context) error {

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -33,7 +33,6 @@ func effectiveMaxIterations(configured int) int {
 }
 
 const currentEnvironmentHintMaxAge = 10 * time.Minute
-const runtimePlannerMemoryWindowSize = 10
 
 type Runtime struct {
 	config             Config
@@ -526,7 +525,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	model = &usageTrackingModel{inner: model, metrics: metrics, promptCapture: promptCapture, contextWindowFn: r.effectiveContextWindow}
 
 	currentHints := r.currentEnvironmentHints()
-	memoryCfg := MemoryConfig{Type: "window", WindowSize: runtimePlannerMemoryWindowSize}
+	memoryCfg := MemoryConfig{Type: "buffer"}
 	var memoryHandle *MemoryHandle
 	if r.memories != nil {
 		memoryHandle, err = r.memories.Get("default", memoryCfg)
@@ -634,7 +633,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		executorHandler = streamCallbackHandler
 	}
 	profiles := r.buildRoleProfiles(resolvedSkills, availableTools, memoryContext, req.RuntimeContext)
-	conversationHistory, err := conversationHistoryMessageContents(ctx, memoryHandle.History, runtimePlannerMemoryWindowSize*2)
+	conversationHistory, err := conversationHistoryMessageContents(ctx, memoryHandle.History)
 	if err != nil {
 		return RunResult{}, err
 	}

--- a/src/agent/internal/agent/session_manager.go
+++ b/src/agent/internal/agent/session_manager.go
@@ -163,6 +163,9 @@ func (m memoryManagerSessionManager) CommitRun(ctx context.Context, req SessionC
 	if req.Metrics != nil {
 		lastPromptTokens = req.Metrics.LastPromptTokens
 	}
+	if floor := m.memories.ConsumePromptTokenFloor(); floor > lastPromptTokens {
+		lastPromptTokens = floor
+	}
 	m.memories.SetLastPromptTokens(lastPromptTokens)
 
 	meta := SessionEventMetadata{


### PR DESCRIPTION
Summary:
- remove the runtime ConversationWindowBuffer cap and use buffer memory for restored active session history
- restore all active session chat messages instead of truncating to the previous 10-turn window
- update coverage to assert early active-session messages remain visible in planner context

Tests:
- go test ./internal/agent