### PR TITLE
fix(agent): align voice wakeup steering with web chat

### DIFF
--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -197,6 +197,8 @@ type audioDialogRunner interface {
 	RunVoiceTurn(ctx context.Context, input agent.TurnInput, utterance []int16, runtime *agent.Runtime) (agent.RunResult, error)
 	RunVoiceTurnWithContext(ctx context.Context, input agent.TurnInput, utterance []int16, runtime *agent.Runtime, turnContext agent.VoiceTurnContext) (agent.RunResult, error)
 	QueueSteer(input agent.TurnInput) bool
+	BeginSteerInterrupt() bool
+	ResumeSteerInterrupt() bool
 	InterruptOutput()
 	Speak(ctx context.Context, text string, interrupt <-chan struct{}) error
 	FlushVAD() []int16
@@ -695,6 +697,7 @@ thinking:
 			return voiceTurnResult{exit: true}
 		case <-events:
 			if interruptOnWakeup {
+				interruptedRun := dialog.BeginSteerInterrupt()
 				nextTurn, exit := captureVoiceSteer(cfg, dialog, sigChan, events)
 				if exit {
 					cancel()
@@ -702,6 +705,9 @@ thinking:
 					return voiceTurnResult{exit: true}
 				}
 				if nextTurn == nil {
+					if interruptedRun {
+						dialog.ResumeSteerInterrupt()
+					}
 					continue
 				}
 				if dialog.QueueSteer(nextTurn.input) {

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -695,12 +695,22 @@ thinking:
 			return voiceTurnResult{exit: true}
 		case <-events:
 			if interruptOnWakeup {
-				cancel()
 				nextTurn, exit := captureVoiceSteer(cfg, dialog, sigChan, events)
-				waitForTurnCancel(resultCh)
 				if exit {
+					cancel()
+					waitForTurnCancel(resultCh)
 					return voiceTurnResult{exit: true}
 				}
+				if nextTurn == nil {
+					continue
+				}
+				if dialog.QueueSteer(nextTurn.input) {
+					log.Println("[steer] queued wakeup correction for active voice run")
+					continue
+				}
+				log.Println("[steer] active voice run no longer accepts steer; running captured correction as next turn")
+				cancel()
+				waitForTurnCancel(resultCh)
 				return voiceTurnResult{interrupted: true, nextTurn: nextTurn}
 			}
 			log.Println("[steer] wakeup received during thinking, ignoring because wakeup steering is disabled")

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -19,12 +19,15 @@ import (
 
 const (
 	wakeupListenTimeout                     = 10 * time.Second
+	defaultVoiceSteerListenTimeout          = 45 * time.Second
 	voiceTurnCancelWaitTimeout              = 2 * time.Second
 	voiceWakeupInterruptedCorrectionContext = "Voice interruption: the user pressed the physical wakeup button " +
 		"while the previous voice turn was still running. The latest voice input was spoken after that interruption. " +
 		"Treat it as a correction or steering update to the interrupted turn, not as an independent new task unless " +
 		"the user explicitly asks to start over."
 )
+
+var voiceSteerListenTimeout = defaultVoiceSteerListenTimeout
 
 var wakeupGPIOPins = []int{33, 32}
 
@@ -803,7 +806,7 @@ func interruptedFollowUpContext(result voiceTurnResult) agent.VoiceTurnContext {
 func captureVoiceSteer(cfg agent.Config, dialog audioDialogRunner, sigChan chan os.Signal, events <-chan voiceEvent) (*pendingVoiceTurn, bool) {
 	log.Println("[steer] wakeup received during thinking, listening for steering input")
 	dialog.InterruptOutput()
-	utterance, exit := listenOneUtterance(dialog, sigChan, events, cfg.VoiceFollowupTimeoutOrDefault())
+	utterance, exit := listenOneUtterance(dialog, sigChan, events, voiceSteerListenTimeoutForConfig(cfg))
 	if exit {
 		return nil, true
 	}
@@ -821,6 +824,13 @@ func captureVoiceSteer(cfg agent.Config, dialog audioDialogRunner, sigChan chan 
 		utterance:   append([]int16(nil), utterance...),
 		turnContext: interruptedVoiceCorrectionContext(),
 	}, false
+}
+
+func voiceSteerListenTimeoutForConfig(_ agent.Config) time.Duration {
+	if voiceSteerListenTimeout > 0 {
+		return voiceSteerListenTimeout
+	}
+	return defaultVoiceSteerListenTimeout
 }
 
 func interruptedVoiceCorrectionContext() agent.VoiceTurnContext {

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -192,6 +192,7 @@ type audioDialogRunner interface {
 	PrepareTurnInput(utterance []int16) (agent.TurnInput, error)
 	RunVoiceTurn(ctx context.Context, input agent.TurnInput, utterance []int16, runtime *agent.Runtime) (agent.RunResult, error)
 	QueueSteer(input agent.TurnInput) bool
+	InterruptOutput()
 	Speak(ctx context.Context, text string, interrupt <-chan struct{}) error
 	FlushVAD() []int16
 	FinishManualUtterance(pending []int16) []int16
@@ -623,6 +624,7 @@ speaking:
 		case <-events:
 			if cfg.VoiceInterruptOnWakeupOrDefault() {
 				log.Println("[interrupt] wakeup received during speaking, stopping playback")
+				dialog.InterruptOutput()
 				cancelSpeak()
 				waitForSpeakCancel(speakCh)
 				return voiceTurnResult{interrupted: true}
@@ -641,6 +643,7 @@ speaking:
 
 func captureAndQueueVoiceSteer(cfg agent.Config, dialog audioDialogRunner, sigChan chan os.Signal, events <-chan voiceEvent) bool {
 	log.Println("[steer] wakeup received during thinking, listening for steering input")
+	dialog.InterruptOutput()
 	utterance, exit := listenOneUtterance(dialog, sigChan, events, cfg.VoiceFollowupTimeoutOrDefault())
 	if exit {
 		return true

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -191,6 +191,7 @@ type audioDialogRunner interface {
 	ProcessUtterance(ctx context.Context, utterance []int16, runtime *agent.Runtime) error
 	PrepareTurnInput(utterance []int16) (agent.TurnInput, error)
 	RunVoiceTurn(ctx context.Context, input agent.TurnInput, utterance []int16, runtime *agent.Runtime) (agent.RunResult, error)
+	QueueSteer(input agent.TurnInput) bool
 	Speak(ctx context.Context, text string, interrupt <-chan struct{}) error
 	FlushVAD() []int16
 	FinishManualUtterance(pending []int16) []int16
@@ -572,20 +573,14 @@ thinking:
 			return voiceTurnResult{exit: true}
 		case <-events:
 			if cfg.VoiceInterruptOnWakeupOrDefault() {
-				log.Println("[interrupt] wakeup received during thinking, canceling current turn")
-				cancel()
-				select {
-				case turnResult := <-resultCh:
-					if turnResult.err != nil {
-						if !errors.Is(turnResult.err, context.Canceled) {
-							log.Printf("[error] %v\n", turnResult.err)
-						}
-					}
-				case <-time.After(2 * time.Second):
-					log.Println("[interrupt] current turn did not finish after cancellation; continuing session")
+				if captureAndQueueVoiceSteer(cfg, dialog, sigChan, events) {
+					cancel()
+					waitForTurnCancel(resultCh)
+					return voiceTurnResult{exit: true}
 				}
-				return voiceTurnResult{interrupted: true}
+				continue
 			}
+			log.Println("[steer] wakeup received during thinking, ignoring because wakeup steering is disabled")
 		case turnResult := <-resultCh:
 			cancel()
 			if turnResult.err != nil {
@@ -642,6 +637,28 @@ speaking:
 	}
 
 	return voiceTurnResult{}
+}
+
+func captureAndQueueVoiceSteer(cfg agent.Config, dialog audioDialogRunner, sigChan chan os.Signal, events <-chan voiceEvent) bool {
+	log.Println("[steer] wakeup received during thinking, listening for steering input")
+	utterance, exit := listenOneUtterance(dialog, sigChan, events, cfg.VoiceFollowupTimeoutOrDefault())
+	if exit {
+		return true
+	}
+	if len(utterance) == 0 {
+		log.Println("[steer] no steering utterance captured")
+		return false
+	}
+	input, err := dialog.PrepareTurnInput(utterance)
+	if err != nil {
+		log.Printf("[steer] prepare steer input failed: %v\n", err)
+		return false
+	}
+	if !dialog.QueueSteer(input) {
+		log.Println("[steer] active voice run was not available for steering")
+		return false
+	}
+	return false
 }
 
 func waitForTurnCancel(resultCh <-chan struct {

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -18,8 +18,12 @@ import (
 )
 
 const (
-	wakeupListenTimeout        = 10 * time.Second
-	voiceTurnCancelWaitTimeout = 2 * time.Second
+	wakeupListenTimeout                     = 10 * time.Second
+	voiceTurnCancelWaitTimeout              = 2 * time.Second
+	voiceWakeupInterruptedCorrectionContext = "Voice interruption: the user pressed the physical wakeup button " +
+		"while the previous voice turn was still running. The latest voice input was spoken after that interruption. " +
+		"Treat it as a correction or steering update to the interrupted turn, not as an independent new task unless " +
+		"the user explicitly asks to start over."
 )
 
 var wakeupGPIOPins = []int{33, 32}
@@ -191,6 +195,7 @@ type audioDialogRunner interface {
 	ProcessUtterance(ctx context.Context, utterance []int16, runtime *agent.Runtime) error
 	PrepareTurnInput(utterance []int16) (agent.TurnInput, error)
 	RunVoiceTurn(ctx context.Context, input agent.TurnInput, utterance []int16, runtime *agent.Runtime) (agent.RunResult, error)
+	RunVoiceTurnWithContext(ctx context.Context, input agent.TurnInput, utterance []int16, runtime *agent.Runtime, turnContext agent.VoiceTurnContext) (agent.RunResult, error)
 	QueueSteer(input agent.TurnInput) bool
 	InterruptOutput()
 	Speak(ctx context.Context, text string, interrupt <-chan struct{}) error
@@ -272,8 +277,9 @@ const (
 )
 
 type pendingVoiceTurn struct {
-	input     agent.TurnInput
-	utterance []int16
+	input       agent.TurnInput
+	utterance   []int16
+	turnContext agent.VoiceTurnContext
 }
 
 type voiceTurnResult struct {
@@ -377,6 +383,10 @@ func startManualAudioLoop(ctx context.Context, dialog audioDialogRunner, runtime
 }
 
 func runWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Runtime, sigChan chan os.Signal, newWatcher wakeupWatcherFactory) {
+	if cfg.InputModeOrDefault() == "stt" && !cfg.VoiceFollowupEnabledOrDefault() {
+		runSingleTurnSTTWakeupMode(cfg, dialog, runtime, sigChan, newWatcher)
+		return
+	}
 	if cfg.InputModeOrDefault() != "stt" || !cfg.VoiceFollowupEnabledOrDefault() {
 		runLegacyWakeupMode(cfg, dialog, runtime, sigChan, newWatcher)
 		return
@@ -387,6 +397,7 @@ func runWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Ru
 	events := make(chan voiceEvent, 1)
 
 	watchers, err := startWakeupWatchers(newWatcher, func() {
+		dialog.InterruptOutput()
 		signalVoiceWakeupEvent(events)
 	})
 	if err != nil {
@@ -420,6 +431,7 @@ func runLegacyWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *ag
 	wakeupEvents := make(chan struct{}, 1)
 
 	watchers, err := startWakeupWatchers(newWatcher, func() {
+		dialog.InterruptOutput()
 		signalWakeupEvent(wakeupEvents)
 	})
 	if err != nil {
@@ -482,6 +494,85 @@ func runLegacyWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *ag
 	}
 }
 
+func runSingleTurnSTTWakeupMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Runtime, sigChan chan os.Signal, newWatcher wakeupWatcherFactory) {
+	log.Printf("\n[ready] Starting GPIO wakeup listeners on %s...", wakeupGPIOPinsLabel())
+
+	events := make(chan voiceEvent, 1)
+
+	watchers, err := startWakeupWatchers(newWatcher, func() {
+		dialog.InterruptOutput()
+		signalVoiceWakeupEvent(events)
+	})
+	if err != nil {
+		log.Printf("[error] Failed to start GPIO wakeup listeners: %v\n", err)
+		os.Exit(1)
+	}
+	defer stopWakeupWatchers(watchers)
+
+	log.Printf("[ready] Waiting for wakeup event (%s)... Ctrl+C to quit", wakeupGPIOPinsLabel())
+
+	var nextTurn *pendingVoiceTurn
+	pendingWakeup := false
+	for {
+		if nextTurn == nil {
+			if !pendingWakeup {
+				select {
+				case <-sigChan:
+					if dialog != nil {
+						dialog.StopRecording()
+					}
+					log.Println("\n[exit] Stopped.")
+					return
+				case <-events:
+					log.Println("\n[wakeup] GPIO wakeup triggered, starting to listen...")
+				}
+			} else {
+				pendingWakeup = false
+			}
+
+			utterance, exit := listenOneUtterance(dialog, sigChan, events, wakeupListenTimeout)
+			if exit {
+				log.Println("\n[exit] Stopped.")
+				return
+			}
+			if len(utterance) == 0 {
+				log.Println("[listen] no utterance captured after wakeup")
+				log.Println("[ready] Waiting for next wakeup event...")
+				continue
+			}
+			input, err := dialog.PrepareTurnInput(utterance)
+			if err != nil {
+				log.Printf("[error] prepare turn input failed: %v\n", err)
+				log.Println("[ready] Waiting for next wakeup event...")
+				continue
+			}
+			nextTurn = &pendingVoiceTurn{
+				input:     input,
+				utterance: append([]int16(nil), utterance...),
+			}
+		}
+
+		turn := nextTurn
+		nextTurn = nil
+		result := runVoiceTurnWithInputContext(cfg, dialog, runtime, turn.input, turn.utterance, sigChan, events, turn.turnContext, true)
+		if result.exit {
+			log.Println("\n[exit] Stopped.")
+			return
+		}
+		if result.nextTurn != nil {
+			nextTurn = result.nextTurn
+			log.Println("[session] turn interrupted, running captured steering input")
+			continue
+		}
+		if result.interrupted {
+			pendingWakeup = true
+			log.Println("[session] playback interrupted, starting a new wakeup turn")
+			continue
+		}
+		log.Println("[ready] Waiting for next wakeup event...")
+	}
+}
+
 func signalVoiceWakeupEvent(events chan<- voiceEvent) {
 	select {
 	case events <- voiceEventWakeup:
@@ -507,10 +598,12 @@ func runVoiceSession(cfg agent.Config, dialog audioDialogRunner, runtime *agent.
 	for {
 		var input agent.TurnInput
 		var utterance []int16
+		var turnContext agent.VoiceTurnContext
 
 		if nextTurn != nil {
 			input = nextTurn.input
 			utterance = nextTurn.utterance
+			turnContext = nextTurn.turnContext
 			nextTurn = nil
 		} else {
 			if maxTurns > 0 && turns >= maxTurns {
@@ -542,7 +635,7 @@ func runVoiceSession(cfg agent.Config, dialog audioDialogRunner, runtime *agent.
 			}
 		}
 
-		result := runVoiceTurnWithInput(cfg, dialog, runtime, input, utterance, sigChan, events)
+		result := runVoiceTurnWithInputContext(cfg, dialog, runtime, input, utterance, sigChan, events, turnContext, cfg.VoiceInterruptOnWakeupOrDefault())
 		if result.exit {
 			return true
 		}
@@ -575,13 +668,17 @@ func runVoiceTurn(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Run
 }
 
 func runVoiceTurnWithInput(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Runtime, input agent.TurnInput, utterance []int16, sigChan chan os.Signal, events <-chan voiceEvent) voiceTurnResult {
+	return runVoiceTurnWithInputContext(cfg, dialog, runtime, input, utterance, sigChan, events, agent.VoiceTurnContext{}, cfg.VoiceInterruptOnWakeupOrDefault())
+}
+
+func runVoiceTurnWithInputContext(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Runtime, input agent.TurnInput, utterance []int16, sigChan chan os.Signal, events <-chan voiceEvent, turnContext agent.VoiceTurnContext, interruptOnWakeup bool) voiceTurnResult {
 	turnCtx, cancel := context.WithCancel(context.Background())
 	resultCh := make(chan struct {
 		result agent.RunResult
 		err    error
 	}, 1)
 	go func() {
-		result, err := dialog.RunVoiceTurn(turnCtx, input, utterance, runtime)
+		result, err := dialog.RunVoiceTurnWithContext(turnCtx, input, utterance, runtime, turnContext)
 		resultCh <- struct {
 			result agent.RunResult
 			err    error
@@ -597,7 +694,7 @@ thinking:
 			waitForTurnCancel(resultCh)
 			return voiceTurnResult{exit: true}
 		case <-events:
-			if cfg.VoiceInterruptOnWakeupOrDefault() {
+			if interruptOnWakeup {
 				cancel()
 				nextTurn, exit := captureVoiceSteer(cfg, dialog, sigChan, events)
 				waitForTurnCancel(resultCh)
@@ -647,7 +744,7 @@ speaking:
 			waitForSpeakCancel(speakCh)
 			return voiceTurnResult{exit: true}
 		case <-events:
-			if cfg.VoiceInterruptOnWakeupOrDefault() {
+			if interruptOnWakeup {
 				log.Println("[interrupt] wakeup received during speaking, stopping playback")
 				dialog.InterruptOutput()
 				cancelSpeak()
@@ -683,9 +780,17 @@ func captureVoiceSteer(cfg agent.Config, dialog audioDialogRunner, sigChan chan 
 		return nil, false
 	}
 	return &pendingVoiceTurn{
-		input:     input,
-		utterance: append([]int16(nil), utterance...),
+		input:       input,
+		utterance:   append([]int16(nil), utterance...),
+		turnContext: interruptedVoiceCorrectionContext(),
 	}, false
+}
+
+func interruptedVoiceCorrectionContext() agent.VoiceTurnContext {
+	return agent.VoiceTurnContext{
+		FollowUpRelation: agent.FollowUpCorrection,
+		RuntimeContext:   voiceWakeupInterruptedCorrectionContext,
+	}
 }
 
 func waitForTurnCancel(resultCh <-chan struct {

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -289,6 +289,7 @@ type voiceTurnResult struct {
 	waitForWakeupRequested bool
 	exit                   bool
 	nextTurn               *pendingVoiceTurn
+	followUpContext        agent.VoiceTurnContext
 }
 
 func runManualMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Runtime, sigChan chan os.Signal) {
@@ -514,6 +515,7 @@ func runSingleTurnSTTWakeupMode(cfg agent.Config, dialog audioDialogRunner, runt
 	log.Printf("[ready] Waiting for wakeup event (%s)... Ctrl+C to quit", wakeupGPIOPinsLabel())
 
 	var nextTurn *pendingVoiceTurn
+	var pendingTurnContext agent.VoiceTurnContext
 	pendingWakeup := false
 	for {
 		if nextTurn == nil {
@@ -540,18 +542,22 @@ func runSingleTurnSTTWakeupMode(cfg agent.Config, dialog audioDialogRunner, runt
 			if len(utterance) == 0 {
 				log.Println("[listen] no utterance captured after wakeup")
 				log.Println("[ready] Waiting for next wakeup event...")
+				pendingTurnContext = agent.VoiceTurnContext{}
 				continue
 			}
 			input, err := dialog.PrepareTurnInput(utterance)
 			if err != nil {
 				log.Printf("[error] prepare turn input failed: %v\n", err)
 				log.Println("[ready] Waiting for next wakeup event...")
+				pendingTurnContext = agent.VoiceTurnContext{}
 				continue
 			}
 			nextTurn = &pendingVoiceTurn{
-				input:     input,
-				utterance: append([]int16(nil), utterance...),
+				input:       input,
+				utterance:   append([]int16(nil), utterance...),
+				turnContext: pendingTurnContext,
 			}
+			pendingTurnContext = agent.VoiceTurnContext{}
 		}
 
 		turn := nextTurn
@@ -568,6 +574,7 @@ func runSingleTurnSTTWakeupMode(cfg agent.Config, dialog audioDialogRunner, runt
 		}
 		if result.interrupted {
 			pendingWakeup = true
+			pendingTurnContext = interruptedFollowUpContext(result)
 			log.Println("[session] playback interrupted, starting a new wakeup turn")
 			continue
 		}
@@ -596,6 +603,7 @@ func runVoiceSession(cfg agent.Config, dialog audioDialogRunner, runtime *agent.
 	turns := 0
 	firstTurn := true
 	var nextTurn *pendingVoiceTurn
+	var pendingTurnContext agent.VoiceTurnContext
 
 	for {
 		var input agent.TurnInput
@@ -635,6 +643,8 @@ func runVoiceSession(cfg agent.Config, dialog audioDialogRunner, runtime *agent.
 				firstTurn = false
 				continue
 			}
+			turnContext = pendingTurnContext
+			pendingTurnContext = agent.VoiceTurnContext{}
 		}
 
 		result := runVoiceTurnWithInputContext(cfg, dialog, runtime, input, utterance, sigChan, events, turnContext, cfg.VoiceInterruptOnWakeupOrDefault())
@@ -652,6 +662,7 @@ func runVoiceSession(cfg agent.Config, dialog audioDialogRunner, runtime *agent.
 			continue
 		}
 		if result.interrupted {
+			pendingTurnContext = interruptedFollowUpContext(result)
 			log.Println("[session] turn interrupted, listening for follow-up")
 			continue
 		}
@@ -765,7 +776,10 @@ speaking:
 				dialog.InterruptOutput()
 				cancelSpeak()
 				waitForSpeakCancel(speakCh)
-				return voiceTurnResult{interrupted: true}
+				return voiceTurnResult{
+					interrupted:     true,
+					followUpContext: interruptedVoiceCorrectionContext(),
+				}
 			}
 		case err := <-speakCh:
 			cancelSpeak()
@@ -777,6 +791,13 @@ speaking:
 	}
 
 	return voiceTurnResult{}
+}
+
+func interruptedFollowUpContext(result voiceTurnResult) agent.VoiceTurnContext {
+	if result.followUpContext != (agent.VoiceTurnContext{}) {
+		return result.followUpContext
+	}
+	return interruptedVoiceCorrectionContext()
 }
 
 func captureVoiceSteer(cfg agent.Config, dialog audioDialogRunner, sigChan chan os.Signal, events <-chan voiceEvent) (*pendingVoiceTurn, bool) {

--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -271,10 +271,16 @@ const (
 	voiceEventWakeup voiceEvent = iota + 1
 )
 
+type pendingVoiceTurn struct {
+	input     agent.TurnInput
+	utterance []int16
+}
+
 type voiceTurnResult struct {
 	interrupted            bool
 	waitForWakeupRequested bool
 	exit                   bool
+	nextTurn               *pendingVoiceTurn
 }
 
 func runManualMode(cfg agent.Config, dialog audioDialogRunner, runtime *agent.Runtime, sigChan chan os.Signal) {
@@ -496,35 +502,46 @@ func runVoiceSession(cfg agent.Config, dialog audioDialogRunner, runtime *agent.
 	maxTurns := cfg.VoiceMaxTurns
 	turns := 0
 	firstTurn := true
+	var nextTurn *pendingVoiceTurn
 
 	for {
-		if maxTurns > 0 && turns >= maxTurns {
-			log.Printf("[session] max turns reached (%d), closing voice session\n", maxTurns)
-			return false
+		var input agent.TurnInput
+		var utterance []int16
+
+		if nextTurn != nil {
+			input = nextTurn.input
+			utterance = nextTurn.utterance
+			nextTurn = nil
+		} else {
+			if maxTurns > 0 && turns >= maxTurns {
+				log.Printf("[session] max turns reached (%d), closing voice session\n", maxTurns)
+				return false
+			}
+
+			timeout := cfg.VoiceFollowupTimeoutOrDefault()
+			if firstTurn {
+				timeout = cfg.VoiceFirstTurnTimeoutOrDefault()
+			}
+
+			var exit bool
+			utterance, exit = listenOneUtterance(dialog, sigChan, events, timeout)
+			if exit {
+				return true
+			}
+			if len(utterance) == 0 {
+				log.Println("[session] listen timeout, closing voice session")
+				return false
+			}
+
+			var err error
+			input, err = dialog.PrepareTurnInput(utterance)
+			if err != nil {
+				log.Printf("[error] prepare turn input failed: %v\n", err)
+				firstTurn = false
+				continue
+			}
 		}
 
-		timeout := cfg.VoiceFollowupTimeoutOrDefault()
-		if firstTurn {
-			timeout = cfg.VoiceFirstTurnTimeoutOrDefault()
-		}
-
-		utterance, exit := listenOneUtterance(dialog, sigChan, events, timeout)
-		if exit {
-			return true
-		}
-		if len(utterance) == 0 {
-			log.Println("[session] listen timeout, closing voice session")
-			return false
-		}
-
-		input, err := dialog.PrepareTurnInput(utterance)
-		if err != nil {
-			log.Printf("[error] prepare turn input failed: %v\n", err)
-			firstTurn = false
-			continue
-		}
-
-		turns++
 		result := runVoiceTurnWithInput(cfg, dialog, runtime, input, utterance, sigChan, events)
 		if result.exit {
 			return true
@@ -534,9 +551,16 @@ func runVoiceSession(cfg agent.Config, dialog audioDialogRunner, runtime *agent.
 			log.Println("[session] agent requested wakeup wait, closing voice session")
 			return false
 		}
+		if result.nextTurn != nil {
+			nextTurn = result.nextTurn
+			log.Println("[session] turn interrupted, running captured steering input")
+			continue
+		}
 		if result.interrupted {
 			log.Println("[session] turn interrupted, listening for follow-up")
+			continue
 		}
+		turns++
 	}
 }
 
@@ -574,12 +598,13 @@ thinking:
 			return voiceTurnResult{exit: true}
 		case <-events:
 			if cfg.VoiceInterruptOnWakeupOrDefault() {
-				if captureAndQueueVoiceSteer(cfg, dialog, sigChan, events) {
-					cancel()
-					waitForTurnCancel(resultCh)
+				cancel()
+				nextTurn, exit := captureVoiceSteer(cfg, dialog, sigChan, events)
+				waitForTurnCancel(resultCh)
+				if exit {
 					return voiceTurnResult{exit: true}
 				}
-				continue
+				return voiceTurnResult{interrupted: true, nextTurn: nextTurn}
 			}
 			log.Println("[steer] wakeup received during thinking, ignoring because wakeup steering is disabled")
 		case turnResult := <-resultCh:
@@ -641,27 +666,26 @@ speaking:
 	return voiceTurnResult{}
 }
 
-func captureAndQueueVoiceSteer(cfg agent.Config, dialog audioDialogRunner, sigChan chan os.Signal, events <-chan voiceEvent) bool {
+func captureVoiceSteer(cfg agent.Config, dialog audioDialogRunner, sigChan chan os.Signal, events <-chan voiceEvent) (*pendingVoiceTurn, bool) {
 	log.Println("[steer] wakeup received during thinking, listening for steering input")
 	dialog.InterruptOutput()
 	utterance, exit := listenOneUtterance(dialog, sigChan, events, cfg.VoiceFollowupTimeoutOrDefault())
 	if exit {
-		return true
+		return nil, true
 	}
 	if len(utterance) == 0 {
 		log.Println("[steer] no steering utterance captured")
-		return false
+		return nil, false
 	}
 	input, err := dialog.PrepareTurnInput(utterance)
 	if err != nil {
 		log.Printf("[steer] prepare steer input failed: %v\n", err)
-		return false
+		return nil, false
 	}
-	if !dialog.QueueSteer(input) {
-		log.Println("[steer] active voice run was not available for steering")
-		return false
-	}
-	return false
+	return &pendingVoiceTurn{
+		input:     input,
+		utterance: append([]int16(nil), utterance...),
+	}, false
 }
 
 func waitForTurnCancel(resultCh <-chan struct {

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -891,14 +892,14 @@ func TestRunWakeupModeStartsNewRecordingForNextWakeup(t *testing.T) {
 	}
 }
 
-func TestRunWakeupModeSTTWakeupInterruptRunsNextTurnAsCorrection(t *testing.T) {
+func TestRunWakeupModeSTTWakeupQueuesCorrectionWhileRunActive(t *testing.T) {
 	sigChan := make(chan os.Signal, 1)
 	watcher := &fakeWakeupWatcher{fireOnStart: true}
 	firstRunStarted := make(chan struct{})
-	ctxCanceled := make(chan struct{})
-	secondRunStarted := make(chan struct{})
+	releaseFirstRun := make(chan struct{})
+	queuedSteer := make(chan struct{})
 	voiceSessionDisabled := false
-	runInputs := make([]string, 0, 2)
+	runInputs := make([]string, 0, 1)
 	var dialog *fakeAudioDialog
 	dialog = &fakeAudioDialog{
 		frameSamples: 2,
@@ -921,20 +922,30 @@ func TestRunWakeupModeSTTWakeupInterruptRunsNextTurnAsCorrection(t *testing.T) {
 			switch input.InputText {
 			case "open the group and send money":
 				close(firstRunStarted)
-				<-ctx.Done()
-				close(ctxCanceled)
-				return agent.RunResult{}, ctx.Err()
-			case "use the shorter search term":
-				close(secondRunStarted)
+				<-releaseFirstRun
 				return agent.RunResult{Output: "revised reply"}, nil
+			case "use the shorter search term":
+				t.Fatal("correction input should be queued as steer while the original run is active")
+				return agent.RunResult{}, nil
 			default:
 				t.Errorf("unexpected run input = %#v", input)
 				return agent.RunResult{}, nil
 			}
 		},
+		queueSteer: func(input agent.TurnInput) bool {
+			if input.InputText != "use the shorter search term" {
+				t.Fatalf("queued steer input = %#v, want captured correction", input)
+			}
+			close(queuedSteer)
+			close(releaseFirstRun)
+			return true
+		},
 		speak: func(ctx context.Context) error {
 			if len(dialog.spoken) == 1 {
-				sigChan <- syscall.SIGTERM
+				go func() {
+					time.Sleep(10 * time.Millisecond)
+					sigChan <- syscall.SIGTERM
+				}()
 			}
 			return nil
 		},
@@ -959,33 +970,21 @@ func TestRunWakeupModeSTTWakeupInterruptRunsNextTurnAsCorrection(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("runWakeupMode did not stop after interrupted STT wakeup")
+		t.Fatal("runWakeupMode did not stop after queued STT wakeup correction")
 	}
 	select {
-	case <-ctxCanceled:
+	case <-queuedSteer:
 	default:
-		t.Fatal("first voice run context was not canceled by wakeup")
+		t.Fatal("wakeup correction was not queued as steer")
 	}
-	select {
-	case <-secondRunStarted:
-	default:
-		t.Fatal("wakeup interrupt did not trigger the correction voice run")
+	if len(runInputs) != 1 || runInputs[0] != "open the group and send money" {
+		t.Fatalf("run inputs = %#v, want only the original request while correction is queued", runInputs)
 	}
-	if len(runInputs) != 2 || runInputs[0] != "open the group and send money" || runInputs[1] != "use the shorter search term" {
-		t.Fatalf("run inputs = %#v, want original request followed by correction input", runInputs)
-	}
-	if len(dialog.voiceTurnContexts) != 2 {
-		t.Fatalf("voice turn contexts = %#v, want 2", dialog.voiceTurnContexts)
+	if len(dialog.voiceTurnContexts) != 1 {
+		t.Fatalf("voice turn contexts = %#v, want one active voice turn", dialog.voiceTurnContexts)
 	}
 	if dialog.voiceTurnContexts[0] != (agent.VoiceTurnContext{}) {
 		t.Fatalf("first voice turn context = %#v, want ordinary new task", dialog.voiceTurnContexts[0])
-	}
-	correctionContext := dialog.voiceTurnContexts[1]
-	if correctionContext.FollowUpRelation != agent.FollowUpCorrection {
-		t.Fatalf("second follow-up relation = %q, want correction", correctionContext.FollowUpRelation)
-	}
-	if !strings.Contains(correctionContext.RuntimeContext, "physical wakeup") || !strings.Contains(correctionContext.RuntimeContext, "interrupted") {
-		t.Fatalf("second runtime context = %q, want physical wakeup interruption context", correctionContext.RuntimeContext)
 	}
 	if got := countDialogOp(dialog.ops, "interrupt_output"); got < 2 {
 		t.Fatalf("interrupt_output count = %d, want initial wakeup and interrupting wakeup; ops=%#v", got, dialog.ops)
@@ -1510,7 +1509,7 @@ func TestRunVoiceSessionDrainsBurstWakeupsWhileAlreadyListening(t *testing.T) {
 	}
 }
 
-func TestRunVoiceSessionWakeupRunsCapturedSteerAsNextTurn(t *testing.T) {
+func TestRunVoiceSessionWakeupFallsBackToNextTurnWhenSteerQueueUnavailable(t *testing.T) {
 	sigChan := make(chan os.Signal, 1)
 	events := make(chan voiceEvent, 2)
 	originalRunStarted := make(chan struct{})
@@ -1577,8 +1576,8 @@ func TestRunVoiceSessionWakeupRunsCapturedSteerAsNextTurn(t *testing.T) {
 	if exit {
 		t.Fatal("runVoiceSession returned exit=true")
 	}
-	if queueSteerCalls != 0 {
-		t.Fatalf("QueueSteer calls = %d, want daemon wakeup interrupt to run captured input as next turn", queueSteerCalls)
+	if queueSteerCalls != 1 {
+		t.Fatalf("QueueSteer calls = %d, want one steer queue attempt before next-turn fallback", queueSteerCalls)
 	}
 	if len(runInputs) != 2 || runInputs[0] != "original request" || runInputs[1] != "change course" {
 		t.Fatalf("run inputs = %#v, want original request followed by captured steer", runInputs)
@@ -1588,6 +1587,91 @@ func TestRunVoiceSessionWakeupRunsCapturedSteerAsNextTurn(t *testing.T) {
 	}
 	if dialog.starts != 2 {
 		t.Fatalf("dialog starts = %d, want original listen plus steer listen", dialog.starts)
+	}
+}
+
+func TestRunVoiceTurnWakeupQueuesSteerWhileOriginalRunActive(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	events := make(chan voiceEvent, 1)
+	runStarted := make(chan struct{})
+	releaseRun := make(chan struct{})
+	queuedSteer := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseRun)
+		})
+	}
+	defer release()
+
+	runInputs := make([]string, 0, 1)
+	dialog := &fakeAudioDialog{
+		frameSamples: 2,
+		chunkBatches: [][]*agent.AudioChunkResult{
+			{{PCM: pcm16BytesFromSamples(500, 600)}},
+		},
+		utterancesToReturn: [][]int16{
+			{500, 600},
+		},
+		repeatEmpty: true,
+		readDelay:   time.Millisecond,
+		prepareTurnInput: func(utterance []int16) (agent.TurnInput, error) {
+			if len(utterance) > 0 && utterance[0] == 500 {
+				return agent.TurnInput{InputText: "改查深圳。", Transcript: "改查深圳。"}, nil
+			}
+			return agent.TurnInput{InputText: "广州。", Transcript: "广州。"}, nil
+		},
+		runVoiceTurn: func(ctx context.Context, input agent.TurnInput, utterance []int16) (agent.RunResult, error) {
+			runInputs = append(runInputs, input.InputText)
+			if input.InputText != "广州。" {
+				t.Fatalf("run input = %q, want only the original request", input.InputText)
+			}
+			close(runStarted)
+			<-releaseRun
+			return agent.RunResult{Output: "steered reply"}, nil
+		},
+		queueSteer: func(input agent.TurnInput) bool {
+			if input.InputText != "改查深圳。" {
+				t.Fatalf("queued steer input = %#v, want captured correction", input)
+			}
+			close(queuedSteer)
+			release()
+			return true
+		},
+	}
+
+	go func() {
+		<-runStarted
+		events <- voiceEventWakeup
+	}()
+
+	result := runVoiceTurnWithInputContext(
+		agent.Config{VoiceFollowupTimeoutMs: 5},
+		dialog,
+		nil,
+		agent.TurnInput{InputText: "广州。", Transcript: "广州。"},
+		[]int16{100, 200},
+		sigChan,
+		events,
+		agent.VoiceTurnContext{},
+		true,
+	)
+	if result.exit || result.interrupted || result.waitForWakeupRequested || result.nextTurn != nil {
+		t.Fatalf("runVoiceTurnWithInputContext result = %#v, want completed original run after queued steer", result)
+	}
+	select {
+	case <-queuedSteer:
+	default:
+		t.Fatal("wakeup correction was not queued as steer")
+	}
+	if len(runInputs) != 1 || runInputs[0] != "广州。" {
+		t.Fatalf("run inputs = %#v, want only original request", runInputs)
+	}
+	if len(dialog.queuedSteers) != 1 || dialog.queuedSteers[0].InputText != "改查深圳。" {
+		t.Fatalf("queued steers = %#v, want captured correction", dialog.queuedSteers)
+	}
+	if len(dialog.spoken) != 1 || dialog.spoken[0] != "steered reply" {
+		t.Fatalf("spoken texts = %#v, want steered reply from original run", dialog.spoken)
 	}
 }
 
@@ -1632,7 +1716,7 @@ func TestCaptureVoiceSteerInterruptsOutputBeforeRecording(t *testing.T) {
 	}
 }
 
-func TestRunVoiceTurnWakeupReturnsCapturedSteerAsNextTurn(t *testing.T) {
+func TestRunVoiceTurnWakeupReturnsCapturedSteerAsNextTurnWhenQueueSteerFails(t *testing.T) {
 	sigChan := make(chan os.Signal, 1)
 	events := make(chan voiceEvent, 1)
 	runStarted := make(chan struct{})
@@ -1657,6 +1741,12 @@ func TestRunVoiceTurnWakeupReturnsCapturedSteerAsNextTurn(t *testing.T) {
 			<-ctx.Done()
 			return agent.RunResult{}, ctx.Err()
 		},
+		queueSteer: func(input agent.TurnInput) bool {
+			if input.InputText != "改查深圳。" {
+				t.Fatalf("queued steer input = %#v, want captured correction", input)
+			}
+			return false
+		},
 	}
 
 	go func() {
@@ -1673,9 +1763,6 @@ func TestRunVoiceTurnWakeupReturnsCapturedSteerAsNextTurn(t *testing.T) {
 	}
 	if len(result.nextTurn.utterance) != 2 || result.nextTurn.utterance[0] != 500 || result.nextTurn.utterance[1] != 600 {
 		t.Fatalf("next turn utterance = %#v, want captured samples", result.nextTurn.utterance)
-	}
-	if len(dialog.queuedSteers) != 0 {
-		t.Fatalf("queued steers = %#v, want daemon wakeup interrupt to bypass QueueSteer", dialog.queuedSteers)
 	}
 	if len(dialog.spoken) != 0 {
 		t.Fatalf("spoken texts = %#v, want no stale reply from interrupted turn", dialog.spoken)

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -17,37 +17,41 @@ import (
 )
 
 type fakeAudioDialog struct {
-	chunks             []*agent.AudioChunkResult
-	chunkBatches       [][]*agent.AudioChunkResult
-	frameSamples       int
-	frames             [][]int16
-	vad                *agent.AudioVAD
-	utterance          []int16
-	utterancesToReturn [][]int16
-	onStart            func(*fakeAudioDialog)
-	onUtterance        func()
-	processUtterance   func(context.Context, []int16, *agent.Runtime) error
-	utterances         [][]int16
-	prepareTurnInput   func([]int16) (agent.TurnInput, error)
-	runTurn            func(context.Context) (agent.RunResult, error)
-	runVoiceTurn       func(context.Context, agent.TurnInput, []int16) (agent.RunResult, error)
-	queueSteer         func(agent.TurnInput) bool
-	interruptOutput    func()
-	speak              func(context.Context) error
-	persistVoiceTurn   func(agent.TurnInput, agent.RunResult, []int16)
-	persistedTurns     []persistedVoiceTurn
-	queuedSteers       []agent.TurnInput
-	vadErr             error
-	onRead             func(*fakeAudioDialog, *agent.AudioChunkResult)
-	spoken             []string
-	voiceTurnContexts  []agent.VoiceTurnContext
-	repeatEmpty        bool
-	readDelay          time.Duration
-	ops                []string
-	starts             int
-	stops              int
-	resets             int
-	recordingActive    bool
+	chunks               []*agent.AudioChunkResult
+	chunkBatches         [][]*agent.AudioChunkResult
+	frameSamples         int
+	frames               [][]int16
+	vad                  *agent.AudioVAD
+	utterance            []int16
+	utterancesToReturn   [][]int16
+	onStart              func(*fakeAudioDialog)
+	onUtterance          func()
+	processUtterance     func(context.Context, []int16, *agent.Runtime) error
+	utterances           [][]int16
+	prepareTurnInput     func([]int16) (agent.TurnInput, error)
+	runTurn              func(context.Context) (agent.RunResult, error)
+	runVoiceTurn         func(context.Context, agent.TurnInput, []int16) (agent.RunResult, error)
+	beginSteerInterrupt  func() bool
+	resumeSteerInterrupt func() bool
+	queueSteer           func(agent.TurnInput) bool
+	interruptOutput      func()
+	speak                func(context.Context) error
+	persistVoiceTurn     func(agent.TurnInput, agent.RunResult, []int16)
+	persistedTurns       []persistedVoiceTurn
+	queuedSteers         []agent.TurnInput
+	steerInterrupts      int
+	steerResumes         int
+	vadErr               error
+	onRead               func(*fakeAudioDialog, *agent.AudioChunkResult)
+	spoken               []string
+	voiceTurnContexts    []agent.VoiceTurnContext
+	repeatEmpty          bool
+	readDelay            time.Duration
+	ops                  []string
+	starts               int
+	stops                int
+	resets               int
+	recordingActive      bool
 }
 
 type persistedVoiceTurn struct {
@@ -191,6 +195,24 @@ func (d *fakeAudioDialog) QueueSteer(input agent.TurnInput) bool {
 	return ok
 }
 
+func (d *fakeAudioDialog) BeginSteerInterrupt() bool {
+	d.ops = append(d.ops, "begin_steer_interrupt")
+	d.steerInterrupts++
+	if d.beginSteerInterrupt != nil {
+		return d.beginSteerInterrupt()
+	}
+	return true
+}
+
+func (d *fakeAudioDialog) ResumeSteerInterrupt() bool {
+	d.ops = append(d.ops, "resume_steer_interrupt")
+	d.steerResumes++
+	if d.resumeSteerInterrupt != nil {
+		return d.resumeSteerInterrupt()
+	}
+	return true
+}
+
 func (d *fakeAudioDialog) InterruptOutput() {
 	d.ops = append(d.ops, "interrupt_output")
 	if d.interruptOutput != nil {
@@ -301,6 +323,18 @@ func opOccursAfter(ops []string, op, after string, afterOccurrence int) bool {
 	for _, got := range ops[afterIndex+1 : nextAfterIndex] {
 		if got == op {
 			return true
+		}
+	}
+	return false
+}
+
+func opOccursBefore(ops []string, op, before string) bool {
+	for _, got := range ops {
+		if got == op {
+			return true
+		}
+		if got == before {
+			return false
 		}
 	}
 	return false
@@ -1672,6 +1706,132 @@ func TestRunVoiceTurnWakeupQueuesSteerWhileOriginalRunActive(t *testing.T) {
 	}
 	if len(dialog.spoken) != 1 || dialog.spoken[0] != "steered reply" {
 		t.Fatalf("spoken texts = %#v, want steered reply from original run", dialog.spoken)
+	}
+}
+
+func TestRunVoiceTurnWakeupBeginsSteerInterruptBeforeRecording(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	events := make(chan voiceEvent, 1)
+	runStarted := make(chan struct{})
+	releaseRun := make(chan struct{})
+	queuedSteer := make(chan struct{})
+	dialog := &fakeAudioDialog{
+		frameSamples: 2,
+		chunkBatches: [][]*agent.AudioChunkResult{
+			{{PCM: pcm16BytesFromSamples(500, 600)}},
+		},
+		utterancesToReturn: [][]int16{
+			{500, 600},
+		},
+		repeatEmpty: true,
+		readDelay:   time.Millisecond,
+		prepareTurnInput: func(utterance []int16) (agent.TurnInput, error) {
+			if len(utterance) > 0 && utterance[0] == 500 {
+				return agent.TurnInput{InputText: "改查深圳。", Transcript: "改查深圳。"}, nil
+			}
+			return agent.TurnInput{InputText: "广州。", Transcript: "广州。"}, nil
+		},
+		runVoiceTurn: func(ctx context.Context, input agent.TurnInput, utterance []int16) (agent.RunResult, error) {
+			close(runStarted)
+			<-releaseRun
+			return agent.RunResult{Output: "steered reply"}, nil
+		},
+		queueSteer: func(input agent.TurnInput) bool {
+			close(queuedSteer)
+			close(releaseRun)
+			return true
+		},
+	}
+
+	go func() {
+		<-runStarted
+		events <- voiceEventWakeup
+	}()
+
+	result := runVoiceTurnWithInputContext(
+		agent.Config{VoiceFollowupTimeoutMs: 5},
+		dialog,
+		nil,
+		agent.TurnInput{InputText: "广州。", Transcript: "广州。"},
+		[]int16{100, 200},
+		sigChan,
+		events,
+		agent.VoiceTurnContext{},
+		true,
+	)
+	if result.exit || result.interrupted || result.waitForWakeupRequested || result.nextTurn != nil {
+		t.Fatalf("runVoiceTurnWithInputContext result = %#v, want completed original run after queued steer", result)
+	}
+	select {
+	case <-queuedSteer:
+	default:
+		t.Fatal("wakeup correction was not queued as steer")
+	}
+	if dialog.steerInterrupts != 1 {
+		t.Fatalf("steer interrupts = %d, want 1", dialog.steerInterrupts)
+	}
+	if !opOccursBefore(dialog.ops, "begin_steer_interrupt", "start") {
+		t.Fatalf("dialog ops = %#v, want interrupt marker before steer recording starts", dialog.ops)
+	}
+}
+
+func TestRunVoiceTurnWakeupEmptySteerResumesOriginalRun(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	events := make(chan voiceEvent, 1)
+	runStarted := make(chan struct{})
+	resumed := make(chan struct{})
+	dialog := &fakeAudioDialog{
+		frameSamples: 2,
+		chunkBatches: [][]*agent.AudioChunkResult{
+			{},
+		},
+		repeatEmpty: true,
+		readDelay:   time.Millisecond,
+		runVoiceTurn: func(ctx context.Context, input agent.TurnInput, utterance []int16) (agent.RunResult, error) {
+			close(runStarted)
+			select {
+			case <-ctx.Done():
+				return agent.RunResult{}, ctx.Err()
+			case <-resumed:
+			}
+			return agent.RunResult{Output: "original reply"}, nil
+		},
+		resumeSteerInterrupt: func() bool {
+			close(resumed)
+			return true
+		},
+	}
+
+	go func() {
+		<-runStarted
+		events <- voiceEventWakeup
+	}()
+
+	result := runVoiceTurnWithInputContext(
+		agent.Config{VoiceFollowupTimeoutMs: 5},
+		dialog,
+		nil,
+		agent.TurnInput{InputText: "广州。", Transcript: "广州。"},
+		[]int16{100, 200},
+		sigChan,
+		events,
+		agent.VoiceTurnContext{},
+		true,
+	)
+	if result.exit || result.interrupted || result.waitForWakeupRequested || result.nextTurn != nil {
+		t.Fatalf("runVoiceTurnWithInputContext result = %#v, want original run to resume after empty steer", result)
+	}
+	if dialog.steerInterrupts != 1 {
+		t.Fatalf("steer interrupts = %d, want 1", dialog.steerInterrupts)
+	}
+	if dialog.steerResumes != 1 {
+		t.Fatalf("steer resumes = %d, want 1", dialog.steerResumes)
+	}
+	if len(dialog.queuedSteers) != 0 {
+		t.Fatalf("queued steers = %#v, want none for empty steer", dialog.queuedSteers)
+	}
+	if len(dialog.spoken) != 1 || dialog.spoken[0] != "original reply" {
+		t.Fatalf("spoken texts = %#v, want original reply", dialog.spoken)
 	}
 }
 

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -30,9 +30,11 @@ type fakeAudioDialog struct {
 	prepareTurnInput   func([]int16) (agent.TurnInput, error)
 	runTurn            func(context.Context) (agent.RunResult, error)
 	runVoiceTurn       func(context.Context, agent.TurnInput, []int16) (agent.RunResult, error)
+	queueSteer         func(agent.TurnInput) bool
 	speak              func(context.Context) error
 	persistVoiceTurn   func(agent.TurnInput, agent.RunResult, []int16)
 	persistedTurns     []persistedVoiceTurn
+	queuedSteers       []agent.TurnInput
 	vadErr             error
 	onRead             func(*fakeAudioDialog, *agent.AudioChunkResult)
 	spoken             []string
@@ -168,6 +170,14 @@ func (d *fakeAudioDialog) RunVoiceTurn(ctx context.Context, input agent.TurnInpu
 		d.persistVoiceTurn(agent.TurnInput{}, result, nil)
 	}
 	return result, nil
+}
+
+func (d *fakeAudioDialog) QueueSteer(input agent.TurnInput) bool {
+	d.queuedSteers = append(d.queuedSteers, input)
+	if d.queueSteer != nil {
+		return d.queueSteer(input)
+	}
+	return true
 }
 
 func (d *fakeAudioDialog) PersistVoiceTurn(input agent.TurnInput, result agent.RunResult, utterance []int16) {
@@ -1393,27 +1403,44 @@ func TestRunVoiceSessionDrainsBurstWakeupsWhileAlreadyListening(t *testing.T) {
 	}
 }
 
-func TestRunVoiceSessionWakeupInterruptsThinking(t *testing.T) {
+func TestRunVoiceSessionWakeupQueuesSteerWhileThinking(t *testing.T) {
 	sigChan := make(chan os.Signal, 1)
 	events := make(chan voiceEvent, 2)
 	runStarted := make(chan struct{})
-	ctxCanceled := make(chan struct{})
+	steerQueued := make(chan struct{})
 	dialog := &fakeAudioDialog{
 		frameSamples: 2,
 		chunkBatches: [][]*agent.AudioChunkResult{
 			{{PCM: pcm16BytesFromSamples(100, 200)}},
+			{{PCM: pcm16BytesFromSamples(300, 400)}},
 			{},
 		},
 		utterancesToReturn: [][]int16{
 			{100, 200},
+			{300, 400},
 		},
 		repeatEmpty: true,
 		readDelay:   time.Millisecond,
+		prepareTurnInput: func(utterance []int16) (agent.TurnInput, error) {
+			if len(utterance) > 0 && utterance[0] == 300 {
+				return agent.TurnInput{InputText: "change course", Transcript: "change course"}, nil
+			}
+			return agent.TurnInput{InputText: "original request", Transcript: "original request"}, nil
+		},
 		runTurn: func(ctx context.Context) (agent.RunResult, error) {
 			close(runStarted)
-			<-ctx.Done()
-			close(ctxCanceled)
-			return agent.RunResult{}, ctx.Err()
+			select {
+			case <-ctx.Done():
+				return agent.RunResult{}, ctx.Err()
+			case <-steerQueued:
+				return agent.RunResult{Output: "reply"}, nil
+			}
+		},
+		queueSteer: func(input agent.TurnInput) bool {
+			if input.InputText == "change course" {
+				close(steerQueued)
+			}
+			return true
 		},
 	}
 
@@ -1422,37 +1449,59 @@ func TestRunVoiceSessionWakeupInterruptsThinking(t *testing.T) {
 		events <- voiceEventWakeup
 	}()
 
-	exit := runVoiceSession(agent.Config{VoiceFollowupTimeoutMs: 5}, dialog, nil, sigChan, events)
+	exit := runVoiceSession(agent.Config{VoiceFollowupTimeoutMs: 5, VoiceMaxTurns: 1}, dialog, nil, sigChan, events)
 	if exit {
 		t.Fatal("runVoiceSession returned exit=true")
 	}
-	select {
-	case <-ctxCanceled:
-	default:
-		t.Fatal("thinking context was not canceled")
+	if len(dialog.queuedSteers) != 1 {
+		t.Fatalf("queued steers = %#v, want one steer", dialog.queuedSteers)
 	}
-	if len(dialog.spoken) != 0 {
-		t.Fatalf("spoken texts = %#v, want no acknowledgement after wakeup interrupt", dialog.spoken)
+	if dialog.queuedSteers[0].InputText != "change course" {
+		t.Fatalf("queued steer = %#v, want change course", dialog.queuedSteers[0])
+	}
+	if len(dialog.spoken) != 1 || dialog.spoken[0] != "reply" {
+		t.Fatalf("spoken texts = %#v, want reply after steered run completes", dialog.spoken)
 	}
 	if dialog.starts != 2 {
-		t.Fatalf("dialog starts = %d, want recording restarted for follow-up listen", dialog.starts)
+		t.Fatalf("dialog starts = %d, want original listen plus steer listen", dialog.starts)
 	}
 }
 
-func TestRunVoiceTurnPersistsCompletedResultReturnedDuringWakeupInterrupt(t *testing.T) {
+func TestRunVoiceTurnWakeupQueuesSteerAndPersistsCompletedResult(t *testing.T) {
 	sigChan := make(chan os.Signal, 1)
 	events := make(chan voiceEvent, 1)
 	runStarted := make(chan struct{})
-	ctxCanceled := make(chan struct{})
+	steerQueued := make(chan struct{})
 	dialog := &fakeAudioDialog{
+		frameSamples: 2,
+		chunkBatches: [][]*agent.AudioChunkResult{
+			{{PCM: pcm16BytesFromSamples(500, 600)}},
+		},
+		utterancesToReturn: [][]int16{
+			{500, 600},
+		},
+		repeatEmpty: true,
+		readDelay:   time.Millisecond,
 		prepareTurnInput: func(utterance []int16) (agent.TurnInput, error) {
+			if len(utterance) > 0 && utterance[0] == 500 {
+				return agent.TurnInput{InputText: "改查深圳。", Transcript: "改查深圳。"}, nil
+			}
 			return agent.TurnInput{InputText: "广州。", Transcript: "广州。"}, nil
 		},
 		runTurn: func(ctx context.Context) (agent.RunResult, error) {
 			close(runStarted)
-			<-ctx.Done()
-			close(ctxCanceled)
-			return agent.RunResult{EpisodeID: "ep_weather", Output: "广州当前天气：小雨。"}, nil
+			select {
+			case <-ctx.Done():
+				return agent.RunResult{}, ctx.Err()
+			case <-steerQueued:
+				return agent.RunResult{EpisodeID: "ep_weather", Output: "深圳当前天气：多云。"}, nil
+			}
+		},
+		queueSteer: func(input agent.TurnInput) bool {
+			if input.InputText == "改查深圳。" {
+				close(steerQueued)
+			}
+			return true
 		},
 	}
 
@@ -1461,14 +1510,12 @@ func TestRunVoiceTurnPersistsCompletedResultReturnedDuringWakeupInterrupt(t *tes
 		events <- voiceEventWakeup
 	}()
 
-	result := runVoiceTurn(agent.Config{}, dialog, nil, []int16{100, 200}, sigChan, events)
-	if !result.interrupted || result.exit || result.waitForWakeupRequested {
-		t.Fatalf("runVoiceTurn = interrupted:%v exit:%v wait:%v, want true false false", result.interrupted, result.exit, result.waitForWakeupRequested)
+	result := runVoiceTurn(agent.Config{VoiceFollowupTimeoutMs: 5}, dialog, nil, []int16{100, 200}, sigChan, events)
+	if result.interrupted || result.exit || result.waitForWakeupRequested {
+		t.Fatalf("runVoiceTurn = interrupted:%v exit:%v wait:%v, want false false false", result.interrupted, result.exit, result.waitForWakeupRequested)
 	}
-	select {
-	case <-ctxCanceled:
-	default:
-		t.Fatal("thinking context was not canceled")
+	if len(dialog.queuedSteers) != 1 || dialog.queuedSteers[0].InputText != "改查深圳。" {
+		t.Fatalf("queued steers = %#v, want Shenzhen steer", dialog.queuedSteers)
 	}
 	if len(dialog.persistedTurns) != 1 {
 		t.Fatalf("persisted turns = %d, want 1", len(dialog.persistedTurns))
@@ -1477,8 +1524,8 @@ func TestRunVoiceTurnPersistsCompletedResultReturnedDuringWakeupInterrupt(t *tes
 	if turn.input.Transcript != "广州。" {
 		t.Fatalf("persisted transcript = %q, want 广州。", turn.input.Transcript)
 	}
-	if turn.result.EpisodeID != "ep_weather" || turn.result.Output != "广州当前天气：小雨。" {
-		t.Fatalf("persisted result = %#v, want completed weather result", turn.result)
+	if turn.result.EpisodeID != "ep_weather" || turn.result.Output != "深圳当前天气：多云。" {
+		t.Fatalf("persisted result = %#v, want completed steered weather result", turn.result)
 	}
 	if len(turn.utterance) != 2 || turn.utterance[0] != 100 || turn.utterance[1] != 200 {
 		t.Fatalf("persisted utterance = %#v, want captured samples", turn.utterance)

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -39,6 +39,7 @@ type fakeAudioDialog struct {
 	vadErr             error
 	onRead             func(*fakeAudioDialog, *agent.AudioChunkResult)
 	spoken             []string
+	voiceTurnContexts  []agent.VoiceTurnContext
 	repeatEmpty        bool
 	readDelay          time.Duration
 	ops                []string
@@ -152,6 +153,11 @@ func (d *fakeAudioDialog) RunAgentTurn(ctx context.Context, input agent.TurnInpu
 }
 
 func (d *fakeAudioDialog) RunVoiceTurn(ctx context.Context, input agent.TurnInput, utterance []int16, runtime *agent.Runtime) (agent.RunResult, error) {
+	return d.RunVoiceTurnWithContext(ctx, input, utterance, runtime, agent.VoiceTurnContext{})
+}
+
+func (d *fakeAudioDialog) RunVoiceTurnWithContext(ctx context.Context, input agent.TurnInput, utterance []int16, runtime *agent.Runtime, turnContext agent.VoiceTurnContext) (agent.RunResult, error) {
+	d.voiceTurnContexts = append(d.voiceTurnContexts, turnContext)
 	if d.runVoiceTurn != nil {
 		return d.runVoiceTurn(ctx, input, utterance)
 	}
@@ -258,6 +264,62 @@ func (d *fakeAudioDialog) VADDebugState() agent.VADDebugState {
 		return d.vad.DebugState()
 	}
 	return agent.VADDebugState{}
+}
+
+func opsHasPrefix(ops, prefix []string) bool {
+	if len(ops) < len(prefix) {
+		return false
+	}
+	for i, want := range prefix {
+		if ops[i] != want {
+			return false
+		}
+	}
+	return true
+}
+
+func countDialogOp(ops []string, op string) int {
+	count := 0
+	for _, got := range ops {
+		if got == op {
+			count++
+		}
+	}
+	return count
+}
+
+func opOccursAfter(ops []string, op, after string, afterOccurrence int) bool {
+	afterIndex := nthDialogOpIndex(ops, after, afterOccurrence)
+	if afterIndex < 0 {
+		return false
+	}
+	nextAfterIndex := nthDialogOpIndex(ops, after, afterOccurrence+1)
+	if nextAfterIndex < 0 {
+		nextAfterIndex = len(ops)
+	}
+	for _, got := range ops[afterIndex+1 : nextAfterIndex] {
+		if got == op {
+			return true
+		}
+	}
+	return false
+}
+
+func nthDialogOpIndex(ops []string, op string, occurrence int) int {
+	if occurrence <= 0 {
+		return -1
+	}
+	seen := 0
+	for i, got := range ops {
+		if got != op {
+			continue
+		}
+		seen++
+		if seen == occurrence {
+			return i
+		}
+	}
+	return -1
 }
 
 type fakeWakeupWatcher struct {
@@ -668,11 +730,9 @@ func TestRunWakeupModeLegacyStartsRecordingWithoutWakeupAck(t *testing.T) {
 	if len(dialog.spoken) != 0 {
 		t.Fatalf("spoken texts = %#v, want no wakeup acknowledgement", dialog.spoken)
 	}
-	if len(dialog.ops) < 2 {
-		t.Fatalf("dialog ops = %#v, want recording start/reset", dialog.ops)
-	}
-	if dialog.ops[0] != "start" || dialog.ops[1] != "reset" {
-		t.Fatalf("dialog ops = %#v, want start/reset without wakeup acknowledgement", dialog.ops)
+	wantPrefix := []string{"interrupt_output", "start", "reset"}
+	if !opsHasPrefix(dialog.ops, wantPrefix) {
+		t.Fatalf("dialog ops = %#v, want prefix %#v without wakeup acknowledgement", dialog.ops, wantPrefix)
 	}
 }
 
@@ -831,36 +891,52 @@ func TestRunWakeupModeStartsNewRecordingForNextWakeup(t *testing.T) {
 	}
 }
 
-func TestRunWakeupModeLegacyWakeupInterruptsProcessing(t *testing.T) {
+func TestRunWakeupModeSTTWakeupInterruptRunsNextTurnAsCorrection(t *testing.T) {
 	sigChan := make(chan os.Signal, 1)
 	watcher := &fakeWakeupWatcher{fireOnStart: true}
-	processingStarted := make(chan struct{})
+	firstRunStarted := make(chan struct{})
 	ctxCanceled := make(chan struct{})
-	secondStart := make(chan struct{})
+	secondRunStarted := make(chan struct{})
 	voiceSessionDisabled := false
+	runInputs := make([]string, 0, 2)
 	var dialog *fakeAudioDialog
 	dialog = &fakeAudioDialog{
 		frameSamples: 2,
-		chunks: []*agent.AudioChunkResult{
-			{PCM: pcm16BytesFromSamples(100, 200)},
+		chunkBatches: [][]*agent.AudioChunkResult{
+			{{PCM: pcm16BytesFromSamples(100, 200)}},
+			{{PCM: pcm16BytesFromSamples(300, 400)}},
 		},
-		utterance: []int16{100, 200},
-		onStart: func(d *fakeAudioDialog) {
-			if d.starts == 2 {
-				close(secondStart)
-				sigChan <- syscall.SIGTERM
+		utterancesToReturn: [][]int16{
+			{100, 200},
+			{300, 400},
+		},
+		prepareTurnInput: func(utterance []int16) (agent.TurnInput, error) {
+			if len(utterance) > 0 && utterance[0] == 300 {
+				return agent.TurnInput{InputText: "use the shorter search term", Transcript: "use the shorter search term"}, nil
 			}
+			return agent.TurnInput{InputText: "open the group and send money", Transcript: "open the group and send money"}, nil
 		},
-		processUtterance: func(ctx context.Context, utterance []int16, runtime *agent.Runtime) error {
-			close(processingStarted)
-			select {
-			case <-ctx.Done():
+		runVoiceTurn: func(ctx context.Context, input agent.TurnInput, utterance []int16) (agent.RunResult, error) {
+			runInputs = append(runInputs, input.InputText)
+			switch input.InputText {
+			case "open the group and send money":
+				close(firstRunStarted)
+				<-ctx.Done()
 				close(ctxCanceled)
-				return ctx.Err()
-			case <-time.After(150 * time.Millisecond):
-				sigChan <- syscall.SIGTERM
-				return errors.New("legacy wakeup did not cancel utterance processing")
+				return agent.RunResult{}, ctx.Err()
+			case "use the shorter search term":
+				close(secondRunStarted)
+				return agent.RunResult{Output: "revised reply"}, nil
+			default:
+				t.Errorf("unexpected run input = %#v", input)
+				return agent.RunResult{}, nil
 			}
+		},
+		speak: func(ctx context.Context) error {
+			if len(dialog.spoken) == 1 {
+				sigChan <- syscall.SIGTERM
+			}
+			return nil
 		},
 	}
 
@@ -874,26 +950,48 @@ func TestRunWakeupModeLegacyWakeupInterruptsProcessing(t *testing.T) {
 	}()
 
 	select {
-	case <-processingStarted:
+	case <-firstRunStarted:
 	case <-time.After(2 * time.Second):
-		t.Fatal("legacy wakeup mode did not start utterance processing")
+		t.Fatal("STT wakeup mode did not start the first voice run")
 	}
 	watcher.callback()
 
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("runWakeupMode did not stop after interrupted legacy wakeup")
+		t.Fatal("runWakeupMode did not stop after interrupted STT wakeup")
 	}
 	select {
 	case <-ctxCanceled:
 	default:
-		t.Fatal("legacy utterance context was not canceled by wakeup")
+		t.Fatal("first voice run context was not canceled by wakeup")
 	}
 	select {
-	case <-secondStart:
+	case <-secondRunStarted:
 	default:
-		t.Fatal("legacy wakeup interrupt did not trigger the next recording")
+		t.Fatal("wakeup interrupt did not trigger the correction voice run")
+	}
+	if len(runInputs) != 2 || runInputs[0] != "open the group and send money" || runInputs[1] != "use the shorter search term" {
+		t.Fatalf("run inputs = %#v, want original request followed by correction input", runInputs)
+	}
+	if len(dialog.voiceTurnContexts) != 2 {
+		t.Fatalf("voice turn contexts = %#v, want 2", dialog.voiceTurnContexts)
+	}
+	if dialog.voiceTurnContexts[0] != (agent.VoiceTurnContext{}) {
+		t.Fatalf("first voice turn context = %#v, want ordinary new task", dialog.voiceTurnContexts[0])
+	}
+	correctionContext := dialog.voiceTurnContexts[1]
+	if correctionContext.FollowUpRelation != agent.FollowUpCorrection {
+		t.Fatalf("second follow-up relation = %q, want correction", correctionContext.FollowUpRelation)
+	}
+	if !strings.Contains(correctionContext.RuntimeContext, "physical wakeup") || !strings.Contains(correctionContext.RuntimeContext, "interrupted") {
+		t.Fatalf("second runtime context = %q, want physical wakeup interruption context", correctionContext.RuntimeContext)
+	}
+	if got := countDialogOp(dialog.ops, "interrupt_output"); got < 2 {
+		t.Fatalf("interrupt_output count = %d, want initial wakeup and interrupting wakeup; ops=%#v", got, dialog.ops)
+	}
+	if !opOccursAfter(dialog.ops, "interrupt_output", "start", 1) {
+		t.Fatalf("dialog ops = %#v, want wakeup interrupt output before second recording start", dialog.ops)
 	}
 }
 
@@ -1028,11 +1126,9 @@ func TestRunWakeupModeVoiceSessionStartsRecordingWithoutWakeupAck(t *testing.T) 
 		t.Fatal("runWakeupMode did not stop after signal")
 	}
 
-	if len(dialog.ops) < 2 {
-		t.Fatalf("dialog ops = %#v, want recording start/reset", dialog.ops)
-	}
-	if dialog.ops[0] != "start" || dialog.ops[1] != "reset" {
-		t.Fatalf("dialog ops = %#v, want start/reset without wakeup acknowledgement", dialog.ops)
+	wantPrefix := []string{"interrupt_output", "start", "reset"}
+	if !opsHasPrefix(dialog.ops, wantPrefix) {
+		t.Fatalf("dialog ops = %#v, want prefix %#v without wakeup acknowledgement", dialog.ops, wantPrefix)
 	}
 	if len(dialog.spoken) != 1 || dialog.spoken[0] != "reply" {
 		t.Fatalf("spoken texts = %#v, want only the agent reply", dialog.spoken)

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -1980,6 +1980,139 @@ func TestRunVoiceSessionWakeupInterruptsSpeaking(t *testing.T) {
 	}
 }
 
+func TestRunVoiceSessionSpeakingInterruptMarksNextUtteranceCorrection(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	events := make(chan voiceEvent, 1)
+	speakStarted := make(chan struct{})
+	ctxCanceled := make(chan struct{})
+	speakCalls := 0
+	dialog := &fakeAudioDialog{
+		frameSamples: 2,
+		chunkBatches: [][]*agent.AudioChunkResult{
+			{{PCM: pcm16BytesFromSamples(100, 200)}},
+			{{PCM: pcm16BytesFromSamples(300, 400)}},
+		},
+		utterancesToReturn: [][]int16{
+			{100, 200},
+			{300, 400},
+		},
+		prepareTurnInput: func(utterance []int16) (agent.TurnInput, error) {
+			if len(utterance) > 0 && utterance[0] == 300 {
+				return agent.TurnInput{InputText: "改成明天。", Transcript: "改成明天。"}, nil
+			}
+			return agent.TurnInput{InputText: "订今天的票。", Transcript: "订今天的票。"}, nil
+		},
+		speak: func(ctx context.Context) error {
+			speakCalls++
+			if speakCalls > 1 {
+				return nil
+			}
+			close(speakStarted)
+			<-ctx.Done()
+			close(ctxCanceled)
+			return ctx.Err()
+		},
+	}
+
+	go func() {
+		<-speakStarted
+		events <- voiceEventWakeup
+	}()
+
+	exit := runVoiceSession(agent.Config{VoiceFollowupTimeoutMs: 50, VoiceMaxTurns: 1}, dialog, nil, sigChan, events)
+	if exit {
+		t.Fatal("runVoiceSession returned exit=true")
+	}
+	select {
+	case <-ctxCanceled:
+	default:
+		t.Fatal("speaking context was not canceled")
+	}
+	if len(dialog.voiceTurnContexts) != 2 {
+		t.Fatalf("voice turn contexts = %#v, want original turn and correction follow-up", dialog.voiceTurnContexts)
+	}
+	if dialog.voiceTurnContexts[0] != (agent.VoiceTurnContext{}) {
+		t.Fatalf("first voice turn context = %#v, want ordinary new task", dialog.voiceTurnContexts[0])
+	}
+	if got, want := dialog.voiceTurnContexts[1], interruptedVoiceCorrectionContext(); got != want {
+		t.Fatalf("second voice turn context = %#v, want %#v", got, want)
+	}
+}
+
+func TestRunWakeupModeSTTSpeakingInterruptMarksNextTurnCorrection(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	watcher := &fakeWakeupWatcher{fireOnStart: true}
+	speakStarted := make(chan struct{})
+	ctxCanceled := make(chan struct{})
+	voiceSessionDisabled := false
+	speakCalls := 0
+	var dialog *fakeAudioDialog
+	dialog = &fakeAudioDialog{
+		frameSamples: 2,
+		chunkBatches: [][]*agent.AudioChunkResult{
+			{{PCM: pcm16BytesFromSamples(100, 200)}},
+			{{PCM: pcm16BytesFromSamples(300, 400)}},
+		},
+		utterancesToReturn: [][]int16{
+			{100, 200},
+			{300, 400},
+		},
+		prepareTurnInput: func(utterance []int16) (agent.TurnInput, error) {
+			if len(utterance) > 0 && utterance[0] == 300 {
+				return agent.TurnInput{InputText: "短一点。", Transcript: "短一点。"}, nil
+			}
+			return agent.TurnInput{InputText: "总结这段内容。", Transcript: "总结这段内容。"}, nil
+		},
+		speak: func(ctx context.Context) error {
+			speakCalls++
+			if speakCalls > 1 {
+				sigChan <- syscall.SIGTERM
+				return nil
+			}
+			close(speakStarted)
+			<-ctx.Done()
+			close(ctxCanceled)
+			return ctx.Err()
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		runWakeupMode(agent.Config{InputMode: "stt", VoiceFollowupEnabled: &voiceSessionDisabled, VoiceFollowupTimeoutMs: 50}, dialog, nil, sigChan, func(pin int, callback func()) (wakeupWatcher, error) {
+			watcher.callback = callback
+			return watcher, nil
+		})
+		close(done)
+	}()
+
+	select {
+	case <-speakStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runWakeupMode did not start speaking")
+	}
+	watcher.callback()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runWakeupMode did not stop after correction turn")
+	}
+	select {
+	case <-ctxCanceled:
+	default:
+		t.Fatal("speaking context was not canceled")
+	}
+	if len(dialog.voiceTurnContexts) != 2 {
+		t.Fatalf("voice turn contexts = %#v, want original turn and correction follow-up", dialog.voiceTurnContexts)
+	}
+	if dialog.voiceTurnContexts[0] != (agent.VoiceTurnContext{}) {
+		t.Fatalf("first voice turn context = %#v, want ordinary new task", dialog.voiceTurnContexts[0])
+	}
+	if got, want := dialog.voiceTurnContexts[1], interruptedVoiceCorrectionContext(); got != want {
+		t.Fatalf("second voice turn context = %#v, want %#v", got, want)
+	}
+}
+
 func pcm16Bytes(sample int16) []byte {
 	return pcm16BytesFromSamples(sample)
 }

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -60,6 +60,15 @@ type persistedVoiceTurn struct {
 	utterance []int16
 }
 
+func withVoiceSteerListenTimeout(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	old := voiceSteerListenTimeout
+	voiceSteerListenTimeout = timeout
+	t.Cleanup(func() {
+		voiceSteerListenTimeout = old
+	})
+}
+
 func (d *fakeAudioDialog) StartRecording() error {
 	if d.recordingActive {
 		return nil
@@ -1776,6 +1785,8 @@ func TestRunVoiceTurnWakeupBeginsSteerInterruptBeforeRecording(t *testing.T) {
 }
 
 func TestRunVoiceTurnWakeupEmptySteerResumesOriginalRun(t *testing.T) {
+	withVoiceSteerListenTimeout(t, 5*time.Millisecond)
+
 	sigChan := make(chan os.Signal, 1)
 	events := make(chan voiceEvent, 1)
 	runStarted := make(chan struct{})
@@ -1832,6 +1843,13 @@ func TestRunVoiceTurnWakeupEmptySteerResumesOriginalRun(t *testing.T) {
 	}
 	if len(dialog.spoken) != 1 || dialog.spoken[0] != "original reply" {
 		t.Fatalf("spoken texts = %#v, want original reply", dialog.spoken)
+	}
+}
+
+func TestVoiceSteerListenTimeoutIgnoresFollowupTimeout(t *testing.T) {
+	cfg := agent.Config{VoiceFollowupTimeoutMs: 5}
+	if got := voiceSteerListenTimeoutForConfig(cfg); got != 45*time.Second {
+		t.Fatalf("voiceSteerListenTimeoutForConfig() = %s, want 45s", got)
 	}
 }
 

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -1414,11 +1414,14 @@ func TestRunVoiceSessionDrainsBurstWakeupsWhileAlreadyListening(t *testing.T) {
 	}
 }
 
-func TestRunVoiceSessionWakeupQueuesSteerWhileThinking(t *testing.T) {
+func TestRunVoiceSessionWakeupRunsCapturedSteerAsNextTurn(t *testing.T) {
 	sigChan := make(chan os.Signal, 1)
 	events := make(chan voiceEvent, 2)
-	runStarted := make(chan struct{})
-	steerQueued := make(chan struct{})
+	originalRunStarted := make(chan struct{})
+	releaseOriginalRun := make(chan struct{})
+	originalRunReturned := make(chan struct{})
+	queueSteerCalls := 0
+	runInputs := make([]string, 0, 2)
 	dialog := &fakeAudioDialog{
 		frameSamples: 2,
 		chunkBatches: [][]*agent.AudioChunkResult{
@@ -1432,31 +1435,45 @@ func TestRunVoiceSessionWakeupQueuesSteerWhileThinking(t *testing.T) {
 		},
 		repeatEmpty: true,
 		readDelay:   time.Millisecond,
+		onStart: func(d *fakeAudioDialog) {
+			if d.starts == 2 {
+				close(releaseOriginalRun)
+			}
+		},
 		prepareTurnInput: func(utterance []int16) (agent.TurnInput, error) {
 			if len(utterance) > 0 && utterance[0] == 300 {
 				return agent.TurnInput{InputText: "change course", Transcript: "change course"}, nil
 			}
 			return agent.TurnInput{InputText: "original request", Transcript: "original request"}, nil
 		},
-		runTurn: func(ctx context.Context) (agent.RunResult, error) {
-			close(runStarted)
-			select {
-			case <-ctx.Done():
-				return agent.RunResult{}, ctx.Err()
-			case <-steerQueued:
-				return agent.RunResult{Output: "reply"}, nil
+		runVoiceTurn: func(ctx context.Context, input agent.TurnInput, utterance []int16) (agent.RunResult, error) {
+			runInputs = append(runInputs, input.InputText)
+			switch input.InputText {
+			case "original request":
+				close(originalRunStarted)
+				<-releaseOriginalRun
+				close(originalRunReturned)
+				return agent.RunResult{Output: "stale reply"}, nil
+			case "change course":
+				return agent.RunResult{Output: "revised reply"}, nil
+			default:
+				t.Errorf("unexpected run input = %#v", input)
+				return agent.RunResult{}, nil
 			}
 		},
 		queueSteer: func(input agent.TurnInput) bool {
-			if input.InputText == "change course" {
-				close(steerQueued)
+			queueSteerCalls++
+			select {
+			case <-originalRunReturned:
+			case <-time.After(time.Second):
+				t.Fatal("original run did not return before QueueSteer")
 			}
-			return true
+			return false
 		},
 	}
 
 	go func() {
-		<-runStarted
+		<-originalRunStarted
 		events <- voiceEventWakeup
 	}()
 
@@ -1464,21 +1481,21 @@ func TestRunVoiceSessionWakeupQueuesSteerWhileThinking(t *testing.T) {
 	if exit {
 		t.Fatal("runVoiceSession returned exit=true")
 	}
-	if len(dialog.queuedSteers) != 1 {
-		t.Fatalf("queued steers = %#v, want one steer", dialog.queuedSteers)
+	if queueSteerCalls != 0 {
+		t.Fatalf("QueueSteer calls = %d, want daemon wakeup interrupt to run captured input as next turn", queueSteerCalls)
 	}
-	if dialog.queuedSteers[0].InputText != "change course" {
-		t.Fatalf("queued steer = %#v, want change course", dialog.queuedSteers[0])
+	if len(runInputs) != 2 || runInputs[0] != "original request" || runInputs[1] != "change course" {
+		t.Fatalf("run inputs = %#v, want original request followed by captured steer", runInputs)
 	}
-	if len(dialog.spoken) != 1 || dialog.spoken[0] != "reply" {
-		t.Fatalf("spoken texts = %#v, want reply after steered run completes", dialog.spoken)
+	if len(dialog.spoken) != 1 || dialog.spoken[0] != "revised reply" {
+		t.Fatalf("spoken texts = %#v, want only revised reply", dialog.spoken)
 	}
 	if dialog.starts != 2 {
 		t.Fatalf("dialog starts = %d, want original listen plus steer listen", dialog.starts)
 	}
 }
 
-func TestCaptureAndQueueVoiceSteerInterruptsOutputBeforeRecording(t *testing.T) {
+func TestCaptureVoiceSteerInterruptsOutputBeforeRecording(t *testing.T) {
 	sigChan := make(chan os.Signal, 1)
 	events := make(chan voiceEvent, 1)
 	dialog := &fakeAudioDialog{
@@ -1494,9 +1511,9 @@ func TestCaptureAndQueueVoiceSteerInterruptsOutputBeforeRecording(t *testing.T) 
 		},
 	}
 
-	exit := captureAndQueueVoiceSteer(agent.Config{VoiceFollowupTimeoutMs: 50}, dialog, sigChan, events)
+	nextTurn, exit := captureVoiceSteer(agent.Config{VoiceFollowupTimeoutMs: 50}, dialog, sigChan, events)
 	if exit {
-		t.Fatal("captureAndQueueVoiceSteer returned exit=true")
+		t.Fatal("captureVoiceSteer returned exit=true")
 	}
 
 	wantOps := []string{"interrupt_output", "start", "reset", "stop"}
@@ -1508,16 +1525,21 @@ func TestCaptureAndQueueVoiceSteerInterruptsOutputBeforeRecording(t *testing.T) 
 			t.Fatalf("dialog ops = %#v, want %#v", dialog.ops, wantOps)
 		}
 	}
-	if len(dialog.queuedSteers) != 1 || dialog.queuedSteers[0].InputText != "change course" {
-		t.Fatalf("queued steers = %#v, want change course", dialog.queuedSteers)
+	if nextTurn == nil || nextTurn.input.InputText != "change course" {
+		t.Fatalf("next turn = %#v, want change course", nextTurn)
+	}
+	if len(nextTurn.utterance) != 2 || nextTurn.utterance[0] != 300 || nextTurn.utterance[1] != 400 {
+		t.Fatalf("next turn utterance = %#v, want captured samples", nextTurn.utterance)
+	}
+	if len(dialog.queuedSteers) != 0 {
+		t.Fatalf("queued steers = %#v, want daemon wakeup interrupt to bypass QueueSteer", dialog.queuedSteers)
 	}
 }
 
-func TestRunVoiceTurnWakeupQueuesSteerAndPersistsCompletedResult(t *testing.T) {
+func TestRunVoiceTurnWakeupReturnsCapturedSteerAsNextTurn(t *testing.T) {
 	sigChan := make(chan os.Signal, 1)
 	events := make(chan voiceEvent, 1)
 	runStarted := make(chan struct{})
-	steerQueued := make(chan struct{})
 	dialog := &fakeAudioDialog{
 		frameSamples: 2,
 		chunkBatches: [][]*agent.AudioChunkResult{
@@ -1536,18 +1558,8 @@ func TestRunVoiceTurnWakeupQueuesSteerAndPersistsCompletedResult(t *testing.T) {
 		},
 		runTurn: func(ctx context.Context) (agent.RunResult, error) {
 			close(runStarted)
-			select {
-			case <-ctx.Done():
-				return agent.RunResult{}, ctx.Err()
-			case <-steerQueued:
-				return agent.RunResult{EpisodeID: "ep_weather", Output: "深圳当前天气：多云。"}, nil
-			}
-		},
-		queueSteer: func(input agent.TurnInput) bool {
-			if input.InputText == "改查深圳。" {
-				close(steerQueued)
-			}
-			return true
+			<-ctx.Done()
+			return agent.RunResult{}, ctx.Err()
 		},
 	}
 
@@ -1557,24 +1569,20 @@ func TestRunVoiceTurnWakeupQueuesSteerAndPersistsCompletedResult(t *testing.T) {
 	}()
 
 	result := runVoiceTurn(agent.Config{VoiceFollowupTimeoutMs: 5}, dialog, nil, []int16{100, 200}, sigChan, events)
-	if result.interrupted || result.exit || result.waitForWakeupRequested {
-		t.Fatalf("runVoiceTurn = interrupted:%v exit:%v wait:%v, want false false false", result.interrupted, result.exit, result.waitForWakeupRequested)
+	if !result.interrupted || result.exit || result.waitForWakeupRequested {
+		t.Fatalf("runVoiceTurn = interrupted:%v exit:%v wait:%v, want true false false", result.interrupted, result.exit, result.waitForWakeupRequested)
 	}
-	if len(dialog.queuedSteers) != 1 || dialog.queuedSteers[0].InputText != "改查深圳。" {
-		t.Fatalf("queued steers = %#v, want Shenzhen steer", dialog.queuedSteers)
+	if result.nextTurn == nil || result.nextTurn.input.InputText != "改查深圳。" {
+		t.Fatalf("next turn = %#v, want Shenzhen steer", result.nextTurn)
 	}
-	if len(dialog.persistedTurns) != 1 {
-		t.Fatalf("persisted turns = %d, want 1", len(dialog.persistedTurns))
+	if len(result.nextTurn.utterance) != 2 || result.nextTurn.utterance[0] != 500 || result.nextTurn.utterance[1] != 600 {
+		t.Fatalf("next turn utterance = %#v, want captured samples", result.nextTurn.utterance)
 	}
-	turn := dialog.persistedTurns[0]
-	if turn.input.Transcript != "广州。" {
-		t.Fatalf("persisted transcript = %q, want 广州。", turn.input.Transcript)
+	if len(dialog.queuedSteers) != 0 {
+		t.Fatalf("queued steers = %#v, want daemon wakeup interrupt to bypass QueueSteer", dialog.queuedSteers)
 	}
-	if turn.result.EpisodeID != "ep_weather" || turn.result.Output != "深圳当前天气：多云。" {
-		t.Fatalf("persisted result = %#v, want completed steered weather result", turn.result)
-	}
-	if len(turn.utterance) != 2 || turn.utterance[0] != 100 || turn.utterance[1] != 200 {
-		t.Fatalf("persisted utterance = %#v, want captured samples", turn.utterance)
+	if len(dialog.spoken) != 0 {
+		t.Fatalf("spoken texts = %#v, want no stale reply from interrupted turn", dialog.spoken)
 	}
 }
 

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -31,6 +31,7 @@ type fakeAudioDialog struct {
 	runTurn            func(context.Context) (agent.RunResult, error)
 	runVoiceTurn       func(context.Context, agent.TurnInput, []int16) (agent.RunResult, error)
 	queueSteer         func(agent.TurnInput) bool
+	interruptOutput    func()
 	speak              func(context.Context) error
 	persistVoiceTurn   func(agent.TurnInput, agent.RunResult, []int16)
 	persistedTurns     []persistedVoiceTurn
@@ -181,6 +182,13 @@ func (d *fakeAudioDialog) QueueSteer(input agent.TurnInput) bool {
 		d.queuedSteers = append(d.queuedSteers, input)
 	}
 	return ok
+}
+
+func (d *fakeAudioDialog) InterruptOutput() {
+	d.ops = append(d.ops, "interrupt_output")
+	if d.interruptOutput != nil {
+		d.interruptOutput()
+	}
 }
 
 func (d *fakeAudioDialog) PersistVoiceTurn(input agent.TurnInput, result agent.RunResult, utterance []int16) {
@@ -1467,6 +1475,41 @@ func TestRunVoiceSessionWakeupQueuesSteerWhileThinking(t *testing.T) {
 	}
 	if dialog.starts != 2 {
 		t.Fatalf("dialog starts = %d, want original listen plus steer listen", dialog.starts)
+	}
+}
+
+func TestCaptureAndQueueVoiceSteerInterruptsOutputBeforeRecording(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	events := make(chan voiceEvent, 1)
+	dialog := &fakeAudioDialog{
+		frameSamples: 2,
+		chunkBatches: [][]*agent.AudioChunkResult{
+			{{PCM: pcm16BytesFromSamples(300, 400)}},
+		},
+		utterancesToReturn: [][]int16{
+			{300, 400},
+		},
+		prepareTurnInput: func(utterance []int16) (agent.TurnInput, error) {
+			return agent.TurnInput{InputText: "change course", Transcript: "change course"}, nil
+		},
+	}
+
+	exit := captureAndQueueVoiceSteer(agent.Config{VoiceFollowupTimeoutMs: 50}, dialog, sigChan, events)
+	if exit {
+		t.Fatal("captureAndQueueVoiceSteer returned exit=true")
+	}
+
+	wantOps := []string{"interrupt_output", "start", "reset", "stop"}
+	if len(dialog.ops) != len(wantOps) {
+		t.Fatalf("dialog ops = %#v, want %#v", dialog.ops, wantOps)
+	}
+	for i, want := range wantOps {
+		if dialog.ops[i] != want {
+			t.Fatalf("dialog ops = %#v, want %#v", dialog.ops, wantOps)
+		}
+	}
+	if len(dialog.queuedSteers) != 1 || dialog.queuedSteers[0].InputText != "change course" {
+		t.Fatalf("queued steers = %#v, want change course", dialog.queuedSteers)
 	}
 }
 

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -173,11 +173,14 @@ func (d *fakeAudioDialog) RunVoiceTurn(ctx context.Context, input agent.TurnInpu
 }
 
 func (d *fakeAudioDialog) QueueSteer(input agent.TurnInput) bool {
-	d.queuedSteers = append(d.queuedSteers, input)
+	ok := true
 	if d.queueSteer != nil {
-		return d.queueSteer(input)
+		ok = d.queueSteer(input)
 	}
-	return true
+	if ok {
+		d.queuedSteers = append(d.queuedSteers, input)
+	}
+	return ok
 }
 
 func (d *fakeAudioDialog) PersistVoiceTurn(input agent.TurnInput, result agent.RunResult, utterance []int16) {

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -22,20 +22,24 @@ var (
 
 // AudioDialog manages the audio conversation loop
 type AudioDialog struct {
-	config        Config
-	audioClient   *AudioServiceClient
-	sttClient     STTClient
-	ttsManager    *tts.ProviderManager
-	vad           *AudioVAD
-	recordActive  bool
-	sessionID     uint64
-	recordReader  *AudioRecordChunkReader
-	speechMu      sync.Mutex
-	progressMu    sync.Mutex
-	progress      *progressSpeaker
-	historyStore  *ChatHistoryStore
-	historyAppend func(Message)
-	audioArchive  *AudioArchiveManager
+	config          Config
+	audioClient     *AudioServiceClient
+	sttClient       STTClient
+	ttsManager      *tts.ProviderManager
+	vad             *AudioVAD
+	recordActive    bool
+	sessionID       uint64
+	recordReader    *AudioRecordChunkReader
+	speechMu        sync.Mutex
+	progressMu      sync.Mutex
+	progress        *progressSpeaker
+	runControlMu    sync.Mutex
+	activeRequestID string
+	pendingSteer    RunSteerMessage
+	hasPendingSteer bool
+	historyStore    *ChatHistoryStore
+	historyAppend   func(Message)
+	audioArchive    *AudioArchiveManager
 }
 
 // NewAudioDialog creates a new audio dialog manager
@@ -299,7 +303,7 @@ func (d *AudioDialog) persistVoiceTurn(input TurnInput, result RunResult, uttera
 
 func (d *AudioDialog) PersistVoiceTurn(input TurnInput, result RunResult, utterance []int16) {
 	d.persistVoiceUserInput(input, utterance, result.EpisodeID, "")
-	d.PersistVoiceAssistantOutput(result)
+	d.persistVoiceAssistantOutput(result, "")
 }
 
 func (d *AudioDialog) PersistVoiceUserInput(input TurnInput, utterance []int16) {
@@ -328,6 +332,10 @@ func (d *AudioDialog) persistVoiceUserInput(input TurnInput, utterance []int16, 
 }
 
 func (d *AudioDialog) PersistVoiceAssistantOutput(result RunResult) {
+	d.persistVoiceAssistantOutput(result, "")
+}
+
+func (d *AudioDialog) persistVoiceAssistantOutput(result RunResult, requestID string) {
 	if d.historyAppend == nil && d.historyStore == nil {
 		return
 	}
@@ -337,6 +345,7 @@ func (d *AudioDialog) PersistVoiceAssistantOutput(result RunResult) {
 		assistantMsg := Message{
 			Type:      "assistant",
 			EpisodeID: result.EpisodeID,
+			RequestID: requestID,
 			Content:   output,
 			Source:    "voice",
 			Timestamp: now,
@@ -345,11 +354,11 @@ func (d *AudioDialog) PersistVoiceAssistantOutput(result RunResult) {
 	}
 }
 
-func (d *AudioDialog) appendVoiceRunEvent(event RunEvent) {
+func (d *AudioDialog) appendVoiceRunEvent(event RunEvent, requestID string) {
 	if d.historyAppend == nil && d.historyStore == nil {
 		return
 	}
-	message := messageFromRunEvent(event, event.EpisodeID, "")
+	message := messageFromRunEvent(event, event.EpisodeID, requestID)
 	if message.Type == "" {
 		return
 	}
@@ -438,7 +447,7 @@ func (d *AudioDialog) RunAgentTurn(ctx context.Context, input TurnInput, runtime
 	if runtime != nil {
 		episodeID = runtime.NewEpisodeID()
 	}
-	return d.runAgentTurnWithEpisode(ctx, input, runtime, episodeID)
+	return d.runAgentTurnWithEpisodeAndRequest(ctx, input, runtime, episodeID, createVoiceRequestID())
 }
 
 func (d *AudioDialog) RunVoiceTurn(ctx context.Context, input TurnInput, utterance []int16, runtime *Runtime) (RunResult, error) {
@@ -446,16 +455,25 @@ func (d *AudioDialog) RunVoiceTurn(ctx context.Context, input TurnInput, utteran
 	if runtime != nil {
 		episodeID = runtime.NewEpisodeID()
 	}
-	d.persistVoiceUserInput(input, utterance, episodeID, "")
-	result, err := d.runAgentTurnWithEpisode(ctx, input, runtime, episodeID)
+	requestID := createVoiceRequestID()
+	d.persistVoiceUserInput(input, utterance, episodeID, requestID)
+	result, err := d.runAgentTurnWithEpisodeAndRequest(ctx, input, runtime, episodeID, requestID)
 	if err != nil {
 		return RunResult{}, err
 	}
-	d.PersistVoiceAssistantOutput(result)
+	d.persistVoiceAssistantOutput(result, requestID)
 	return result, nil
 }
 
-func (d *AudioDialog) runAgentTurnWithEpisode(ctx context.Context, input TurnInput, runtime *Runtime, episodeID string) (RunResult, error) {
+func (d *AudioDialog) runAgentTurnWithEpisodeAndRequest(ctx context.Context, input TurnInput, runtime *Runtime, episodeID, requestID string) (RunResult, error) {
+	if requestID == "" {
+		requestID = createVoiceRequestID()
+	}
+	if !d.beginVoiceRunControl(requestID) {
+		return RunResult{}, fmt.Errorf("voice run already active")
+	}
+	defer d.endVoiceRunControl(requestID)
+
 	d.playPromptSound(promptSoundAgentSend, "agent send", true)
 
 	// Send to LLM
@@ -473,12 +491,16 @@ func (d *AudioDialog) runAgentTurnWithEpisode(ctx context.Context, input TurnInp
 		Input:       input.InputText,
 		Attachments: input.Attachments,
 		Turn:        input,
+		RequestID:   requestID,
 		MaxTokens:   d.config.VoiceMaxResponseTokensOrDefault(),
 		EventHandler: func(event RunEvent) {
-			d.appendVoiceRunEvent(event)
+			d.appendVoiceRunEvent(event, requestID)
 			d.HandleRunEvent(ctx, event)
 		},
 		StreamFinalChunks: true,
+		SteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
+			return d.consumePendingSteer(requestID)
+		},
 	}
 	req.EpisodeID = strings.TrimSpace(episodeID)
 
@@ -507,6 +529,77 @@ func (d *AudioDialog) runAgentTurnWithEpisode(ctx context.Context, input TurnInp
 
 	log.Printf("[llm] Response received\n")
 	return result, nil
+}
+
+func createVoiceRequestID() string {
+	return fmt.Sprintf("voice-%x", time.Now().UnixNano())
+}
+
+func (d *AudioDialog) beginVoiceRunControl(requestID string) bool {
+	d.runControlMu.Lock()
+	defer d.runControlMu.Unlock()
+	if d.activeRequestID != "" {
+		return false
+	}
+	d.activeRequestID = requestID
+	d.pendingSteer = RunSteerMessage{}
+	d.hasPendingSteer = false
+	return true
+}
+
+func (d *AudioDialog) endVoiceRunControl(requestID string) {
+	d.runControlMu.Lock()
+	defer d.runControlMu.Unlock()
+	if d.activeRequestID != requestID {
+		return
+	}
+	d.activeRequestID = ""
+	d.pendingSteer = RunSteerMessage{}
+	d.hasPendingSteer = false
+}
+
+func (d *AudioDialog) QueueSteer(input TurnInput) bool {
+	content := steerContentFromTurnInput(input)
+	if content == "" {
+		return false
+	}
+	d.runControlMu.Lock()
+	defer d.runControlMu.Unlock()
+	if d.activeRequestID == "" {
+		return false
+	}
+	d.pendingSteer = RunSteerMessage{
+		ID:        createSteerID(),
+		RequestID: d.activeRequestID,
+		Content:   content,
+		Timestamp: time.Now(),
+	}
+	d.hasPendingSteer = true
+	log.Printf("[steer] Queued voice steer: request_id=%s len=%d\n", d.activeRequestID, len(content))
+	return true
+}
+
+func (d *AudioDialog) consumePendingSteer(requestID string) (RunSteerMessage, bool) {
+	d.runControlMu.Lock()
+	defer d.runControlMu.Unlock()
+	if requestID == "" || d.activeRequestID != requestID || !d.hasPendingSteer {
+		return RunSteerMessage{}, false
+	}
+	steer := d.pendingSteer
+	d.pendingSteer = RunSteerMessage{}
+	d.hasPendingSteer = false
+	return steer, true
+}
+
+func steerContentFromTurnInput(input TurnInput) string {
+	input = normalizeTurnInput(input)
+	if content := strings.TrimSpace(input.InputText); content != "" {
+		if content == voiceAudioInputPlaceholder && strings.TrimSpace(input.Transcript) == "" {
+			return ""
+		}
+		return content
+	}
+	return strings.TrimSpace(input.Transcript)
 }
 
 func (d *AudioDialog) HandleRunEvent(ctx context.Context, event RunEvent) {
@@ -654,7 +747,7 @@ func (d *AudioDialog) ProcessTextInput(ctx context.Context, text string, runtime
 		Input: text,
 		Turn:  NewTextTurnInput(text, nil),
 		EventHandler: func(event RunEvent) {
-			d.appendVoiceRunEvent(event)
+			d.appendVoiceRunEvent(event, "")
 			d.HandleRunEvent(ctx, event)
 		},
 		StreamFinalChunks: true,

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -13,7 +13,10 @@ import (
 	"aiden-agent/internal/agent/tts"
 )
 
-const toolDescriptionSpeechTimeout = 15 * time.Second
+const (
+	toolDescriptionSpeechTimeout = 15 * time.Second
+	outputInterruptWaitTimeout   = 250 * time.Millisecond
+)
 
 var (
 	recordingStartRetryTimeout  = 5 * time.Second
@@ -31,6 +34,8 @@ type AudioDialog struct {
 	sessionID       uint64
 	recordReader    *AudioRecordChunkReader
 	speechMu        sync.Mutex
+	outputMu        sync.Mutex
+	activeOutputs   map[*activeTTSOutput]struct{}
 	progressMu      sync.Mutex
 	progress        *progressSpeaker
 	runControlMu    sync.Mutex
@@ -40,6 +45,67 @@ type AudioDialog struct {
 	historyStore    *ChatHistoryStore
 	historyAppend   func(Message)
 	audioArchive    *AudioArchiveManager
+}
+
+type activeTTSOutput struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu     sync.Mutex
+	stream *streamSessionWriter
+}
+
+func newActiveTTSOutput(cancel context.CancelFunc) *activeTTSOutput {
+	return &activeTTSOutput{
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+}
+
+func (o *activeTTSOutput) setStream(stream *streamSessionWriter) {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.stream = stream
+}
+
+func (o *activeTTSOutput) clearStream(stream *streamSessionWriter) {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.stream == stream {
+		o.stream = nil
+	}
+}
+
+func (o *activeTTSOutput) interrupt() {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	stream := o.stream
+	o.mu.Unlock()
+	if stream != nil {
+		stream.interrupt()
+	}
+	if o.cancel != nil {
+		o.cancel()
+	}
+}
+
+func (o *activeTTSOutput) finish() {
+	if o == nil {
+		return
+	}
+	select {
+	case <-o.done:
+	default:
+		close(o.done)
+	}
 }
 
 // NewAudioDialog creates a new audio dialog manager
@@ -261,6 +327,95 @@ func (d *AudioDialog) VADFrameSamples() int {
 
 func (d *AudioDialog) VADDebugState() VADDebugState {
 	return d.vad.DebugState()
+}
+
+func (d *AudioDialog) registerActiveOutput(output *activeTTSOutput) func() {
+	if output == nil {
+		return func() {}
+	}
+	d.outputMu.Lock()
+	if d.activeOutputs == nil {
+		d.activeOutputs = make(map[*activeTTSOutput]struct{})
+	}
+	d.activeOutputs[output] = struct{}{}
+	d.outputMu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			d.outputMu.Lock()
+			delete(d.activeOutputs, output)
+			d.outputMu.Unlock()
+			output.finish()
+		})
+	}
+}
+
+func (d *AudioDialog) snapshotActiveOutputs() []*activeTTSOutput {
+	d.outputMu.Lock()
+	defer d.outputMu.Unlock()
+	if len(d.activeOutputs) == 0 {
+		return nil
+	}
+	outputs := make([]*activeTTSOutput, 0, len(d.activeOutputs))
+	for output := range d.activeOutputs {
+		outputs = append(outputs, output)
+	}
+	return outputs
+}
+
+func (d *AudioDialog) beginActiveManagedTTSStream(ctx context.Context) (*streamSessionWriter, func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	streamCtx, streamCancel := context.WithCancel(ctx)
+	stream, err := beginManagedTTSStream(streamCtx, d.ttsManager, d.audioClient, d.config)
+	if err != nil {
+		streamCancel()
+		return nil, nil, err
+	}
+	stream.setCancel(streamCancel)
+	output := newActiveTTSOutput(streamCancel)
+	output.setStream(stream)
+	unregister := d.registerActiveOutput(output)
+	return stream, func() {
+		unregister()
+		streamCancel()
+	}, nil
+}
+
+// InterruptOutput immediately stops any TTS output owned by this dialog.
+func (d *AudioDialog) InterruptOutput() {
+	if d == nil {
+		return
+	}
+	d.progressMu.Lock()
+	progress := d.progress
+	d.progressMu.Unlock()
+	if progress != nil {
+		progress.Cancel()
+	}
+
+	outputs := d.snapshotActiveOutputs()
+	for _, output := range outputs {
+		output.interrupt()
+	}
+	waitForActiveOutputs(outputs, outputInterruptWaitTimeout)
+}
+
+func waitForActiveOutputs(outputs []*activeTTSOutput, timeout time.Duration) {
+	if len(outputs) == 0 || timeout <= 0 {
+		return
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for _, output := range outputs {
+		select {
+		case <-output.done:
+		case <-timer.C:
+			return
+		}
+	}
 }
 
 // ProcessUtterance processes a detected utterance
@@ -505,12 +660,15 @@ func (d *AudioDialog) runAgentTurnWithEpisodeAndRequest(ctx context.Context, inp
 	req.EpisodeID = strings.TrimSpace(episodeID)
 
 	var newStream *streamSessionWriter
+	unregisterStream := func() {}
 	if d.config.VoiceStreamingTTSEnabledOrDefault() && d.ttsManager != nil {
-		stream, err := beginManagedTTSStream(ctx, d.ttsManager, d.audioClient, d.config)
+		stream, unregister, err := d.beginActiveManagedTTSStream(ctx)
 		if err != nil {
 			log.Printf("[error] TTS BeginStream failed: %v\n", err)
 		} else {
 			newStream = stream
+			unregisterStream = unregister
+			defer unregisterStream()
 			req.StreamWriter = newCancelOnFirstWriteWriter(speechStreamWriterForConfig(newStream, d.config), progress.Cancel)
 		}
 	}
@@ -521,7 +679,7 @@ func (d *AudioDialog) runAgentTurnWithEpisodeAndRequest(ctx context.Context, inp
 		if closeErr != nil {
 			log.Printf("[error] new TTS stream failed: %v", closeErr)
 		}
-		result.SpeechStreamed = closeErr == nil && newStream.spoke
+		result.SpeechStreamed = closeErr == nil && newStream.spokeSuccessfully()
 	}
 	if err != nil {
 		return RunResult{}, fmt.Errorf("LLM request failed: %w", err)
@@ -683,15 +841,22 @@ func (d *AudioDialog) speak(ctx context.Context, text string, interrupt <-chan s
 		if err := baseCtx.Err(); err != nil {
 			return err
 		}
+		outputCtx, cancelOutput := context.WithCancel(baseCtx)
+		output := newActiveTTSOutput(cancelOutput)
+		unregisterOutput := d.registerActiveOutput(output)
+		defer func() {
+			unregisterOutput()
+			cancelOutput()
+		}()
 		d.speechMu.Lock()
 		defer d.speechMu.Unlock()
-		if err := baseCtx.Err(); err != nil {
+		if err := outputCtx.Err(); err != nil {
 			return err
 		}
-		speakCtx := baseCtx
+		speakCtx := outputCtx
 		cancelTimeout := func() {}
 		if timeoutAfterLock > 0 {
-			speakCtx, cancelTimeout = context.WithTimeout(baseCtx, timeoutAfterLock)
+			speakCtx, cancelTimeout = context.WithTimeout(outputCtx, timeoutAfterLock)
 			defer cancelTimeout()
 		}
 		if err := speakCtx.Err(); err != nil {
@@ -699,7 +864,13 @@ func (d *AudioDialog) speak(ctx context.Context, text string, interrupt <-chan s
 		}
 		log.Printf("[reply] %s\n", text)
 		log.Printf("[tts] Starting streaming playback...\n")
-		_, err := speakWithTTSManager(speakCtx, d.ttsManager, d.audioClient, d.config, text)
+		_, err := speakWithTTSManagerObserved(speakCtx, d.ttsManager, d.audioClient, d.config, text, func(stream *streamSessionWriter) func() {
+			stream.setCancel(cancelOutput)
+			output.setStream(stream)
+			return func() {
+				output.clearStream(stream)
+			}
+		})
 		if err != nil {
 			log.Printf("[error] TTS streaming failed: %v", err)
 			return err
@@ -753,12 +924,15 @@ func (d *AudioDialog) ProcessTextInput(ctx context.Context, text string, runtime
 		StreamFinalChunks: true,
 	}
 	var newStream *streamSessionWriter
+	unregisterStream := func() {}
 	if d.config.VoiceStreamingTTSEnabledOrDefault() && d.ttsManager != nil {
-		stream, err := beginManagedTTSStream(ctx, d.ttsManager, d.audioClient, d.config)
+		stream, unregister, err := d.beginActiveManagedTTSStream(ctx)
 		if err != nil {
 			log.Printf("[error] TTS BeginStream failed: %v\n", err)
 		} else {
 			newStream = stream
+			unregisterStream = unregister
+			defer unregisterStream()
 			req.StreamWriter = newCancelOnFirstWriteWriter(speechStreamWriterForConfig(newStream, d.config), progress.Cancel)
 		}
 	}
@@ -769,7 +943,7 @@ func (d *AudioDialog) ProcessTextInput(ctx context.Context, text string, runtime
 		if closeErr != nil {
 			log.Printf("[error] new TTS stream failed: %v", closeErr)
 		}
-		result.SpeechStreamed = closeErr == nil && newStream.spoke
+		result.SpeechStreamed = closeErr == nil && newStream.spokeSuccessfully()
 	}
 	if err != nil {
 		return fmt.Errorf("LLM request failed: %w", err)

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -40,6 +40,7 @@ type AudioDialog struct {
 	progress              *progressSpeaker
 	runControlMu          sync.Mutex
 	activeRequestID       string
+	acceptingSteer        bool
 	pendingSteer          RunSteerMessage
 	hasPendingSteer       bool
 	steerInterruptCh      chan struct{}
@@ -676,6 +677,9 @@ func (d *AudioDialog) runAgentTurnWithActiveRequest(ctx context.Context, input T
 		SteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
 			return d.consumePendingSteer(requestID)
 		},
+		FinalSteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
+			return d.consumeFinalPendingSteer(requestID)
+		},
 		SteerInterrupt: func() <-chan struct{} {
 			return d.steerInterruptChannel(requestID)
 		},
@@ -700,6 +704,7 @@ func (d *AudioDialog) runAgentTurnWithActiveRequest(ctx context.Context, input T
 	}
 
 	result, err := runtime.Run(ctx, req)
+	d.stopAcceptingSteer(requestID)
 	if newStream != nil {
 		closeErr := newStream.closeAndWait()
 		if closeErr != nil {
@@ -733,6 +738,7 @@ func (d *AudioDialog) beginVoiceRunControl(requestID string) bool {
 		return false
 	}
 	d.activeRequestID = requestID
+	d.acceptingSteer = true
 	d.pendingSteer = RunSteerMessage{}
 	d.hasPendingSteer = false
 	d.steerInterruptCh = make(chan struct{})
@@ -752,6 +758,7 @@ func (d *AudioDialog) endVoiceRunControl(requestID string) {
 	}
 	d.resolveSteerInterruptLocked(RunSteerMessage{}, false)
 	d.activeRequestID = ""
+	d.acceptingSteer = false
 	d.pendingSteer = RunSteerMessage{}
 	d.hasPendingSteer = false
 	d.steerInterruptCh = nil
@@ -769,7 +776,7 @@ func (d *AudioDialog) QueueSteer(input TurnInput) bool {
 	}
 	d.runControlMu.Lock()
 	defer d.runControlMu.Unlock()
-	if d.activeRequestID == "" {
+	if d.activeRequestID == "" || !d.acceptingSteer {
 		return false
 	}
 	steer := RunSteerMessage{
@@ -795,7 +802,7 @@ func (d *AudioDialog) BeginSteerInterrupt() bool {
 	}
 	d.runControlMu.Lock()
 	defer d.runControlMu.Unlock()
-	if d.activeRequestID == "" {
+	if d.activeRequestID == "" || !d.acceptingSteer {
 		return false
 	}
 	if d.steerInterruptActive {
@@ -820,7 +827,7 @@ func (d *AudioDialog) ResumeSteerInterrupt() bool {
 	}
 	d.runControlMu.Lock()
 	defer d.runControlMu.Unlock()
-	if d.activeRequestID == "" || !d.steerInterruptActive {
+	if d.activeRequestID == "" || !d.acceptingSteer || !d.steerInterruptActive {
 		return false
 	}
 	d.resolveSteerInterruptLocked(RunSteerMessage{}, false)
@@ -831,7 +838,7 @@ func (d *AudioDialog) ResumeSteerInterrupt() bool {
 func (d *AudioDialog) consumePendingSteer(requestID string) (RunSteerMessage, bool) {
 	d.runControlMu.Lock()
 	defer d.runControlMu.Unlock()
-	if requestID == "" || d.activeRequestID != requestID || !d.hasPendingSteer {
+	if requestID == "" || d.activeRequestID != requestID || !d.acceptingSteer || !d.hasPendingSteer {
 		return RunSteerMessage{}, false
 	}
 	steer := d.pendingSteer
@@ -840,10 +847,42 @@ func (d *AudioDialog) consumePendingSteer(requestID string) (RunSteerMessage, bo
 	return steer, true
 }
 
-func (d *AudioDialog) steerInterruptChannel(requestID string) <-chan struct{} {
+func (d *AudioDialog) consumeFinalPendingSteer(requestID string) (RunSteerMessage, bool) {
+	d.runControlMu.Lock()
+	defer d.runControlMu.Unlock()
+	if requestID == "" || d.activeRequestID != requestID || !d.acceptingSteer {
+		return RunSteerMessage{}, false
+	}
+	if d.hasPendingSteer {
+		steer := d.pendingSteer
+		d.pendingSteer = RunSteerMessage{}
+		d.hasPendingSteer = false
+		return steer, true
+	}
+	d.closeSteerAcceptanceLocked()
+	return RunSteerMessage{}, false
+}
+
+func (d *AudioDialog) stopAcceptingSteer(requestID string) {
 	d.runControlMu.Lock()
 	defer d.runControlMu.Unlock()
 	if requestID == "" || d.activeRequestID != requestID {
+		return
+	}
+	d.closeSteerAcceptanceLocked()
+}
+
+func (d *AudioDialog) closeSteerAcceptanceLocked() {
+	d.acceptingSteer = false
+	d.pendingSteer = RunSteerMessage{}
+	d.hasPendingSteer = false
+	d.resolveSteerInterruptLocked(RunSteerMessage{}, false)
+}
+
+func (d *AudioDialog) steerInterruptChannel(requestID string) <-chan struct{} {
+	d.runControlMu.Lock()
+	defer d.runControlMu.Unlock()
+	if requestID == "" || d.activeRequestID != requestID || !d.acceptingSteer {
 		return nil
 	}
 	return d.steerInterruptCh
@@ -851,7 +890,7 @@ func (d *AudioDialog) steerInterruptChannel(requestID string) <-chan struct{} {
 
 func (d *AudioDialog) waitForSteerInterrupt(ctx context.Context, requestID string) (RunSteerMessage, bool, error) {
 	d.runControlMu.Lock()
-	if requestID == "" || d.activeRequestID != requestID || !d.steerInterruptActive {
+	if requestID == "" || d.activeRequestID != requestID || !d.acceptingSteer || !d.steerInterruptActive {
 		d.runControlMu.Unlock()
 		return RunSteerMessage{}, false, nil
 	}
@@ -869,7 +908,7 @@ func (d *AudioDialog) waitForSteerInterrupt(ctx context.Context, requestID strin
 
 	d.runControlMu.Lock()
 	defer d.runControlMu.Unlock()
-	if requestID == "" || d.activeRequestID != requestID {
+	if requestID == "" || d.activeRequestID != requestID || !d.acceptingSteer {
 		return RunSteerMessage{}, false, nil
 	}
 	steer := d.steerInterruptSteer

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -25,38 +25,23 @@ var (
 
 // AudioDialog manages the audio conversation loop
 type AudioDialog struct {
-	config                Config
-	audioClient           *AudioServiceClient
-	sttClient             STTClient
-	ttsManager            *tts.ProviderManager
-	vad                   *AudioVAD
-	recordActive          bool
-	sessionID             uint64
-	recordReader          *AudioRecordChunkReader
-	speechMu              sync.Mutex
-	outputMu              sync.Mutex
-	activeOutputs         map[*activeTTSOutput]struct{}
-	progressMu            sync.Mutex
-	progress              *progressSpeaker
-	runControlMu          sync.Mutex
-	activeRequestID       string
-	acceptingSteer        bool
-	pendingSteer          RunSteerMessage
-	hasPendingSteer       bool
-	steerInterruptCh      chan struct{}
-	steerInterruptReady   chan struct{}
-	steerInterruptActive  bool
-	steerInterruptDone    bool
-	steerInterruptSteer   RunSteerMessage
-	steerInterruptHasText bool
-	historyStore          *ChatHistoryStore
-	historyAppend         func(Message)
-	audioArchive          *AudioArchiveManager
-}
-
-type VoiceTurnContext struct {
-	FollowUpRelation string
-	RuntimeContext   string
+	config        Config
+	audioClient   *AudioServiceClient
+	sttClient     STTClient
+	ttsManager    *tts.ProviderManager
+	vad           *AudioVAD
+	recordActive  bool
+	sessionID     uint64
+	recordReader  *AudioRecordChunkReader
+	speechMu      sync.Mutex
+	outputMu      sync.Mutex
+	activeOutputs map[*activeTTSOutput]struct{}
+	progressMu    sync.Mutex
+	progress      *progressSpeaker
+	runControl    voiceRunControl
+	historyStore  *ChatHistoryStore
+	historyAppend func(Message)
+	audioArchive  *AudioArchiveManager
 }
 
 type activeTTSOutput struct {
@@ -720,53 +705,18 @@ func (d *AudioDialog) runAgentTurnWithActiveRequest(ctx context.Context, input T
 	return result, nil
 }
 
-func normalizeVoiceTurnContext(turnContext VoiceTurnContext) VoiceTurnContext {
-	return VoiceTurnContext{
-		FollowUpRelation: normalizeFollowUpRelation(turnContext.FollowUpRelation),
-		RuntimeContext:   strings.TrimSpace(turnContext.RuntimeContext),
-	}
-}
-
-func createVoiceRequestID() string {
-	return fmt.Sprintf("voice-%x", time.Now().UnixNano())
-}
-
 func (d *AudioDialog) beginVoiceRunControl(requestID string) bool {
-	d.runControlMu.Lock()
-	defer d.runControlMu.Unlock()
-	if d.activeRequestID != "" {
+	if d == nil {
 		return false
 	}
-	d.activeRequestID = requestID
-	d.acceptingSteer = true
-	d.pendingSteer = RunSteerMessage{}
-	d.hasPendingSteer = false
-	d.steerInterruptCh = make(chan struct{})
-	d.steerInterruptReady = nil
-	d.steerInterruptActive = false
-	d.steerInterruptDone = false
-	d.steerInterruptSteer = RunSteerMessage{}
-	d.steerInterruptHasText = false
-	return true
+	return d.runControl.begin(requestID)
 }
 
 func (d *AudioDialog) endVoiceRunControl(requestID string) {
-	d.runControlMu.Lock()
-	defer d.runControlMu.Unlock()
-	if d.activeRequestID != requestID {
+	if d == nil {
 		return
 	}
-	d.resolveSteerInterruptLocked(RunSteerMessage{}, false)
-	d.activeRequestID = ""
-	d.acceptingSteer = false
-	d.pendingSteer = RunSteerMessage{}
-	d.hasPendingSteer = false
-	d.steerInterruptCh = nil
-	d.steerInterruptReady = nil
-	d.steerInterruptActive = false
-	d.steerInterruptDone = false
-	d.steerInterruptSteer = RunSteerMessage{}
-	d.steerInterruptHasText = false
+	d.runControl.end(requestID)
 }
 
 func (d *AudioDialog) QueueSteer(input TurnInput) bool {
@@ -774,25 +724,15 @@ func (d *AudioDialog) QueueSteer(input TurnInput) bool {
 	if content == "" {
 		return false
 	}
-	d.runControlMu.Lock()
-	defer d.runControlMu.Unlock()
-	if d.activeRequestID == "" || !d.acceptingSteer {
+	queued, ok := d.runControl.queueSteer(content)
+	if !ok {
 		return false
 	}
-	steer := RunSteerMessage{
-		ID:        createSteerID(),
-		RequestID: d.activeRequestID,
-		Content:   content,
-		Timestamp: time.Now(),
-	}
-	if d.steerInterruptActive && !d.steerInterruptDone {
-		d.resolveSteerInterruptLocked(steer, true)
-		log.Printf("[steer] Queued interrupted voice steer: request_id=%s len=%d\n", d.activeRequestID, len(content))
+	if queued.interrupted {
+		log.Printf("[steer] Queued interrupted voice steer: request_id=%s len=%d\n", queued.requestID, queued.contentLength)
 		return true
 	}
-	d.pendingSteer = steer
-	d.hasPendingSteer = true
-	log.Printf("[steer] Queued voice steer: request_id=%s len=%d\n", d.activeRequestID, len(content))
+	log.Printf("[steer] Queued voice steer: request_id=%s len=%d\n", queued.requestID, queued.contentLength)
 	return true
 }
 
@@ -800,24 +740,13 @@ func (d *AudioDialog) BeginSteerInterrupt() bool {
 	if d == nil {
 		return false
 	}
-	d.runControlMu.Lock()
-	defer d.runControlMu.Unlock()
-	if d.activeRequestID == "" || !d.acceptingSteer {
+	requestID, started, ok := d.runControl.beginInterrupt()
+	if !ok {
 		return false
 	}
-	if d.steerInterruptActive {
-		return true
+	if started {
+		log.Printf("[steer] Voice run interrupted, waiting for steering input: request_id=%s\n", requestID)
 	}
-	if d.steerInterruptCh == nil {
-		d.steerInterruptCh = make(chan struct{})
-	}
-	d.steerInterruptReady = make(chan struct{})
-	d.steerInterruptActive = true
-	d.steerInterruptDone = false
-	d.steerInterruptSteer = RunSteerMessage{}
-	d.steerInterruptHasText = false
-	close(d.steerInterruptCh)
-	log.Printf("[steer] Voice run interrupted, waiting for steering input: request_id=%s\n", d.activeRequestID)
 	return true
 }
 
@@ -825,128 +754,47 @@ func (d *AudioDialog) ResumeSteerInterrupt() bool {
 	if d == nil {
 		return false
 	}
-	d.runControlMu.Lock()
-	defer d.runControlMu.Unlock()
-	if d.activeRequestID == "" || !d.acceptingSteer || !d.steerInterruptActive {
+	requestID, ok := d.runControl.resumeInterrupt()
+	if !ok {
 		return false
 	}
-	d.resolveSteerInterruptLocked(RunSteerMessage{}, false)
-	log.Printf("[steer] Voice steer interruption resumed without input: request_id=%s\n", d.activeRequestID)
+	log.Printf("[steer] Voice steer interruption resumed without input: request_id=%s\n", requestID)
 	return true
 }
 
 func (d *AudioDialog) consumePendingSteer(requestID string) (RunSteerMessage, bool) {
-	d.runControlMu.Lock()
-	defer d.runControlMu.Unlock()
-	if requestID == "" || d.activeRequestID != requestID || !d.acceptingSteer || !d.hasPendingSteer {
+	if d == nil {
 		return RunSteerMessage{}, false
 	}
-	steer := d.pendingSteer
-	d.pendingSteer = RunSteerMessage{}
-	d.hasPendingSteer = false
-	return steer, true
+	return d.runControl.consumePending(requestID)
 }
 
 func (d *AudioDialog) consumeFinalPendingSteer(requestID string) (RunSteerMessage, bool) {
-	d.runControlMu.Lock()
-	defer d.runControlMu.Unlock()
-	if requestID == "" || d.activeRequestID != requestID || !d.acceptingSteer {
+	if d == nil {
 		return RunSteerMessage{}, false
 	}
-	if d.hasPendingSteer {
-		steer := d.pendingSteer
-		d.pendingSteer = RunSteerMessage{}
-		d.hasPendingSteer = false
-		return steer, true
-	}
-	d.closeSteerAcceptanceLocked()
-	return RunSteerMessage{}, false
+	return d.runControl.consumeFinalPending(requestID)
 }
 
 func (d *AudioDialog) stopAcceptingSteer(requestID string) {
-	d.runControlMu.Lock()
-	defer d.runControlMu.Unlock()
-	if requestID == "" || d.activeRequestID != requestID {
+	if d == nil {
 		return
 	}
-	d.closeSteerAcceptanceLocked()
-}
-
-func (d *AudioDialog) closeSteerAcceptanceLocked() {
-	d.acceptingSteer = false
-	d.pendingSteer = RunSteerMessage{}
-	d.hasPendingSteer = false
-	d.resolveSteerInterruptLocked(RunSteerMessage{}, false)
+	d.runControl.stopAccepting(requestID)
 }
 
 func (d *AudioDialog) steerInterruptChannel(requestID string) <-chan struct{} {
-	d.runControlMu.Lock()
-	defer d.runControlMu.Unlock()
-	if requestID == "" || d.activeRequestID != requestID || !d.acceptingSteer {
+	if d == nil {
 		return nil
 	}
-	return d.steerInterruptCh
+	return d.runControl.interruptChannel(requestID)
 }
 
 func (d *AudioDialog) waitForSteerInterrupt(ctx context.Context, requestID string) (RunSteerMessage, bool, error) {
-	d.runControlMu.Lock()
-	if requestID == "" || d.activeRequestID != requestID || !d.acceptingSteer || !d.steerInterruptActive {
-		d.runControlMu.Unlock()
+	if d == nil {
 		return RunSteerMessage{}, false, nil
 	}
-	ready := d.steerInterruptReady
-	d.runControlMu.Unlock()
-	if ready == nil {
-		return RunSteerMessage{}, false, nil
-	}
-
-	select {
-	case <-ctx.Done():
-		return RunSteerMessage{}, false, ctx.Err()
-	case <-ready:
-	}
-
-	d.runControlMu.Lock()
-	defer d.runControlMu.Unlock()
-	if requestID == "" || d.activeRequestID != requestID || !d.acceptingSteer {
-		return RunSteerMessage{}, false, nil
-	}
-	steer := d.steerInterruptSteer
-	hasText := d.steerInterruptHasText
-	d.resetSteerInterruptLocked()
-	return steer, hasText, nil
-}
-
-func (d *AudioDialog) resolveSteerInterruptLocked(steer RunSteerMessage, hasText bool) {
-	if !d.steerInterruptActive || d.steerInterruptDone {
-		return
-	}
-	d.steerInterruptSteer = steer
-	d.steerInterruptHasText = hasText
-	d.steerInterruptDone = true
-	if d.steerInterruptReady != nil {
-		close(d.steerInterruptReady)
-	}
-}
-
-func (d *AudioDialog) resetSteerInterruptLocked() {
-	d.steerInterruptCh = make(chan struct{})
-	d.steerInterruptReady = nil
-	d.steerInterruptActive = false
-	d.steerInterruptDone = false
-	d.steerInterruptSteer = RunSteerMessage{}
-	d.steerInterruptHasText = false
-}
-
-func steerContentFromTurnInput(input TurnInput) string {
-	input = normalizeTurnInput(input)
-	if content := strings.TrimSpace(input.InputText); content != "" {
-		if content == voiceAudioInputPlaceholder && strings.TrimSpace(input.Transcript) == "" {
-			return ""
-		}
-		return content
-	}
-	return strings.TrimSpace(input.Transcript)
+	return d.runControl.waitForInterrupt(ctx, requestID)
 }
 
 func (d *AudioDialog) HandleRunEvent(ctx context.Context, event RunEvent) {

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -47,6 +47,11 @@ type AudioDialog struct {
 	audioArchive    *AudioArchiveManager
 }
 
+type VoiceTurnContext struct {
+	FollowUpRelation string
+	RuntimeContext   string
+}
+
 type activeTTSOutput struct {
 	cancel context.CancelFunc
 	done   chan struct{}
@@ -602,17 +607,21 @@ func (d *AudioDialog) RunAgentTurn(ctx context.Context, input TurnInput, runtime
 	if runtime != nil {
 		episodeID = runtime.NewEpisodeID()
 	}
-	return d.runAgentTurnWithEpisodeAndRequest(ctx, input, runtime, episodeID, createVoiceRequestID())
+	return d.runAgentTurnWithEpisodeAndRequest(ctx, input, runtime, episodeID, createVoiceRequestID(), VoiceTurnContext{})
 }
 
 func (d *AudioDialog) RunVoiceTurn(ctx context.Context, input TurnInput, utterance []int16, runtime *Runtime) (RunResult, error) {
+	return d.RunVoiceTurnWithContext(ctx, input, utterance, runtime, VoiceTurnContext{})
+}
+
+func (d *AudioDialog) RunVoiceTurnWithContext(ctx context.Context, input TurnInput, utterance []int16, runtime *Runtime, turnContext VoiceTurnContext) (RunResult, error) {
 	episodeID := ""
 	if runtime != nil {
 		episodeID = runtime.NewEpisodeID()
 	}
 	requestID := createVoiceRequestID()
 	d.persistVoiceUserInput(input, utterance, episodeID, requestID)
-	result, err := d.runAgentTurnWithEpisodeAndRequest(ctx, input, runtime, episodeID, requestID)
+	result, err := d.runAgentTurnWithEpisodeAndRequest(ctx, input, runtime, episodeID, requestID, turnContext)
 	if err != nil {
 		return RunResult{}, err
 	}
@@ -620,10 +629,11 @@ func (d *AudioDialog) RunVoiceTurn(ctx context.Context, input TurnInput, utteran
 	return result, nil
 }
 
-func (d *AudioDialog) runAgentTurnWithEpisodeAndRequest(ctx context.Context, input TurnInput, runtime *Runtime, episodeID, requestID string) (RunResult, error) {
+func (d *AudioDialog) runAgentTurnWithEpisodeAndRequest(ctx context.Context, input TurnInput, runtime *Runtime, episodeID, requestID string, turnContext VoiceTurnContext) (RunResult, error) {
 	if requestID == "" {
 		requestID = createVoiceRequestID()
 	}
+	turnContext = normalizeVoiceTurnContext(turnContext)
 	if !d.beginVoiceRunControl(requestID) {
 		return RunResult{}, fmt.Errorf("voice run already active")
 	}
@@ -643,11 +653,13 @@ func (d *AudioDialog) runAgentTurnWithEpisodeAndRequest(ctx context.Context, inp
 	}()
 
 	req := RunRequest{
-		Input:       input.InputText,
-		Attachments: input.Attachments,
-		Turn:        input,
-		RequestID:   requestID,
-		MaxTokens:   d.config.VoiceMaxResponseTokensOrDefault(),
+		Input:            input.InputText,
+		Attachments:      input.Attachments,
+		Turn:             input,
+		RequestID:        requestID,
+		RuntimeContext:   turnContext.RuntimeContext,
+		FollowUpRelation: turnContext.FollowUpRelation,
+		MaxTokens:        d.config.VoiceMaxResponseTokensOrDefault(),
 		EventHandler: func(event RunEvent) {
 			d.appendVoiceRunEvent(event, requestID)
 			d.HandleRunEvent(ctx, event)
@@ -687,6 +699,13 @@ func (d *AudioDialog) runAgentTurnWithEpisodeAndRequest(ctx context.Context, inp
 
 	log.Printf("[llm] Response received\n")
 	return result, nil
+}
+
+func normalizeVoiceTurnContext(turnContext VoiceTurnContext) VoiceTurnContext {
+	return VoiceTurnContext{
+		FollowUpRelation: normalizeFollowUpRelation(turnContext.FollowUpRelation),
+		RuntimeContext:   strings.TrimSpace(turnContext.RuntimeContext),
+	}
 }
 
 func createVoiceRequestID() string {
@@ -891,9 +910,17 @@ func (d *AudioDialog) playPromptSoundAsync(kind promptSoundKind, label string) {
 }
 
 func (d *AudioDialog) playPromptSound(kind promptSoundKind, label string, wait bool) {
+	outputCtx, cancelOutput := context.WithCancel(context.Background())
+	output := newActiveTTSOutput(cancelOutput)
+	unregisterOutput := d.registerActiveOutput(output)
+	defer func() {
+		unregisterOutput()
+		cancelOutput()
+	}()
+
 	d.speechMu.Lock()
 	defer d.speechMu.Unlock()
-	if err := playPromptSound(context.Background(), d.audioClient, kind, wait); err != nil {
+	if err := playPromptSound(outputCtx, d.audioClient, kind, wait); err != nil {
 		log.Printf("[audio] %s prompt sound failed: %v\n", label, err)
 	}
 }

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -25,26 +25,32 @@ var (
 
 // AudioDialog manages the audio conversation loop
 type AudioDialog struct {
-	config          Config
-	audioClient     *AudioServiceClient
-	sttClient       STTClient
-	ttsManager      *tts.ProviderManager
-	vad             *AudioVAD
-	recordActive    bool
-	sessionID       uint64
-	recordReader    *AudioRecordChunkReader
-	speechMu        sync.Mutex
-	outputMu        sync.Mutex
-	activeOutputs   map[*activeTTSOutput]struct{}
-	progressMu      sync.Mutex
-	progress        *progressSpeaker
-	runControlMu    sync.Mutex
-	activeRequestID string
-	pendingSteer    RunSteerMessage
-	hasPendingSteer bool
-	historyStore    *ChatHistoryStore
-	historyAppend   func(Message)
-	audioArchive    *AudioArchiveManager
+	config                Config
+	audioClient           *AudioServiceClient
+	sttClient             STTClient
+	ttsManager            *tts.ProviderManager
+	vad                   *AudioVAD
+	recordActive          bool
+	sessionID             uint64
+	recordReader          *AudioRecordChunkReader
+	speechMu              sync.Mutex
+	outputMu              sync.Mutex
+	activeOutputs         map[*activeTTSOutput]struct{}
+	progressMu            sync.Mutex
+	progress              *progressSpeaker
+	runControlMu          sync.Mutex
+	activeRequestID       string
+	pendingSteer          RunSteerMessage
+	hasPendingSteer       bool
+	steerInterruptCh      chan struct{}
+	steerInterruptReady   chan struct{}
+	steerInterruptActive  bool
+	steerInterruptDone    bool
+	steerInterruptSteer   RunSteerMessage
+	steerInterruptHasText bool
+	historyStore          *ChatHistoryStore
+	historyAppend         func(Message)
+	audioArchive          *AudioArchiveManager
 }
 
 type VoiceTurnContext struct {
@@ -670,6 +676,12 @@ func (d *AudioDialog) runAgentTurnWithActiveRequest(ctx context.Context, input T
 		SteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
 			return d.consumePendingSteer(requestID)
 		},
+		SteerInterrupt: func() <-chan struct{} {
+			return d.steerInterruptChannel(requestID)
+		},
+		SteerWaiter: func(ctx context.Context) (RunSteerMessage, bool, error) {
+			return d.waitForSteerInterrupt(ctx, requestID)
+		},
 	}
 	req.EpisodeID = strings.TrimSpace(episodeID)
 
@@ -723,6 +735,12 @@ func (d *AudioDialog) beginVoiceRunControl(requestID string) bool {
 	d.activeRequestID = requestID
 	d.pendingSteer = RunSteerMessage{}
 	d.hasPendingSteer = false
+	d.steerInterruptCh = make(chan struct{})
+	d.steerInterruptReady = nil
+	d.steerInterruptActive = false
+	d.steerInterruptDone = false
+	d.steerInterruptSteer = RunSteerMessage{}
+	d.steerInterruptHasText = false
 	return true
 }
 
@@ -732,9 +750,16 @@ func (d *AudioDialog) endVoiceRunControl(requestID string) {
 	if d.activeRequestID != requestID {
 		return
 	}
+	d.resolveSteerInterruptLocked(RunSteerMessage{}, false)
 	d.activeRequestID = ""
 	d.pendingSteer = RunSteerMessage{}
 	d.hasPendingSteer = false
+	d.steerInterruptCh = nil
+	d.steerInterruptReady = nil
+	d.steerInterruptActive = false
+	d.steerInterruptDone = false
+	d.steerInterruptSteer = RunSteerMessage{}
+	d.steerInterruptHasText = false
 }
 
 func (d *AudioDialog) QueueSteer(input TurnInput) bool {
@@ -747,14 +772,59 @@ func (d *AudioDialog) QueueSteer(input TurnInput) bool {
 	if d.activeRequestID == "" {
 		return false
 	}
-	d.pendingSteer = RunSteerMessage{
+	steer := RunSteerMessage{
 		ID:        createSteerID(),
 		RequestID: d.activeRequestID,
 		Content:   content,
 		Timestamp: time.Now(),
 	}
+	if d.steerInterruptActive && !d.steerInterruptDone {
+		d.resolveSteerInterruptLocked(steer, true)
+		log.Printf("[steer] Queued interrupted voice steer: request_id=%s len=%d\n", d.activeRequestID, len(content))
+		return true
+	}
+	d.pendingSteer = steer
 	d.hasPendingSteer = true
 	log.Printf("[steer] Queued voice steer: request_id=%s len=%d\n", d.activeRequestID, len(content))
+	return true
+}
+
+func (d *AudioDialog) BeginSteerInterrupt() bool {
+	if d == nil {
+		return false
+	}
+	d.runControlMu.Lock()
+	defer d.runControlMu.Unlock()
+	if d.activeRequestID == "" {
+		return false
+	}
+	if d.steerInterruptActive {
+		return true
+	}
+	if d.steerInterruptCh == nil {
+		d.steerInterruptCh = make(chan struct{})
+	}
+	d.steerInterruptReady = make(chan struct{})
+	d.steerInterruptActive = true
+	d.steerInterruptDone = false
+	d.steerInterruptSteer = RunSteerMessage{}
+	d.steerInterruptHasText = false
+	close(d.steerInterruptCh)
+	log.Printf("[steer] Voice run interrupted, waiting for steering input: request_id=%s\n", d.activeRequestID)
+	return true
+}
+
+func (d *AudioDialog) ResumeSteerInterrupt() bool {
+	if d == nil {
+		return false
+	}
+	d.runControlMu.Lock()
+	defer d.runControlMu.Unlock()
+	if d.activeRequestID == "" || !d.steerInterruptActive {
+		return false
+	}
+	d.resolveSteerInterruptLocked(RunSteerMessage{}, false)
+	log.Printf("[steer] Voice steer interruption resumed without input: request_id=%s\n", d.activeRequestID)
 	return true
 }
 
@@ -768,6 +838,65 @@ func (d *AudioDialog) consumePendingSteer(requestID string) (RunSteerMessage, bo
 	d.pendingSteer = RunSteerMessage{}
 	d.hasPendingSteer = false
 	return steer, true
+}
+
+func (d *AudioDialog) steerInterruptChannel(requestID string) <-chan struct{} {
+	d.runControlMu.Lock()
+	defer d.runControlMu.Unlock()
+	if requestID == "" || d.activeRequestID != requestID {
+		return nil
+	}
+	return d.steerInterruptCh
+}
+
+func (d *AudioDialog) waitForSteerInterrupt(ctx context.Context, requestID string) (RunSteerMessage, bool, error) {
+	d.runControlMu.Lock()
+	if requestID == "" || d.activeRequestID != requestID || !d.steerInterruptActive {
+		d.runControlMu.Unlock()
+		return RunSteerMessage{}, false, nil
+	}
+	ready := d.steerInterruptReady
+	d.runControlMu.Unlock()
+	if ready == nil {
+		return RunSteerMessage{}, false, nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return RunSteerMessage{}, false, ctx.Err()
+	case <-ready:
+	}
+
+	d.runControlMu.Lock()
+	defer d.runControlMu.Unlock()
+	if requestID == "" || d.activeRequestID != requestID {
+		return RunSteerMessage{}, false, nil
+	}
+	steer := d.steerInterruptSteer
+	hasText := d.steerInterruptHasText
+	d.resetSteerInterruptLocked()
+	return steer, hasText, nil
+}
+
+func (d *AudioDialog) resolveSteerInterruptLocked(steer RunSteerMessage, hasText bool) {
+	if !d.steerInterruptActive || d.steerInterruptDone {
+		return
+	}
+	d.steerInterruptSteer = steer
+	d.steerInterruptHasText = hasText
+	d.steerInterruptDone = true
+	if d.steerInterruptReady != nil {
+		close(d.steerInterruptReady)
+	}
+}
+
+func (d *AudioDialog) resetSteerInterruptLocked() {
+	d.steerInterruptCh = make(chan struct{})
+	d.steerInterruptReady = nil
+	d.steerInterruptActive = false
+	d.steerInterruptDone = false
+	d.steerInterruptSteer = RunSteerMessage{}
+	d.steerInterruptHasText = false
 }
 
 func steerContentFromTurnInput(input TurnInput) string {

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -607,7 +607,12 @@ func (d *AudioDialog) RunAgentTurn(ctx context.Context, input TurnInput, runtime
 	if runtime != nil {
 		episodeID = runtime.NewEpisodeID()
 	}
-	return d.runAgentTurnWithEpisodeAndRequest(ctx, input, runtime, episodeID, createVoiceRequestID(), VoiceTurnContext{})
+	requestID := createVoiceRequestID()
+	if !d.beginVoiceRunControl(requestID) {
+		return RunResult{}, fmt.Errorf("voice run already active")
+	}
+	defer d.endVoiceRunControl(requestID)
+	return d.runAgentTurnWithActiveRequest(ctx, input, runtime, episodeID, requestID, VoiceTurnContext{})
 }
 
 func (d *AudioDialog) RunVoiceTurn(ctx context.Context, input TurnInput, utterance []int16, runtime *Runtime) (RunResult, error) {
@@ -620,8 +625,12 @@ func (d *AudioDialog) RunVoiceTurnWithContext(ctx context.Context, input TurnInp
 		episodeID = runtime.NewEpisodeID()
 	}
 	requestID := createVoiceRequestID()
+	if !d.beginVoiceRunControl(requestID) {
+		return RunResult{}, fmt.Errorf("voice run already active")
+	}
+	defer d.endVoiceRunControl(requestID)
 	d.persistVoiceUserInput(input, utterance, episodeID, requestID)
-	result, err := d.runAgentTurnWithEpisodeAndRequest(ctx, input, runtime, episodeID, requestID, turnContext)
+	result, err := d.runAgentTurnWithActiveRequest(ctx, input, runtime, episodeID, requestID, turnContext)
 	if err != nil {
 		return RunResult{}, err
 	}
@@ -629,15 +638,8 @@ func (d *AudioDialog) RunVoiceTurnWithContext(ctx context.Context, input TurnInp
 	return result, nil
 }
 
-func (d *AudioDialog) runAgentTurnWithEpisodeAndRequest(ctx context.Context, input TurnInput, runtime *Runtime, episodeID, requestID string, turnContext VoiceTurnContext) (RunResult, error) {
-	if requestID == "" {
-		requestID = createVoiceRequestID()
-	}
+func (d *AudioDialog) runAgentTurnWithActiveRequest(ctx context.Context, input TurnInput, runtime *Runtime, episodeID, requestID string, turnContext VoiceTurnContext) (RunResult, error) {
 	turnContext = normalizeVoiceTurnContext(turnContext)
-	if !d.beginVoiceRunControl(requestID) {
-		return RunResult{}, fmt.Errorf("voice run already active")
-	}
-	defer d.endVoiceRunControl(requestID)
 
 	d.playPromptSound(promptSoundAgentSend, "agent send", true)
 

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -747,6 +747,90 @@ func TestAudioDialogRunAgentTurnAppendsRunEventsToVoiceHistory(t *testing.T) {
 	}
 }
 
+func TestAudioDialogRunAgentTurnConsumesQueuedSteer(t *testing.T) {
+	firstCallStarted := make(chan struct{})
+	releaseFirstCall := make(chan struct{})
+	model := &blockingFirstCallModel{
+		firstCallStarted: firstCallStarted,
+		releaseFirstCall: releaseFirstCall,
+		responses: []*llms.ContentResponse{
+			contentResponse("first answer"),
+			contentResponse("steered answer"),
+		},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:           ModelConfig{Provider: "fake"},
+			Instruction:     "Answer directly.",
+			ForceSimpleLoop: true,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+	dialog := &AudioDialog{
+		config: Config{
+			Model: ModelConfig{Provider: "fake"},
+		},
+	}
+	var messages []Message
+	dialog.SetHistoryAppender(func(message Message) {
+		messages = append(messages, message)
+	})
+
+	resultCh := make(chan struct {
+		result RunResult
+		err    error
+	}, 1)
+	go func() {
+		result, err := dialog.RunAgentTurn(context.Background(), TurnInput{InputText: "original"}, runtime)
+		resultCh <- struct {
+			result RunResult
+			err    error
+		}{result: result, err: err}
+	}()
+
+	select {
+	case <-firstCallStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first model call did not start")
+	}
+	if !dialog.QueueSteer(TurnInput{InputText: "change direction", Transcript: "change direction"}) {
+		t.Fatal("QueueSteer returned false while voice run was active")
+	}
+	close(releaseFirstCall)
+
+	var runResult struct {
+		result RunResult
+		err    error
+	}
+	select {
+	case runResult = <-resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("RunAgentTurn did not finish")
+	}
+	if runResult.err != nil {
+		t.Fatalf("RunAgentTurn() error = %v", runResult.err)
+	}
+	if runResult.result.Output != "steered answer" {
+		t.Fatalf("Output = %q, want steered answer", runResult.result.Output)
+	}
+	steerMessage, ok := firstAudioDialogTestMessageOfType(messages, "steer")
+	if !ok {
+		t.Fatalf("missing steer history message: %#v", messages)
+	}
+	if steerMessage.Content != "change direction" {
+		t.Fatalf("steer content = %q, want change direction", steerMessage.Content)
+	}
+	if !strings.HasPrefix(steerMessage.RequestID, "voice-") {
+		t.Fatalf("steer request_id = %q, want voice-*", steerMessage.RequestID)
+	}
+	if dialog.QueueSteer(TurnInput{InputText: "too late"}) {
+		t.Fatal("QueueSteer returned true after voice run completed")
+	}
+}
+
 func TestAudioDialogRunVoiceTurnPersistsUserBeforeRunEvents(t *testing.T) {
 	configDir := t.TempDir()
 	model := &scriptedModel{
@@ -888,6 +972,41 @@ func TestAudioDialogProcessUtteranceSavesAudioFile(t *testing.T) {
 	if _, err := os.Stat(userMsg.AudioFile); err != nil {
 		t.Errorf("Audio file should exist at %s: %v", userMsg.AudioFile, err)
 	}
+}
+
+type blockingFirstCallModel struct {
+	firstCallStarted chan struct{}
+	releaseFirstCall chan struct{}
+	responses        []*llms.ContentResponse
+	callCount        int
+}
+
+func (m *blockingFirstCallModel) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	call := m.callCount
+	m.callCount++
+	if call == 0 {
+		close(m.firstCallStarted)
+		select {
+		case <-m.releaseFirstCall:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if call >= len(m.responses) {
+		return contentResponse(""), nil
+	}
+	return m.responses[call], nil
+}
+
+func (m *blockingFirstCallModel) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	resp, err := m.GenerateContent(ctx, nil, options...)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil || len(resp.Choices) == 0 || resp.Choices[0] == nil {
+		return "", nil
+	}
+	return resp.Choices[0].Content, nil
 }
 
 func boolPtr(value bool) *bool {

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -831,6 +831,70 @@ func TestAudioDialogRunAgentTurnConsumesQueuedSteer(t *testing.T) {
 	}
 }
 
+func TestAudioDialogRejectsSteerAfterRuntimeFinishesBeforeVoiceHistoryPersist(t *testing.T) {
+	model := &scriptedModel{responses: roleDirectResponses("final answer")}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:           ModelConfig{Provider: "fake"},
+			Instruction:     "Answer directly.",
+			ForceSimpleLoop: true,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+	dialog := &AudioDialog{
+		config: Config{
+			Model: ModelConfig{Provider: "fake"},
+		},
+	}
+
+	assistantAppendStarted := make(chan struct{})
+	releaseAssistantAppend := make(chan struct{})
+	dialog.SetHistoryAppender(func(message Message) {
+		if message.Type != "assistant" {
+			return
+		}
+		close(assistantAppendStarted)
+		<-releaseAssistantAppend
+	})
+
+	resultCh := make(chan struct {
+		result RunResult
+		err    error
+	}, 1)
+	go func() {
+		result, err := dialog.RunVoiceTurnWithContext(context.Background(), TurnInput{InputText: "original"}, nil, runtime, VoiceTurnContext{})
+		resultCh <- struct {
+			result RunResult
+			err    error
+		}{result: result, err: err}
+	}()
+
+	select {
+	case <-assistantAppendStarted:
+	case <-time.After(time.Second):
+		t.Fatal("assistant history append did not start")
+	}
+	if dialog.QueueSteer(TurnInput{InputText: "too late", Transcript: "too late"}) {
+		t.Fatal("QueueSteer returned true after runtime finished consuming steer")
+	}
+	close(releaseAssistantAppend)
+
+	select {
+	case runResult := <-resultCh:
+		if runResult.err != nil {
+			t.Fatalf("RunVoiceTurnWithContext() error = %v", runResult.err)
+		}
+		if runResult.result.Output != "final answer" {
+			t.Fatalf("Output = %q, want final answer", runResult.result.Output)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("RunVoiceTurnWithContext did not finish")
+	}
+}
+
 func TestAudioDialogBeginSteerInterruptWaitsForQueuedCorrection(t *testing.T) {
 	firstCallStarted := make(chan struct{})
 	releaseFirstCall := make(chan struct{})

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -831,6 +831,79 @@ func TestAudioDialogRunAgentTurnConsumesQueuedSteer(t *testing.T) {
 	}
 }
 
+func TestAudioDialogBeginSteerInterruptWaitsForQueuedCorrection(t *testing.T) {
+	firstCallStarted := make(chan struct{})
+	releaseFirstCall := make(chan struct{})
+	model := &blockingFirstCallModel{
+		firstCallStarted: firstCallStarted,
+		releaseFirstCall: releaseFirstCall,
+		responses: []*llms.ContentResponse{
+			contentResponse("stale answer"),
+			contentResponse("corrected answer"),
+		},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:           ModelConfig{Provider: "fake"},
+			Instruction:     "Answer directly.",
+			ForceSimpleLoop: true,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+	dialog := &AudioDialog{
+		config: Config{
+			Model: ModelConfig{Provider: "fake"},
+		},
+	}
+
+	resultCh := make(chan struct {
+		result RunResult
+		err    error
+	}, 1)
+	go func() {
+		result, err := dialog.RunAgentTurn(context.Background(), TurnInput{InputText: "original"}, runtime)
+		resultCh <- struct {
+			result RunResult
+			err    error
+		}{result: result, err: err}
+	}()
+
+	select {
+	case <-firstCallStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first model call did not start")
+	}
+	if !dialog.BeginSteerInterrupt() {
+		t.Fatal("BeginSteerInterrupt returned false while voice run was active")
+	}
+	if !dialog.QueueSteer(TurnInput{InputText: "change direction", Transcript: "change direction"}) {
+		t.Fatal("QueueSteer returned false for interrupted voice run")
+	}
+	close(releaseFirstCall)
+
+	var runResult struct {
+		result RunResult
+		err    error
+	}
+	select {
+	case runResult = <-resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("RunAgentTurn did not finish")
+	}
+	if runResult.err != nil {
+		t.Fatalf("RunAgentTurn() error = %v", runResult.err)
+	}
+	if runResult.result.Output != "corrected answer" {
+		t.Fatalf("Output = %q, want corrected answer", runResult.result.Output)
+	}
+	if dialog.ResumeSteerInterrupt() {
+		t.Fatal("ResumeSteerInterrupt returned true after interrupted steer was consumed")
+	}
+}
+
 func TestAudioDialogRunVoiceTurnDoesNotPersistUserWhenVoiceRunActive(t *testing.T) {
 	dialog := &AudioDialog{
 		config: Config{

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -831,6 +831,40 @@ func TestAudioDialogRunAgentTurnConsumesQueuedSteer(t *testing.T) {
 	}
 }
 
+func TestAudioDialogRunVoiceTurnDoesNotPersistUserWhenVoiceRunActive(t *testing.T) {
+	dialog := &AudioDialog{
+		config: Config{
+			Model:        ModelConfig{Provider: "fake"},
+			Audio:        AudioConfig{SampleRate: 16000},
+			AudioArchive: AudioArchiveConfig{Enabled: false},
+		},
+		audioArchive: NewAudioArchiveManager(AudioArchiveConfig{Enabled: false}),
+	}
+	var messages []Message
+	dialog.SetHistoryAppender(func(message Message) {
+		messages = append(messages, message)
+	})
+
+	if !dialog.beginVoiceRunControl("existing-request") {
+		t.Fatal("beginVoiceRunControl returned false for setup")
+	}
+	defer dialog.endVoiceRunControl("existing-request")
+
+	_, err := dialog.RunVoiceTurnWithContext(
+		context.Background(),
+		TurnInput{InputText: "late correction", Transcript: "late correction"},
+		[]int16{100, -100},
+		nil,
+		VoiceTurnContext{FollowUpRelation: FollowUpCorrection},
+	)
+	if err == nil || !strings.Contains(err.Error(), "voice run already active") {
+		t.Fatalf("RunVoiceTurnWithContext() error = %v, want voice run already active", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("persisted messages = %#v, want none when voice run is already active", messages)
+	}
+}
+
 func TestAudioDialogRunVoiceTurnPersistsUserBeforeRunEvents(t *testing.T) {
 	configDir := t.TempDir()
 	model := &scriptedModel{

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -36,6 +36,9 @@ type roleCollaborativeExecutor struct {
 	ForceSimpleLoop       bool
 	ToolCallSpeech        bool
 	SteerProvider         func(context.Context) (RunSteerMessage, bool)
+	SteerInterrupt        func() <-chan struct{}
+	SteerWaiter           func(context.Context) (RunSteerMessage, bool, error)
+	handledSteerInterrupt <-chan struct{}
 }
 
 const roleModelCallTimeout = 120 * time.Second
@@ -232,6 +235,13 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 		TodoReminderToolCalls: e.TodoReminderToolCalls,
 	}
 	for i := 0; i < e.MaxIterations; i++ {
+		consumedInterrupt, err := e.consumeSteerInterruptIfSignaled(ctx, inputs, &state)
+		if err != nil {
+			return nil, err
+		}
+		if consumedInterrupt {
+			continue
+		}
 		switch state.Phase {
 		case phaseDecision, phaseDefault, phasePlan:
 			turn, err := e.callPlannerTurn(ctx, inputs, &state, toolSpecs, options...)
@@ -239,8 +249,17 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 				return nil, err
 			}
 			switch turn.Kind {
+			case plannerTurnSteer:
+				continue
 			case plannerTurnFinish:
-				consumed, err := e.consumePendingSteer(ctx, inputs, &state)
+				consumed, err := e.consumeSteerInterruptIfSignaled(ctx, inputs, &state)
+				if err != nil {
+					return nil, err
+				}
+				if consumed {
+					continue
+				}
+				consumed, err = e.consumePendingSteer(ctx, inputs, &state)
 				if err != nil {
 					return nil, err
 				}
@@ -297,6 +316,13 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					state.World.UpdateFromStep(*turn.Step, len(state.ToolSteps))
 				}
 				if turn.Kind == plannerTurnTool {
+					consumed, err := e.consumeSteerInterruptIfSignaled(ctx, inputs, &state)
+					if err != nil {
+						return nil, err
+					}
+					if consumed {
+						continue
+					}
 					if _, err := e.consumePendingSteer(ctx, inputs, &state); err != nil {
 						return nil, err
 					}
@@ -323,6 +349,8 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 				return nil, err
 			}
 			switch turn.Kind {
+			case executorTurnSteer:
+				continue
 			case executorTurnTool, executorTurnInvalidMeta, executorTurnSleep:
 				if turn.Step != nil {
 					state.ToolSteps = append(state.ToolSteps, *turn.Step)
@@ -335,6 +363,13 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					state.ExecutionResults = append(state.ExecutionResults, execution)
 					if e.Recorder != nil {
 						e.Recorder.RecordExecution(execution)
+					}
+					consumed, err := e.consumeSteerInterruptIfSignaled(ctx, inputs, &state)
+					if err != nil {
+						return nil, err
+					}
+					if consumed {
+						continue
 					}
 					if _, err := e.consumePendingSteer(ctx, inputs, &state); err != nil {
 						return nil, err
@@ -388,7 +423,15 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					if finalAnswer == "" {
 						finalAnswer = stepSummary
 					}
-					consumed, err := e.consumePendingSteer(ctx, inputs, &state)
+					consumed, err := e.consumeSteerInterruptIfSignaled(ctx, inputs, &state)
+					if err != nil {
+						return nil, err
+					}
+					if consumed {
+						state.Phase = phaseDefault
+						continue
+					}
+					consumed, err = e.consumePendingSteer(ctx, inputs, &state)
 					if err != nil {
 						return nil, err
 					}
@@ -479,6 +522,11 @@ func (e *roleCollaborativeExecutor) callPlannerTurn(
 		return plannerTurnResult{}, err
 	}
 	e.emitRoleOutput(ctx, RolePlanner, roleResponseDebugText(res))
+	if consumed, err := e.consumeSteerInterruptIfSignaled(ctx, inputs, state); err != nil {
+		return plannerTurnResult{}, err
+	} else if consumed {
+		return plannerTurnResult{Kind: plannerTurnSteer}, nil
+	}
 
 	actions, finish, err := parser.ParseOutput(res)
 	if errors.Is(err, agents.ErrUnableToParseOutput) {
@@ -570,6 +618,11 @@ func (e *roleCollaborativeExecutor) callRouteTurn(
 		return plannerTurnResult{}, err
 	}
 	e.emitRoleOutput(ctx, RolePlanner, roleResponseDebugText(res))
+	if consumed, err := e.consumeSteerInterruptIfSignaled(ctx, inputs, state); err != nil {
+		return plannerTurnResult{}, err
+	} else if consumed {
+		return plannerTurnResult{Kind: plannerTurnSteer}, nil
+	}
 
 	parser := &FunctionAgent{Tools: appendLoopMetaTools(e.Tools), OutputKey: e.OutputKey, ToolCallSpeech: e.ToolCallSpeech}
 	actions, _, parseErr := parser.ParseOutput(res)
@@ -626,12 +679,12 @@ func (e *roleCollaborativeExecutor) executePlannerToolAction(
 	toolSpecs *ToolSpecs,
 	action schema.AgentAction,
 ) (plannerTurnResult, error) {
-	toolExecution := executeToolCall(ctx, ToolCallExecution{
+	toolExecution := e.executeToolCall(ctx, ToolCallExecution{
 		Specs:    toolSpecs,
 		Action:   action,
 		Callback: e.CallbacksHandler,
 	})
-	if toolExecution.Error != nil {
+	if toolExecution.Error != nil && !(errors.Is(toolExecution.Error, context.Canceled) && e.steerInterruptSignaled(ctx)) {
 		return plannerTurnResult{}, toolExecution.Error
 	}
 	execution := roleExecutionResult{
@@ -721,12 +774,98 @@ func (e *roleCollaborativeExecutor) emitTodoClosed(ctx context.Context, todo Tod
 	handler.HandleTodoClosed(ctx, snapshot, reason)
 }
 
+func (e *roleCollaborativeExecutor) executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallExecutionResult {
+	interruptCh := (<-chan struct{})(nil)
+	if e != nil && e.SteerInterrupt != nil {
+		interruptCh = e.SteerInterrupt()
+	}
+	if interruptCh == nil {
+		return executeToolCall(ctx, execution)
+	}
+
+	toolCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-interruptCh:
+			cancel()
+		case <-toolCtx.Done():
+		case <-done:
+		}
+	}()
+	result := executeToolCall(toolCtx, execution)
+	close(done)
+	cancel()
+	return result
+}
+
 func (e *roleCollaborativeExecutor) consumePendingSteer(ctx context.Context, inputs map[string]string, state *roleLoopState) (bool, error) {
 	if e == nil || e.SteerProvider == nil || state == nil {
 		return false, nil
 	}
 	steer, ok := e.SteerProvider(ctx)
 	if !ok {
+		return false, nil
+	}
+	return e.appendSteerMessage(ctx, inputs, state, steer)
+}
+
+func (e *roleCollaborativeExecutor) consumeSteerInterruptIfSignaled(ctx context.Context, inputs map[string]string, state *roleLoopState) (bool, error) {
+	if e == nil || e.SteerInterrupt == nil || e.SteerWaiter == nil || state == nil {
+		return false, nil
+	}
+	interruptCh := e.SteerInterrupt()
+	if interruptCh == nil {
+		return false, nil
+	}
+	if e.handledSteerInterrupt == interruptCh {
+		return false, nil
+	}
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case <-interruptCh:
+	default:
+		return false, nil
+	}
+	e.handledSteerInterrupt = interruptCh
+
+	steer, ok, err := e.SteerWaiter(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	if consumed, err := e.appendSteerMessage(ctx, inputs, state, steer); err != nil || !consumed {
+		return consumed, err
+	}
+	state.Phase = phaseDefault
+	state.clearStepExecution()
+	state.PlanExhausted = false
+	return true, nil
+}
+
+func (e *roleCollaborativeExecutor) steerInterruptSignaled(ctx context.Context) bool {
+	if e == nil || e.SteerInterrupt == nil {
+		return false
+	}
+	interruptCh := e.SteerInterrupt()
+	if interruptCh == nil {
+		return false
+	}
+	select {
+	case <-ctx.Done():
+		return false
+	case <-interruptCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (e *roleCollaborativeExecutor) appendSteerMessage(ctx context.Context, inputs map[string]string, state *roleLoopState, steer RunSteerMessage) (bool, error) {
+	if e == nil || state == nil {
 		return false, nil
 	}
 	if steer.Timestamp.IsZero() {
@@ -764,6 +903,11 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 		return executorTurnResult{}, err
 	}
 	e.emitRoleOutput(ctx, RoleExecutor, roleResponseDebugText(res))
+	if consumed, err := e.consumeSteerInterruptIfSignaled(ctx, inputs, state); err != nil {
+		return executorTurnResult{}, err
+	} else if consumed {
+		return executorTurnResult{Kind: executorTurnSteer}, nil
+	}
 
 	actions, finish, err := parser.ParseOutput(res)
 	if errors.Is(err, agents.ErrUnableToParseOutput) {
@@ -827,12 +971,12 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 		return turn, nil
 	}
 
-	toolExecution := executeToolCall(ctx, ToolCallExecution{
+	toolExecution := e.executeToolCall(ctx, ToolCallExecution{
 		Specs:    toolSpecs,
 		Action:   action,
 		Callback: e.CallbacksHandler,
 	})
-	if toolExecution.Error != nil {
+	if toolExecution.Error != nil && !(errors.Is(toolExecution.Error, context.Canceled) && e.steerInterruptSignaled(ctx)) {
 		return executorTurnResult{}, toolExecution.Error
 	}
 	actionCopy := toolExecution.Step.Action

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -36,6 +36,7 @@ type roleCollaborativeExecutor struct {
 	ForceSimpleLoop       bool
 	ToolCallSpeech        bool
 	SteerProvider         func(context.Context) (RunSteerMessage, bool)
+	FinalSteerProvider    func(context.Context) (RunSteerMessage, bool)
 	SteerInterrupt        func() <-chan struct{}
 	SteerWaiter           func(context.Context) (RunSteerMessage, bool, error)
 	handledSteerInterrupt <-chan struct{}
@@ -259,18 +260,26 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 				if consumed {
 					continue
 				}
+				canFinish := state.Phase == phaseDecision || state.Phase == phaseDefault || state.canAcceptPlannerFinal(turn.Answer)
+				if canFinish {
+					consumed, err = e.consumeFinalPendingSteer(ctx, inputs, &state)
+					if err != nil {
+						return nil, err
+					}
+					if consumed {
+						continue
+					}
+					if e.Recorder != nil {
+						e.Recorder.RecordDefaultFinish(turn.Answer)
+					}
+					return e.finishRun(ctx, turn.Answer, turn.Answer, &state)
+				}
 				consumed, err = e.consumePendingSteer(ctx, inputs, &state)
 				if err != nil {
 					return nil, err
 				}
 				if consumed {
 					continue
-				}
-				if state.Phase == phaseDecision || state.Phase == phaseDefault || state.canAcceptPlannerFinal(turn.Answer) {
-					if e.Recorder != nil {
-						e.Recorder.RecordDefaultFinish(turn.Answer)
-					}
-					return e.finishRun(ctx, turn.Answer, turn.Answer, &state)
 				}
 				continue
 			case plannerTurnUseSimpleMode:
@@ -329,6 +338,20 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					state.noteDefaultToolCallAndMaybeTodoReminder()
 				}
 				if turn.Kind == plannerTurnSleep {
+					consumed, err := e.consumeSteerInterruptIfSignaled(ctx, inputs, &state)
+					if err != nil {
+						return nil, err
+					}
+					if consumed {
+						continue
+					}
+					consumed, err = e.consumeFinalPendingSteer(ctx, inputs, &state)
+					if err != nil {
+						return nil, err
+					}
+					if consumed {
+						continue
+					}
 					answer := waitForWakeupFinalAnswer(turn.Step)
 					if e.Recorder != nil {
 						e.Recorder.RecordDefaultFinish(answer)
@@ -376,6 +399,20 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					}
 				}
 				if turn.Kind == executorTurnSleep {
+					consumed, err := e.consumeSteerInterruptIfSignaled(ctx, inputs, &state)
+					if err != nil {
+						return nil, err
+					}
+					if consumed {
+						continue
+					}
+					consumed, err = e.consumeFinalPendingSteer(ctx, inputs, &state)
+					if err != nil {
+						return nil, err
+					}
+					if consumed {
+						continue
+					}
 					answer := waitForWakeupFinalAnswer(turn.Step)
 					if e.Recorder != nil {
 						e.Recorder.RecordDefaultFinish(answer)
@@ -431,7 +468,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 						state.Phase = phaseDefault
 						continue
 					}
-					consumed, err = e.consumePendingSteer(ctx, inputs, &state)
+					consumed, err = e.consumeFinalPendingSteer(ctx, inputs, &state)
 					if err != nil {
 						return nil, err
 					}
@@ -804,6 +841,24 @@ func (e *roleCollaborativeExecutor) consumePendingSteer(ctx context.Context, inp
 		return false, nil
 	}
 	steer, ok := e.SteerProvider(ctx)
+	if !ok {
+		return false, nil
+	}
+	return e.appendSteerMessage(ctx, inputs, state, steer)
+}
+
+func (e *roleCollaborativeExecutor) consumeFinalPendingSteer(ctx context.Context, inputs map[string]string, state *roleLoopState) (bool, error) {
+	if e == nil || state == nil {
+		return false, nil
+	}
+	provider := e.FinalSteerProvider
+	if provider == nil {
+		provider = e.SteerProvider
+	}
+	if provider == nil {
+		return false, nil
+	}
+	steer, ok := provider(ctx)
 	if !ok {
 		return false, nil
 	}

--- a/src/agent/internal/agent/role_loop.go
+++ b/src/agent/internal/agent/role_loop.go
@@ -32,6 +32,7 @@ const (
 	plannerTurnCancelPlan
 	plannerTurnInvalidMeta
 	plannerTurnSleep
+	plannerTurnSteer
 )
 
 type plannerTurnResult struct {
@@ -69,6 +70,7 @@ const (
 	executorTurnAbortStep
 	executorTurnInvalidMeta
 	executorTurnSleep
+	executorTurnSteer
 )
 
 type executorTurnResult struct {

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -77,6 +77,10 @@ type RunRequest struct {
 	MaxTokens         int
 	EventHandler      func(RunEvent)
 	SteerProvider     func(context.Context) (RunSteerMessage, bool)
+	// FinalSteerProvider is called at terminal executor boundaries. It should
+	// atomically consume one last pending steer if available; otherwise it should
+	// close the request's steer acceptance window.
+	FinalSteerProvider func(context.Context) (RunSteerMessage, bool)
 	// SteerInterrupt signals that the current run should pause before scheduling
 	// more model/tool work while an out-of-band steering input is being captured.
 	SteerInterrupt func() <-chan struct{}
@@ -678,6 +682,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	executor.ToolCallSpeech = r.config.VoiceToolCallSpeechOrDefault()
 	executor.SteerInterrupt = req.SteerInterrupt
 	executor.SteerWaiter = req.SteerWaiter
+	executor.FinalSteerProvider = req.FinalSteerProvider
 
 	output, err := chains.Run(ctx, executor, normalizedInput, callOptions...)
 	if err != nil {

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -77,6 +77,12 @@ type RunRequest struct {
 	MaxTokens         int
 	EventHandler      func(RunEvent)
 	SteerProvider     func(context.Context) (RunSteerMessage, bool)
+	// SteerInterrupt signals that the current run should pause before scheduling
+	// more model/tool work while an out-of-band steering input is being captured.
+	SteerInterrupt func() <-chan struct{}
+	// SteerWaiter waits for the out-of-band steering capture to resolve. ok=false
+	// means the interruption produced no usable input and the run may continue.
+	SteerWaiter func(context.Context) (RunSteerMessage, bool, error)
 }
 
 type RunResult struct {
@@ -670,6 +676,8 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	executor.ConversationHistory = conversationHistory
 	executor.TodoReminderToolCalls = r.config.TodoReminderToolCallsOrDefault()
 	executor.ToolCallSpeech = r.config.VoiceToolCallSpeechOrDefault()
+	executor.SteerInterrupt = req.SteerInterrupt
+	executor.SteerWaiter = req.SteerWaiter
 
 	output, err := chains.Run(ctx, executor, normalizedInput, callOptions...)
 	if err != nil {

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -66,7 +66,10 @@ type RunRequest struct {
 	// RuntimeContext is dynamic per-turn system context, such as connected
 	// hardware/app state. It is not persisted as user configuration.
 	RuntimeContext string
-	StreamWriter   io.Writer
+	// FollowUpRelation overrides automatic session follow-up classification for
+	// inputs whose relationship to the previous turn is known by the caller.
+	FollowUpRelation string
+	StreamWriter     io.Writer
 	// StreamFinalChunks allows final-answer chunks to be written through
 	// StreamWriter for audio paths. Non-final LLM calls must remain
 	// non-streaming because they may be planner, tool-call, or verifier turns.
@@ -548,14 +551,15 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		episodeID = newTaskEpisodeID(startTime.UTC())
 	}
 	beginResult, err := r.beginSession(ctx, SessionBeginRequest{
-		AgentName:    "default",
-		Input:        normalizedInput,
-		Turn:         turnInput,
-		SessionID:    r.telemetrySessionID,
-		EpisodeID:    episodeID,
-		RequestID:    req.RequestID,
-		RunID:        runID,
-		CurrentHints: currentHints,
+		AgentName:        "default",
+		Input:            normalizedInput,
+		Turn:             turnInput,
+		SessionID:        r.telemetrySessionID,
+		EpisodeID:        episodeID,
+		RequestID:        req.RequestID,
+		RunID:            runID,
+		CurrentHints:     currentHints,
+		FollowUpRelation: req.FollowUpRelation,
 	})
 	if err != nil {
 		return RunResult{}, err

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1431,6 +1431,20 @@ type scriptedModel struct {
 	tools        [][]llms.Tool
 }
 
+type blockingFinalWriter struct {
+	started     chan struct{}
+	release     chan struct{}
+	startedOnce atomic.Bool
+}
+
+func (w *blockingFinalWriter) Write(p []byte) (int, error) {
+	if w.startedOnce.CompareAndSwap(false, true) {
+		close(w.started)
+	}
+	<-w.release
+	return len(p), nil
+}
+
 type staticTool struct {
 	name   string
 	output string
@@ -2728,6 +2742,73 @@ func TestRuntimeRunOpenRouterStreamsOnlyWhenRequested(t *testing.T) {
 	}
 	if stream.String() != "completed" {
 		t.Fatalf("unexpected stream output: %q", stream.String())
+	}
+}
+
+func TestRuntimeRunFinalSteerProviderClosesBeforeFinalStreaming(t *testing.T) {
+	model := &scriptedModel{
+		responses:    roleDirectResponses("final answer"),
+		streamChunks: [][]string{{}},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:           ModelConfig{Provider: "fake"},
+			Instruction:     "Answer directly.",
+			ForceSimpleLoop: true,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+
+	finalSteerClosed := make(chan struct{})
+	writer := &blockingFinalWriter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	resultCh := make(chan struct {
+		result RunResult
+		err    error
+	}, 1)
+	go func() {
+		result, err := runtime.Run(context.Background(), RunRequest{
+			Input:             "hello",
+			StreamWriter:      writer,
+			StreamFinalChunks: true,
+			FinalSteerProvider: func(ctx context.Context) (RunSteerMessage, bool) {
+				close(finalSteerClosed)
+				return RunSteerMessage{}, false
+			},
+		})
+		resultCh <- struct {
+			result RunResult
+			err    error
+		}{result: result, err: err}
+	}()
+
+	select {
+	case <-writer.started:
+	case <-time.After(time.Second):
+		t.Fatal("final stream writer was not called")
+	}
+	select {
+	case <-finalSteerClosed:
+	default:
+		t.Fatal("FinalSteerProvider was not called before final streaming")
+	}
+	close(writer.release)
+
+	select {
+	case runResult := <-resultCh:
+		if runResult.err != nil {
+			t.Fatalf("Run() error = %v", runResult.err)
+		}
+		if runResult.result.Output != "final answer" {
+			t.Fatalf("Output = %q, want final answer", runResult.result.Output)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not finish")
 	}
 }
 

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -421,6 +421,189 @@ func TestRuntimeRunAttachesPendingSteerToNextToolCall(t *testing.T) {
 	})
 }
 
+func TestRuntimeRunSteerInterruptPausesAfterNonCancelableTool(t *testing.T) {
+	model := &scriptedModel{
+		responses: roleToolResponses("slow", `{"__arg1":"original action"}`, "Changed course."),
+	}
+	toolStarted := make(chan struct{})
+	releaseTool := make(chan struct{})
+	tool := &blockingTool{
+		name:         "slow",
+		description:  "Slow tool.",
+		output:       "tool output",
+		started:      toolStarted,
+		release:      releaseTool,
+		ignoreCancel: true,
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Use tools."},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{"slow": tool}},
+		NewSkillIndex(),
+	)
+
+	interruptCh := make(chan struct{})
+	waitCalled := make(chan struct{})
+	releaseSteer := make(chan struct{})
+	resultCh := make(chan struct {
+		result RunResult
+		err    error
+	}, 1)
+	go func() {
+		result, err := runtime.Run(context.Background(), RunRequest{
+			Input: "do the original action",
+			SteerInterrupt: func() <-chan struct{} {
+				return interruptCh
+			},
+			SteerWaiter: func(ctx context.Context) (RunSteerMessage, bool, error) {
+				close(waitCalled)
+				select {
+				case <-ctx.Done():
+					return RunSteerMessage{}, false, ctx.Err()
+				case <-releaseSteer:
+				}
+				return RunSteerMessage{ID: "steer-1", Content: "Use the updated instruction instead."}, true, nil
+			},
+		})
+		resultCh <- struct {
+			result RunResult
+			err    error
+		}{result: result, err: err}
+	}()
+
+	select {
+	case <-toolStarted:
+	case <-time.After(time.Second):
+		t.Fatal("tool did not start")
+	}
+	close(interruptCh)
+	close(releaseTool)
+	select {
+	case <-waitCalled:
+	case <-time.After(time.Second):
+		t.Fatal("runtime did not pause for steering after interrupted tool returned")
+	}
+	if model.callCount != 1 {
+		t.Fatalf("model call count while waiting for steer = %d, want 1", model.callCount)
+	}
+	close(releaseSteer)
+
+	var runResult struct {
+		result RunResult
+		err    error
+	}
+	select {
+	case runResult = <-resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("runtime did not finish after steering release")
+	}
+	if runResult.err != nil {
+		t.Fatalf("Run() error = %v", runResult.err)
+	}
+	if runResult.result.Output != "Changed course." {
+		t.Fatalf("output = %q, want Changed course.", runResult.result.Output)
+	}
+	if len(tool.inputs) != 1 || tool.inputs[0] != "original action" {
+		t.Fatalf("tool inputs = %#v, want only original action", tool.inputs)
+	}
+	if len(model.messages) < 2 {
+		t.Fatalf("expected second model call after steer, got %#v", model.messages)
+	}
+	role, text, ok := runtimeLastMessageText(model.messages[1])
+	if !ok || role != llms.ChatMessageTypeHuman || text != "Use the updated instruction instead." {
+		t.Fatalf("second model call missing steer message: %#v", model.messages[1])
+	}
+}
+
+func TestRuntimeRunEmptySteerInterruptResumesAfterCancelableTool(t *testing.T) {
+	model := &scriptedModel{
+		responses: roleToolResponses("slow", `{"__arg1":"original action"}`, "Original done."),
+	}
+	toolStarted := make(chan struct{})
+	toolCanceled := make(chan struct{})
+	tool := &blockingTool{
+		name:        "slow",
+		description: "Slow tool.",
+		output:      "tool output",
+		started:     toolStarted,
+		canceled:    toolCanceled,
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Use tools."},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{"slow": tool}},
+		NewSkillIndex(),
+	)
+
+	interruptCh := make(chan struct{})
+	waitCalled := make(chan struct{})
+	releaseWait := make(chan struct{})
+	resultCh := make(chan struct {
+		result RunResult
+		err    error
+	}, 1)
+	go func() {
+		result, err := runtime.Run(context.Background(), RunRequest{
+			Input: "do the original action",
+			SteerInterrupt: func() <-chan struct{} {
+				return interruptCh
+			},
+			SteerWaiter: func(ctx context.Context) (RunSteerMessage, bool, error) {
+				close(waitCalled)
+				select {
+				case <-ctx.Done():
+					return RunSteerMessage{}, false, ctx.Err()
+				case <-releaseWait:
+				}
+				return RunSteerMessage{}, false, nil
+			},
+		})
+		resultCh <- struct {
+			result RunResult
+			err    error
+		}{result: result, err: err}
+	}()
+
+	select {
+	case <-toolStarted:
+	case <-time.After(time.Second):
+		t.Fatal("tool did not start")
+	}
+	close(interruptCh)
+	select {
+	case <-toolCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("tool context was not canceled after steer interrupt")
+	}
+	select {
+	case <-waitCalled:
+	case <-time.After(time.Second):
+		t.Fatal("runtime did not wait for empty steer decision")
+	}
+	close(releaseWait)
+
+	var runResult struct {
+		result RunResult
+		err    error
+	}
+	select {
+	case runResult = <-resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("runtime did not resume after empty steer decision")
+	}
+	if runResult.err != nil {
+		t.Fatalf("Run() error = %v", runResult.err)
+	}
+	if runResult.result.Output != "Original done." {
+		t.Fatalf("output = %q, want Original done.", runResult.result.Output)
+	}
+	if len(tool.inputs) != 1 || tool.inputs[0] != "original action" {
+		t.Fatalf("tool inputs = %#v, want only original action", tool.inputs)
+	}
+}
+
 func TestRuntimeRunAttachesPendingSteerBeforeFinalAnswer(t *testing.T) {
 	model := &scriptedModel{
 		responses: []*llms.ContentResponse{
@@ -1546,6 +1729,43 @@ func (t *stubTool) Call(_ context.Context, input string) (string, error) {
 		return "", t.err
 	}
 	return t.output, nil
+}
+
+type blockingTool struct {
+	name         string
+	description  string
+	output       string
+	inputs       []string
+	started      chan struct{}
+	release      chan struct{}
+	canceled     chan struct{}
+	ignoreCancel bool
+}
+
+func (t *blockingTool) Name() string { return t.name }
+
+func (t *blockingTool) Description() string { return t.description }
+
+func (t *blockingTool) Call(ctx context.Context, input string) (string, error) {
+	t.inputs = append(t.inputs, input)
+	if t.started != nil {
+		close(t.started)
+	}
+	if t.ignoreCancel {
+		if t.release != nil {
+			<-t.release
+		}
+		return t.output, nil
+	}
+	select {
+	case <-ctx.Done():
+		if t.canceled != nil {
+			close(t.canceled)
+		}
+		return "", ctx.Err()
+	case <-t.release:
+		return t.output, nil
+	}
 }
 
 func TestBuildLLMStructuredSummarizeFnParsesStrictJSON(t *testing.T) {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -848,6 +848,76 @@ func TestRuntimeRunResumeCorrectionUsesRootRequestAndCommittedPlan(t *testing.T)
 	}
 }
 
+func TestRuntimeRunForcedFollowUpRelationMarksInterruptedCorrection(t *testing.T) {
+	ctx := context.Background()
+	storageDir := filepath.Join(t.TempDir(), "memory")
+	rootRequest := "打开微信，进入 Aden AI agent 群，发送100块钱红包"
+	correction := "短一点的搜索词"
+	interruptionContext := "Voice interruption: the user pressed the physical wakeup button after interrupting the previous voice turn. Treat the latest voice input as a correction to that interrupted turn."
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			contentResponse("started"),
+			contentResponse("updated"),
+		},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:           ModelConfig{Provider: "fake"},
+			Instruction:     "Answer directly.",
+			ForceSimpleLoop: true,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(storageDir),
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+
+	if _, err := runtime.Run(ctx, RunRequest{
+		Input:     rootRequest,
+		RequestID: "req-voice-root",
+	}); err != nil {
+		t.Fatalf("first Run() error = %v", err)
+	}
+	if _, err := runtime.Run(ctx, RunRequest{
+		Input:            correction,
+		RequestID:        "req-voice-correction",
+		FollowUpRelation: FollowUpCorrection,
+		RuntimeContext:   interruptionContext,
+	}); err != nil {
+		t.Fatalf("correction Run() error = %v", err)
+	}
+	if len(model.messages) < 2 {
+		t.Fatalf("expected second model prompt, got %#v", model.messages)
+	}
+	correctionPrompt := messageText(model.messages[1])
+	for _, want := range []string{
+		"## Runtime context",
+		"physical wakeup",
+		"after interrupting the previous voice turn",
+		"Original user request / root request",
+		rootRequest,
+		"Latest user message",
+		correction,
+		"Follow-up classification:",
+		FollowUpCorrection,
+		"Latest correction",
+	} {
+		if !strings.Contains(correctionPrompt, want) {
+			t.Fatalf("correction prompt missing %q:\n%s", want, correctionPrompt)
+		}
+	}
+
+	events := readSessionEvents(t, filepath.Join(storageDir, "session", "events.jsonl"))
+	if !sessionEventsContain(events, func(event SessionEvent) bool {
+		return event.Type == "user_input" &&
+			event.Content == correction &&
+			event.Relation == FollowUpCorrection &&
+			event.RequestID == "req-voice-correction"
+	}) {
+		t.Fatalf("session events missing forced correction relation: %#v", events)
+	}
+}
+
 func TestRuntimeRunIncludesAvailableSkillCatalog(t *testing.T) {
 	index := NewSkillIndex()
 	index.skills["planner"] = &SkillDefinition{

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -878,7 +878,7 @@ func (s *Server) handleChatAsync(
 			if closeErr != nil && s.logger != nil {
 				s.logger.Error("new TTS stream failed: %v", closeErr)
 			}
-			result.SpeechStreamed = closeErr == nil && newStream.spoke
+			result.SpeechStreamed = closeErr == nil && newStream.spokeSuccessfully()
 		}
 
 		pending.mu.Lock()
@@ -1129,7 +1129,7 @@ func (s *Server) handleChatSync(
 		if closeErr != nil && s.logger != nil {
 			s.logger.Error("new TTS stream failed: %v", closeErr)
 		}
-		result.SpeechStreamed = closeErr == nil && newStream.spoke
+		result.SpeechStreamed = closeErr == nil && newStream.spokeSuccessfully()
 	}
 
 	if err != nil {
@@ -1311,7 +1311,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 		if closeErr != nil && s.logger != nil {
 			s.logger.Error("new TTS stream failed: %v", closeErr)
 		}
-		result.SpeechStreamed = closeErr == nil && newStream.spoke
+		result.SpeechStreamed = closeErr == nil && newStream.spokeSuccessfully()
 	}
 	if err != nil {
 		if req.RequestID != "" && s.liveActivity != nil {

--- a/src/agent/internal/agent/session_boundary.go
+++ b/src/agent/internal/agent/session_boundary.go
@@ -26,6 +26,7 @@ const (
 	BoundaryReasonSmallSession     = "small_session"
 	BoundaryReasonDefaultNew       = "default_new"
 	BoundaryReasonScoreContinue    = "score_continue"
+	BoundaryReasonForcedFollowUp   = "forced_follow_up"
 )
 
 // BoundaryConfig tunes ClassifyTurnBoundary. All fields are positive; zero

--- a/src/agent/internal/agent/session_context_view.go
+++ b/src/agent/internal/agent/session_context_view.go
@@ -123,6 +123,23 @@ func currentInputFromMemoryInputs(inputs map[string]any) string {
 	}
 }
 
+func normalizeFollowUpRelation(relation string) string {
+	switch strings.TrimSpace(relation) {
+	case FollowUpRootRequest:
+		return FollowUpRootRequest
+	case FollowUpContinuation:
+		return FollowUpContinuation
+	case FollowUpCorrection:
+		return FollowUpCorrection
+	case FollowUpReplacement:
+		return FollowUpReplacement
+	case FollowUpNewTask:
+		return FollowUpNewTask
+	default:
+		return ""
+	}
+}
+
 func ClassifyFollowUpRelation(prevEvents []SessionEvent, input string, boundary string) string {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {

--- a/src/agent/internal/agent/session_manager.go
+++ b/src/agent/internal/agent/session_manager.go
@@ -19,14 +19,15 @@ type SessionManager interface {
 
 // SessionBeginRequest contains the run data needed before prompt construction.
 type SessionBeginRequest struct {
-	AgentName    string
-	Input        string
-	Turn         TurnInput
-	SessionID    string
-	EpisodeID    string
-	RequestID    string
-	RunID        string
-	CurrentHints CurrentEnvironmentHints
+	AgentName        string
+	Input            string
+	Turn             TurnInput
+	SessionID        string
+	EpisodeID        string
+	RequestID        string
+	RunID            string
+	CurrentHints     CurrentEnvironmentHints
+	FollowUpRelation string
 }
 
 // SessionBeginResult contains session state computed before prompt construction.
@@ -79,7 +80,7 @@ func (m memoryManagerSessionManager) BeginRun(ctx context.Context, req SessionBe
 	if turn.InputText == "" {
 		turn = NewTextTurnInput(req.Input, nil)
 	}
-	boundary, relation := m.handleSessionBoundary(turn.InputText)
+	boundary, relation := m.handleSessionBoundary(turn.InputText, req.FollowUpRelation)
 	if m.memories != nil {
 		agentName := req.AgentName
 		if agentName == "" {
@@ -99,8 +100,13 @@ func (m memoryManagerSessionManager) BeginRun(ctx context.Context, req SessionBe
 	return SessionBeginResult{Boundary: boundary}, nil
 }
 
-func (m memoryManagerSessionManager) handleSessionBoundary(input string) (sessionBoundaryTelemetry, string) {
+func (m memoryManagerSessionManager) handleSessionBoundary(input string, forcedRelation string) (sessionBoundaryTelemetry, string) {
 	var telemetry sessionBoundaryTelemetry
+	if forcedRelation = normalizeFollowUpRelation(forcedRelation); forcedRelation != "" {
+		telemetry.Decision = BoundaryContinue
+		telemetry.Reason = BoundaryReasonForcedFollowUp
+		return telemetry, forcedRelation
+	}
 	if m.memories == nil || m.memories.storageDir == "" {
 		return telemetry, FollowUpRootRequest
 	}

--- a/src/agent/internal/agent/tts/sink.go
+++ b/src/agent/internal/agent/tts/sink.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -16,11 +17,13 @@ const (
 
 // AudioServiceSink implements AudioSink by writing PCM to AudioServiceClient.
 type AudioServiceSink struct {
+	mu        sync.Mutex
 	audio     AudioServiceBackend
 	format    AudioFormat
 	sessionID uint64
 	started   bool
 	stopped   bool
+	finalSent bool
 	pcmBytes  int
 	pending   []byte
 }
@@ -41,7 +44,9 @@ func NewAudioServiceSink(audio AudioServiceBackend, format AudioFormat) *AudioSe
 func (s *AudioServiceSink) Format() AudioFormat { return s.format }
 
 func (s *AudioServiceSink) WritePCM(data []byte) error {
-	if s.stopped {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopped || s.finalSent {
 		return ErrSessionClosed
 	}
 	if len(data) == 0 {
@@ -111,30 +116,59 @@ func (s *AudioServiceSink) pcmBytesForDuration(d time.Duration) int {
 }
 
 // PCMBytes returns how many PCM bytes were accepted by the audio backend.
-func (s *AudioServiceSink) PCMBytes() int { return s.pcmBytes }
+func (s *AudioServiceSink) PCMBytes() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pcmBytes
+}
 
 func (s *AudioServiceSink) Drain(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.mu.Lock()
 	if s.stopped {
+		s.mu.Unlock()
 		return nil
 	}
-	if err := s.flushPending(); err != nil {
-		return err
-	}
-	if !s.started {
-		return nil
-	}
-	if tailBytes := s.pcmBytesForDuration(playbackTailSilenceDuration); tailBytes > 0 {
-		if err := s.writePCMChunks(make([]byte, tailBytes)); err != nil {
-			return fmt.Errorf("write tail silence: %w", err)
+	if !s.finalSent {
+		if err := ctx.Err(); err != nil {
+			s.mu.Unlock()
+			return err
 		}
+		if err := s.flushPending(); err != nil {
+			s.mu.Unlock()
+			return err
+		}
+		if !s.started {
+			s.stopped = true
+			s.mu.Unlock()
+			return nil
+		}
+		if tailBytes := s.pcmBytesForDuration(playbackTailSilenceDuration); tailBytes > 0 {
+			if err := ctx.Err(); err != nil {
+				s.mu.Unlock()
+				return err
+			}
+			if err := s.writePCMChunks(make([]byte, tailBytes)); err != nil {
+				s.mu.Unlock()
+				return fmt.Errorf("write tail silence: %w", err)
+			}
+		}
+		// Send final chunk to signal end of stream.
+		if err := ctx.Err(); err != nil {
+			s.mu.Unlock()
+			return err
+		}
+		if err := s.audio.WritePlayChunk(s.sessionID, nil, true); err != nil {
+			s.mu.Unlock()
+			return fmt.Errorf("send final chunk: %w", err)
+		}
+		s.finalSent = true
 	}
-	// Send final chunk to signal end of stream.
-	if err := s.audio.WritePlayChunk(s.sessionID, nil, true); err != nil {
-		return fmt.Errorf("send final chunk: %w", err)
-	}
-	s.stopped = true
-
 	wait := EstimatedPlaybackDrainDuration(s.format, s.pcmBytes)
+	s.mu.Unlock()
+
 	waitCtx, cancel := context.WithTimeout(ctx, drainTimeout)
 	defer cancel()
 	if err := waitForEstimatedDrain(waitCtx, wait); err != nil {
@@ -143,28 +177,38 @@ func (s *AudioServiceSink) Drain(ctx context.Context) error {
 		}
 		return err
 	}
+	s.mu.Lock()
+	if !s.stopped {
+		s.stopped = true
+	}
+	s.mu.Unlock()
 	return nil
 }
 
 func (s *AudioServiceSink) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.stopped {
 		return nil
 	}
 	if !s.started {
 		s.pending = nil
 		s.stopped = true
+		s.finalSent = true
 		return nil
 	}
 	err := s.audio.StopPlayback(s.sessionID)
 	if err == nil {
 		s.pending = nil
 		s.stopped = true
+		s.finalSent = true
 		return nil
 	}
 	msg := strings.ToLower(err.Error())
 	if strings.Contains(msg, "session_not_found") || strings.Contains(msg, "not found") {
 		s.pending = nil
 		s.stopped = true
+		s.finalSent = true
 		return nil
 	}
 	return err

--- a/src/agent/internal/agent/tts_helpers.go
+++ b/src/agent/internal/agent/tts_helpers.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"aiden-agent/internal/agent/tts"
@@ -134,7 +135,13 @@ func beginManagedTTSStream(ctx context.Context, manager *tts.ProviderManager, au
 	return &streamSessionWriter{session: session, sink: targetSink}, nil
 }
 
+type ttsStreamObserver func(*streamSessionWriter) func()
+
 func speakWithTTSManager(ctx context.Context, manager *tts.ProviderManager, audio *AudioServiceClient, cfg Config, text string) (bool, error) {
+	return speakWithTTSManagerObserved(ctx, manager, audio, cfg, text, nil)
+}
+
+func speakWithTTSManagerObserved(ctx context.Context, manager *tts.ProviderManager, audio *AudioServiceClient, cfg Config, text string, observe ttsStreamObserver) (bool, error) {
 	text = strings.TrimSpace(text)
 	if text == "" || manager == nil || audio == nil {
 		return false, nil
@@ -161,9 +168,16 @@ func speakWithTTSManager(ctx context.Context, manager *tts.ProviderManager, audi
 			}
 			return false, err
 		}
+		unobserve := func() {}
+		if observe != nil {
+			if cleanup := observe(stream); cleanup != nil {
+				unobserve = cleanup
+			}
+		}
 
 		if _, err := stream.Write([]byte(text)); err != nil {
 			_ = stream.closeAndWait()
+			unobserve()
 			lastErr = err
 			if isTransientTTSError(err) && attempt < maxRetries {
 				continue
@@ -172,14 +186,16 @@ func speakWithTTSManager(ctx context.Context, manager *tts.ProviderManager, audi
 		}
 
 		if err := stream.closeAndWait(); err != nil {
+			unobserve()
 			lastErr = err
 			if isTransientTTSError(err) && attempt < maxRetries {
 				continue
 			}
 			return false, err
 		}
+		unobserve()
 
-		return stream.spoke, nil
+		return stream.spokeSuccessfully(), nil
 	}
 	return false, lastErr
 }
@@ -242,28 +258,89 @@ func (a *ttsLoggerAdapter) Warn(format string, args ...any) {
 // LLM streaming output is written byte-slice by byte-slice; we forward each
 // fragment to the TTS session immediately.
 type streamSessionWriter struct {
-	session tts.StreamSession
-	sink    *tts.AudioServiceSink
-	spoke   bool
-	lastErr error
+	mu          sync.Mutex
+	session     tts.StreamSession
+	sink        *tts.AudioServiceSink
+	cancel      context.CancelFunc
+	spoke       bool
+	lastErr     error
+	interrupted bool
+}
+
+func (w *streamSessionWriter) setCancel(cancel context.CancelFunc) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.cancel = cancel
 }
 
 func (w *streamSessionWriter) Write(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
-	if err := w.session.WriteText(string(p)); err != nil {
-		if w.lastErr == nil {
+	w.mu.Lock()
+	if w.interrupted {
+		w.mu.Unlock()
+		return len(p), nil
+	}
+	session := w.session
+	w.mu.Unlock()
+
+	if err := session.WriteText(string(p)); err != nil {
+		w.mu.Lock()
+		if w.lastErr == nil && !w.interrupted {
 			w.lastErr = err
 		}
+		w.mu.Unlock()
 	}
 	// Always return success so the LLM stream is not interrupted by TTS errors.
 	return len(p), nil
 }
 
+func (w *streamSessionWriter) interrupt() {
+	w.mu.Lock()
+	if w.interrupted {
+		w.mu.Unlock()
+		return
+	}
+	w.interrupted = true
+	w.spoke = false
+	sink := w.sink
+	cancel := w.cancel
+	w.mu.Unlock()
+
+	if sink != nil {
+		_ = sink.Stop()
+	}
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (w *streamSessionWriter) spokeSuccessfully() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.spoke && !w.interrupted
+}
+
 // closeAndWait flushes the session and waits for playback to drain.
 func (w *streamSessionWriter) closeAndWait() error {
-	closeErr := w.session.Close()
+	w.mu.Lock()
+	if w.interrupted {
+		w.spoke = false
+		w.mu.Unlock()
+		return nil
+	}
+	session := w.session
+	w.mu.Unlock()
+
+	closeErr := session.Close()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.interrupted {
+		w.spoke = false
+		return nil
+	}
 	if w.lastErr != nil {
 		return w.lastErr
 	}

--- a/src/agent/internal/agent/tts_provider_integration_test.go
+++ b/src/agent/internal/agent/tts_provider_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/tmc/langchaingo/llms"
 	langtools "github.com/tmc/langchaingo/tools"
@@ -294,6 +295,131 @@ func TestAudioDialogRunAgentTurnStreamsSpeechFromStructuredAnswer(t *testing.T) 
 	}
 }
 
+func TestAudioDialogInterruptOutputStopsActiveStreamingTTS(t *testing.T) {
+	model := newBlockingStreamingModel("old answer", "ignored stale suffix", "final answer")
+	runtime := NewRuntimeWithDeps(
+		Config{Model: ModelConfig{Provider: "fake"}},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+	streamingEnabled := true
+	summaryDisabled := false
+	provider := newInterruptibleAudioTTSProvider("dialog-provider", 48000, false)
+	audioOps := &recordedAudioOps{}
+	dialog := &AudioDialog{
+		config: Config{
+			Model:                     ModelConfig{Provider: "fake"},
+			Audio:                     AudioConfig{SampleRate: 48000},
+			VoiceStreamingTTSEnabled:  &streamingEnabled,
+			VoiceSpeechSummaryEnabled: &summaryDisabled,
+		},
+		audioClient: NewAudioServiceClient(startRecordedTTSPlaybackAudioSocket(t, audioOps)),
+		ttsManager:  ttsmodule.NewProviderManager(provider, nil),
+	}
+
+	resultCh := make(chan audioDialogRunResult, 1)
+	go func() {
+		result, err := dialog.RunAgentTurn(context.Background(), TurnInput{InputText: "hello"}, runtime)
+		resultCh <- audioDialogRunResult{result: result, err: err}
+	}()
+
+	waitForTestSignal(t, provider.firstWriteDone(), "streaming TTS playback to start")
+	dialog.InterruptOutput()
+	model.release()
+
+	turnResult := waitForAudioDialogRunResult(t, resultCh)
+	if turnResult.err != nil {
+		t.Fatalf("RunAgentTurn() error = %v", turnResult.err)
+	}
+	if turnResult.result.SpeechStreamed {
+		t.Fatal("SpeechStreamed = true, want false after streaming TTS interrupt")
+	}
+	if got := provider.texts(); len(got) != 1 || got[0] != "old answer" {
+		t.Fatalf("provider texts = %#v, want only the pre-interrupt stream chunk", got)
+	}
+	if got := provider.closeCalls(); got != 0 {
+		t.Fatalf("stream Close calls = %d, want 0 after interrupt", got)
+	}
+	if got := audioOps.countOp("stop_playback"); got != 1 {
+		t.Fatalf("stop_playback count = %d, want 1", got)
+	}
+	if got := audioOps.finalChunkCountAfterFirstStop(); got != 0 {
+		t.Fatalf("final write_play_chunk count after stop = %d, want 0 after interrupt", got)
+	}
+}
+
+func TestAudioDialogProcessUtteranceSpeaksFinalAnswerWhenStreamingTTSInterrupted(t *testing.T) {
+	model := newBlockingStreamingModel("old answer", "ignored stale suffix", "final answer")
+	runtime := NewRuntimeWithDeps(
+		Config{Model: ModelConfig{Provider: "fake"}},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+	streamingEnabled := true
+	summaryDisabled := false
+	provider := newInterruptibleAudioTTSProvider("dialog-provider", 48000, false)
+	dialog := &AudioDialog{
+		config: Config{
+			InputMode:                 "audio",
+			Model:                     ModelConfig{Provider: "fake"},
+			Audio:                     AudioConfig{SampleRate: 48000},
+			VoiceStreamingTTSEnabled:  &streamingEnabled,
+			VoiceSpeechSummaryEnabled: &summaryDisabled,
+		},
+		audioClient: NewAudioServiceClient(startRecordedTTSPlaybackAudioSocket(t, &recordedAudioOps{})),
+		ttsManager:  ttsmodule.NewProviderManager(provider, nil),
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- dialog.ProcessUtterance(context.Background(), []int16{1, 2}, runtime)
+	}()
+
+	waitForTestSignal(t, provider.firstWriteDone(), "streaming TTS playback to start")
+	dialog.InterruptOutput()
+	model.release()
+
+	if err := waitForError(t, errCh); err != nil {
+		t.Fatalf("ProcessUtterance() error = %v", err)
+	}
+	if got := provider.texts(); len(got) != 2 || got[0] != "old answer" || got[1] != "final answer" {
+		t.Fatalf("provider texts = %#v, want interrupted stream then normal final Speak", got)
+	}
+}
+
+func TestAudioDialogInterruptOutputStopsBackgroundToolSpeech(t *testing.T) {
+	provider := newInterruptibleAudioTTSProvider("dialog-provider", 48000, true)
+	audioOps := &recordedAudioOps{}
+	dialog := &AudioDialog{
+		config: Config{
+			Model: ModelConfig{Provider: "fake"},
+			Audio: AudioConfig{SampleRate: 48000},
+		},
+		audioClient: NewAudioServiceClient(startRecordedTTSPlaybackAudioSocket(t, audioOps)),
+		ttsManager:  ttsmodule.NewProviderManager(provider, nil),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		dialog.SpeakToolDescription("tool is running")
+		close(done)
+	}()
+
+	waitForTestSignal(t, provider.firstWriteDone(), "tool TTS playback to start")
+	dialog.InterruptOutput()
+	waitForTestSignal(t, done, "tool TTS to stop")
+
+	if got := audioOps.countOp("stop_playback"); got != 1 {
+		t.Fatalf("stop_playback count = %d, want 1", got)
+	}
+	if got := audioOps.finalChunkCount(); got != 0 {
+		t.Fatalf("final write_play_chunk count = %d, want 0 after tool speech interrupt", got)
+	}
+}
+
 func TestRuntimeRunStreamsStructuredSpeechToWriter(t *testing.T) {
 	model := &rawStreamingModel{
 		content: `{"speech":"短口播。","text":"完整回答保留给屏幕。"}`,
@@ -352,6 +478,260 @@ func (m *rawStreamingModel) GenerateContent(ctx context.Context, messages []llms
 		}
 	}
 	return contentResponse(m.content), nil
+}
+
+type audioDialogRunResult struct {
+	result RunResult
+	err    error
+}
+
+type blockingStreamingModel struct {
+	firstChunk  string
+	secondChunk string
+	content     string
+	released    chan struct{}
+	releaseOnce sync.Once
+}
+
+func newBlockingStreamingModel(firstChunk, secondChunk, content string) *blockingStreamingModel {
+	return &blockingStreamingModel{
+		firstChunk:  firstChunk,
+		secondChunk: secondChunk,
+		content:     content,
+		released:    make(chan struct{}),
+	}
+}
+
+func (m *blockingStreamingModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return m.content, nil
+}
+
+func (m *blockingStreamingModel) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	var callOptions llms.CallOptions
+	for _, option := range options {
+		option(&callOptions)
+	}
+	if callOptions.StreamingFunc != nil {
+		if err := callOptions.StreamingFunc(ctx, []byte(m.firstChunk)); err != nil {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-m.released:
+		}
+		if m.secondChunk != "" {
+			if err := callOptions.StreamingFunc(ctx, []byte(m.secondChunk)); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return contentResponse(m.content), nil
+}
+
+func (m *blockingStreamingModel) release() {
+	m.releaseOnce.Do(func() {
+		close(m.released)
+	})
+}
+
+type interruptibleAudioTTSProvider struct {
+	name        string
+	pcmBytes    int
+	blockWrites bool
+	firstWrite  chan struct{}
+	writeOnce   sync.Once
+	closeCount  atomic.Int32
+	mu          sync.Mutex
+	seen        []string
+}
+
+func newInterruptibleAudioTTSProvider(name string, pcmBytes int, blockWrites bool) *interruptibleAudioTTSProvider {
+	return &interruptibleAudioTTSProvider{
+		name:        name,
+		pcmBytes:    pcmBytes,
+		blockWrites: blockWrites,
+		firstWrite:  make(chan struct{}),
+	}
+}
+
+func (p *interruptibleAudioTTSProvider) Name() string { return p.name }
+
+func (p *interruptibleAudioTTSProvider) Capabilities() ttsmodule.Capabilities {
+	return ttsmodule.Capabilities{}
+}
+
+func (p *interruptibleAudioTTSProvider) BeginStream(ctx context.Context, sink ttsmodule.AudioSink) (ttsmodule.StreamSession, error) {
+	return &interruptibleAudioTTSSession{provider: p, ctx: ctx, sink: sink}, nil
+}
+
+func (p *interruptibleAudioTTSProvider) Close() error { return nil }
+
+func (p *interruptibleAudioTTSProvider) firstWriteDone() <-chan struct{} {
+	return p.firstWrite
+}
+
+func (p *interruptibleAudioTTSProvider) signalFirstWrite() {
+	p.writeOnce.Do(func() {
+		close(p.firstWrite)
+	})
+}
+
+func (p *interruptibleAudioTTSProvider) texts() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.seen...)
+}
+
+func (p *interruptibleAudioTTSProvider) closeCalls() int {
+	return int(p.closeCount.Load())
+}
+
+type interruptibleAudioTTSSession struct {
+	provider *interruptibleAudioTTSProvider
+	ctx      context.Context
+	sink     ttsmodule.AudioSink
+	err      error
+}
+
+func (s *interruptibleAudioTTSSession) WriteText(text string) error {
+	s.provider.mu.Lock()
+	s.provider.seen = append(s.provider.seen, text)
+	s.provider.mu.Unlock()
+
+	if s.provider.pcmBytes > 0 {
+		if err := s.sink.WritePCM(make([]byte, s.provider.pcmBytes)); err != nil {
+			s.err = err
+			s.provider.signalFirstWrite()
+			return err
+		}
+	}
+	s.provider.signalFirstWrite()
+
+	if s.provider.blockWrites {
+		<-s.ctx.Done()
+		s.err = s.ctx.Err()
+		return s.err
+	}
+	return nil
+}
+
+func (s *interruptibleAudioTTSSession) Flush() error { return nil }
+
+func (s *interruptibleAudioTTSSession) Close() error {
+	s.provider.closeCount.Add(1)
+	if err := s.sink.Drain(s.ctx); err != nil {
+		s.err = err
+		return err
+	}
+	return nil
+}
+
+func (s *interruptibleAudioTTSSession) Err() error { return s.err }
+
+type recordedAudioOps struct {
+	mu  sync.Mutex
+	ops []audioRequest
+}
+
+func startRecordedTTSPlaybackAudioSocket(t *testing.T, ops *recordedAudioOps) string {
+	t.Helper()
+	if ops == nil {
+		ops = &recordedAudioOps{}
+	}
+	return startFakeAudioServiceSocket(t, func(req audioRequest) (audioResponse, []byte) {
+		ops.append(req)
+		switch req.Op {
+		case "start_playback":
+			return audioResponse{Status: "OK", SessionID: stringUint64(7)}, nil
+		case "write_play_chunk":
+			return audioResponse{Status: "OK"}, nil
+		case "health":
+			return audioResponse{Status: "OK", PlaybackSessions: 0}, nil
+		case "stop_playback":
+			return audioResponse{Status: "OK"}, nil
+		default:
+			return audioResponse{Status: "INTERNAL_ERROR"}, nil
+		}
+	})
+}
+
+func (r *recordedAudioOps) append(req audioRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ops = append(r.ops, req)
+}
+
+func (r *recordedAudioOps) countOp(op string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for _, req := range r.ops {
+		if req.Op == op {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *recordedAudioOps) finalChunkCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for _, req := range r.ops {
+		if req.Op == "write_play_chunk" && req.IsFinal {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *recordedAudioOps) finalChunkCountAfterFirstStop() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	seenStop := false
+	for _, req := range r.ops {
+		if req.Op == "stop_playback" {
+			seenStop = true
+			continue
+		}
+		if seenStop && req.Op == "write_play_chunk" && req.IsFinal {
+			count++
+		}
+	}
+	return count
+}
+
+func waitForTestSignal(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+func waitForAudioDialogRunResult(t *testing.T, ch <-chan audioDialogRunResult) audioDialogRunResult {
+	t.Helper()
+	select {
+	case result := <-ch:
+		return result
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for RunAgentTurn")
+		return audioDialogRunResult{}
+	}
+}
+
+func waitForError(t *testing.T, ch <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for operation")
+		return nil
+	}
 }
 
 type failingStreamSession struct {

--- a/src/agent/internal/agent/tts_test.go
+++ b/src/agent/internal/agent/tts_test.go
@@ -102,6 +102,35 @@ func TestPlayPromptSoundReturnsContextErrorWhenCanceledBeforeRetry(t *testing.T)
 	}
 }
 
+func TestAudioDialogInterruptOutputStopsPromptSound(t *testing.T) {
+	audioServer := newTestAudioService(t)
+	audioServer.healthPlaybackSessions = []uint32{1}
+	firstStart := make(chan struct{})
+	var once sync.Once
+	audioServer.onStartPlayback = func() {
+		once.Do(func() {
+			close(firstStart)
+		})
+	}
+	dialog := &AudioDialog{
+		audioClient: NewAudioServiceClient(audioServer.socketPath),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		dialog.playPromptSound(promptSoundRecordingStart, "recording", true)
+		close(done)
+	}()
+
+	waitForTestSignal(t, firstStart, "prompt sound playback to start")
+	dialog.InterruptOutput()
+	waitForTestSignal(t, done, "prompt sound to stop")
+
+	if got := audioServer.countOp("stop_playback"); got != 1 {
+		t.Fatalf("stop_playback count = %d, want 1", got)
+	}
+}
+
 type testAudioService struct {
 	socketPath               string
 	listener                 net.Listener

--- a/src/agent/internal/agent/voice_run_control.go
+++ b/src/agent/internal/agent/voice_run_control.go
@@ -1,0 +1,253 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+type VoiceTurnContext struct {
+	FollowUpRelation string
+	RuntimeContext   string
+}
+
+type queuedVoiceSteer struct {
+	requestID     string
+	contentLength int
+	interrupted   bool
+}
+
+type voiceRunControl struct {
+	mu              sync.Mutex
+	activeRequestID string
+	acceptingSteer  bool
+	pendingSteer    RunSteerMessage
+	hasPendingSteer bool
+	interrupt       voiceSteerInterruptState
+}
+
+type voiceSteerInterruptState struct {
+	signal  chan struct{}
+	ready   chan struct{}
+	active  bool
+	done    bool
+	steer   RunSteerMessage
+	hasText bool
+}
+
+func normalizeVoiceTurnContext(turnContext VoiceTurnContext) VoiceTurnContext {
+	return VoiceTurnContext{
+		FollowUpRelation: normalizeFollowUpRelation(turnContext.FollowUpRelation),
+		RuntimeContext:   strings.TrimSpace(turnContext.RuntimeContext),
+	}
+}
+
+func createVoiceRequestID() string {
+	return fmt.Sprintf("voice-%x", time.Now().UnixNano())
+}
+
+func (c *voiceRunControl) begin(requestID string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.activeRequestID != "" {
+		return false
+	}
+	c.activeRequestID = requestID
+	c.acceptingSteer = true
+	c.clearPendingLocked()
+	c.interrupt = voiceSteerInterruptState{signal: make(chan struct{})}
+	return true
+}
+
+func (c *voiceRunControl) end(requestID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.activeRequestID != requestID {
+		return
+	}
+	c.resolveInterruptLocked(RunSteerMessage{}, false)
+	c.activeRequestID = ""
+	c.acceptingSteer = false
+	c.clearPendingLocked()
+	c.interrupt = voiceSteerInterruptState{}
+}
+
+func (c *voiceRunControl) queueSteer(content string) (queuedVoiceSteer, bool) {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return queuedVoiceSteer{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.activeRequestID == "" || !c.acceptingSteer {
+		return queuedVoiceSteer{}, false
+	}
+	steer := RunSteerMessage{
+		ID:        createSteerID(),
+		RequestID: c.activeRequestID,
+		Content:   content,
+		Timestamp: time.Now(),
+	}
+	queued := queuedVoiceSteer{
+		requestID:     c.activeRequestID,
+		contentLength: len(content),
+	}
+	if c.interrupt.active && !c.interrupt.done {
+		c.resolveInterruptLocked(steer, true)
+		queued.interrupted = true
+		return queued, true
+	}
+	c.pendingSteer = steer
+	c.hasPendingSteer = true
+	return queued, true
+}
+
+func (c *voiceRunControl) beginInterrupt() (string, bool, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.activeRequestID == "" || !c.acceptingSteer {
+		return "", false, false
+	}
+	if c.interrupt.active {
+		return c.activeRequestID, false, true
+	}
+	if c.interrupt.signal == nil {
+		c.interrupt.signal = make(chan struct{})
+	}
+	c.interrupt.ready = make(chan struct{})
+	c.interrupt.active = true
+	c.interrupt.done = false
+	c.interrupt.steer = RunSteerMessage{}
+	c.interrupt.hasText = false
+	close(c.interrupt.signal)
+	return c.activeRequestID, true, true
+}
+
+func (c *voiceRunControl) resumeInterrupt() (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.activeRequestID == "" || !c.acceptingSteer || !c.interrupt.active {
+		return "", false
+	}
+	requestID := c.activeRequestID
+	c.resolveInterruptLocked(RunSteerMessage{}, false)
+	return requestID, true
+}
+
+func (c *voiceRunControl) consumePending(requestID string) (RunSteerMessage, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if requestID == "" || c.activeRequestID != requestID || !c.acceptingSteer || !c.hasPendingSteer {
+		return RunSteerMessage{}, false
+	}
+	return c.consumePendingLocked()
+}
+
+func (c *voiceRunControl) consumeFinalPending(requestID string) (RunSteerMessage, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if requestID == "" || c.activeRequestID != requestID || !c.acceptingSteer {
+		return RunSteerMessage{}, false
+	}
+	if c.hasPendingSteer {
+		return c.consumePendingLocked()
+	}
+	c.closeAcceptanceLocked()
+	return RunSteerMessage{}, false
+}
+
+func (c *voiceRunControl) stopAccepting(requestID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if requestID == "" || c.activeRequestID != requestID {
+		return
+	}
+	c.closeAcceptanceLocked()
+}
+
+func (c *voiceRunControl) interruptChannel(requestID string) <-chan struct{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if requestID == "" || c.activeRequestID != requestID || !c.acceptingSteer {
+		return nil
+	}
+	return c.interrupt.signal
+}
+
+func (c *voiceRunControl) waitForInterrupt(ctx context.Context, requestID string) (RunSteerMessage, bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c.mu.Lock()
+	if requestID == "" || c.activeRequestID != requestID || !c.acceptingSteer || !c.interrupt.active {
+		c.mu.Unlock()
+		return RunSteerMessage{}, false, nil
+	}
+	ready := c.interrupt.ready
+	c.mu.Unlock()
+	if ready == nil {
+		return RunSteerMessage{}, false, nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return RunSteerMessage{}, false, ctx.Err()
+	case <-ready:
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if requestID == "" || c.activeRequestID != requestID || !c.acceptingSteer {
+		return RunSteerMessage{}, false, nil
+	}
+	steer := c.interrupt.steer
+	hasText := c.interrupt.hasText
+	c.resetInterruptLocked()
+	return steer, hasText, nil
+}
+
+func (c *voiceRunControl) consumePendingLocked() (RunSteerMessage, bool) {
+	steer := c.pendingSteer
+	c.clearPendingLocked()
+	return steer, true
+}
+
+func (c *voiceRunControl) closeAcceptanceLocked() {
+	c.acceptingSteer = false
+	c.clearPendingLocked()
+	c.resolveInterruptLocked(RunSteerMessage{}, false)
+}
+
+func (c *voiceRunControl) clearPendingLocked() {
+	c.pendingSteer = RunSteerMessage{}
+	c.hasPendingSteer = false
+}
+
+func (c *voiceRunControl) resolveInterruptLocked(steer RunSteerMessage, hasText bool) {
+	if !c.interrupt.active || c.interrupt.done {
+		return
+	}
+	c.interrupt.steer = steer
+	c.interrupt.hasText = hasText
+	c.interrupt.done = true
+	if c.interrupt.ready != nil {
+		close(c.interrupt.ready)
+	}
+}
+
+func (c *voiceRunControl) resetInterruptLocked() {
+	c.interrupt = voiceSteerInterruptState{signal: make(chan struct{})}
+}
+
+func steerContentFromTurnInput(input TurnInput) string {
+	input = normalizeTurnInput(input)
+	if content := strings.TrimSpace(input.InputText); content != "" {
+		if content == voiceAudioInputPlaceholder && strings.TrimSpace(input.Transcript) == "" {
+			return ""
+		}
+		return content
+	}
+	return strings.TrimSpace(input.Transcript)
+}


### PR DESCRIPTION
## Summary
- add voice run request IDs and pending steer support to AudioDialog
- queue follow-up wakeup speech as a steer during active voice thinking instead of canceling the run
- preserve explicit signal cancellation and speaking interruption behavior

## Tests
- go test ./internal/agent ./cmd/daemon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice interruption during thinking now captures a correction steer and queues it for the next turn (with fallback when queuing isn’t available).
  * Interrupting output during speaking now stops active playback before continuing with correction capture.
  * Voice/session turns now support explicit follow-up relationship overrides.
* **Bug Fixes**
  * Interrupted streaming TTS and prompt playback no longer get marked as successfully streamed.
  * Steering interruption now properly pauses/resumes execution and cancels in-flight tool work.
* **Tests**
  * Expanded coverage for steer queuing/fallback, wakeup-to-follow-up sequencing, interrupt ordering, and interruption behavior across streaming TTS and prompt sound.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->