### PR TITLE
fix(agent): reinforce tool-call speech guidance

### DIFF
--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -225,8 +225,12 @@ func (a *FunctionAgent) constructFunctionScratchPad(steps []schema.AgentStep) []
 				ID:   scratchpadToolCallID(steps[j].Action, i, j),
 				Type: "function",
 				FunctionCall: &llms.FunctionCall{
-					Name:      steps[j].Action.Tool,
-					Arguments: encodeToolArguments(steps[j].Action.ToolInput),
+					Name: steps[j].Action.Tool,
+					Arguments: encodeToolArgumentsWithSpeech(
+						steps[j].Action.ToolInput,
+						toolSpeechFromAction(steps[j].Action),
+						a.ToolCallSpeech,
+					),
 				},
 			})
 		}
@@ -498,6 +502,10 @@ func extractToolInput(raw string) string {
 }
 
 func encodeToolArguments(input string) string {
+	return encodeToolArgumentsWithSpeech(input, "", false)
+}
+
+func encodeToolArgumentsWithSpeech(input string, speech string, includeSpeech bool) string {
 	args := map[string]any{}
 	trimmed := strings.TrimSpace(input)
 	if strings.HasPrefix(trimmed, "{") {
@@ -510,6 +518,11 @@ func encodeToolArguments(input string) string {
 	}
 	if len(args) == 0 && trimmed != "" {
 		args["input"] = input
+	}
+	if includeSpeech {
+		if speech = strings.TrimSpace(speech); speech != "" {
+			args[toolCallSpeechField] = speech
+		}
 	}
 	encoded, err := json.Marshal(args)
 	if err != nil {

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -311,6 +311,43 @@ func TestFunctionAgentScratchpadDoesNotReplayToolSpeechAsArgument(t *testing.T) 
 	}
 }
 
+func TestFunctionAgentScratchpadReplaysToolSpeechWhenEnabled(t *testing.T) {
+	agent := &FunctionAgent{ToolCallSpeech: true}
+	messages := agent.constructFunctionScratchPad([]schema.AgentStep{{
+		Action: schema.AgentAction{
+			Tool:      "echo",
+			ToolInput: "hello",
+			Log:       formatToolActionLog("echo", `{"input":"hello","speech":"Echoing text."}`, "", "Echoing text.", "\n"),
+			ToolID:    "call_1",
+		},
+		Observation: "ok",
+	}})
+
+	if len(messages) == 0 || len(messages[0].Parts) != 1 {
+		t.Fatalf("unexpected scratchpad messages: %#v", messages)
+	}
+	toolCall, ok := messages[0].Parts[0].(llms.ToolCall)
+	if !ok {
+		t.Fatalf("expected tool call part, got %T", messages[0].Parts[0])
+	}
+	var args map[string]string
+	if err := json.Unmarshal([]byte(toolCall.FunctionCall.Arguments), &args); err != nil {
+		t.Fatalf("decode tool arguments: %v", err)
+	}
+	if args["input"] != "hello" {
+		t.Fatalf("scratchpad input = %q", args["input"])
+	}
+	if args["speech"] != "Echoing text." {
+		t.Fatalf("scratchpad speech = %q, want LLM tool-call speech", args["speech"])
+	}
+	if _, ok := args["description"]; ok {
+		t.Fatalf("scratchpad should not replay description argument: %#v", args)
+	}
+	if _, ok := args["__arg1"]; ok {
+		t.Fatalf("scratchpad should not replay __arg1: %#v", args)
+	}
+}
+
 func TestFunctionAgentScratchpadReplaysToolDescriptionAsAssistantText(t *testing.T) {
 	agent := &FunctionAgent{}
 	messages := agent.constructFunctionScratchPad([]schema.AgentStep{{

--- a/src/agent/internal/agent/prompt.go
+++ b/src/agent/internal/agent/prompt.go
@@ -95,7 +95,7 @@ func combinedAgentInstruction(cfg AgentConfig) string {
 func defaultAgentBehavior(cfg AgentConfig) string {
 	toolCallSpeechRule := "- When calling a tool, do not add speech or description arguments to tool inputs."
 	if cfg.VoiceToolCallSpeechOrDefault() {
-		toolCallSpeechRule = "- When calling a user-visible tool, set the optional tool argument speech to concise natural TTS text in the user's language. Keep speech under 20 Chinese characters or 8 English words. Do not put spoken prefaces in assistant text and do not add a description argument; speech is consumed by the runtime and is not passed to the real tool."
+		toolCallSpeechRule = "- Include the speech argument on every tool call that observes, waits for, reads, or changes external state; this includes screenshot, wait_for_stable_screen, quick_action, mouse_click, touch_gesture, keyboard_text, keyboard_tap, open_app, recall_memory, recall_device_memory, recall_session_chunks, and similar UI/device/memory tools. Assistant text before a tool call is not a substitute for the speech argument; put the spoken status in speech on the tool call itself. Keep speech under 20 Chinese characters or 8 English words, in the user's language. Do not add a description argument; speech is consumed by the runtime and is not passed to the real tool."
 	}
 	return strings.Join([]string{
 		"### Environment",

--- a/src/agent/internal/agent/prompt_test.go
+++ b/src/agent/internal/agent/prompt_test.go
@@ -148,6 +148,34 @@ func TestRolePromptsIncludeGlobalEnvironmentAndDeviceGuidance(t *testing.T) {
 	}
 }
 
+func TestRolePromptsRequireToolCallSpeechForExternalStateTools(t *testing.T) {
+	enabled := true
+	profiles := buildRoleProfiles(
+		AgentConfig{VoiceToolCallSpeech: &enabled},
+		ResolvedSkills{},
+		nil,
+		MemoryContext{},
+	)
+
+	for _, profile := range []RoleProfile{profiles.Planner, profiles.Executor} {
+		for _, want := range []string{
+			"Include the speech argument on every tool call that observes, waits for, reads, or changes external state",
+			"screenshot, wait_for_stable_screen, quick_action, mouse_click, touch_gesture, keyboard_text, keyboard_tap, open_app, recall_memory",
+			"Assistant text before a tool call is not a substitute for the speech argument",
+		} {
+			if !strings.Contains(profile.SystemPrompt, want) {
+				t.Fatalf("%s prompt missing tool-call speech requirement %q:\n%s", profile.Name, want, profile.SystemPrompt)
+			}
+		}
+		if strings.Contains(profile.SystemPrompt, "user-visible tool") {
+			t.Fatalf("%s prompt should not use ambiguous user-visible tool wording:\n%s", profile.Name, profile.SystemPrompt)
+		}
+		if strings.Contains(profile.SystemPrompt, "When voice tool-call speech is enabled") {
+			t.Fatalf("%s prompt should not ask the model to reason about whether voice tool-call speech is enabled:\n%s", profile.Name, profile.SystemPrompt)
+		}
+	}
+}
+
 func TestCombinedAgentInstructionFallsBackWhenEmpty(t *testing.T) {
 	if got := combinedAgentInstruction(AgentConfig{}); got != "" {
 		t.Fatalf("combinedAgentInstruction() = %q, want empty string", got)

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -894,10 +894,10 @@ func (e *roleCollaborativeExecutor) roleMessages(profile RoleProfile, inputs map
 	}
 
 	if profile.Name == RoleExecutor && len(state.StepToolSteps) > 0 {
-		scratchpad := (&FunctionAgent{Tools: appendExecutorMetaTools(e.Tools), ScreenshotPruning: e.ScreenshotPruning}).constructFunctionScratchPad(state.StepToolSteps)
+		scratchpad := (&FunctionAgent{Tools: appendExecutorMetaTools(e.Tools), ScreenshotPruning: e.ScreenshotPruning, ToolCallSpeech: e.ToolCallSpeech}).constructFunctionScratchPad(state.StepToolSteps)
 		messages = append(messages, scratchpad...)
 	} else if roleSeesToolScratchpad(profile.Name) && len(state.ToolSteps) > 0 {
-		scratchpad := (&FunctionAgent{Tools: e.Tools, ScreenshotPruning: e.ScreenshotPruning}).constructFunctionScratchPad(state.ToolSteps)
+		scratchpad := (&FunctionAgent{Tools: e.Tools, ScreenshotPruning: e.ScreenshotPruning, ToolCallSpeech: e.ToolCallSpeech}).constructFunctionScratchPad(state.ToolSteps)
 		messages = append(messages, scratchpad...)
 	}
 

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -68,6 +69,57 @@ func TestEnterPlanModePreservesToolSteps(t *testing.T) {
 	if len(state.ToolSteps) != 1 {
 		t.Fatalf("tool steps = %d, want 1", len(state.ToolSteps))
 	}
+}
+
+func TestExecutorScratchpadReplaysToolSpeechWhenEnabled(t *testing.T) {
+	executor := newRoleCollaborativeExecutor(
+		&scriptedModel{},
+		RoleProfiles{},
+		nil,
+		nil,
+		10,
+		nil,
+		nil,
+		nil,
+		ScreenshotPruningConfig{},
+		nil,
+	)
+	executor.ToolCallSpeech = true
+	state := roleLoopState{
+		StepToolSteps: []schema.AgentStep{{
+			Action: schema.AgentAction{
+				Tool:      "mouse_click",
+				ToolInput: `{"button":"left","x":500,"y":850}`,
+				Log:       formatToolActionLog("mouse_click", `{"button":"left","speech":"点击支付按钮","x":500,"y":850}`, "", "点击支付按钮", "\n"),
+				ToolID:    "call_1",
+			},
+			Observation: "ok",
+		}},
+	}
+
+	messages := executor.roleMessages(
+		RoleProfile{Name: RoleExecutor, SystemPrompt: "system"},
+		map[string]string{"input": "continue"},
+		state,
+		"task",
+	)
+	for _, message := range messages {
+		for _, part := range message.Parts {
+			toolCall, ok := part.(llms.ToolCall)
+			if !ok || toolCall.FunctionCall == nil || toolCall.FunctionCall.Name != "mouse_click" {
+				continue
+			}
+			var args map[string]any
+			if err := json.Unmarshal([]byte(toolCall.FunctionCall.Arguments), &args); err != nil {
+				t.Fatalf("decode scratchpad tool arguments: %v", err)
+			}
+			if args["speech"] != "点击支付按钮" {
+				t.Fatalf("scratchpad speech = %#v, want previous tool-call speech; args=%#v", args["speech"], args)
+			}
+			return
+		}
+	}
+	t.Fatalf("scratchpad mouse_click tool call not found: %#v", messages)
 }
 
 func TestCommitPlanOnlyInPlanMode(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace ambiguous user-visible tool speech guidance with explicit external-state tool requirements
- replay prior tool-call speech in scratchpad examples when voice tool-call speech is enabled
- add regression coverage for prompt wording and scratchpad replay behavior

## Tests
- `go test ./internal/agent -run 'TestFunctionAgentScratchpadReplaysToolSpeechWhenEnabled|TestExecutorScratchpadReplaysToolSpeechWhenEnabled|TestFunctionAgentScratchpadDoesNotReplayToolSpeechAsArgument|TestRolePromptsRequireToolCallSpeechForExternalStateTools' -count=1`\n- `go test ./internal/agent -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool calls now support speech arguments that describe agent actions when interacting with UI elements and external systems. Speech information is automatically captured and replayed to ensure consistent agent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->