### PR TITLE
feat(agent): raise session boundary gap and clean up utilities

### DIFF
--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -161,8 +161,8 @@ Optional. Place `memory/extraction.yaml` under the config directory to control s
 | `compress_at_percent` | `50` | Percentage trigger: compaction starts when `prompt_tokens / context_window >= compress_at_percent%`. |
 | `summary_max_chunks` | `10` | Number of chunk summaries kept in the Recent Chunks section of `summary.md`. Older entries move to the archive and are folded into the Rolling Summary. |
 | `session_boundary_enabled` | `true` | Classify each new user turn as continuing the current session or starting a new one. A `new` boundary archives the current `memory/session/` directory and recreates an empty active session. |
-| `session_boundary_short_gap_seconds` | default boundary config | Gap below which a turn is treated as continuation regardless of lexical signals. |
-| `session_boundary_long_gap_seconds` | default boundary config | Gap above which a turn is treated as a fresh session regardless of lexical signals. |
+| `session_boundary_short_gap_seconds` | `300` | Gap below which a turn is treated as continuation regardless of lexical signals. |
+| `session_boundary_long_gap_seconds` | `1800` | Gap above which a turn is treated as a fresh session regardless of lexical signals. |
 | `tag_candidates` | see defaults | Candidate keywords matched when tagging chunk summaries. |
 | `entity_suffixes` | `["App","app","APP"]` | Suffixes recognized during entity extraction. |
 

--- a/docs/04-agent/context-lifecycle.md
+++ b/docs/04-agent/context-lifecycle.md
@@ -149,6 +149,9 @@ normalize input and activate requested skills
 resolve model, context window, tools, and memory handle
   |
   v
+begin session: detect/rotate boundary and append current user input
+  |
+  v
 MemoryPlane.Retrieve(input, attachments, skills, tools, current hints)
   |
   v
@@ -161,7 +164,7 @@ build role profiles and planner memory
 phased role loop (decision / default / plan / execution)
   |
   v
-append conversation exchange and save snapshot
+commit session: append assistant output and save snapshot
   |
   v
 request session-memory maintenance
@@ -180,7 +183,11 @@ Runtime context is supplied per request and is not written back into memory. The
 
 ### Session Hot Window
 
-After a run completes, `MemoryManager.AppendExchange` records the user input and final answer. `SaveSnapshot` persists the current window, and `RequestMaintenance` schedules filesystem maintenance.
+At run begin, session management detects whether the input starts a new session
+and appends the current user input to `memory/session/events.jsonl`. At run
+commit, it appends the assistant output, persists the current snapshot with
+`SaveSnapshot`, and schedules filesystem maintenance with
+`RequestMaintenance`.
 
 The hot window lives in:
 
@@ -188,8 +195,10 @@ The hot window lives in:
 memory/session/events.jsonl
 ```
 
-At prompt time, retained hot-window events render as normal planner
-`Conversation history:`. Prompt construction does not add hot-window labels or
+At prompt time, retained hot-window events are converted into native chat
+messages and inserted between the planner system prompt and the current planner
+task message. Prompt construction does not render them inside a
+`Conversation history:` text block and does not add hot-window labels or
 boundary markers.
 
 When session-boundary detection classifies a user turn as a new session, the

--- a/docs/04-agent/session-memory.md
+++ b/docs/04-agent/session-memory.md
@@ -1,12 +1,12 @@
 # Session Memory Compaction
 
-This document describes Aiden Agent's session-level conversation memory compaction. The mechanism turns a growing event stream into chunk summaries and keeps only the latest hot window in the planner prompt.
+This document describes Aiden Agent's session-level conversation memory compaction. The mechanism turns a growing event stream into chunk summaries and keeps only the latest hot window available to the planner as native chat messages.
 
 This is separate from the [Memory Plane design](memory-plane.md). Memory Plane handles device and task-episode experience memory; session memory handles the dialogue history for one active session.
 
 ## Flow
 
-After each runtime turn, the Agent persists the hot-window events and schedules `MemoryManager.RequestMaintenance`. `MemoryManager.Save` runs the same maintenance path synchronously for callers that use it directly.
+Runtime appends the current user input at run begin and the assistant output at run commit. After commit, the Agent schedules `MemoryManager.RequestMaintenance`. `MemoryManager.Save` runs the same maintenance path synchronously for callers that use it directly.
 
 ```text
 read session/events.jsonl under FileLock
