### PR TITLE
fix(agent): omit empty active skills prompt section

### DIFF
--- a/src/agent/internal/agent/role_profile.go
+++ b/src/agent/internal/agent/role_profile.go
@@ -232,9 +232,13 @@ func buildRoleProfile(
 		"",
 		"## Available skills",
 		skills.CatalogSummary(),
-		"",
-		"## Active skills",
-		skills.CombinedInstructions(),
+	}
+	if text := strings.TrimSpace(skills.CombinedInstructions()); text != "" {
+		parts = append(parts,
+			"",
+			"## Active skills",
+			text,
+		)
 	}
 	if text := strings.TrimSpace(cfg.RuntimeContext); text != "" {
 		parts = append(parts,

--- a/src/agent/internal/agent/role_profile_test.go
+++ b/src/agent/internal/agent/role_profile_test.go
@@ -134,6 +134,26 @@ func TestBuildRoleProfilesInjectsSkillsAndCapabilities(t *testing.T) {
 	}
 }
 
+func TestBuildRoleProfilesOmitsActiveSkillsSectionWhenEmpty(t *testing.T) {
+	profiles := buildRoleProfiles(
+		AgentConfig{},
+		ResolvedSkills{},
+		nil,
+		MemoryContext{},
+	)
+
+	for _, profile := range []RoleProfile{profiles.Planner, profiles.Executor} {
+		for _, unexpected := range []string{
+			"## Active skills",
+			"No extra skill is active.",
+		} {
+			if strings.Contains(profile.SystemPrompt, unexpected) {
+				t.Fatalf("%s profile should omit empty active skills section, found %q:\n%s", profile.Name, unexpected, profile.SystemPrompt)
+			}
+		}
+	}
+}
+
 func TestBuildRoleProfilesInjectsVerifierCautionMemory(t *testing.T) {
 	skills := ResolvedSkills{
 		Names:        []string{"ui"},

--- a/src/agent/internal/agent/skills.go
+++ b/src/agent/internal/agent/skills.go
@@ -216,7 +216,7 @@ func truncateRunes(s string, max int) string {
 
 func (r ResolvedSkills) CombinedInstructions() string {
 	if len(r.Instructions) == 0 {
-		return "No extra skill is active."
+		return ""
 	}
 	return strings.Join(r.Instructions, "\n")
 }


### PR DESCRIPTION
Summary:
- Omit the Active skills prompt section when no skill instructions are active.
- Keep active skill instructions visible when present.

Tests:
- go test ./internal/agent -count=1