### PR TITLE
fix(agent): reduce root request prompt authority

### DIFF
--- a/src/agent/internal/agent/chat_history_memory_test.go
+++ b/src/agent/internal/agent/chat_history_memory_test.go
@@ -265,11 +265,13 @@ func TestRuntimeRunIncludesFullActivePlannerHistoryAndSessionRootContext(t *test
 		"prior assistant 02",
 		"prior user 11",
 		"prior assistant 11",
-		"Root request: prior user 00",
 	} {
 		if !strings.Contains(plannerTaskPrompt, want) {
 			t.Fatalf("planner task prompt missing %q:\n%s", want, plannerTaskPrompt)
 		}
+	}
+	if strings.Contains(plannerTaskPrompt, "Root request:") {
+		t.Fatalf("planner task prompt should not repeat root request in session context:\n%s", plannerTaskPrompt)
 	}
 }
 

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -1338,7 +1338,7 @@ func writeRequestObjectiveAndCriteria(builder *strings.Builder, inputs map[strin
 	if latestUserMessage == "" {
 		latestUserMessage = strings.TrimSpace(inputs["input"])
 	}
-	builder.WriteString("\n\nOriginal user request / root request (authoritative; do not replace it with a subtask):\n")
+	builder.WriteString("\n\nOriginal user request / root request:\n")
 	builder.WriteString(rootRequest)
 	if latestUserMessage != "" && latestUserMessage != rootRequest {
 		builder.WriteString("\n\nLatest user message:\n")

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -1349,11 +1349,10 @@ func writeRequestContextAndCriteria(builder *strings.Builder, inputs map[string]
 			builder.WriteByte('\n')
 		}
 	}
-	builder.WriteString("\n\nCompletion criteria:\n")
 	if len(state.CompletionCriteria) == 0 {
-		builder.WriteString("- Satisfy every explicit requirement in the original user request.\n")
 		return
 	}
+	builder.WriteString("\n\nCompletion criteria:\n")
 	for _, criterion := range state.CompletionCriteria {
 		if criterion = strings.TrimSpace(criterion); criterion != "" {
 			builder.WriteString("- ")
@@ -1787,7 +1786,7 @@ func parsePlannerDecision(res *llms.ContentResponse, fallbackStep string) planne
 		if toolDesc != "" {
 			return plannerDecision{
 				Objective:          strings.TrimSpace(fallbackStep),
-				CompletionCriteria: uniqueNonEmpty([]string{"Satisfy every explicit requirement in the original user request."}),
+				CompletionCriteria: uniqueNonEmpty([]string{defaultCompletionCriterion}),
 				Plan:               uniqueNonEmpty([]string{toolDesc}),
 				NextStep:           toolDesc,
 				Reason:             "planner incorrectly returned tool_call instead of JSON; extracted description field as next_step",
@@ -1802,7 +1801,7 @@ func parsePlannerDecision(res *llms.ContentResponse, fallbackStep string) planne
 	}
 	return plannerDecision{
 		Objective:          strings.TrimSpace(fallbackStep),
-		CompletionCriteria: uniqueNonEmpty([]string{"Satisfy every explicit requirement in the original user request."}),
+		CompletionCriteria: uniqueNonEmpty([]string{defaultCompletionCriterion}),
 		Plan:               uniqueNonEmpty([]string{text}),
 		NextStep:           text,
 		Reason:             "planner returned non-JSON content",

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -1009,7 +1009,7 @@ func buildPlannerStatePrompt(inputs map[string]string, state roleLoopState, task
 	builder.WriteString(task)
 	writeLoopMode(&builder, state)
 	writeWorldState(&builder, state.World)
-	writeRequestObjectiveAndCriteria(&builder, inputs, state)
+	writeRequestContextAndCriteria(&builder, inputs, state)
 	writeSessionContext(&builder, inputs)
 	if history := strings.TrimSpace(inputs["history"]); history != "" {
 		builder.WriteString("\n\nConversation history:\n")
@@ -1027,7 +1027,7 @@ func buildExecutorStatePrompt(inputs map[string]string, state roleLoopState, tas
 	var builder strings.Builder
 	builder.WriteString(task)
 	writeWorldState(&builder, state.World)
-	writeRequestObjectiveAndCriteria(&builder, inputs, state)
+	writeRequestContextAndCriteria(&builder, inputs, state)
 	writeSessionContext(&builder, inputs)
 	if history := strings.TrimSpace(inputs["history"]); history != "" {
 		builder.WriteString("\n\nConversation history:\n")
@@ -1063,7 +1063,7 @@ func buildVerifierStatePrompt(inputs map[string]string, state roleLoopState, tas
 	var builder strings.Builder
 	builder.WriteString(task)
 	writeWorldState(&builder, state.World)
-	writeRequestObjectiveAndCriteria(&builder, inputs, state)
+	writeRequestContextAndCriteria(&builder, inputs, state)
 	writeSessionContext(&builder, inputs)
 	writeCurrentPlan(&builder, state)
 	writePriorPlanStepResults(&builder, state)
@@ -1329,7 +1329,7 @@ func intLabel(label string, value *int) string {
 	return fmt.Sprintf("%s=%d", label, *value)
 }
 
-func writeRequestObjectiveAndCriteria(builder *strings.Builder, inputs map[string]string, state roleLoopState) {
+func writeRequestContextAndCriteria(builder *strings.Builder, inputs map[string]string, state roleLoopState) {
 	rootRequest := strings.TrimSpace(inputs[rootRequestInputKey])
 	if rootRequest == "" {
 		rootRequest = strings.TrimSpace(inputs["input"])
@@ -1348,12 +1348,6 @@ func writeRequestObjectiveAndCriteria(builder *strings.Builder, inputs map[strin
 			builder.WriteString(relation)
 			builder.WriteByte('\n')
 		}
-	}
-	builder.WriteString("\n\nCurrent objective:\n")
-	if objective := strings.TrimSpace(state.Objective); objective != "" {
-		builder.WriteString(objective)
-	} else {
-		builder.WriteString(rootRequest)
 	}
 	builder.WriteString("\n\nCompletion criteria:\n")
 	if len(state.CompletionCriteria) == 0 {

--- a/src/agent/internal/agent/role_loop.go
+++ b/src/agent/internal/agent/role_loop.go
@@ -18,6 +18,8 @@ const (
 	phaseExecution loopPhase = "execution"
 )
 
+const defaultCompletionCriterion = "Satisfy the current user request."
+
 type plannerTurnKind int
 
 const (
@@ -268,7 +270,7 @@ func parseCommitPlanInput(raw string) (plannerDecision, error) {
 		decision.Objective = decision.Plan[0]
 	}
 	if len(decision.CompletionCriteria) == 0 {
-		decision.CompletionCriteria = []string{"Satisfy every explicit requirement in the original user request."}
+		decision.CompletionCriteria = []string{defaultCompletionCriterion}
 	}
 	return decision, nil
 }

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -808,7 +808,7 @@ func TestRecordPlanStepResultSurvivesStepClear(t *testing.T) {
 	}
 }
 
-func TestRequestObjectivePromptDoesNotMarkRootRequestAuthoritative(t *testing.T) {
+func TestRequestContextPromptDoesNotMarkRootRequestAuthoritative(t *testing.T) {
 	inputs := map[string]string{
 		"input":             "打开微信",
 		rootRequestInputKey: "查天气",
@@ -820,6 +820,7 @@ func TestRequestObjectivePromptDoesNotMarkRootRequestAuthoritative(t *testing.T)
 	for _, unwanted := range []string{
 		"Original user request / root request (authoritative; do not replace it with a subtask)",
 		"authoritative; do not replace it with a subtask",
+		"Current objective:",
 	} {
 		if strings.Contains(prompt, unwanted) {
 			t.Fatalf("planner prompt should not contain %q:\n%s", unwanted, prompt)

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -808,6 +808,28 @@ func TestRecordPlanStepResultSurvivesStepClear(t *testing.T) {
 	}
 }
 
+func TestRequestObjectivePromptDoesNotMarkRootRequestAuthoritative(t *testing.T) {
+	inputs := map[string]string{
+		"input":             "打开微信",
+		rootRequestInputKey: "查天气",
+		latestUserInputKey:  "打开微信",
+		followUpRelationKey: FollowUpContinuation,
+	}
+	prompt := buildPlannerStatePrompt(inputs, roleLoopState{}, "Planner task.")
+
+	for _, unwanted := range []string{
+		"Original user request / root request (authoritative; do not replace it with a subtask)",
+		"authoritative; do not replace it with a subtask",
+	} {
+		if strings.Contains(prompt, unwanted) {
+			t.Fatalf("planner prompt should not contain %q:\n%s", unwanted, prompt)
+		}
+	}
+	if !strings.Contains(prompt, "Original user request") {
+		t.Fatalf("planner prompt should still include the original request as context:\n%s", prompt)
+	}
+}
+
 func TestExecutorPromptIncludesPriorPlanStepResults(t *testing.T) {
 	state := roleLoopState{
 		Plan:          []string{"read account id", "use account id"},

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -821,6 +821,7 @@ func TestRequestContextPromptDoesNotMarkRootRequestAuthoritative(t *testing.T) {
 		"Original user request / root request (authoritative; do not replace it with a subtask)",
 		"authoritative; do not replace it with a subtask",
 		"Current objective:",
+		"Satisfy every explicit requirement in the original user request.",
 	} {
 		if strings.Contains(prompt, unwanted) {
 			t.Fatalf("planner prompt should not contain %q:\n%s", unwanted, prompt)

--- a/src/agent/internal/agent/session_context_view.go
+++ b/src/agent/internal/agent/session_context_view.go
@@ -328,16 +328,15 @@ func latestVerifierSummary(events []SessionEvent, taskRootIndex, latestUserIndex
 }
 
 func formatSessionContextView(view sessionContextView) string {
-	if strings.TrimSpace(view.RootUserRequest) == "" && strings.TrimSpace(view.LatestUserMessage) == "" {
+	if strings.TrimSpace(view.LatestUserMessage) == "" &&
+		strings.TrimSpace(view.FollowUpRelation) == "" &&
+		strings.TrimSpace(view.LatestCorrection) == "" &&
+		view.LatestCommittedPlan == nil &&
+		strings.TrimSpace(view.LatestVerifierSummary) == "" {
 		return ""
 	}
 	var builder strings.Builder
-	builder.WriteString("Session context view (runtime-normalized, priority ordered):\n")
-	if root := strings.TrimSpace(view.RootUserRequest); root != "" {
-		builder.WriteString("- Root request: ")
-		builder.WriteString(singleLineHistoryText(root))
-		builder.WriteByte('\n')
-	}
+	builder.WriteString("Session context view:\n")
 	if latest := strings.TrimSpace(view.LatestUserMessage); latest != "" {
 		builder.WriteString("- Latest user message: ")
 		builder.WriteString(singleLineHistoryText(latest))
@@ -378,10 +377,6 @@ func formatSessionContextView(view sessionContextView) string {
 		builder.WriteString(summary)
 		builder.WriteByte('\n')
 	}
-	builder.WriteString("\nContext priority:\n")
-	builder.WriteString("- explicit cancellation or replacement > latest correction > root request > planner inference\n")
-	builder.WriteString("- verified evidence > unverified role_output\n")
-	builder.WriteString("- committed plan > ordinary chat summary\n")
 	return strings.TrimSpace(builder.String())
 }
 

--- a/src/agent/internal/agent/session_context_view_test.go
+++ b/src/agent/internal/agent/session_context_view_test.go
@@ -37,6 +37,8 @@ func TestFormatSessionContextViewOmitsFollowUpInterpretationText(t *testing.T) {
 	}
 	for _, unwanted := range []string{
 		"Interpretation:",
+		"Context priority:",
+		"Root request:",
 		"continue the existing task using the root request as the authority",
 		"treat the latest user message",
 	} {


### PR DESCRIPTION
## Summary
- Remove authoritative wording from the root request prompt section.
- Stop repeating the root request and priority rules in the session context view.
- Remove the derived Current objective section and rename the request prompt helper to match its narrower role.

## Tests
- go test ./internal/agent -run 'TestFormatSessionContextViewOmitsFollowUpInterpretationText|TestRuntimeRunIncludesFullActivePlannerHistoryAndSessionRootContext|TestRequestObjectivePromptDoesNotMarkRootRequestAuthoritative'
- go test ./internal/agent -run 'TestRequestContextPromptDoesNotMarkRootRequestAuthoritative|TestExecutorPromptIncludesPriorPlanStepResults|TestExecutorPromptIncludesPlannerEvidence|TestVerifierPrompt'
- go test ./internal/agent