@@ -178,12 +178,12 @@ The Rolling Summary currently has a 100-line cap (`maxRollingSummaryLines`). Whe
 ## Hot-Window Prompt Placement
 
 Compressed session summaries are loaded into the role memory context, while the
-retained hot-window events are restored as normal `ChatMessageHistory` records.
-At prompt time the planner sees those records under the regular
-`Conversation history:` section of its task prompt. Compressed-history state is
-not exposed through a hot-window label, and no synthetic hot-window start/end
-markers are added. The session compaction thresholds and model context budget
-are the controls for prompt growth.
+retained hot-window events are converted into native chat messages and inserted
+between the planner system prompt and the current planner task message. They are
+not rendered inside a `Conversation history:` text block. Compressed-history
+state is not exposed through a hot-window label, and no synthetic hot-window
+start/end markers are added. The session compaction thresholds and model context
+budget are the controls for prompt growth.
 
 **Note**: The `chat_history` store, while persisted, is NOT injected into the
 planner context. See `context-lifecycle.md` for rationale.

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -1834,8 +1834,8 @@ func TestSummaryMaxChunksConfigDefaultAndCustom(t *testing.T) {
 	if !cfg.SessionBoundaryEnabled {
 		t.Fatalf("expected session boundary detection to be enabled by default")
 	}
-	if cfg.SessionBoundaryShortGapSeconds != 180 {
-		t.Fatalf("expected default short gap 180s, got %d", cfg.SessionBoundaryShortGapSeconds)
+	if cfg.SessionBoundaryShortGapSeconds != 300 {
+		t.Fatalf("expected default short gap 300s, got %d", cfg.SessionBoundaryShortGapSeconds)
 	}
 	if cfg.SessionBoundaryLongGapSeconds != 1800 {
 		t.Fatalf("expected default long gap 1800s, got %d", cfg.SessionBoundaryLongGapSeconds)

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -3212,7 +3212,7 @@ func TestRuntimeRunRotatesSessionOnNewBoundary(t *testing.T) {
 	storageDir := filepath.Join(configDir, "memory")
 	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
 	oldSummary := "OLD SESSION SUMMARY MUST NOT ENTER NEW PROMPT"
-	now := time.Now().UTC().Add(-4 * time.Minute)
+	now := time.Now().UTC().Add(-6 * time.Minute)
 	for i := 0; i < DefaultBoundaryConfig().SmallSessionEventThreshold+1; i++ {
 		if _, err := session.AppendEvent(context.Background(), SessionEvent{
 			EventID: fmt.Sprintf("evt_old_%d", i),
@@ -3327,7 +3327,7 @@ func TestRuntimeRunRepairsTruncatedSessionTailBeforeBoundaryRotation(t *testing.
 	configDir := t.TempDir()
 	storageDir := filepath.Join(configDir, "memory")
 	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
-	now := time.Now().UTC().Add(-4 * time.Minute)
+	now := time.Now().UTC().Add(-6 * time.Minute)
 	for i := 0; i < DefaultBoundaryConfig().SmallSessionEventThreshold+1; i++ {
 		if _, err := session.AppendEvent(context.Background(), SessionEvent{
 			EventID: fmt.Sprintf("evt_old_%d", i),
@@ -3399,7 +3399,7 @@ func TestRuntimeRunKeepsSmallSessionOnUnrelatedInput(t *testing.T) {
 	configDir := t.TempDir()
 	storageDir := filepath.Join(configDir, "memory")
 	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
-	now := time.Now().UTC().Add(-4 * time.Minute)
+	now := time.Now().UTC().Add(-6 * time.Minute)
 	for i := 0; i < DefaultBoundaryConfig().SmallSessionEventThreshold; i++ {
 		if _, err := session.AppendEvent(context.Background(), SessionEvent{
 			EventID: fmt.Sprintf("evt_small_%d", i),
@@ -3460,7 +3460,7 @@ func TestRuntimeRunKeepsNeutralFollowUpWithActiveEpisode(t *testing.T) {
 	configDir := t.TempDir()
 	storageDir := filepath.Join(configDir, "memory")
 	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
-	now := time.Now().UTC().Add(-4 * time.Minute)
+	now := time.Now().UTC().Add(-6 * time.Minute)
 	for i, content := range []string{"查一下今天天气", "今天多云"} {
 		role := "user"
 		eventType := "user_input"

--- a/src/agent/internal/agent/session_boundary.go
+++ b/src/agent/internal/agent/session_boundary.go
@@ -53,7 +53,7 @@ type BoundaryConfig struct {
 // DefaultBoundaryConfig returns the sane defaults for voice agent usage.
 func DefaultBoundaryConfig() BoundaryConfig {
 	return BoundaryConfig{
-		ShortGapSeconds:            180,
+		ShortGapSeconds:            300,
 		LongGapSeconds:             1800,
 		SmallSessionEventThreshold: 16,
 		ContinueScoreThreshold:     2,

--- a/src/agent/internal/agent/session_boundary_test.go
+++ b/src/agent/internal/agent/session_boundary_test.go
@@ -59,7 +59,7 @@ func TestClassifyTurnBoundary_RunningEpisodeOverridesNoPrevEvents(t *testing.T) 
 }
 
 func TestClassifyTurnBoundary_TimeGapShort(t *testing.T) {
-	// Short gap (< 3m default): strong continuation, even on a generic action verb.
+	// Short gap (< 5m default): strong continuation, even on a generic action verb.
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
 	prev := []SessionEvent{eventAt(now.Add(-2*time.Minute), "user_input", "打开微信")}
@@ -90,7 +90,7 @@ func TestClassifyTurnBoundary_ContinuationMarker(t *testing.T) {
 	// Mid-range gap + sentence-initial continuation marker → continue.
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
+	prev := eventsAt(now.Add(-6*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
 	cases := []string{
 		"对了再帮我看下后天的",
 		"然后呢？",
@@ -116,7 +116,7 @@ func TestClassifyTurnBoundary_ActionVerbStartsNewTask(t *testing.T) {
 	// Mid-range gap + sentence-initial action verb on new entity → new.
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
+	prev := eventsAt(now.Add(-6*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
 	cases := []string{
 		"打开微信",
 		"发消息给老婆",
@@ -142,7 +142,7 @@ func TestClassifyTurnBoundary_ActionVerbStartsNewTask(t *testing.T) {
 func TestClassifyTurnBoundary_IgnoresAppDivergence(t *testing.T) {
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查天气")
+	prev := eventsAt(now.Add(-6*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查天气")
 	for i := range prev {
 		prev[i].AppName = "WeatherApp"
 	}
@@ -163,7 +163,7 @@ func TestClassifyTurnBoundary_IgnoresAppDivergence(t *testing.T) {
 func TestClassifyTurnBoundary_SmallSessionContinuesUnrelatedMidGap(t *testing.T) {
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold, "user_input", "查一下今天天气")
+	prev := eventsAt(now.Add(-6*time.Minute), cfg.SmallSessionEventThreshold, "user_input", "查一下今天天气")
 
 	boundary, reason := ClassifyTurnBoundary(prev, "打开微信", now, cfg, BoundaryEpisodeContext{})
 	if boundary != BoundaryContinue {
@@ -179,7 +179,7 @@ func TestClassifyTurnBoundary_RunningEpisodeBiasesContinue(t *testing.T) {
 	// Same input + no episode → new (default bias).
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
+	prev := eventsAt(now.Add(-6*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
 	neutralInput := "好的"
 
 	withEpisode := BoundaryEpisodeContext{HasRunning: true}
@@ -198,7 +198,7 @@ func TestClassifyTurnBoundary_RunningEpisodeBiasesContinue(t *testing.T) {
 func TestClassifyTurnBoundary_ActiveEpisodeBiasesNeutralFollowUpContinue(t *testing.T) {
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
+	prev := eventsAt(now.Add(-6*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
 
 	boundary, reason := ClassifyTurnBoundary(prev, "确认", now, cfg, BoundaryEpisodeContext{HasActive: true})
 	if boundary != BoundaryContinue {
@@ -216,7 +216,7 @@ func TestClassifyTurnBoundary_BiasFavorsFalsePositiveContinue(t *testing.T) {
 	// a single weak continuation signal appears.
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := eventsAt(now.Add(-4*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下天气")
+	prev := eventsAt(now.Add(-6*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下天气")
 	// Weak marker "把它" should be enough.
 	boundary, _ := ClassifyTurnBoundary(prev, "把它保存下来", now, cfg, BoundaryEpisodeContext{})
 	if boundary != BoundaryContinue {
@@ -244,8 +244,8 @@ func TestClassifyTurnBoundary_MalformedTimestampFallsBack(t *testing.T) {
 
 func TestDefaultBoundaryConfig_SaneDefaults(t *testing.T) {
 	cfg := DefaultBoundaryConfig()
-	if cfg.ShortGapSeconds != 180 {
-		t.Errorf("ShortGapSeconds = %d, want 180", cfg.ShortGapSeconds)
+	if cfg.ShortGapSeconds != 300 {
+		t.Errorf("ShortGapSeconds = %d, want 300", cfg.ShortGapSeconds)
 	}
 	if cfg.SmallSessionEventThreshold != 16 {
 		t.Errorf("SmallSessionEventThreshold = %d, want 16", cfg.SmallSessionEventThreshold)

--- a/src/audio_volume_state.cpp
+++ b/src/audio_volume_state.cpp
@@ -19,6 +19,68 @@ void set_error(std::string* error, const std::string& msg) {
     }
 }
 
+class ScopedFile {
+public:
+    explicit ScopedFile(FILE* file) : file_(file) {}
+    ~ScopedFile() {
+        if (file_) {
+            std::fclose(file_);
+        }
+    }
+
+    FILE* get() const { return file_; }
+
+private:
+    ScopedFile(const ScopedFile&) = delete;
+    ScopedFile& operator=(const ScopedFile&) = delete;
+
+    FILE* file_;
+};
+
+class ScopedFd {
+public:
+    explicit ScopedFd(int fd) : fd_(fd) {}
+    ~ScopedFd() {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+    }
+
+    int get() const { return fd_; }
+
+    int release() {
+        int fd = fd_;
+        fd_ = -1;
+        return fd;
+    }
+
+private:
+    ScopedFd(const ScopedFd&) = delete;
+    ScopedFd& operator=(const ScopedFd&) = delete;
+
+    int fd_;
+};
+
+class TempFileCleanup {
+public:
+    explicit TempFileCleanup(const std::string& path) : path_(path), armed_(false) {}
+    ~TempFileCleanup() {
+        if (armed_) {
+            ::unlink(path_.c_str());
+        }
+    }
+
+    void arm() { armed_ = true; }
+    void disarm() { armed_ = false; }
+
+private:
+    TempFileCleanup(const TempFileCleanup&) = delete;
+    TempFileCleanup& operator=(const TempFileCleanup&) = delete;
+
+    std::string path_;
+    bool armed_;
+};
+
 std::string parent_dir(const std::string& path) {
     size_t slash = path.find_last_of('/');
     if (slash == std::string::npos) return ".";
@@ -88,8 +150,8 @@ AudioVolumeStateLoadStatus load_playback_volume_state(const char* path,
         return AudioVolumeStateLoadStatus::ERROR;
     }
 
-    FILE* fp = std::fopen(path, "r");
-    if (!fp) {
+    ScopedFile fp(std::fopen(path, "r"));
+    if (!fp.get()) {
         if (errno == ENOENT) {
             return AudioVolumeStateLoadStatus::MISSING;
         }
@@ -99,9 +161,8 @@ AudioVolumeStateLoadStatus load_playback_volume_state(const char* path,
 
     char buf[64] = {0};
     errno = 0;
-    if (!std::fgets(buf, sizeof(buf), fp)) {
+    if (!std::fgets(buf, sizeof(buf), fp.get())) {
         int saved_errno = errno;
-        std::fclose(fp);
         if (saved_errno != 0) {
             set_error(error, std::string("read ") + path + ": " + std::strerror(saved_errno));
             return AudioVolumeStateLoadStatus::ERROR;
@@ -111,8 +172,7 @@ AudioVolumeStateLoadStatus load_playback_volume_state(const char* path,
     }
 
     char extra[2] = {0};
-    bool too_long = std::fgets(extra, sizeof(extra), fp) != nullptr;
-    std::fclose(fp);
+    bool too_long = std::fgets(extra, sizeof(extra), fp.get()) != nullptr;
     if (too_long) {
         set_error(error, "volume state has trailing content");
         return AudioVolumeStateLoadStatus::INVALID;
@@ -160,57 +220,51 @@ bool save_playback_volume_state(const char* path,
     }
 
     std::string tmp = state_path + ".tmp";
-    int fd = ::open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
-    if (fd < 0) {
+    TempFileCleanup tmp_file(tmp);
+    ScopedFd fd(::open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644));
+    if (fd.get() < 0) {
         set_error(error, "open " + tmp + ": " + std::strerror(errno));
         return false;
     }
-    if (::fchmod(fd, 0644) != 0) {
+    tmp_file.arm();
+    if (::fchmod(fd.get(), 0644) != 0) {
         set_error(error, "chmod " + tmp + ": " + std::strerror(errno));
-        ::close(fd);
-        ::unlink(tmp.c_str());
         return false;
     }
 
     char buf[16];
     int len = std::snprintf(buf, sizeof(buf), "%d\n", volume);
     if (len <= 0 || static_cast<size_t>(len) >= sizeof(buf) ||
-        !write_all(fd, buf, static_cast<size_t>(len))) {
+        !write_all(fd.get(), buf, static_cast<size_t>(len))) {
         set_error(error, "write " + tmp + ": " + std::strerror(errno));
-        ::close(fd);
-        ::unlink(tmp.c_str());
         return false;
     }
 
-    if (::fsync(fd) != 0) {
+    if (::fsync(fd.get()) != 0) {
         set_error(error, "fsync " + tmp + ": " + std::strerror(errno));
-        ::close(fd);
-        ::unlink(tmp.c_str());
         return false;
     }
-    if (::close(fd) != 0) {
+    if (::close(fd.release()) != 0) {
         set_error(error, "close " + tmp + ": " + std::strerror(errno));
-        ::unlink(tmp.c_str());
         return false;
     }
     if (::rename(tmp.c_str(), state_path.c_str()) != 0) {
         set_error(error, "rename " + tmp + " -> " + state_path + ": " + std::strerror(errno));
-        ::unlink(tmp.c_str());
         return false;
     }
+    tmp_file.disarm();
 
     std::string dir = parent_dir(state_path);
-    int dirfd = ::open(dir.c_str(), O_RDONLY | O_DIRECTORY);
-    if (dirfd < 0) {
+    ScopedFd dirfd(::open(dir.c_str(), O_RDONLY | O_DIRECTORY));
+    if (dirfd.get() < 0) {
         set_error(error, "open dir " + dir + ": " + std::strerror(errno));
         return false;
     }
-    if (::fsync(dirfd) != 0) {
+    if (::fsync(dirfd.get()) != 0) {
         set_error(error, "fsync dir " + dir + ": " + std::strerror(errno));
-        ::close(dirfd);
         return false;
     }
-    if (::close(dirfd) != 0) {
+    if (::close(dirfd.release()) != 0) {
         set_error(error, "close dir " + dir + ": " + std::strerror(errno));
         return false;
     }

--- a/src/frame_service_protocol.cpp
+++ b/src/frame_service_protocol.cpp
@@ -1,6 +1,5 @@
 #include "frame_service_protocol.h"
 #include "service_status.h"
-#include <string.h>
 
 namespace aiden {
 
@@ -42,14 +41,14 @@ static uint64_t read_le64(const uint8_t* data) {
 
 std::vector<uint8_t> encode_frame_wire_prefix(uint32_t header_len, uint64_t payload_len) {
     std::vector<uint8_t> out;
-    out.reserve(12);
+    out.reserve(kFrameWirePrefixSize);
     write_le32(out, header_len);
     write_le64(out, payload_len);
     return out;
 }
 
 bool decode_frame_wire_prefix(const uint8_t* data, size_t len, FrameWirePrefix* out) {
-    if (!data || !out || len < 12) {
+    if (!data || !out || len < kFrameWirePrefixSize) {
         return false;
     }
     out->header_len = read_le32(data);

--- a/src/frame_service_protocol.h
+++ b/src/frame_service_protocol.h
@@ -35,6 +35,8 @@ struct FrameWirePrefix {
     uint64_t payload_len = 0;
 };
 
+static const size_t kFrameWirePrefixSize = sizeof(uint32_t) + sizeof(uint64_t);
+
 const char* frame_service_status_to_string(FrameServiceStatus status);
 bool frame_service_status_from_string(const char* text, FrameServiceStatus* out);
 

--- a/src/uds_message.cpp
+++ b/src/uds_message.cpp
@@ -92,7 +92,7 @@ FrameServiceStatus read_uds_message(int fd, UdsMessage* out) {
         return FrameServiceStatus::INTERNAL_ERROR;
     }
 
-    uint8_t prefix_bytes[12];
+    uint8_t prefix_bytes[kFrameWirePrefixSize];
     FrameServiceStatus status = read_exact(fd, prefix_bytes, sizeof(prefix_bytes));
     if (status != FrameServiceStatus::OK) {
         return status;

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -151,14 +151,6 @@ int required_json_int(cJSON* object, const char* key) {
     return item->valueint;
 }
 
-std::string read_file(const std::string& path) {
-    std::ifstream in(path.c_str());
-    REQUIRE(in.good());
-    std::ostringstream buffer;
-    buffer << in.rdbuf();
-    return buffer.str();
-}
-
 std::string replace_all(std::string text, const std::string& needle, const std::string& replacement) {
     size_t pos = 0;
     while ((pos = text.find(needle, pos)) != std::string::npos) {

--- a/tests/config_web_source_test.cpp
+++ b/tests/config_web_source_test.cpp
@@ -872,10 +872,9 @@ TEST_CASE("config web clears legacy wifi fields for explicit empty network lists
     source_buffer << source_in.rdbuf();
     const std::string source = source_buffer.str();
 
-    CHECK(source.find("void sync_wifi_legacy_fields_from_networks(aiden::WifiNetworkConfig* wifi)") != std::string::npos);
-    CHECK(source.find("wifi->ssid.clear();") != std::string::npos);
-    CHECK(source.find("wifi->psk.clear();") != std::string::npos);
-    CHECK(source.find("sync_wifi_legacy_fields_from_networks(wifi);") != std::string::npos);
+    CHECK(source.find("if (json_is_array(networks))") != std::string::npos);
+    CHECK(source.find("wifi->networks.clear();") != std::string::npos);
+    CHECK(source.find("aiden::sync_legacy_wifi_fields(wifi);") != std::string::npos);
 }
 
 TEST_CASE("config web preserves hid pointer mode and avoids hot-restarting usbhid") {

--- a/tests/frame_service_protocol_test.cpp
+++ b/tests/frame_service_protocol_test.cpp
@@ -10,6 +10,7 @@ using aiden::decode_frame_wire_prefix;
 using aiden::encode_frame_wire_prefix;
 using aiden::frame_service_status_from_string;
 using aiden::frame_service_status_to_string;
+using aiden::kFrameWirePrefixSize;
 
 TEST_CASE("frame service status converts to stable protocol strings") {
     CHECK(std::string(frame_service_status_to_string(FrameServiceStatus::OK)) == "OK");
@@ -46,7 +47,7 @@ TEST_CASE("frame service status rejects unknown protocol strings") {
 TEST_CASE("frame wire prefix encodes header and payload lengths as little endian") {
     std::vector<uint8_t> bytes = encode_frame_wire_prefix(0x01020304u, 0x0102030405060708ull);
 
-    REQUIRE(bytes.size() == 12);
+    REQUIRE(bytes.size() == kFrameWirePrefixSize);
     CHECK(bytes[0] == 0x04);
     CHECK(bytes[1] == 0x03);
     CHECK(bytes[2] == 0x02);
@@ -72,10 +73,10 @@ TEST_CASE("frame wire prefix decodes header and payload lengths") {
 
 TEST_CASE("frame wire prefix rejects incomplete input") {
     uint8_t short_bytes[11] = {};
-    uint8_t full_bytes[12] = {};
+    uint8_t full_bytes[kFrameWirePrefixSize] = {};
     FrameWirePrefix prefix{};
 
     CHECK_FALSE(decode_frame_wire_prefix(short_bytes, sizeof(short_bytes), &prefix));
-    CHECK_FALSE(decode_frame_wire_prefix(nullptr, 12, &prefix));
+    CHECK_FALSE(decode_frame_wire_prefix(nullptr, kFrameWirePrefixSize, &prefix));
     CHECK_FALSE(decode_frame_wire_prefix(full_bytes, sizeof(full_bytes), nullptr));
 }

--- a/tests/frame_service_server_test.cpp
+++ b/tests/frame_service_server_test.cpp
@@ -84,7 +84,7 @@ void request_latest_frame_raw(int fd) {
 }
 
 void read_response_header(int fd, aiden::FrameWirePrefix* prefix) {
-    uint8_t prefix_bytes[12];
+    uint8_t prefix_bytes[aiden::kFrameWirePrefixSize];
     read_exact_or_fail(fd, prefix_bytes, sizeof(prefix_bytes));
     REQUIRE(aiden::decode_frame_wire_prefix(prefix_bytes, sizeof(prefix_bytes), prefix));
     std::vector<uint8_t> header(prefix->header_len);

--- a/tests/wifi_config_test.cpp
+++ b/tests/wifi_config_test.cpp
@@ -197,3 +197,15 @@ TEST_CASE("removing the last wifi network clears legacy credentials") {
     CHECK(rendered.find("network={") == std::string::npos);
     CHECK(rendered.find("obsolete") == std::string::npos);
 }
+
+TEST_CASE("sync_legacy_wifi_fields clears legacy credentials for empty networks") {
+    aiden::WifiNetworkConfig wifi;
+    wifi.ssid = "legacy";
+    wifi.psk = "legacy-password";
+
+    aiden::sync_legacy_wifi_fields(&wifi);
+
+    CHECK(wifi.networks.empty());
+    CHECK(wifi.ssid.empty());
+    CHECK(wifi.psk.empty());
+}


### PR DESCRIPTION
## Summary
- raise the default session-boundary short gap to 300 seconds and update boundary tests/docs
- align session-memory lifecycle docs with native chat-message hot-window placement
- clean up protocol prefix sizing, UDS tests, and audio volume state resource handling
- remove duplicate config-web E2E helper and add direct Wi-Fi legacy field coverage

## Tests
- go test ./internal/agent
- go test ./cmd/daemon
- cmake --build build-host-tests --target aiden_tests
- ctest --test-dir build-host-tests --output-on-failure