### PR TITLE
fix(agent): remove follow-up interpretation prompting

### DIFF
--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -1344,12 +1344,8 @@ func writeRequestObjectiveAndCriteria(builder *strings.Builder, inputs map[strin
 		builder.WriteString("\n\nLatest user message:\n")
 		builder.WriteString(latestUserMessage)
 		if relation := strings.TrimSpace(inputs[followUpRelationKey]); relation != "" {
-			builder.WriteString("\n\nInterpretation:\n")
-			builder.WriteString("- follow_up_classification: ")
+			builder.WriteString("\n\nFollow-up classification:\n")
 			builder.WriteString(relation)
-			builder.WriteByte('\n')
-			builder.WriteString("- ")
-			builder.WriteString(interpretationForFollowUpRelation(relation))
 			builder.WriteByte('\n')
 		}
 	}

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -818,7 +818,7 @@ func TestRuntimeRunResumeCorrectionUsesRootRequestAndCommittedPlan(t *testing.T)
 		rootRequest,
 		"Latest user message",
 		correction,
-		"Interpretation:",
+		"Follow-up classification:",
 		"correction",
 		"Latest committed plan",
 		"在微信群发送100块钱红包",

--- a/src/agent/internal/agent/session_context_view.go
+++ b/src/agent/internal/agent/session_context_view.go
@@ -34,7 +34,6 @@ type sessionContextView struct {
 	RootUserRequest       string
 	LatestUserMessage     string
 	FollowUpRelation      string
-	Interpretation        string
 	LatestCommittedPlan   *plannerDecision
 	LatestVerifierSummary string
 	LatestCorrection      string
@@ -178,7 +177,6 @@ func BuildSessionContextView(events []SessionEvent, currentInput string) session
 		RootUserRequest:   root,
 		LatestUserMessage: latestContent,
 		FollowUpRelation:  relation,
-		Interpretation:    interpretationForFollowUpRelation(relation),
 	}
 	if relation == FollowUpCorrection {
 		view.LatestCorrection = latestContent
@@ -329,21 +327,6 @@ func latestVerifierSummary(events []SessionEvent, taskRootIndex, latestUserIndex
 	return ""
 }
 
-func interpretationForFollowUpRelation(relation string) string {
-	switch relation {
-	case FollowUpCorrection:
-		return "treat the latest user message as a correction to the root request unless it explicitly replaces the task"
-	case FollowUpReplacement:
-		return "treat the latest user message as an explicit replacement and do not continue the previous task"
-	case FollowUpNewTask:
-		return "treat the latest user message as a new task; prior session context is lower priority"
-	case FollowUpContinuation:
-		return "continue the existing task using the root request as the authority"
-	default:
-		return "treat this as the root request"
-	}
-}
-
 func formatSessionContextView(view sessionContextView) string {
 	if strings.TrimSpace(view.RootUserRequest) == "" && strings.TrimSpace(view.LatestUserMessage) == "" {
 		return ""
@@ -363,11 +346,6 @@ func formatSessionContextView(view sessionContextView) string {
 	if relation := strings.TrimSpace(view.FollowUpRelation); relation != "" {
 		builder.WriteString("- Follow-up classification: ")
 		builder.WriteString(relation)
-		builder.WriteByte('\n')
-	}
-	if interpretation := strings.TrimSpace(view.Interpretation); interpretation != "" {
-		builder.WriteString("- Interpretation: ")
-		builder.WriteString(interpretation)
 		builder.WriteByte('\n')
 	}
 	if correction := strings.TrimSpace(view.LatestCorrection); correction != "" {

--- a/src/agent/internal/agent/session_context_view_test.go
+++ b/src/agent/internal/agent/session_context_view_test.go
@@ -1,6 +1,9 @@
 package agent
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestBuildSessionContextViewUsesLatestTaskRootForContinuation(t *testing.T) {
 	events := []SessionEvent{
@@ -17,5 +20,28 @@ func TestBuildSessionContextViewUsesLatestTaskRootForContinuation(t *testing.T) 
 	}
 	if view.LatestCommittedPlan != nil {
 		t.Fatalf("latest committed plan should not cross task root, got %#v", view.LatestCommittedPlan)
+	}
+}
+
+func TestFormatSessionContextViewOmitsFollowUpInterpretationText(t *testing.T) {
+	events := []SessionEvent{
+		{Type: "user_input", Role: "user", Content: "打开微信", Relation: FollowUpRootRequest},
+		{Type: "assistant_output", Role: "assistant", Content: "正在打开微信"},
+		{Type: "user_input", Role: "user", Content: "我喜欢吃小龙虾", Relation: FollowUpContinuation},
+	}
+
+	view := BuildSessionContextView(events, "我喜欢吃小龙虾")
+	formatted := formatSessionContextView(view)
+	if !strings.Contains(formatted, "- Follow-up classification: continuation") {
+		t.Fatalf("formatted context missing follow-up classification:\n%s", formatted)
+	}
+	for _, unwanted := range []string{
+		"Interpretation:",
+		"continue the existing task using the root request as the authority",
+		"treat the latest user message",
+	} {
+		if strings.Contains(formatted, unwanted) {
+			t.Fatalf("formatted context should not contain %q:\n%s", unwanted, formatted)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Remove natural-language interpretation text for follow-up classifications from planner context
- Keep the raw follow-up classification as a structured signal only
- Add regression coverage to ensure authority-style interpretation text is not injected

## Tests
- go test ./internal/agent
- go test ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified follow-up classification output by removing redundant interpretation text from session context display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->