### PR TITLE
fix(agent): inject verifier memory cautions

### DIFF
--- a/docs/04-agent/context-lifecycle.md
+++ b/docs/04-agent/context-lifecycle.md
@@ -8,14 +8,14 @@ Each run is assembled from several layers. Some layers are persisted memory, whi
 
 | Layer | Source | Visibility | Persistence |
 | --- | --- | --- | --- |
-| Base instruction | built-in runtime instruction, optional `agent.toml` `custom_instruction`, and `additional_prompt` | planner, executor, verifier | configuration |
-| Runtime defaults | built-in prompt rules, current date, host runtime information | planner, executor, verifier | not persisted |
-| Skills | skill index plus active `SKILL.md` content | planner, executor, verifier | skill files and skill state |
-| Runtime context | `RunRequest.RuntimeContext`, for example phone bridge state | planner, executor, verifier | not persisted |
+| Base instruction | built-in runtime instruction, optional `agent.toml` `custom_instruction`, and `additional_prompt` | planner and executor | configuration |
+| Runtime defaults | built-in prompt rules, current date, host runtime information | planner and executor receive all defaults; verifier receives current date and verifier role rules only | not persisted |
+| Skills | skill index plus active `SKILL.md` content | planner and executor | skill files and skill state |
+| Runtime context | `RunRequest.RuntimeContext`, for example phone bridge state | planner and executor | not persisted |
 | Tool catalog | resolved built-in tools plus skill tools | planner and executor can call; verifier does not receive a tool catalog | not persisted in memory |
 | Planner loop meta tools | `use_simple_mode`, `enter_plan_mode`, `commit_plan`, `cancel_plan` | planner only | not persisted in memory |
 | Executor loop meta tools | `finish_step`, `abort_step` | executor only | not persisted in memory |
-| Retrieved memory context | `MemoryPlane.Retrieve` output | planner and verifier only | filesystem memory |
+| Retrieved memory context | `MemoryPlane.Retrieve` output | planner receives common and planner memory; verifier receives failure/conflict caution memory only | filesystem memory |
 | Planner conversation history | hot-window memory, optional compressed-history markers, optional persisted chat history | planner only | filesystem memory |
 | Role loop state | phase, objective, plan, `plan_step_index`, next step, tool evidence, verifier feedback, world state | role-specific | current run only |
 | Input attachments | `RunRequest.Attachments`, plus latest screenshot image when available | role user messages | current run only |
