### PR TITLE
fix(agent): play full fallback speech output

### DIFF
--- a/src/agent/cmd/daemon/config_commands.go
+++ b/src/agent/cmd/daemon/config_commands.go
@@ -142,7 +142,6 @@ type agentDTO struct {
 	VoiceToolCallSpeech        bool    `json:"voice_tool_call_speech"`
 	VoiceProgressSpeechEnabled bool    `json:"voice_progress_speech_enabled"`
 	VoiceSpeechSummaryEnabled  bool    `json:"voice_speech_summary_enabled"`
-	VoiceSpeechMaxRunes        int     `json:"voice_speech_max_runes"`
 	VoiceMaxResponseTokens     int     `json:"voice_max_response_tokens"`
 	MaxIterations              int     `json:"max_iterations"`
 	ForceSimpleLoop            bool    `json:"force_simple_loop"`
@@ -268,7 +267,6 @@ func (d webConfigDTO) toAgentConfig() agent.Config {
 		VoiceToolCallSpeech:        boolPtr(d.Agent.VoiceToolCallSpeech),
 		VoiceProgressSpeechEnabled: boolPtr(d.Agent.VoiceProgressSpeechEnabled),
 		VoiceSpeechSummaryEnabled:  boolPtr(d.Agent.VoiceSpeechSummaryEnabled),
-		VoiceSpeechMaxRunes:        d.Agent.VoiceSpeechMaxRunes,
 		VoiceMaxResponseTokens:     d.Agent.VoiceMaxResponseTokens,
 		MaxIterations:              d.Agent.MaxIterations,
 		ForceSimpleLoop:            d.Agent.ForceSimpleLoop,
@@ -387,7 +385,6 @@ func webConfigDTOFromAgentConfig(cfg agent.Config) webConfigDTO {
 			VoiceToolCallSpeech:        cfg.VoiceToolCallSpeechOrDefault(),
 			VoiceProgressSpeechEnabled: cfg.VoiceProgressSpeechEnabledOrDefault(),
 			VoiceSpeechSummaryEnabled:  cfg.VoiceSpeechSummaryEnabledOrDefault(),
-			VoiceSpeechMaxRunes:        cfg.VoiceSpeechMaxRunesOrDefault(),
 			VoiceMaxResponseTokens:     cfg.VoiceMaxResponseTokensOrDefault(),
 			MaxIterations:              cfg.MaxIterations,
 			ForceSimpleLoop:            cfg.ForceSimpleLoop,
@@ -610,8 +607,6 @@ func parseValidationErrors(err error) []ValidationError {
 		field = "voice_first_turn_timeout_ms"
 	} else if strings.Contains(errMsg, "voice_max_turns") {
 		field = "voice_max_turns"
-	} else if strings.Contains(errMsg, "voice_speech_max_runes") {
-		field = "voice_speech_max_runes"
 	} else if strings.Contains(errMsg, "voice_max_response_tokens") {
 		field = "voice_max_response_tokens"
 	} else if strings.Contains(errMsg, "screenshot_keep_n") {

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -255,7 +255,6 @@ func TestProcessUtteranceSpeaksFullOutputWhenSpeechMissing(t *testing.T) {
 			InputMode:                 "audio",
 			VoiceStreamingTTSEnabled:  boolPtr(false),
 			VoiceSpeechSummaryEnabled: boolPtr(true),
-			VoiceSpeechMaxRunes:       22,
 		},
 		audioClient:  NewAudioServiceClient(startTTSPlaybackAudioSocket(t)),
 		ttsManager:   ttsmodule.NewProviderManager(provider, nil),

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -229,9 +229,10 @@ func TestProcessUtteranceAudioModeSendsWAVAttachmentToRuntime(t *testing.T) {
 	}
 }
 
-func TestProcessUtteranceSpeaksSpeechTextWithoutChangingHistoryOutput(t *testing.T) {
+func TestProcessUtteranceSpeaksFullOutputWhenSpeechMissing(t *testing.T) {
+	output := "已完成设置，当前音量是 42。\n\n- 读取音量\n- 确认状态\n\n这段详细说明保留给屏幕。"
 	model := &scriptedModel{
-		responses: roleDirectResponses("已完成设置，当前音量是 42。\n\n- 读取音量\n- 确认状态\n\n这段详细说明保留给屏幕。"),
+		responses: roleDirectResponses(output),
 	}
 	store := NewChatHistoryStore(t.TempDir())
 	runtime := NewRuntimeWithDeps(
@@ -269,11 +270,8 @@ func TestProcessUtteranceSpeaksSpeechTextWithoutChangingHistoryOutput(t *testing
 	if len(texts) != 1 {
 		t.Fatalf("unexpected TTS texts: %#v", texts)
 	}
-	if strings.Contains(texts[0], "读取音量") || strings.Contains(texts[0], "详细说明") {
-		t.Fatalf("TTS should use spoken summary, got %q", texts[0])
-	}
-	if !strings.Contains(texts[0], "当前音量是 42") {
-		t.Fatalf("TTS summary lost conclusion: %q", texts[0])
+	if texts[0] != output {
+		t.Fatalf("TTS should use full output, got %q want %q", texts[0], output)
 	}
 
 	messages, err := store.Load(context.Background())

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -231,6 +231,7 @@ func TestProcessUtteranceAudioModeSendsWAVAttachmentToRuntime(t *testing.T) {
 
 func TestProcessUtteranceSpeaksFullOutputWhenSpeechMissing(t *testing.T) {
 	output := "已完成设置，当前音量是 42。\n\n- 读取音量\n- 确认状态\n\n这段详细说明保留给屏幕。"
+	expectedSpeech := "已完成设置，当前音量是 42。\n\n读取音量\n确认状态\n\n这段详细说明保留给屏幕。"
 	model := &scriptedModel{
 		responses: roleDirectResponses(output),
 	}
@@ -270,8 +271,8 @@ func TestProcessUtteranceSpeaksFullOutputWhenSpeechMissing(t *testing.T) {
 	if len(texts) != 1 {
 		t.Fatalf("unexpected TTS texts: %#v", texts)
 	}
-	if texts[0] != output {
-		t.Fatalf("TTS should use full output, got %q want %q", texts[0], output)
+	if texts[0] != expectedSpeech {
+		t.Fatalf("TTS should use normalized full output, got %q want %q", texts[0], expectedSpeech)
 	}
 
 	messages, err := store.Load(context.Background())

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -123,7 +123,6 @@ type Config struct {
 	VoiceToolCallSpeech        *bool              `toml:"voice_tool_call_speech,omitempty"`
 	VoiceProgressSpeechEnabled *bool              `toml:"voice_progress_speech_enabled,omitempty"`
 	VoiceSpeechSummaryEnabled  *bool              `toml:"voice_speech_summary_enabled,omitempty"`
-	VoiceSpeechMaxRunes        int                `toml:"voice_speech_max_runes,omitempty"`
 	VoiceMaxResponseTokens     int                `toml:"voice_max_response_tokens,omitempty"`
 	TodoReminderToolCalls      int                `toml:"todo_reminder_tool_calls,omitempty"`
 	MaxIterations              int                `toml:"max_iterations,omitempty"`
@@ -806,9 +805,6 @@ func (c Config) Validate() error {
 	if c.VoiceMaxTurns < 0 {
 		return fmt.Errorf("voice_max_turns must be >= 0, got %d", c.VoiceMaxTurns)
 	}
-	if c.VoiceSpeechMaxRunes < 0 {
-		return fmt.Errorf("voice_speech_max_runes must be >= 0, got %d", c.VoiceSpeechMaxRunes)
-	}
 	if c.VoiceMaxResponseTokens < 0 {
 		return fmt.Errorf("voice_max_response_tokens must be >= 0, got %d", c.VoiceMaxResponseTokens)
 	}
@@ -1062,13 +1058,6 @@ func (c Config) VoiceSpeechSummaryEnabledOrDefault() bool {
 		return *c.VoiceSpeechSummaryEnabled
 	}
 	return true
-}
-
-func (c Config) VoiceSpeechMaxRunesOrDefault() int {
-	if c.VoiceSpeechMaxRunes > 0 {
-		return c.VoiceSpeechMaxRunes
-	}
-	return defaultVoiceSpeechMaxRunes
 }
 
 func (c Config) VoiceMaxResponseTokensOrDefault() int {

--- a/src/agent/internal/agent/config_defaults.go
+++ b/src/agent/internal/agent/config_defaults.go
@@ -38,7 +38,7 @@ const (
 	defaultVoiceFollowupTimeoutMs  = 6000
 	defaultVoiceFirstTurnTimeoutMs = 10000
 	defaultVoiceMaxTurns           = 0
-	defaultVoiceMaxResponseTokens  = 400
+	defaultVoiceMaxResponseTokens  = 300
 	defaultTodoReminderToolCalls   = 3
 	defaultMaxIterations           = -1
 	defaultScreenshotKeepN         = 3

--- a/src/agent/internal/agent/config_defaults.go
+++ b/src/agent/internal/agent/config_defaults.go
@@ -38,7 +38,6 @@ const (
 	defaultVoiceFollowupTimeoutMs  = 6000
 	defaultVoiceFirstTurnTimeoutMs = 10000
 	defaultVoiceMaxTurns           = 0
-	defaultVoiceSpeechMaxRunes     = 120
 	defaultVoiceMaxResponseTokens  = 400
 	defaultTodoReminderToolCalls   = 3
 	defaultMaxIterations           = -1
@@ -124,7 +123,6 @@ func DefaultConfig() Config {
 		VoiceToolCallSpeech:        defaultBoolPtr(false),
 		VoiceProgressSpeechEnabled: defaultBoolPtr(true),
 		VoiceSpeechSummaryEnabled:  defaultBoolPtr(true),
-		VoiceSpeechMaxRunes:        defaultVoiceSpeechMaxRunes,
 		VoiceMaxResponseTokens:     defaultVoiceMaxResponseTokens,
 		TodoReminderToolCalls:      defaultTodoReminderToolCalls,
 		MaxIterations:              defaultMaxIterations,

--- a/src/agent/internal/agent/config_meta.go
+++ b/src/agent/internal/agent/config_meta.go
@@ -303,8 +303,6 @@ func ConfigMeta() ConfigMetadata {
 						VisibleWhen: all(in("agent.input_mode", "stt", "audio"))},
 					{Key: "voice_speech_summary_enabled", Widget: WidgetBoolean, Default: defaults.VoiceSpeechSummaryEnabledOrDefault(),
 						VisibleWhen: all(in("agent.input_mode", "stt", "audio"))},
-					{Key: "voice_speech_max_runes", Widget: WidgetNumber, Default: defaults.VoiceSpeechMaxRunes,
-						VisibleWhen: all(in("agent.input_mode", "stt", "audio"), truthy("agent.voice_speech_summary_enabled"))},
 					{Key: "voice_max_response_tokens", Widget: WidgetNumber, Default: defaults.VoiceMaxResponseTokens,
 						VisibleWhen: all(in("agent.input_mode", "stt", "audio"))},
 					{Key: "todo_reminder_tool_calls", Widget: WidgetNumber, Default: defaults.TodoReminderToolCallsOrDefault()},

--- a/src/agent/internal/agent/config_meta_test.go
+++ b/src/agent/internal/agent/config_meta_test.go
@@ -234,7 +234,6 @@ func TestConfigMeta_RuntimeDefaultsMatch(t *testing.T) {
 		{"agent.voice_tool_call_speech", defaults.VoiceToolCallSpeechOrDefault()},
 		{"agent.voice_progress_speech_enabled", defaults.VoiceProgressSpeechEnabledOrDefault()},
 		{"agent.voice_speech_summary_enabled", defaults.VoiceSpeechSummaryEnabledOrDefault()},
-		{"agent.voice_speech_max_runes", defaults.VoiceSpeechMaxRunes},
 		{"agent.voice_max_response_tokens", defaults.VoiceMaxResponseTokens},
 		{"agent.todo_reminder_tool_calls", defaults.TodoReminderToolCallsOrDefault()},
 		{"agent.max_iterations", defaults.MaxIterations},

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -871,9 +871,6 @@ func TestVoiceSessionConfigDefaults(t *testing.T) {
 	if !cfg.VoiceSpeechSummaryEnabledOrDefault() {
 		t.Fatal("VoiceSpeechSummaryEnabledOrDefault() = false, want true")
 	}
-	if cfg.VoiceSpeechMaxRunesOrDefault() != 120 {
-		t.Fatalf("VoiceSpeechMaxRunesOrDefault() = %d, want 120", cfg.VoiceSpeechMaxRunesOrDefault())
-	}
 	if cfg.VoiceMaxResponseTokensOrDefault() != 400 {
 		t.Fatalf("VoiceMaxResponseTokensOrDefault() = %d, want 400", cfg.VoiceMaxResponseTokensOrDefault())
 	}
@@ -895,7 +892,6 @@ func TestVoiceSessionConfigOverrides(t *testing.T) {
 		VoiceToolCallSpeech:        &toolSpeech,
 		VoiceProgressSpeechEnabled: &progressSpeechDisabled,
 		VoiceSpeechSummaryEnabled:  &summaryDisabled,
-		VoiceSpeechMaxRunes:        64,
 		VoiceMaxResponseTokens:     123,
 	}
 
@@ -922,9 +918,6 @@ func TestVoiceSessionConfigOverrides(t *testing.T) {
 	}
 	if cfg.VoiceSpeechSummaryEnabledOrDefault() {
 		t.Fatal("VoiceSpeechSummaryEnabledOrDefault() = true, want false")
-	}
-	if cfg.VoiceSpeechMaxRunesOrDefault() != 64 {
-		t.Fatalf("VoiceSpeechMaxRunesOrDefault() = %d, want 64", cfg.VoiceSpeechMaxRunesOrDefault())
 	}
 	if cfg.VoiceMaxResponseTokensOrDefault() != 123 {
 		t.Fatalf("VoiceMaxResponseTokensOrDefault() = %d, want 123", cfg.VoiceMaxResponseTokensOrDefault())
@@ -968,14 +961,6 @@ func TestVoiceSessionConfigValidationRejectsNegativeValues(t *testing.T) {
 				VoiceMaxResponseTokens: -1,
 			},
 			want: "voice_max_response_tokens must be >= 0",
-		},
-		{
-			name: "negative voice speech max runes",
-			cfg: Config{
-				Model:               ModelConfig{Provider: "fake"},
-				VoiceSpeechMaxRunes: -1,
-			},
-			want: "voice_speech_max_runes must be >= 0",
 		},
 		{
 			name: "negative todo reminder tool calls",

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -871,8 +871,8 @@ func TestVoiceSessionConfigDefaults(t *testing.T) {
 	if !cfg.VoiceSpeechSummaryEnabledOrDefault() {
 		t.Fatal("VoiceSpeechSummaryEnabledOrDefault() = false, want true")
 	}
-	if cfg.VoiceMaxResponseTokensOrDefault() != 400 {
-		t.Fatalf("VoiceMaxResponseTokensOrDefault() = %d, want 400", cfg.VoiceMaxResponseTokensOrDefault())
+	if cfg.VoiceMaxResponseTokensOrDefault() != 300 {
+		t.Fatalf("VoiceMaxResponseTokensOrDefault() = %d, want 300", cfg.VoiceMaxResponseTokensOrDefault())
 	}
 }
 

--- a/src/agent/internal/agent/speech_text.go
+++ b/src/agent/internal/agent/speech_text.go
@@ -4,145 +4,16 @@ import (
 	"encoding/json"
 	"io"
 	"strings"
-	"unicode"
-	"unicode/utf8"
 )
 
-// BuildSpeechText derives a short, spoken-friendly text from the full assistant
-// output. The full output remains the source of truth for UI, history, and memory.
-func BuildSpeechText(output string, cfg Config) string {
+// BuildSpeechText returns the full assistant output for fallback TTS. Structured
+// speech/text responses remain the preferred path for concise spoken output.
+func BuildSpeechText(output string, _ Config) string {
 	output = strings.TrimSpace(output)
 	if output == "" {
 		return ""
 	}
-	if !cfg.VoiceSpeechSummaryEnabledOrDefault() {
-		return output
-	}
-
-	text := stripSpeechUnfriendlyMarkdown(output)
-	text = strings.Join(strings.Fields(text), " ")
-	if text == "" {
-		text = strings.Join(strings.Fields(output), " ")
-	}
-	if sentence := firstSpeechSentence(text); sentence != "" {
-		text = sentence
-	}
-	return truncateSpeechRunes(text, cfg.VoiceSpeechMaxRunesOrDefault())
-}
-
-func stripSpeechUnfriendlyMarkdown(output string) string {
-	lines := strings.Split(output, "\n")
-	var kept []string
-	inCodeBlock := false
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
-			inCodeBlock = !inCodeBlock
-			continue
-		}
-		if inCodeBlock || trimmed == "" {
-			continue
-		}
-		if isMarkdownListLine(trimmed) || isMarkdownTableLine(trimmed) {
-			continue
-		}
-		kept = append(kept, strings.TrimSpace(stripMarkdownDecorators(trimmed)))
-	}
-	return strings.Join(kept, " ")
-}
-
-func isMarkdownListLine(line string) bool {
-	if strings.HasPrefix(line, "- ") || strings.HasPrefix(line, "* ") || strings.HasPrefix(line, "+ ") {
-		return true
-	}
-	i := 0
-	for ; i < len(line); i++ {
-		r, size := utf8.DecodeRuneInString(line[i:])
-		if !unicode.IsDigit(r) {
-			break
-		}
-		i += size - 1
-	}
-	if i == 0 || i >= len(line)-1 {
-		return false
-	}
-	return (line[i] == '.' || line[i] == ')') && line[i+1] == ' '
-}
-
-func isMarkdownTableLine(line string) bool {
-	if !strings.Contains(line, "|") {
-		return false
-	}
-	trimmed := strings.Trim(line, "| ")
-	if trimmed == "" {
-		return true
-	}
-	for _, r := range trimmed {
-		if r != '-' && r != ':' && r != '|' && !unicode.IsSpace(r) {
-			return strings.Count(line, "|") >= 2
-		}
-	}
-	return true
-}
-
-func stripMarkdownDecorators(line string) string {
-	replacer := strings.NewReplacer(
-		"**", "",
-		"__", "",
-		"`", "",
-		"#", "",
-		"> ", "",
-	)
-	return replacer.Replace(line)
-}
-
-func truncateSpeechRunes(text string, maxRunes int) string {
-	if maxRunes <= 0 || utf8.RuneCountInString(text) <= maxRunes {
-		return strings.TrimSpace(text)
-	}
-	runes := []rune(text)
-	minSentenceCut := maxRunes / 3
-	if minSentenceCut < 8 {
-		minSentenceCut = 8
-	}
-	sentenceCut := 0
-	softCut := 0
-	for i := 0; i < maxRunes && i < len(runes); i++ {
-		switch runes[i] {
-		case '。', '！', '？', '.', '!', '?', ';', '；':
-			if i+1 >= minSentenceCut {
-				sentenceCut = i + 1
-			}
-		case '，', ',', '、':
-			if i >= maxRunes/2 {
-				softCut = i
-			}
-		}
-	}
-	if sentenceCut > 0 {
-		return strings.TrimSpace(string(runes[:sentenceCut]))
-	}
-	if softCut > 0 {
-		return strings.TrimSpace(string(runes[:softCut]))
-	}
-	return strings.TrimSpace(string(runes[:maxRunes]))
-}
-
-func firstSpeechSentence(text string) string {
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return ""
-	}
-	runes := []rune(text)
-	for i, r := range runes {
-		switch r {
-		case '。', '！', '？', '.', '!', '?', ';', '；':
-			if i >= 5 {
-				return strings.TrimSpace(string(runes[:i+1]))
-			}
-		}
-	}
-	return ""
+	return output
 }
 
 type SpeechStreamWriter = JSONFieldStreamWriter

--- a/src/agent/internal/agent/speech_text.go
+++ b/src/agent/internal/agent/speech_text.go
@@ -3,7 +3,13 @@ package agent
 import (
 	"encoding/json"
 	"io"
+	"regexp"
 	"strings"
+)
+
+var (
+	markdownImagePattern = regexp.MustCompile(`!\[([^\]]*)\]\(([^)]*)\)`)
+	markdownLinkPattern  = regexp.MustCompile(`\[([^\]]+)\]\(([^)]*)\)`)
 )
 
 // BuildSpeechText returns the full assistant output for fallback TTS. Structured
@@ -13,7 +19,147 @@ func BuildSpeechText(output string, _ Config) string {
 	if output == "" {
 		return ""
 	}
-	return output
+	return normalizeMarkdownForSpeech(output)
+}
+
+func normalizeMarkdownForSpeech(output string) string {
+	lines := strings.Split(output, "\n")
+	normalized := make([]string, 0, len(lines))
+	inFence := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isMarkdownFenceLine(trimmed) {
+			inFence = !inFence
+			continue
+		}
+		if !inFence {
+			if isMarkdownTableSeparatorLine(trimmed) {
+				continue
+			}
+			trimmed = stripMarkdownLinePrefix(trimmed)
+			trimmed = normalizeMarkdownTableRow(trimmed)
+			trimmed = normalizeInlineMarkdown(trimmed)
+		}
+		normalized = append(normalized, trimmed)
+	}
+	return strings.TrimSpace(strings.Join(normalized, "\n"))
+}
+
+func isMarkdownFenceLine(line string) bool {
+	return strings.HasPrefix(line, "```") || strings.HasPrefix(line, "~~~")
+}
+
+func isMarkdownTableSeparatorLine(line string) bool {
+	if !strings.Contains(line, "|") || !strings.Contains(line, "-") {
+		return false
+	}
+	for _, r := range line {
+		if r != '|' && r != '-' && r != ':' && r != ' ' && r != '\t' {
+			return false
+		}
+	}
+	return true
+}
+
+func stripMarkdownLinePrefix(line string) string {
+	line = stripMarkdownBlockquotePrefix(line)
+	line = stripMarkdownHeadingPrefix(line)
+	line = stripMarkdownListPrefix(line)
+	line = stripMarkdownTaskPrefix(line)
+	return strings.TrimSpace(line)
+}
+
+func stripMarkdownBlockquotePrefix(line string) string {
+	for strings.HasPrefix(line, ">") {
+		line = strings.TrimSpace(strings.TrimPrefix(line, ">"))
+	}
+	return line
+}
+
+func stripMarkdownHeadingPrefix(line string) string {
+	hashes := 0
+	for hashes < len(line) && hashes < 6 && line[hashes] == '#' {
+		hashes++
+	}
+	if hashes > 0 && hashes < len(line) && line[hashes] == ' ' {
+		return strings.TrimSpace(line[hashes+1:])
+	}
+	return line
+}
+
+func stripMarkdownListPrefix(line string) string {
+	if len(line) >= 2 && (line[0] == '-' || line[0] == '*' || line[0] == '+') && line[1] == ' ' {
+		return strings.TrimSpace(line[2:])
+	}
+	i := 0
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' {
+		i++
+	}
+	if i > 0 && i+1 < len(line) && (line[i] == '.' || line[i] == ')') && line[i+1] == ' ' {
+		return strings.TrimSpace(line[i+2:])
+	}
+	return line
+}
+
+func stripMarkdownTaskPrefix(line string) string {
+	if len(line) >= 4 && line[0] == '[' && line[2] == ']' && line[3] == ' ' {
+		marker := line[1]
+		if marker == ' ' || marker == 'x' || marker == 'X' {
+			return strings.TrimSpace(line[4:])
+		}
+	}
+	return line
+}
+
+func normalizeMarkdownTableRow(line string) string {
+	if strings.Count(line, "|") < 2 {
+		return line
+	}
+	parts := strings.Split(strings.Trim(line, "|"), "|")
+	cells := make([]string, 0, len(parts))
+	for _, part := range parts {
+		cell := strings.TrimSpace(part)
+		if cell != "" {
+			cells = append(cells, cell)
+		}
+	}
+	if len(cells) == 0 {
+		return ""
+	}
+	return strings.Join(cells, "，")
+}
+
+func normalizeInlineMarkdown(text string) string {
+	text = markdownImagePattern.ReplaceAllStringFunc(text, func(match string) string {
+		parts := markdownImagePattern.FindStringSubmatch(match)
+		alt := strings.TrimSpace(parts[1])
+		url := strings.TrimSpace(parts[2])
+		if alt == "" && url == "" {
+			return ""
+		}
+		if alt == "" {
+			return "图片（" + url + "）"
+		}
+		if url == "" {
+			return "图片：" + alt
+		}
+		return "图片：" + alt + "（" + url + "）"
+	})
+	text = markdownLinkPattern.ReplaceAllStringFunc(text, func(match string) string {
+		parts := markdownLinkPattern.FindStringSubmatch(match)
+		label := strings.TrimSpace(parts[1])
+		url := strings.TrimSpace(parts[2])
+		if url == "" {
+			return label
+		}
+		return label + "（" + url + "）"
+	})
+	text = strings.ReplaceAll(text, "~~", "")
+	text = strings.ReplaceAll(text, "**", "")
+	text = strings.ReplaceAll(text, "__", "")
+	text = strings.ReplaceAll(text, "`", "")
+	text = strings.ReplaceAll(text, "*", "")
+	return strings.TrimSpace(text)
 }
 
 type SpeechStreamWriter = JSONFieldStreamWriter

--- a/src/agent/internal/agent/speech_text_test.go
+++ b/src/agent/internal/agent/speech_text_test.go
@@ -3,10 +3,9 @@ package agent
 import (
 	"strings"
 	"testing"
-	"unicode/utf8"
 )
 
-func TestBuildSpeechTextSummarizesVerboseOutputForTTS(t *testing.T) {
+func TestBuildSpeechTextKeepsFullOutputWhenSummaryEnabled(t *testing.T) {
 	output := strings.Join([]string{
 		"已完成设置，当前音量是 42。",
 		"",
@@ -24,20 +23,8 @@ func TestBuildSpeechTextSummarizesVerboseOutputForTTS(t *testing.T) {
 
 	speech := BuildSpeechText(output, Config{VoiceSpeechMaxRunes: 40})
 
-	if speech == "" {
-		t.Fatal("BuildSpeechText() returned empty speech")
-	}
-	if strings.Contains(speech, "```") || strings.Contains(speech, `{"volume":42}`) {
-		t.Fatalf("speech should drop code blocks, got %q", speech)
-	}
-	if strings.Contains(speech, "- 我先打开") {
-		t.Fatalf("speech should drop markdown list detail, got %q", speech)
-	}
-	if !strings.Contains(speech, "当前音量是 42") {
-		t.Fatalf("speech should keep the main conclusion, got %q", speech)
-	}
-	if utf8.RuneCountInString(speech) > 40 {
-		t.Fatalf("speech length = %d runes, want <= 40: %q", utf8.RuneCountInString(speech), speech)
+	if speech != strings.TrimSpace(output) {
+		t.Fatalf("speech = %q, want full output %q", speech, strings.TrimSpace(output))
 	}
 }
 
@@ -49,6 +36,16 @@ func TestBuildSpeechTextKeepsOutputWhenSummaryDisabled(t *testing.T) {
 
 	if speech != strings.TrimSpace(output) {
 		t.Fatalf("speech = %q, want original output", speech)
+	}
+}
+
+func TestBuildSpeechTextDoesNotKeepOnlyFirstSentence(t *testing.T) {
+	output := "CodeFace，你好！\n\n我仔细搜寻了记忆，但没有找到今天的对话历史记录。你可以再问我一次，我会尽力回答。"
+
+	speech := BuildSpeechText(output, Config{})
+
+	if speech != strings.TrimSpace(output) {
+		t.Fatalf("speech = %q, want full output %q", speech, strings.TrimSpace(output))
 	}
 }
 

--- a/src/agent/internal/agent/speech_text_test.go
+++ b/src/agent/internal/agent/speech_text_test.go
@@ -21,7 +21,7 @@ func TestBuildSpeechTextKeepsFullOutputWhenSummaryEnabled(t *testing.T) {
 		"这段额外说明不应该进入播报摘要，因为它太长也不适合口播。",
 	}, "\n")
 
-	speech := BuildSpeechText(output, Config{VoiceSpeechMaxRunes: 40})
+	speech := BuildSpeechText(output, Config{})
 	want := strings.Join([]string{
 		"已完成设置，当前音量是 42。",
 		"",
@@ -101,7 +101,7 @@ func TestBuildSpeechTextKeepsOutputWhenSummaryDisabled(t *testing.T) {
 	disabled := false
 	output := "第一句很长，但用户仍然应该能在关闭摘要时听到完整内容。\n\n第二段也要保留。"
 
-	speech := BuildSpeechText(output, Config{VoiceSpeechSummaryEnabled: &disabled, VoiceSpeechMaxRunes: 10})
+	speech := BuildSpeechText(output, Config{VoiceSpeechSummaryEnabled: &disabled})
 
 	if speech != strings.TrimSpace(output) {
 		t.Fatalf("speech = %q, want original output", speech)

--- a/src/agent/internal/agent/speech_text_test.go
+++ b/src/agent/internal/agent/speech_text_test.go
@@ -22,9 +22,78 @@ func TestBuildSpeechTextKeepsFullOutputWhenSummaryEnabled(t *testing.T) {
 	}, "\n")
 
 	speech := BuildSpeechText(output, Config{VoiceSpeechMaxRunes: 40})
+	want := strings.Join([]string{
+		"已完成设置，当前音量是 42。",
+		"",
+		"详细信息如下：",
+		"我先打开了设置。",
+		"然后读取了音量状态。",
+		"最后确认没有继续修改。",
+		"",
+		`{"volume":42}`,
+		"",
+		"这段额外说明不应该进入播报摘要，因为它太长也不适合口播。",
+	}, "\n")
 
-	if speech != strings.TrimSpace(output) {
-		t.Fatalf("speech = %q, want full output %q", speech, strings.TrimSpace(output))
+	if speech != want {
+		t.Fatalf("speech = %q, want normalized full output %q", speech, want)
+	}
+}
+
+func TestBuildSpeechTextNormalizesMarkdownWithoutDroppingContent(t *testing.T) {
+	output := strings.Join([]string{
+		"# 状态更新",
+		"",
+		"**重点**：已完成 `audio_service` 检查。",
+		"",
+		"- 当前音量是 **42**。",
+		"1. 播放 fallback output。",
+		"",
+		"详情见 [PR #237](https://github.com/AidenAI-IO/aiden-hardware-demo/pull/237)。",
+		"",
+		"> 请继续验证。",
+	}, "\n")
+
+	speech := BuildSpeechText(output, Config{})
+	want := strings.Join([]string{
+		"状态更新",
+		"",
+		"重点：已完成 audio_service 检查。",
+		"",
+		"当前音量是 42。",
+		"播放 fallback output。",
+		"",
+		"详情见 PR #237（https://github.com/AidenAI-IO/aiden-hardware-demo/pull/237）。",
+		"",
+		"请继续验证。",
+	}, "\n")
+
+	if speech != want {
+		t.Fatalf("speech = %q, want %q", speech, want)
+	}
+}
+
+func TestBuildSpeechTextNormalizesTablesAndTasksWithoutDroppingContent(t *testing.T) {
+	output := strings.Join([]string{
+		"| 项目 | 状态 |",
+		"| --- | --- |",
+		"| 音频 | 已修复 |",
+		"",
+		"- [x] 保留正文",
+		"- [ ] 继续验证",
+	}, "\n")
+
+	speech := BuildSpeechText(output, Config{})
+	want := strings.Join([]string{
+		"项目，状态",
+		"音频，已修复",
+		"",
+		"保留正文",
+		"继续验证",
+	}, "\n")
+
+	if speech != want {
+		t.Fatalf("speech = %q, want %q", speech, want)
 	}
 }
 

--- a/src/agent_toml.cpp
+++ b/src/agent_toml.cpp
@@ -283,8 +283,6 @@ void apply_kv(AgentToml& cfg,
             if (!assign_bool(&cfg.voice_progress_speech_enabled, raw, &sub_err)) fail(sub_err);
         } else if (key == "voice_speech_summary_enabled") {
             if (!assign_bool(&cfg.voice_speech_summary_enabled, raw, &sub_err)) fail(sub_err);
-        } else if (key == "voice_speech_max_runes") {
-            if (!assign_non_negative_int(&cfg.voice_speech_max_runes, raw, &sub_err)) fail(sub_err);
         } else if (key == "voice_max_response_tokens") {
             if (!assign_int(&cfg.voice_max_response_tokens, raw, &sub_err)) fail(sub_err);
         } else if (key == "max_iterations") {
@@ -621,7 +619,6 @@ bool save_agent_toml(const char* path, const AgentToml& cfg, std::string* error)
     emit_bool(out, "voice_tool_call_speech", cfg.voice_tool_call_speech);
     emit_bool(out, "voice_progress_speech_enabled", cfg.voice_progress_speech_enabled);
     emit_bool(out, "voice_speech_summary_enabled", cfg.voice_speech_summary_enabled);
-    if (cfg.voice_speech_max_runes != 0) emit_int(out, "voice_speech_max_runes", cfg.voice_speech_max_runes);
     if (cfg.voice_max_response_tokens != 0) emit_int(out, "voice_max_response_tokens", cfg.voice_max_response_tokens);
     if (cfg.max_iterations != 0) emit_int(out, "max_iterations", cfg.max_iterations);
     emit_bool(out, "force_simple_loop", cfg.force_simple_loop);

--- a/src/agent_toml.h
+++ b/src/agent_toml.h
@@ -114,7 +114,7 @@ struct AgentToml {
     bool voice_tool_call_speech = false;
     bool voice_progress_speech_enabled = true;
     bool voice_speech_summary_enabled = true;
-    int voice_max_response_tokens = 400;
+    int voice_max_response_tokens = 300;
     int max_iterations = -1;
     bool force_simple_loop = false;
     int screenshot_keep_n = 3;

--- a/src/agent_toml.h
+++ b/src/agent_toml.h
@@ -114,7 +114,6 @@ struct AgentToml {
     bool voice_tool_call_speech = false;
     bool voice_progress_speech_enabled = true;
     bool voice_speech_summary_enabled = true;
-    int voice_speech_max_runes = 120;
     int voice_max_response_tokens = 400;
     int max_iterations = -1;
     bool force_simple_loop = false;

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -552,7 +552,6 @@ bool validate_known_config_field_types(cJSON* root, std::string* error) {
         {"agent", "voice_tool_call_speech", CONFIG_FIELD_BOOL},
         {"agent", "voice_progress_speech_enabled", CONFIG_FIELD_BOOL},
         {"agent", "voice_speech_summary_enabled", CONFIG_FIELD_BOOL},
-        {"agent", "voice_speech_max_runes", CONFIG_FIELD_NUMBER},
         {"agent", "voice_max_response_tokens", CONFIG_FIELD_NUMBER},
         {"agent", "max_iterations", CONFIG_FIELD_NUMBER},
         {"agent", "force_simple_loop", CONFIG_FIELD_BOOL},
@@ -1468,7 +1467,6 @@ cJSON* config_to_json(const aiden::AgentToml& config, bool include_secrets = fal
     cJSON_AddBoolToObject(agent, "voice_tool_call_speech", config.voice_tool_call_speech ? 1 : 0);
     cJSON_AddBoolToObject(agent, "voice_progress_speech_enabled", config.voice_progress_speech_enabled ? 1 : 0);
     cJSON_AddBoolToObject(agent, "voice_speech_summary_enabled", config.voice_speech_summary_enabled ? 1 : 0);
-    cJSON_AddNumberToObject(agent, "voice_speech_max_runes", config.voice_speech_max_runes);
     cJSON_AddNumberToObject(agent, "voice_max_response_tokens", config.voice_max_response_tokens);
     cJSON_AddNumberToObject(agent, "max_iterations", config.max_iterations);
     cJSON_AddBoolToObject(agent, "force_simple_loop", config.force_simple_loop ? 1 : 0);
@@ -1738,7 +1736,6 @@ void update_config_from_json(cJSON* root, aiden::AgentToml* config) {
         set_json_bool(&config->voice_tool_call_speech, agent, "voice_tool_call_speech");
         set_json_bool(&config->voice_progress_speech_enabled, agent, "voice_progress_speech_enabled");
         set_json_bool(&config->voice_speech_summary_enabled, agent, "voice_speech_summary_enabled");
-        set_json_int(&config->voice_speech_max_runes, agent, "voice_speech_max_runes");
         set_json_int(&config->voice_max_response_tokens, agent, "voice_max_response_tokens");
         set_json_int(&config->max_iterations, agent, "max_iterations");
         set_json_bool(&config->force_simple_loop, agent, "force_simple_loop");
@@ -3970,7 +3967,7 @@ ApiResponse handle_config_test(const Options& options, const std::string& body) 
         const char* numeric_keys[] = {
             "silence_ms", "min_speech_ms",
             "voice_followup_timeout_ms", "voice_first_turn_timeout_ms",
-            "voice_max_turns", "voice_speech_max_runes", "voice_max_response_tokens",
+            "voice_max_turns", "voice_max_response_tokens",
             "screenshot_keep_n", "screenshot_prune_interval",
             "screen_stable_timeout_ms", "screen_stable_ms", NULL
         };

--- a/src/config_web_html.h
+++ b/src/config_web_html.h
@@ -145,7 +145,6 @@ static const char* CONFIG_WEB_HTML =
     "            <div class=\"field\"><label>voice_tool_call_speech</label><input id=\"agent_voice_tool_call_speech\" type=\"checkbox\" data-section=\"agent\"></div>\n"
     "            <div class=\"field\"><label>voice_progress_speech_enabled</label><input id=\"agent_voice_progress_speech_enabled\" type=\"checkbox\" data-section=\"agent\"></div>\n"
     "            <div class=\"field\"><label>voice_speech_summary_enabled</label><input id=\"agent_voice_speech_summary_enabled\" type=\"checkbox\" data-section=\"agent\"></div>\n"
-    "            <div class=\"field\"><label>voice_speech_max_runes</label><input id=\"agent_voice_speech_max_runes\" type=\"number\" data-section=\"agent\"></div>\n"
     "            <div class=\"field\"><label>voice_max_response_tokens</label><input id=\"agent_voice_max_response_tokens\" type=\"number\" data-section=\"agent\"></div>\n"
     "            <div class=\"field\"><label>max_iterations</label><input id=\"agent_max_iterations\" type=\"number\" data-section=\"agent\"></div>\n"
     "            <div class=\"field\"><label>force_simple_loop</label><input id=\"agent_force_simple_loop\" type=\"checkbox\" data-section=\"agent\"></div>\n"

--- a/tests/agent_stub_main.cpp
+++ b/tests/agent_stub_main.cpp
@@ -76,7 +76,7 @@ const char* kDefaultConfig =
     "\"voice_followup_timeout_ms\":6000,\"voice_first_turn_timeout_ms\":10000,"
     "\"voice_max_turns\":0,\"voice_interrupt_on_wakeup\":true,"
     "\"voice_streaming_tts_enabled\":true,\"voice_tool_call_speech\":false,"
-    "\"voice_speech_summary_enabled\":true,\"voice_speech_max_runes\":120,"
+    "\"voice_speech_summary_enabled\":true,"
     "\"voice_max_response_tokens\":400,\"max_iterations\":-1,\"force_simple_loop\":false,"
     "\"screenshot_keep_n\":3,"
     "\"screenshot_prune_interval\":25,\"screen_stable_timeout_ms\":3500,"

--- a/tests/agent_stub_main.cpp
+++ b/tests/agent_stub_main.cpp
@@ -77,7 +77,7 @@ const char* kDefaultConfig =
     "\"voice_max_turns\":0,\"voice_interrupt_on_wakeup\":true,"
     "\"voice_streaming_tts_enabled\":true,\"voice_tool_call_speech\":false,"
     "\"voice_speech_summary_enabled\":true,"
-    "\"voice_max_response_tokens\":400,\"max_iterations\":-1,\"force_simple_loop\":false,"
+    "\"voice_max_response_tokens\":300,\"max_iterations\":-1,\"force_simple_loop\":false,"
     "\"screenshot_keep_n\":3,"
     "\"screenshot_prune_interval\":25,\"screen_stable_timeout_ms\":3500,"
     "\"screen_stable_ms\":500,\"screen_stable_diff_threshold\":2}"

--- a/tests/agent_toml_test.cpp
+++ b/tests/agent_toml_test.cpp
@@ -42,7 +42,6 @@ TEST_CASE("agent_toml round-trip preserves Go-agent schema fields") {
     cfg.voice_tool_call_speech = false;
     cfg.voice_progress_speech_enabled = false;
     cfg.voice_speech_summary_enabled = false;
-    cfg.voice_speech_max_runes = 80;
     cfg.voice_max_response_tokens = 240;
     cfg.max_iterations = 6;
     cfg.force_simple_loop = true;
@@ -141,7 +140,6 @@ TEST_CASE("agent_toml round-trip preserves Go-agent schema fields") {
 	CHECK(loaded.voice_tool_call_speech == false);
 	CHECK(loaded.voice_progress_speech_enabled == false);
 	CHECK(loaded.voice_speech_summary_enabled == false);
-	CHECK(loaded.voice_speech_max_runes == 80);
 	CHECK(loaded.voice_max_response_tokens == 240);
 	CHECK(loaded.max_iterations == 6);
 	CHECK(loaded.force_simple_loop == true);
@@ -332,18 +330,19 @@ TEST_CASE("agent_toml strips inline comments after unquoted scalars") {
     std::remove(path.c_str());
 }
 
-TEST_CASE("agent_toml rejects negative voice speech max runes") {
-    std::string path = make_temp_path("negative_voice_speech_max_runes.toml");
+TEST_CASE("agent_toml ignores legacy voice speech max runes") {
+    std::string path = make_temp_path("legacy_voice_speech_max_runes.toml");
     {
         std::ofstream out(path);
         out << "voice_speech_max_runes = -1\n";
+        out << "voice_max_response_tokens = 240\n";
     }
 
     aiden::AgentToml cfg;
     std::string err;
-    CHECK_FALSE(aiden::load_agent_toml(path.c_str(), cfg, &err));
-    CHECK(err.find("voice_speech_max_runes") != std::string::npos);
-    CHECK(err.find(">= 0") != std::string::npos);
+    REQUIRE(aiden::load_agent_toml(path.c_str(), cfg, &err));
+    CHECK(err.empty());
+    CHECK(cfg.voice_max_response_tokens == 240);
 
     std::remove(path.c_str());
 }

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -195,7 +195,7 @@ std::string resolved_config_json(const std::string& search_provider, bool search
         "\"voice_max_turns\":0,\"voice_interrupt_on_wakeup\":true,"
         "\"voice_streaming_tts_enabled\":true,\"voice_tool_call_speech\":false,"
         "\"voice_speech_summary_enabled\":true,"
-        "\"voice_max_response_tokens\":400,\"max_iterations\":-1,\"force_simple_loop\":false,"
+        "\"voice_max_response_tokens\":300,\"max_iterations\":-1,\"force_simple_loop\":false,"
         "\"screenshot_keep_n\":3,"
         "\"screenshot_prune_interval\":25,\"screen_stable_timeout_ms\":3500,"
         "\"screen_stable_ms\":500,\"screen_stable_diff_threshold\":2}"

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -194,7 +194,7 @@ std::string resolved_config_json(const std::string& search_provider, bool search
         "\"voice_followup_timeout_ms\":6000,\"voice_first_turn_timeout_ms\":10000,"
         "\"voice_max_turns\":0,\"voice_interrupt_on_wakeup\":true,"
         "\"voice_streaming_tts_enabled\":true,\"voice_tool_call_speech\":false,"
-        "\"voice_speech_summary_enabled\":true,\"voice_speech_max_runes\":120,"
+        "\"voice_speech_summary_enabled\":true,"
         "\"voice_max_response_tokens\":400,\"max_iterations\":-1,\"force_simple_loop\":false,"
         "\"screenshot_keep_n\":3,"
         "\"screenshot_prune_interval\":25,\"screen_stable_timeout_ms\":3500,"

--- a/tests/config_web_source_test.cpp
+++ b/tests/config_web_source_test.cpp
@@ -975,7 +975,6 @@ TEST_CASE("config web resolved config validation keeps required fields and type 
     CHECK(source.find("\"search\", \"has_api_key\", CONFIG_FIELD_BOOL") != std::string::npos);
     CHECK(source.find("\"voice_progress_speech_enabled\", CONFIG_FIELD_BOOL") != std::string::npos);
     CHECK(source.find("\"voice_speech_summary_enabled\", CONFIG_FIELD_BOOL") != std::string::npos);
-    CHECK(source.find("\"voice_speech_max_runes\", CONFIG_FIELD_NUMBER") != std::string::npos);
 }
 
 TEST_CASE("config web rendered config controls are registered in field type guards") {


### PR DESCRIPTION
## Summary
- Remove fallback speech summarization/truncation from BuildSpeechText.
- Preserve structured speech/text behavior when a speech field is present.
- Normalize Markdown syntax for fallback speech without dropping content: headings, lists, tasks, blockquotes, tables, links, inline code, emphasis, and fenced code blocks are converted to spoken-friendly text.
- Remove the now-unused voice_speech_max_runes config/API/UI field and keep TOML loading tolerant of the legacy key.
- Lower the default voice_max_response_tokens from 400 to 300 for shorter voice turns.
- Update dialog, speech, config, and config_web tests for normalized full-output fallback playback.

## Tests
- go test ./internal/agent ./cmd/daemon
- cmake -S . -B build-tests -DAIDEN_TESTS=ON
- cmake --build build-tests --target aiden_tests -j 8
- ./build-tests/bin/aiden_tests