@@ -82,7 +82,7 @@ Simple tasks should stay in `default` (direct answer, one tool call, or at most 
 
 ## Prompt Shape
 
-For the current multi-role loop, `Runtime.Run` builds `RoleProfiles` before execution. Each role system prompt contains:
+For the current multi-role loop, `Runtime.Run` builds `RoleProfiles` before execution. Planner and executor system prompts contain:
 
 1. role identity;
 2. base instruction;
@@ -91,8 +91,10 @@ For the current multi-role loop, `Runtime.Run` builds `RoleProfiles` before exec
 5. active skill instructions;
 6. request-local runtime context, if provided;
 7. role rules;
-8. available tool information, except verifier;
+8. available tool information;
 9. role-specific rendered memory context, if any.
+
+The verifier system prompt is intentionally narrower. It contains the current date, verifier role rules, and an optional `## Verifier memory cautions` block. It does not receive base instruction, default behavior, skills, runtime context, tool catalog, common memory, or planner memory.
 
 The per-call user message is then built from the current loop state:
 
@@ -114,7 +116,7 @@ type MemoryContext struct {
 }
 ```
 
-`Common` is rendered for both planner and verifier. It currently includes:
+`Common` is rendered into planner memory context. It currently includes:
 
 - `session/summary.md`, the compressed session summary;
 - `long_term/profile.md`, the synthesized user profile.
@@ -132,6 +134,8 @@ Verifier-specific retrieval includes:
 - failure memories;
 - conflicting memories;
 - failed task episodes relevant to the current request.
+
+Verifier-specific retrieval is rendered as `## Verifier memory cautions`. These entries are historical failure/conflict warnings only; they are not proof of completion. Verifier approval must still be based on the current executor outcome, tool observations, screenshots, or current step evidence.
 
 Each hit is filtered by applicability, ranked by the store search logic, routed by memory type, and trimmed per category before rendering.
 

--- a/docs/04-agent/memory-plane.md
+++ b/docs/04-agent/memory-plane.md
@@ -516,7 +516,7 @@ go r.memoryPlane.CommitEpisode(context.Background(), episode)
 func buildRoleProfiles(..., memory MemoryContext) RoleProfiles
 ```
 
-planner prompt 拼 `memory.Planner` 和 `memory.Common`，verifier prompt 拼 `memory.Verifier` 和 `memory.Common`，executor 为空。
+The planner prompt receives `memory.Planner` plus `memory.Common`. The verifier prompt receives only `memory.Verifier.FailureModes` and `memory.Verifier.Conflicts` as a caution block; `memory.Common` is not injected into verifier. The executor prompt receives no memory context.
 
 ### Tools
 

--- a/docs/04-agent/skills.md
+++ b/docs/04-agent/skills.md
@@ -54,7 +54,7 @@ Agent loop 采用 `default` / `plan` / `execution` 三阶段状态机，详见 [
   - 是唯一允许创建或修改计划的角色；
   - 额外可见 loop meta tools：`use_simple_mode`、`enter_plan_mode`、`commit_plan`、`cancel_plan`。
 - `executor`：仅在 `execution` 阶段运行；只能执行 planner 已提交的 `next_step`，通过 `finish_step` / `abort_step` 进入 verifier 复核，不能修改计划或决定结束。
-- `verifier`：仅在 `execution` 阶段运行；system prompt 仅含 `## Role rules`；每次只验证当前 executor 执行的 `step_text` 是否完成；中间步成功则继续下一步，最后一步成功才 `can_finish`；step 失败才 `needs_replan`；不接收工具目录或全局 memory。
+- `verifier`: runs only in `execution`; its system prompt contains the current date, `## Role rules`, and optional `## Verifier memory cautions`; each turn verifies only the current executor `step_text`; intermediate step success advances to the next step, and only final-step success may set `can_finish`; step failure sets `needs_replan`; it does not receive the tool catalog, skills, base instruction, runtime context, or global memory.
 
 `planner` 和 `executor` 都会收到可调用的 function tools。`verifier` 不调用工具，只基于 executor 证据做复核。
 

--- a/src/agent/internal/agent/memory_plane.go
+++ b/src/agent/internal/agent/memory_plane.go
@@ -850,6 +850,31 @@ func (c MemoryContext) RenderForRole(role RoleName) string {
 	return strings.TrimSpace(strings.Join(parts, "\n\n"))
 }
 
+func (c MemoryContext) RenderVerifierCautionBlock() string {
+	if len(c.Verifier.FailureModes) == 0 && len(c.Verifier.Conflicts) == 0 {
+		return ""
+	}
+	var builder strings.Builder
+	builder.WriteString("## Verifier memory cautions\n")
+	builder.WriteString("Use these entries as historical failure/conflict warnings only. They are not proof of completion. Approve only when current executor_outcome, tool observations, screenshots, or current step evidence proves the current step.\n")
+	appendSection := func(name string, hits []MemoryHit) {
+		if len(hits) == 0 {
+			return
+		}
+		builder.WriteString("\n### ")
+		builder.WriteString(name)
+		builder.WriteByte('\n')
+		for _, hit := range hits {
+			builder.WriteString("- ")
+			builder.WriteString(renderMemoryHitLine(hit))
+			builder.WriteByte('\n')
+		}
+	}
+	appendSection("Failure modes", c.Verifier.FailureModes)
+	appendSection("Conflicts", c.Verifier.Conflicts)
+	return strings.TrimSpace(builder.String())
+}
+
 func (c *MemoryContext) trim(limit int) {
 	trimHits := func(values []MemoryHit) []MemoryHit {
 		if limit <= 0 || len(values) <= limit {

--- a/src/agent/internal/agent/role_profile.go
+++ b/src/agent/internal/agent/role_profile.go
@@ -72,7 +72,10 @@ func buildRoleProfiles(cfg AgentConfig, skills ResolvedSkills, availableTools []
 				"For platform-specific tools such as quick_action, use the platform shown in World State (ios/android/mac) and pass it explicitly in the tool input.",
 			},
 		),
-		Verifier: buildVerifierRoleProfile(verifierRoleRules(cfg, openAppAvailable)),
+		Verifier: buildVerifierRoleProfile(
+			verifierRoleRules(cfg, openAppAvailable),
+			roleMemory.RenderVerifierCautionBlock(),
+		),
 	}
 }
 
@@ -113,6 +116,7 @@ func verifierRoleRules(cfg AgentConfig, openAppAvailable bool) []string {
 		"If the current step succeeded and more committed plan steps remain: return can_finish=false and needs_replan=false.",
 		"If the current step succeeded and this is the final committed plan step: return can_finish=true with final_answer for the user.",
 		finalAnswerRule,
+		"Use verifier memory cautions as historical failure/conflict warnings only. They are not proof of completion; approve only when current executor_outcome, tool observations, screenshots, or current step evidence proves the current step.",
 		"If the current step failed, had no effect, or evidence is insufficient: return can_finish=false and needs_replan=true with a brief reason for the planner.",
 		"If the screenshot clearly identifies app/page/platform, include observed_state with app_name, page_name, platform (ios/android/mac), visible_text, dialogs, and confidence; otherwise leave unknown fields empty.",
 		formatRule,
@@ -188,7 +192,7 @@ func plannerRoleRules(cfg AgentConfig, openAppAvailable bool) []string {
 	return rules
 }
 
-func buildVerifierRoleProfile(roleRules []string) RoleProfile {
+func buildVerifierRoleProfile(roleRules []string, cautionBlock string) RoleProfile {
 	parts := []string{
 		currentDateContext(),
 		"",
@@ -196,6 +200,9 @@ func buildVerifierRoleProfile(roleRules []string) RoleProfile {
 	}
 	for _, rule := range roleRules {
 		parts = append(parts, "- "+rule)
+	}
+	if text := strings.TrimSpace(cautionBlock); text != "" {
+		parts = append(parts, "", text)
 	}
 	return RoleProfile{
 		Name:         RoleVerifier,

--- a/src/agent/internal/agent/role_profile_test.go
+++ b/src/agent/internal/agent/role_profile_test.go
@@ -73,7 +73,7 @@ func TestBuildRoleProfilesInjectsSkillsAndCapabilities(t *testing.T) {
 		"extra",
 	} {
 		if strings.Contains(profiles.Verifier.SystemPrompt, unexpected) {
-			t.Fatalf("verifier profile should only keep role rules, found %q:\n%s", unexpected, profiles.Verifier.SystemPrompt)
+			t.Fatalf("verifier profile should not include general prompt context, found %q:\n%s", unexpected, profiles.Verifier.SystemPrompt)
 		}
 	}
 	if !strings.Contains(profiles.Planner.SystemPrompt, "MEMORY CONTEXT") {
@@ -131,6 +131,83 @@ func TestBuildRoleProfilesInjectsSkillsAndCapabilities(t *testing.T) {
 	if !strings.Contains(profiles.Verifier.SystemPrompt, "current executor step") ||
 		!strings.Contains(profiles.Verifier.SystemPrompt, "final committed plan step") {
 		t.Fatalf("verifier prompt should focus on per-step verification:\n%s", profiles.Verifier.SystemPrompt)
+	}
+}
+
+func TestBuildRoleProfilesInjectsVerifierCautionMemory(t *testing.T) {
+	skills := ResolvedSkills{
+		Names:        []string{"ui"},
+		Instructions: []string{"[ui] skill instruction should stay out"},
+	}
+	memory := MemoryContext{
+		Common: RoleMemoryContext{
+			SessionSummary: "COMMON SESSION SHOULD STAY OUT",
+			Profile:        "COMMON PROFILE SHOULD STAY OUT",
+		},
+		Planner: RoleMemoryContext{
+			Procedures: []MemoryHit{{
+				ID:      "planner_proc",
+				Type:    "procedure",
+				Summary: "planner procedure should stay out",
+			}},
+		},
+		Verifier: RoleMemoryContext{
+			FailureModes: []MemoryHit{
+				{
+					ID:      "failure_mem",
+					Type:    "failure",
+					Summary: "require fresh screen evidence before approving",
+				},
+				{
+					ID:      "failed_episode",
+					Type:    "task_episode_failure",
+					Summary: "prior failed episode approved a stale screen",
+				},
+			},
+			Conflicts: []MemoryHit{{
+				ID:      "conflict_mem",
+				Type:    "conflict",
+				Summary: "old route conflicts with the current layout",
+			}},
+		},
+	}
+
+	profiles := buildRoleProfiles(
+		AgentConfig{Instruction: "BASE SHOULD STAY OUT"},
+		skills,
+		nil,
+		memory,
+	)
+	prompt := profiles.Verifier.SystemPrompt
+
+	for _, want := range []string{
+		"## Verifier memory cautions",
+		"historical failure/conflict warnings only",
+		"not proof of completion",
+		"current executor_outcome, tool observations, screenshots, or current step evidence",
+		"failure_mem",
+		"require fresh screen evidence before approving",
+		"failed_episode",
+		"prior failed episode approved a stale screen",
+		"conflict_mem",
+		"old route conflicts with the current layout",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("verifier prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	for _, unexpected := range []string{
+		"## Base instruction",
+		"BASE SHOULD STAY OUT",
+		"[ui] skill instruction should stay out",
+		"COMMON SESSION SHOULD STAY OUT",
+		"COMMON PROFILE SHOULD STAY OUT",
+		"planner_proc",
+		"planner procedure should stay out",
+	} {
+		if strings.Contains(prompt, unexpected) {
+			t.Fatalf("verifier caution memory leaked %q:\n%s", unexpected, prompt)
+		}
 	}
 }
 
@@ -473,7 +550,7 @@ func TestRoleCollaborativeExecutorShowsCurrentStepForVerifier(t *testing.T) {
 	verifierUserPrompt := messageText([]llms.MessageContent{model.messages[4][len(model.messages[4])-1]})
 	if strings.Contains(verifierSystemPrompt, "## Base instruction") ||
 		strings.Contains(verifierSystemPrompt, "## Available skills") {
-		t.Fatalf("verifier system prompt should only contain role rules:\n%s", verifierSystemPrompt)
+		t.Fatalf("verifier system prompt should not include base instructions or skills:\n%s", verifierSystemPrompt)
 	}
 	for _, want := range []string{
 		"Original user request",


### PR DESCRIPTION
## Summary
- inject verifier-only failure/conflict memory cautions into the verifier system prompt
- clarify that verifier memory is historical warning context, not completion proof
- update docs to match verifier prompt visibility

## Tests
- go test ./internal/agent -run 'TestBuildRoleProfiles|TestRoleCollaborativeExecutorShowsCurrentStepForVerifier|TestRolePrompts|TestMemoryPlane'\n- go test ./internal/agent\n- git diff --check