### PR TITLE
fix(agent): restrict world-state screenshots to verifier

### DIFF
--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -20,7 +20,7 @@ TOML 是当前支持的配置格式；JSON 配置已废弃。
 custom_instruction = ""
 max_iterations = -1
 screenshot_keep_n = 3
-screenshot_prune_interval = 25
+screenshot_prune_interval = 5
 input_mode = "text"
 
 [model]
@@ -108,7 +108,7 @@ frame_socket = "/run/frame_service/frame_service.sock"
 | `additional_prompt` | - | 额外 prompt 字段；运行时会追加到 base instruction 后面 |
 | `max_iterations` | `-1` | 单次运行最大工具调用循环次数；`-1` 表示不限制 |
 | `screenshot_keep_n` | `3` | LLM 上下文中截图裁剪的最近保留数量；未设置或 `0` 使用默认值 |
-| `screenshot_prune_interval` | `25` | 截图超过 `screenshot_keep_n + screenshot_prune_interval` 后，按批次把旧截图替换为占位符；未设置或 `0` 使用默认值 |
+| `screenshot_prune_interval` | `5` | 截图超过 `screenshot_keep_n + screenshot_prune_interval` 后，按批次把旧截图替换为占位符；未设置或 `0` 使用默认值 |
 | `input_mode` | `text` / `stt` / `audio` | 输入模式 |
 | `trigger_mode` | `manual` / `wakeup` | 语音模式触发方式 |
 | `vad_backend` | `rknn` | VAD 后端：`rknn` 使用 NPU encoder + CPU LSTM/decoder，`cpu` 使用纯 CPU helper |

--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -20,7 +20,7 @@ TOML 是当前支持的配置格式；JSON 配置已废弃。
 custom_instruction = ""
 max_iterations = -1
 screenshot_keep_n = 3
-screenshot_prune_interval = 5
+screenshot_prune_interval = 2
 input_mode = "text"
 
 [model]
@@ -108,7 +108,7 @@ frame_socket = "/run/frame_service/frame_service.sock"
 | `additional_prompt` | - | 额外 prompt 字段；运行时会追加到 base instruction 后面 |
 | `max_iterations` | `-1` | 单次运行最大工具调用循环次数；`-1` 表示不限制 |
 | `screenshot_keep_n` | `3` | LLM 上下文中截图裁剪的最近保留数量；未设置或 `0` 使用默认值 |
-| `screenshot_prune_interval` | `5` | 截图超过 `screenshot_keep_n + screenshot_prune_interval` 后，按批次把旧截图替换为占位符；未设置或 `0` 使用默认值 |
+| `screenshot_prune_interval` | `2` | 截图超过 `screenshot_keep_n + screenshot_prune_interval` 后，按批次把旧截图替换为占位符；未设置或 `0` 使用默认值 |
 | `input_mode` | `text` / `stt` / `audio` | 输入模式 |
 | `trigger_mode` | `manual` / `wakeup` | 语音模式触发方式 |
 | `vad_backend` | `rknn` | VAD 后端：`rknn` 使用 NPU encoder + CPU LSTM/decoder，`cpu` 使用纯 CPU helper |

--- a/docs/04-agent/context-lifecycle.md
+++ b/docs/04-agent/context-lifecycle.md
@@ -18,7 +18,7 @@ Each run is assembled from several layers. Some layers are persisted memory, whi
 | Retrieved memory context | `MemoryPlane.Retrieve` output | planner receives common and planner memory; verifier receives failure/conflict caution memory only | filesystem memory |
 | Planner conversation history | hot-window memory, optional compressed-history markers, optional persisted chat history | planner only | filesystem memory |
 | Role loop state | phase, objective, plan, `plan_step_index`, next step, tool evidence, verifier feedback, world state | role-specific | current run only |
-| Input attachments | `RunRequest.Attachments`, plus latest screenshot image when available | role user messages | current run only |
+| Input attachments | `RunRequest.Attachments`; verifier-only latest screenshot image when world state has one | role user messages | current run only |
 
 The executor intentionally does not receive global memory or full conversation history. It receives the planner-approved `next_step`, latest world state, and the latest local execution result only.
 
@@ -100,9 +100,9 @@ The per-call user message is then built from the current loop state:
 
 - planner sees the current loop mode, world state, original request, conversation history, draft or committed plan, executor results, and verifier feedback;
 - executor sees the current world state and the planner-approved `next_step`;
-- verifier sees the current world state, the step under verification (`step_index`, `step_text`, `is_final_committed_step`), and the latest executor result for that step only.
+- verifier sees the current world state, the step under verification (`step_index`, `step_text`, `is_final_committed_step`), the latest executor result for that step, and the latest world-state screenshot image when available.
 
-Planner and executor receive the tool scratchpad after tools have run. The latest screenshot image is attached to the role message when the world state has screenshot bytes.
+Planner and executor receive tool scratchpads after tools have run. `WorldState.LatestScreenshot` is retained as verifier-only visual evidence: planner and executor do not receive it through World State, which keeps their world-state prompt prefix stable for model cache reuse.
 
 ## Retrieved Memory Context
 

--- a/overlay/userdata/agent/agent.toml
+++ b/overlay/userdata/agent/agent.toml
@@ -8,7 +8,7 @@ force_simple_loop = false
 # keep the latest N screenshots and batch-prune older screenshots every interval
 # to keep long runs bounded without changing the cached message prefix every turn.
 screenshot_keep_n = 3
-screenshot_prune_interval = 25
+screenshot_prune_interval = 5
 
 # Input mode:
 # - text: run HTTP server with Web UI

--- a/overlay/userdata/agent/agent.toml
+++ b/overlay/userdata/agent/agent.toml
@@ -8,7 +8,7 @@ force_simple_loop = false
 # keep the latest N screenshots and batch-prune older screenshots every interval
 # to keep long runs bounded without changing the cached message prefix every turn.
 screenshot_keep_n = 3
-screenshot_prune_interval = 5
+screenshot_prune_interval = 2
 
 # Input mode:
 # - text: run HTTP server with Web UI

--- a/src/agent/internal/agent/config_defaults.go
+++ b/src/agent/internal/agent/config_defaults.go
@@ -47,7 +47,7 @@ const (
 	defaultTodoReminderToolCalls   = 3
 	defaultMaxIterations           = -1
 	defaultScreenshotKeepN         = 3
-	defaultScreenshotPruneInterval = 25
+	defaultScreenshotPruneInterval = 5
 	defaultTelemetryProvider       = "langfuse"
 	defaultTelemetryTimeoutSec     = 30
 	defaultTelemetryMaxRetry       = 2

--- a/src/agent/internal/agent/config_defaults.go
+++ b/src/agent/internal/agent/config_defaults.go
@@ -47,7 +47,7 @@ const (
 	defaultTodoReminderToolCalls   = 3
 	defaultMaxIterations           = -1
 	defaultScreenshotKeepN         = 3
-	defaultScreenshotPruneInterval = 5
+	defaultScreenshotPruneInterval = 2
 	defaultTelemetryProvider       = "langfuse"
 	defaultTelemetryTimeoutSec     = 30
 	defaultTelemetryMaxRetry       = 2

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -43,8 +43,8 @@ func TestConfigScreenshotPruningDefaultsAndOverrides(t *testing.T) {
 		t.Fatalf("Validate() error = %v", err)
 	}
 	pruning := cfg.ScreenshotPruningOrDefault()
-	if pruning.KeepN != 3 || pruning.Interval != 25 {
-		t.Fatalf("default screenshot pruning = %#v, want keep_n=3 interval=25", pruning)
+	if pruning.KeepN != 3 || pruning.Interval != 5 {
+		t.Fatalf("default screenshot pruning = %#v, want keep_n=3 interval=5", pruning)
 	}
 
 	cfg.ScreenshotKeepN = 5

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -43,8 +43,8 @@ func TestConfigScreenshotPruningDefaultsAndOverrides(t *testing.T) {
 		t.Fatalf("Validate() error = %v", err)
 	}
 	pruning := cfg.ScreenshotPruningOrDefault()
-	if pruning.KeepN != 3 || pruning.Interval != 5 {
-		t.Fatalf("default screenshot pruning = %#v, want keep_n=3 interval=5", pruning)
+	if pruning.KeepN != 3 || pruning.Interval != 2 {
+		t.Fatalf("default screenshot pruning = %#v, want keep_n=3 interval=2", pruning)
 	}
 
 	cfg.ScreenshotKeepN = 5

--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -22,6 +22,12 @@ type visualObservationTool interface {
 	ReturnsVisualObservation() bool
 }
 
+type visualScreenshotObservation struct {
+	Result     postActionScreenshotResult
+	ImageBytes []byte
+	MIMEType   string
+}
+
 type structuredInputTool interface {
 	ArgsSchema() map[string]any
 }
@@ -274,27 +280,12 @@ func scratchpadToolCallID(action schema.AgentAction, groupStart, index int) stri
 }
 
 func (a *FunctionAgent) observationMessagesForStep(step schema.AgentStep, includeVisual bool) (string, []llms.MessageContent) {
-	if !a.isVisualObservationTool(step.Action.Tool) {
+	visual, ok := a.visualScreenshotObservation(step)
+	if !ok {
 		return compactToolObservation(step.Observation), nil
 	}
+	result := visual.Result
 
-	var result postActionScreenshotResult
-	if err := json.Unmarshal([]byte(step.Observation), &result); err != nil {
-		return compactToolObservation(step.Observation), nil
-	}
-	if result.Data == "" {
-		return compactToolObservation(step.Observation), nil
-	}
-
-	imageBytes, err := base64.StdEncoding.DecodeString(result.Data)
-	if err != nil {
-		return compactToolObservation(step.Observation), nil
-	}
-	if len(imageBytes) == 0 {
-		return compactToolObservation(step.Observation), nil
-	}
-
-	mimeType := "image/jpeg"
 	imageAvailability := "The image is attached in the next message."
 	if !includeVisual {
 		imageAvailability = "The image is replaced with a placeholder in the next message."
@@ -321,9 +312,6 @@ func (a *FunctionAgent) observationMessagesForStep(step schema.AgentStep, includ
 			imageAvailability,
 		)
 	}
-	if result.Format != "" && result.Format != "jpeg" {
-		mimeType = "image/" + result.Format
-	}
 	caption := fmt.Sprintf("This image is the screenshot observation returned by the %s tool. Use it when answering the original request.", step.Action.Tool)
 	if !includeVisual {
 		return toolContent, []llms.MessageContent{{
@@ -339,7 +327,7 @@ func (a *FunctionAgent) observationMessagesForStep(step schema.AgentStep, includ
 		Role: llms.ChatMessageTypeHuman,
 		Parts: []llms.ContentPart{
 			llms.TextPart(caption),
-			buildImagePart(mimeType, imageBytes),
+			buildImagePart(visual.MIMEType, visual.ImageBytes),
 		},
 	}}
 }
@@ -355,22 +343,65 @@ func (a *FunctionAgent) countVisualObservations(steps []schema.AgentStep) int {
 }
 
 func (a *FunctionAgent) hasVisualObservation(step schema.AgentStep) bool {
-	if !a.isVisualObservationTool(step.Action.Tool) {
-		return false
-	}
+	_, ok := a.visualScreenshotObservation(step)
+	return ok
+}
 
-	var result postActionScreenshotResult
-	if err := json.Unmarshal([]byte(step.Observation), &result); err != nil {
-		return false
+func (a *FunctionAgent) visualScreenshotObservation(step schema.AgentStep) (visualScreenshotObservation, bool) {
+	if !a.isVisualObservationTool(step.Action.Tool) {
+		return visualScreenshotObservation{}, false
 	}
-	if result.Data == "" {
-		return false
+	return parseScreenshotObservation(step.Observation)
+}
+
+func parseScreenshotObservation(observation string) (visualScreenshotObservation, bool) {
+	var result postActionScreenshotResult
+	if err := json.Unmarshal([]byte(observation), &result); err != nil {
+		return visualScreenshotObservation{}, false
+	}
+	if result.Width <= 0 || result.Height <= 0 || strings.TrimSpace(result.Data) == "" {
+		return visualScreenshotObservation{}, false
 	}
 	imageBytes, err := base64.StdEncoding.DecodeString(result.Data)
 	if err != nil || len(imageBytes) == 0 {
-		return false
+		return visualScreenshotObservation{}, false
 	}
-	return true
+	format, ok := normalizeScreenshotFormat(result.Format)
+	if !ok {
+		return visualScreenshotObservation{}, false
+	}
+	result.Format = format
+	if result.Size <= 0 {
+		result.Size = len(imageBytes)
+	}
+	return visualScreenshotObservation{
+		Result:     result,
+		ImageBytes: imageBytes,
+		MIMEType:   screenshotMIMEType(format),
+	}, true
+}
+
+func normalizeScreenshotFormat(format string) (string, bool) {
+	format = strings.ToLower(strings.TrimSpace(format))
+	format = strings.TrimPrefix(format, "image/")
+	switch format {
+	case "":
+		return "jpeg", true
+	case "jpg", "jpeg":
+		return "jpeg", true
+	case "png", "webp", "gif":
+		return format, true
+	default:
+		return "", false
+	}
+}
+
+func screenshotMIMEType(format string) string {
+	format, ok := normalizeScreenshotFormat(format)
+	if !ok {
+		format = "jpeg"
+	}
+	return "image/" + format
 }
 
 func compactToolObservation(observation string) string {

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -731,3 +731,26 @@ func TestFunctionAgentRejectsEmptyVisualObservationData(t *testing.T) {
 		t.Fatalf("unexpected compacted observation: %q", toolContent)
 	}
 }
+
+func TestFunctionAgentRejectsVisualObservationWithoutDimensions(t *testing.T) {
+	agent := &FunctionAgent{
+		Tools: []langtools.Tool{&stubTool{name: "screenshot", visual: true}},
+	}
+	observation := `{"width":0,"height":240,"format":"jpeg","size":4,"data":"` +
+		base64.StdEncoding.EncodeToString([]byte("image-bytes")) + `"}`
+	step := schema.AgentStep{
+		Action:      schema.AgentAction{Tool: "screenshot"},
+		Observation: observation,
+	}
+
+	if agent.countVisualObservations([]schema.AgentStep{step}) != 0 {
+		t.Fatal("screenshot with invalid dimensions counted as a visual observation")
+	}
+	toolContent, followups := agent.observationMessagesForStep(step, true)
+	if followups != nil {
+		t.Fatalf("expected no followup messages for invalid screenshot dimensions, got %#v", followups)
+	}
+	if toolContent != observation {
+		t.Fatalf("unexpected compacted observation: %q", toolContent)
+	}
+}

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -410,45 +410,45 @@ func TestFunctionAgentScratchpadPrunesScreenshotsInBatches(t *testing.T) {
 		Tools: []langtools.Tool{&stubTool{name: "screenshot", visual: true}},
 	}
 
-	messages29 := agent.constructFunctionScratchPad(screenshotSteps(29))
-	imageURLs29 := scratchpadImageURLs(messages29)
-	if got := scratchpadToolResponseCount(messages29); got != 29 {
-		t.Fatalf("expected all 29 tool responses to remain, got %d", got)
+	messages9 := agent.constructFunctionScratchPad(screenshotSteps(9))
+	imageURLs9 := scratchpadImageURLs(messages9)
+	if got := scratchpadToolResponseCount(messages9); got != 9 {
+		t.Fatalf("expected all 9 tool responses to remain, got %d", got)
 	}
-	if got := scratchpadImagePlaceholderCount(messages29); got != 25 {
-		t.Fatalf("expected first prune batch to replace 25 images, got %d", got)
+	if got := scratchpadImagePlaceholderCount(messages9); got != 5 {
+		t.Fatalf("expected first prune batch to replace 5 images, got %d", got)
 	}
-	if len(imageURLs29) != 4 {
-		t.Fatalf("expected 4 full images after first prune batch, got %d (%#v)", len(imageURLs29), imageURLs29)
+	if len(imageURLs9) != 4 {
+		t.Fatalf("expected 4 full images after first prune batch, got %d (%#v)", len(imageURLs9), imageURLs9)
 	}
-	for i, url := range imageURLs29 {
-		expected := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString([]byte("image-"+strconv.Itoa(i+26)))
+	for i, url := range imageURLs9 {
+		expected := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString([]byte("image-"+strconv.Itoa(i+6)))
 		if url != expected {
 			t.Fatalf("image %d = %q, want %q", i, url, expected)
 		}
 	}
 
-	messages30 := agent.constructFunctionScratchPad(screenshotSteps(30))
-	if !reflect.DeepEqual(messages29, messages30[:len(messages29)]) {
+	messages10 := agent.constructFunctionScratchPad(screenshotSteps(10))
+	if !reflect.DeepEqual(messages9, messages10[:len(messages9)]) {
 		t.Fatalf("message prefix changed between batch pruning events")
 	}
-	if got := scratchpadImagePlaceholderCount(messages30); got != 25 {
+	if got := scratchpadImagePlaceholderCount(messages10); got != 5 {
 		t.Fatalf("expected placeholder count to remain stable between prune batches, got %d", got)
 	}
-	if len(scratchpadImageURLs(messages30)) != 5 {
+	if len(scratchpadImageURLs(messages10)) != 5 {
 		t.Fatalf("expected one appended full image between prune batches")
 	}
 
-	messages54 := agent.constructFunctionScratchPad(screenshotSteps(54))
-	imageURLs54 := scratchpadImageURLs(messages54)
-	if got := scratchpadImagePlaceholderCount(messages54); got != 50 {
-		t.Fatalf("expected second prune batch to replace 50 total images, got %d", got)
+	messages14 := agent.constructFunctionScratchPad(screenshotSteps(14))
+	imageURLs14 := scratchpadImageURLs(messages14)
+	if got := scratchpadImagePlaceholderCount(messages14); got != 10 {
+		t.Fatalf("expected second prune batch to replace 10 total images, got %d", got)
 	}
-	if len(imageURLs54) != 4 {
-		t.Fatalf("expected 4 full images after second prune batch, got %d (%#v)", len(imageURLs54), imageURLs54)
+	if len(imageURLs14) != 4 {
+		t.Fatalf("expected 4 full images after second prune batch, got %d (%#v)", len(imageURLs14), imageURLs14)
 	}
-	for i, url := range imageURLs54 {
-		expected := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString([]byte("image-"+strconv.Itoa(i+51)))
+	for i, url := range imageURLs14 {
+		expected := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString([]byte("image-"+strconv.Itoa(i+11)))
 		if url != expected {
 			t.Fatalf("second batch image %d = %q, want %q", i, url, expected)
 		}

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -410,45 +410,45 @@ func TestFunctionAgentScratchpadPrunesScreenshotsInBatches(t *testing.T) {
 		Tools: []langtools.Tool{&stubTool{name: "screenshot", visual: true}},
 	}
 
-	messages9 := agent.constructFunctionScratchPad(screenshotSteps(9))
-	imageURLs9 := scratchpadImageURLs(messages9)
-	if got := scratchpadToolResponseCount(messages9); got != 9 {
-		t.Fatalf("expected all 9 tool responses to remain, got %d", got)
+	messages6 := agent.constructFunctionScratchPad(screenshotSteps(6))
+	imageURLs6 := scratchpadImageURLs(messages6)
+	if got := scratchpadToolResponseCount(messages6); got != 6 {
+		t.Fatalf("expected all 6 tool responses to remain, got %d", got)
 	}
-	if got := scratchpadImagePlaceholderCount(messages9); got != 5 {
-		t.Fatalf("expected first prune batch to replace 5 images, got %d", got)
+	if got := scratchpadImagePlaceholderCount(messages6); got != 2 {
+		t.Fatalf("expected first prune batch to replace 2 images, got %d", got)
 	}
-	if len(imageURLs9) != 4 {
-		t.Fatalf("expected 4 full images after first prune batch, got %d (%#v)", len(imageURLs9), imageURLs9)
+	if len(imageURLs6) != 4 {
+		t.Fatalf("expected 4 full images after first prune batch, got %d (%#v)", len(imageURLs6), imageURLs6)
 	}
-	for i, url := range imageURLs9 {
-		expected := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString([]byte("image-"+strconv.Itoa(i+6)))
+	for i, url := range imageURLs6 {
+		expected := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString([]byte("image-"+strconv.Itoa(i+3)))
 		if url != expected {
 			t.Fatalf("image %d = %q, want %q", i, url, expected)
 		}
 	}
 
-	messages10 := agent.constructFunctionScratchPad(screenshotSteps(10))
-	if !reflect.DeepEqual(messages9, messages10[:len(messages9)]) {
+	messages7 := agent.constructFunctionScratchPad(screenshotSteps(7))
+	if !reflect.DeepEqual(messages6, messages7[:len(messages6)]) {
 		t.Fatalf("message prefix changed between batch pruning events")
 	}
-	if got := scratchpadImagePlaceholderCount(messages10); got != 5 {
+	if got := scratchpadImagePlaceholderCount(messages7); got != 2 {
 		t.Fatalf("expected placeholder count to remain stable between prune batches, got %d", got)
 	}
-	if len(scratchpadImageURLs(messages10)) != 5 {
+	if len(scratchpadImageURLs(messages7)) != 5 {
 		t.Fatalf("expected one appended full image between prune batches")
 	}
 
-	messages14 := agent.constructFunctionScratchPad(screenshotSteps(14))
-	imageURLs14 := scratchpadImageURLs(messages14)
-	if got := scratchpadImagePlaceholderCount(messages14); got != 10 {
-		t.Fatalf("expected second prune batch to replace 10 total images, got %d", got)
+	messages8 := agent.constructFunctionScratchPad(screenshotSteps(8))
+	imageURLs8 := scratchpadImageURLs(messages8)
+	if got := scratchpadImagePlaceholderCount(messages8); got != 4 {
+		t.Fatalf("expected second prune batch to replace 4 total images, got %d", got)
 	}
-	if len(imageURLs14) != 4 {
-		t.Fatalf("expected 4 full images after second prune batch, got %d (%#v)", len(imageURLs14), imageURLs14)
+	if len(imageURLs8) != 4 {
+		t.Fatalf("expected 4 full images after second prune batch, got %d (%#v)", len(imageURLs8), imageURLs8)
 	}
-	for i, url := range imageURLs14 {
-		expected := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString([]byte("image-"+strconv.Itoa(i+11)))
+	for i, url := range imageURLs8 {
+		expected := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString([]byte("image-"+strconv.Itoa(i+5)))
 		if url != expected {
 			t.Fatalf("second batch image %d = %q, want %q", i, url, expected)
 		}

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -901,7 +901,7 @@ func (e *roleCollaborativeExecutor) roleMessages(profile RoleProfile, inputs map
 		messages = append(messages, scratchpad...)
 	}
 
-	omitWorldStateLatestScreenshot := profile.Name == RoleExecutor && currentExecutorScratchpadHasLatestScreenshot(state)
+	omitWorldStateLatestScreenshot := profile.Name == RoleExecutor && executorLatestToolResultHasScreenshotObservation(state)
 	statePrompt := buildRoleStatePrompt(profile.Name, inputs, state, task)
 	messages = append(messages, llms.MessageContent{
 		Role:  llms.ChatMessageTypeHuman,
@@ -1030,7 +1030,7 @@ func buildExecutorStatePrompt(inputs map[string]string, state roleLoopState, tas
 	var builder strings.Builder
 	builder.WriteString(task)
 	writeWorldStateWithOptions(&builder, state.World, worldStatePromptOptions{
-		OmitLatestScreenshot: currentExecutorScratchpadHasLatestScreenshot(state),
+		OmitLatestScreenshot: executorLatestToolResultHasScreenshotObservation(state),
 	})
 	writeRequestContextAndCriteria(&builder, inputs, state)
 	writeSessionContext(&builder, inputs)
@@ -1327,28 +1327,18 @@ func writeWorldStateWithOptions(builder *strings.Builder, world worldState, opti
 	}
 }
 
-func currentExecutorScratchpadHasLatestScreenshot(state roleLoopState) bool {
-	latest := state.World.LatestScreenshot
-	if latest == nil || len(latest.Data) == 0 || len(state.StepToolSteps) == 0 {
+func executorLatestToolResultHasScreenshotObservation(state roleLoopState) bool {
+	if len(state.StepToolSteps) == 0 {
 		return false
 	}
-	for _, step := range state.StepToolSteps {
-		screenshot, ok := screenshotFromStep(step, latest.StepNumber)
-		if !ok {
-			continue
-		}
-		if worldScreenshotImageMatches(screenshot, *latest) {
-			return true
-		}
-	}
-	return false
+
+	latestStep := state.StepToolSteps[len(state.StepToolSteps)-1]
+	return stepHasScreenshotObservation(latestStep)
 }
 
-func worldScreenshotImageMatches(a, b worldScreenshot) bool {
-	return a.Width == b.Width &&
-		a.Height == b.Height &&
-		strings.EqualFold(a.Format, b.Format) &&
-		bytes.Equal(a.Data, b.Data)
+func stepHasScreenshotObservation(step schema.AgentStep) bool {
+	_, ok := screenshotFromStep(step, 0)
+	return ok
 }
 
 func appendWorldStateLine(builder *strings.Builder, prefix, value string) {

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -901,10 +901,11 @@ func (e *roleCollaborativeExecutor) roleMessages(profile RoleProfile, inputs map
 		messages = append(messages, scratchpad...)
 	}
 
+	omitWorldStateLatestScreenshot := profile.Name == RoleExecutor && currentExecutorScratchpadHasLatestScreenshot(state)
 	statePrompt := buildRoleStatePrompt(profile.Name, inputs, state, task)
 	messages = append(messages, llms.MessageContent{
 		Role:  llms.ChatMessageTypeHuman,
-		Parts: buildRoleUserMessageParts(statePrompt, e.InputAttachments, state.World),
+		Parts: buildRoleUserMessageParts(statePrompt, e.InputAttachments, state.World, omitWorldStateLatestScreenshot),
 	})
 	for _, steer := range state.SteerMessages {
 		messages = append(messages, llms.MessageContent{
@@ -1028,7 +1029,9 @@ func buildPlannerStatePrompt(inputs map[string]string, state roleLoopState, task
 func buildExecutorStatePrompt(inputs map[string]string, state roleLoopState, task string) string {
 	var builder strings.Builder
 	builder.WriteString(task)
-	writeWorldState(&builder, state.World)
+	writeWorldStateWithOptions(&builder, state.World, worldStatePromptOptions{
+		OmitLatestScreenshot: currentExecutorScratchpadHasLatestScreenshot(state),
+	})
 	writeRequestContextAndCriteria(&builder, inputs, state)
 	writeSessionContext(&builder, inputs)
 	if history := strings.TrimSpace(inputs["history"]); history != "" {
@@ -1207,15 +1210,23 @@ func compactPromptLine(value string, max int) string {
 	return truncateForLog(singleLineHistoryText(value), max)
 }
 
-func buildRoleUserMessageParts(input string, attachments []InputAttachment, world worldState) []llms.ContentPart {
+func buildRoleUserMessageParts(input string, attachments []InputAttachment, world worldState, omitWorldStateLatestScreenshot bool) []llms.ContentPart {
 	parts := buildUserMessageParts(input, attachments)
-	if world.LatestScreenshot == nil || len(world.LatestScreenshot.Data) == 0 {
+	if omitWorldStateLatestScreenshot || world.LatestScreenshot == nil || len(world.LatestScreenshot.Data) == 0 {
 		return parts
 	}
 	return append(parts, buildImagePart(world.LatestScreenshot.MIMEType(), world.LatestScreenshot.Data))
 }
 
+type worldStatePromptOptions struct {
+	OmitLatestScreenshot bool
+}
+
 func writeWorldState(builder *strings.Builder, world worldState) {
+	writeWorldStateWithOptions(builder, world, worldStatePromptOptions{})
+}
+
+func writeWorldStateWithOptions(builder *strings.Builder, world worldState, options worldStatePromptOptions) {
 	builder.WriteString("\n\nWorld State (shared across planner, executor, and verifier):\n")
 	if world.DeviceEnvironment != nil {
 		env := world.DeviceEnvironment
@@ -1252,28 +1263,30 @@ func writeWorldState(builder *strings.Builder, world worldState) {
 			builder.WriteByte('\n')
 		}
 	}
-	if world.LatestScreenshot == nil {
-		builder.WriteString("- Latest screenshot: none yet.\n")
-	} else {
-		screenshot := world.LatestScreenshot
-		builder.WriteString(fmt.Sprintf(
-			"- Latest screenshot: step=%d source_tool=%s size=%dx%d format=%s bytes=%d. The current screenshot image is attached to this message.\n",
-			screenshot.StepNumber,
-			screenshot.SourceTool,
-			screenshot.Width,
-			screenshot.Height,
-			screenshot.Format,
-			screenshot.Size,
-		))
-		if input := strings.TrimSpace(screenshot.ToolInput); input != "" {
-			builder.WriteString("- Screenshot source input: ")
-			builder.WriteString(input)
-			builder.WriteByte('\n')
-		}
-		if actionOutput := strings.TrimSpace(screenshot.ActionOutput); actionOutput != "" {
-			builder.WriteString("- Post-action output before screenshot: ")
-			builder.WriteString(compactToolObservation(actionOutput))
-			builder.WriteByte('\n')
+	if !options.OmitLatestScreenshot {
+		if world.LatestScreenshot == nil {
+			builder.WriteString("- Latest screenshot: none yet.\n")
+		} else {
+			screenshot := world.LatestScreenshot
+			builder.WriteString(fmt.Sprintf(
+				"- Latest screenshot: step=%d source_tool=%s size=%dx%d format=%s bytes=%d. The current screenshot image is attached to this message.\n",
+				screenshot.StepNumber,
+				screenshot.SourceTool,
+				screenshot.Width,
+				screenshot.Height,
+				screenshot.Format,
+				screenshot.Size,
+			))
+			if input := strings.TrimSpace(screenshot.ToolInput); input != "" {
+				builder.WriteString("- Screenshot source input: ")
+				builder.WriteString(input)
+				builder.WriteByte('\n')
+			}
+			if actionOutput := strings.TrimSpace(screenshot.ActionOutput); actionOutput != "" {
+				builder.WriteString("- Post-action output before screenshot: ")
+				builder.WriteString(compactToolObservation(actionOutput))
+				builder.WriteByte('\n')
+			}
 		}
 	}
 	if world.Observation != nil {
@@ -1312,6 +1325,30 @@ func writeWorldState(builder *strings.Builder, world worldState) {
 			builder.WriteByte('\n')
 		}
 	}
+}
+
+func currentExecutorScratchpadHasLatestScreenshot(state roleLoopState) bool {
+	latest := state.World.LatestScreenshot
+	if latest == nil || len(latest.Data) == 0 || len(state.StepToolSteps) == 0 {
+		return false
+	}
+	for _, step := range state.StepToolSteps {
+		screenshot, ok := screenshotFromStep(step, latest.StepNumber)
+		if !ok {
+			continue
+		}
+		if worldScreenshotImageMatches(screenshot, *latest) {
+			return true
+		}
+	}
+	return false
+}
+
+func worldScreenshotImageMatches(a, b worldScreenshot) bool {
+	return a.Width == b.Width &&
+		a.Height == b.Height &&
+		strings.EqualFold(a.Format, b.Format) &&
+		bytes.Equal(a.Data, b.Data)
 }
 
 func appendWorldStateLine(builder *strings.Builder, prefix, value string) {

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -109,6 +109,9 @@ type roleLoopState struct {
 }
 
 type worldState struct {
+	// LatestScreenshot is verifier-only visual evidence. Planner and executor
+	// receive screenshots through tool scratchpads/results so their world-state
+	// prompt prefix stays stable for model cache reuse.
 	LatestScreenshot  *worldScreenshot
 	Observation       *worldStateObservation
 	DeviceEnvironment *worldDeviceEnvironment
@@ -294,7 +297,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 			case plannerTurnTool, plannerTurnInvalidMeta, plannerTurnSleep:
 				if turn.Step != nil {
 					state.ToolSteps = append(state.ToolSteps, *turn.Step)
-					state.World.UpdateFromStep(*turn.Step, len(state.ToolSteps))
+					state.World.UpdateFromStep(*turn.Step, len(state.ToolSteps), e.Tools)
 				}
 				if turn.Kind == plannerTurnTool {
 					if _, err := e.consumePendingSteer(ctx, inputs, &state); err != nil {
@@ -327,7 +330,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 				if turn.Step != nil {
 					state.ToolSteps = append(state.ToolSteps, *turn.Step)
 					state.StepToolSteps = append(state.StepToolSteps, *turn.Step)
-					state.World.UpdateFromStep(*turn.Step, len(state.ToolSteps))
+					state.World.UpdateFromStep(*turn.Step, len(state.ToolSteps), e.Tools)
 				}
 				if turn.Kind == executorTurnTool {
 					execution := roleExecutionResult{Action: turn.Action, Step: turn.Step}
@@ -901,11 +904,13 @@ func (e *roleCollaborativeExecutor) roleMessages(profile RoleProfile, inputs map
 		messages = append(messages, scratchpad...)
 	}
 
-	omitWorldStateLatestScreenshot := profile.Name == RoleExecutor && executorLatestToolResultHasScreenshotObservation(state)
-	statePrompt := buildRoleStatePrompt(profile.Name, inputs, state, task)
+	includeWorldStateLatestScreenshot := profile.Name == RoleVerifier
+	statePrompt := buildRoleStatePromptWithOptions(profile.Name, inputs, state, task, roleStatePromptOptions{
+		IncludeWorldStateLatestScreenshot: includeWorldStateLatestScreenshot,
+	})
 	messages = append(messages, llms.MessageContent{
 		Role:  llms.ChatMessageTypeHuman,
-		Parts: buildRoleUserMessageParts(statePrompt, e.InputAttachments, state.World, omitWorldStateLatestScreenshot),
+		Parts: buildRoleUserMessageParts(statePrompt, e.InputAttachments, state.World, includeWorldStateLatestScreenshot),
 	})
 	for _, steer := range state.SteerMessages {
 		messages = append(messages, llms.MessageContent{
@@ -995,13 +1000,23 @@ func roleSeesToolScratchpad(role RoleName) bool {
 }
 
 func buildRoleStatePrompt(role RoleName, inputs map[string]string, state roleLoopState, task string) string {
+	return buildRoleStatePromptWithOptions(role, inputs, state, task, roleStatePromptOptions{})
+}
+
+type roleStatePromptOptions struct {
+	IncludeWorldStateLatestScreenshot bool
+}
+
+func buildRoleStatePromptWithOptions(role RoleName, inputs map[string]string, state roleLoopState, task string, options roleStatePromptOptions) string {
 	switch role {
 	case RolePlanner:
 		return buildPlannerStatePrompt(inputs, state, task)
 	case RoleExecutor:
 		return buildExecutorStatePrompt(inputs, state, task)
 	case RoleVerifier:
-		return buildVerifierStatePrompt(inputs, state, task)
+		return buildVerifierStatePromptWithOptions(inputs, state, task, worldStatePromptOptions{
+			IncludeLatestScreenshot: options.IncludeWorldStateLatestScreenshot,
+		})
 	default:
 		return buildPlannerStatePrompt(inputs, state, task)
 	}
@@ -1029,9 +1044,7 @@ func buildPlannerStatePrompt(inputs map[string]string, state roleLoopState, task
 func buildExecutorStatePrompt(inputs map[string]string, state roleLoopState, task string) string {
 	var builder strings.Builder
 	builder.WriteString(task)
-	writeWorldStateWithOptions(&builder, state.World, worldStatePromptOptions{
-		OmitLatestScreenshot: executorLatestToolResultHasScreenshotObservation(state),
-	})
+	writeWorldState(&builder, state.World)
 	writeRequestContextAndCriteria(&builder, inputs, state)
 	writeSessionContext(&builder, inputs)
 	if history := strings.TrimSpace(inputs["history"]); history != "" {
@@ -1065,9 +1078,13 @@ func buildExecutorStatePrompt(inputs map[string]string, state roleLoopState, tas
 }
 
 func buildVerifierStatePrompt(inputs map[string]string, state roleLoopState, task string) string {
+	return buildVerifierStatePromptWithOptions(inputs, state, task, worldStatePromptOptions{})
+}
+
+func buildVerifierStatePromptWithOptions(inputs map[string]string, state roleLoopState, task string, worldOptions worldStatePromptOptions) string {
 	var builder strings.Builder
 	builder.WriteString(task)
-	writeWorldState(&builder, state.World)
+	writeWorldStateWithOptions(&builder, state.World, worldOptions)
 	writeRequestContextAndCriteria(&builder, inputs, state)
 	writeSessionContext(&builder, inputs)
 	writeCurrentPlan(&builder, state)
@@ -1210,16 +1227,16 @@ func compactPromptLine(value string, max int) string {
 	return truncateForLog(singleLineHistoryText(value), max)
 }
 
-func buildRoleUserMessageParts(input string, attachments []InputAttachment, world worldState, omitWorldStateLatestScreenshot bool) []llms.ContentPart {
+func buildRoleUserMessageParts(input string, attachments []InputAttachment, world worldState, includeWorldStateLatestScreenshot bool) []llms.ContentPart {
 	parts := buildUserMessageParts(input, attachments)
-	if omitWorldStateLatestScreenshot || world.LatestScreenshot == nil || len(world.LatestScreenshot.Data) == 0 {
+	if !includeWorldStateLatestScreenshot || world.LatestScreenshot == nil || len(world.LatestScreenshot.Data) == 0 {
 		return parts
 	}
 	return append(parts, buildImagePart(world.LatestScreenshot.MIMEType(), world.LatestScreenshot.Data))
 }
 
 type worldStatePromptOptions struct {
-	OmitLatestScreenshot bool
+	IncludeLatestScreenshot bool
 }
 
 func writeWorldState(builder *strings.Builder, world worldState) {
@@ -1263,7 +1280,7 @@ func writeWorldStateWithOptions(builder *strings.Builder, world worldState, opti
 			builder.WriteByte('\n')
 		}
 	}
-	if !options.OmitLatestScreenshot {
+	if options.IncludeLatestScreenshot {
 		if world.LatestScreenshot == nil {
 			builder.WriteString("- Latest screenshot: none yet.\n")
 		} else {
@@ -1309,7 +1326,7 @@ func writeWorldStateWithOptions(builder *strings.Builder, world worldState, opti
 			if obs.SourceRole != "" {
 				builder.WriteString(fmt.Sprintf(" source_role=%s", obs.SourceRole))
 			}
-			if obs.ScreenshotStep > 0 {
+			if options.IncludeLatestScreenshot && obs.ScreenshotStep > 0 {
 				builder.WriteString(fmt.Sprintf(" screenshot_step=%d", obs.ScreenshotStep))
 			}
 			builder.WriteByte('\n')
@@ -1325,20 +1342,6 @@ func writeWorldStateWithOptions(builder *strings.Builder, world worldState, opti
 			builder.WriteByte('\n')
 		}
 	}
-}
-
-func executorLatestToolResultHasScreenshotObservation(state roleLoopState) bool {
-	if len(state.StepToolSteps) == 0 {
-		return false
-	}
-
-	latestStep := state.StepToolSteps[len(state.StepToolSteps)-1]
-	return stepHasScreenshotObservation(latestStep)
-}
-
-func stepHasScreenshotObservation(step schema.AgentStep) bool {
-	_, ok := screenshotFromStep(step, 0)
-	return ok
 }
 
 func appendWorldStateLine(builder *strings.Builder, prefix, value string) {
@@ -1596,8 +1599,8 @@ func (s roleLoopState) latestExecutionResult() (roleExecutionResult, bool) {
 	return s.ExecutionResults[len(s.ExecutionResults)-1], true
 }
 
-func (s *worldState) UpdateFromStep(step schema.AgentStep, stepNumber int) {
-	screenshot, ok := screenshotFromStep(step, stepNumber)
+func (s *worldState) UpdateFromStep(step schema.AgentStep, stepNumber int, tools []langtools.Tool) {
+	screenshot, ok := screenshotFromVisualStep(step, stepNumber, tools)
 	if !ok {
 		return
 	}
@@ -1676,44 +1679,38 @@ func normalizeObservedWorldState(observed observedWorldState) observedWorldState
 }
 
 func screenshotFromStep(step schema.AgentStep, stepNumber int) (worldScreenshot, bool) {
-	var result postActionScreenshotResult
-	if err := json.Unmarshal([]byte(step.Observation), &result); err != nil {
+	visual, ok := parseScreenshotObservation(step.Observation)
+	if !ok {
 		return worldScreenshot{}, false
 	}
-	if result.Width <= 0 || result.Height <= 0 || result.Data == "" {
+	return worldScreenshotFromVisualObservation(step, stepNumber, visual), true
+}
+
+func screenshotFromVisualStep(step schema.AgentStep, stepNumber int, tools []langtools.Tool) (worldScreenshot, bool) {
+	visual, ok := (&FunctionAgent{Tools: tools}).visualScreenshotObservation(step)
+	if !ok {
 		return worldScreenshot{}, false
 	}
-	imageBytes, err := base64.StdEncoding.DecodeString(result.Data)
-	if err != nil || len(imageBytes) == 0 {
-		return worldScreenshot{}, false
-	}
-	format := strings.TrimSpace(result.Format)
-	if format == "" {
-		format = "jpeg"
-	}
-	size := result.Size
-	if size <= 0 {
-		size = len(imageBytes)
-	}
+	return worldScreenshotFromVisualObservation(step, stepNumber, visual), true
+}
+
+func worldScreenshotFromVisualObservation(step schema.AgentStep, stepNumber int, visual visualScreenshotObservation) worldScreenshot {
+	result := visual.Result
 	return worldScreenshot{
 		SourceTool:   step.Action.Tool,
 		ToolInput:    normalizeToolInput(step.Action.ToolInput),
 		ActionOutput: strings.TrimSpace(result.ActionOutput),
 		Width:        result.Width,
 		Height:       result.Height,
-		Format:       format,
-		Size:         size,
-		Data:         imageBytes,
+		Format:       result.Format,
+		Size:         result.Size,
+		Data:         visual.ImageBytes,
 		StepNumber:   stepNumber,
-	}, true
+	}
 }
 
 func (s worldScreenshot) MIMEType() string {
-	format := strings.TrimSpace(s.Format)
-	if format == "" {
-		format = "jpeg"
-	}
-	return "image/" + format
+	return screenshotMIMEType(s.Format)
 }
 
 func (s roleLoopState) lastCandidateAnswer() string {

--- a/src/agent/internal/agent/role_profile_test.go
+++ b/src/agent/internal/agent/role_profile_test.go
@@ -785,6 +785,73 @@ func TestRoleCollaborativeExecutorSharesScreenshotWorldStateAcrossRoles(t *testi
 	}
 }
 
+func TestRoleCollaborativeExecutorOmitsWorldStateLatestScreenshotWhenExecutorScratchpadHasIt(t *testing.T) {
+	jpegBytes := []byte("executor-scratchpad-jpeg")
+	encodedImage := base64.StdEncoding.EncodeToString(jpegBytes)
+	imageURL := "data:image/jpeg;base64," + encodedImage
+	model := &scriptedModel{
+		responses: roleCommittedExecutionResponses(
+			[]string{"inspect screen"},
+			toolCallResponse("call_1", "screenshot", `{"__arg1":"{}"}`),
+			finishStepToolCall("inspected screen"),
+			verifierFinishResponse("done"),
+		),
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Use tools."},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"screenshot": &stubTool{
+				name:        "screenshot",
+				description: "Capture screen.",
+				visual:      true,
+				output:      `{"width":320,"height":240,"format":"jpeg","size":16,"data":"` + encodedImage + `"}`,
+			},
+		}},
+		NewSkillIndex(),
+	)
+
+	result, err := runtime.Run(context.Background(), RunRequest{Input: "inspect current screen"})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Output != "done" {
+		t.Fatalf("unexpected output: %q", result.Output)
+	}
+	if model.callCount != 5 {
+		t.Fatalf("model call count = %d, want 5", model.callCount)
+	}
+
+	executorFollowup := model.messages[3]
+	prompt := messageText(executorFollowup)
+	if !hasMessageRole(executorFollowup, llms.ChatMessageTypeTool) {
+		t.Fatalf("executor follow-up should receive current step scratchpad: %#v", executorFollowup)
+	}
+	if got := imageURLCount(executorFollowup, imageURL); got != 1 {
+		t.Fatalf("executor follow-up should include screenshot only from scratchpad, got %d copies", got)
+	}
+	for _, want := range []string{
+		"World State (shared across planner, executor, and verifier):",
+		"This image is the screenshot observation returned by the screenshot tool.",
+		"Original user request",
+		"inspect current screen",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("executor follow-up missing %q:\n%s", want, prompt)
+		}
+	}
+	for _, unexpected := range []string{
+		"Latest screenshot:",
+		"The current screenshot image is attached to this message.",
+		"Screenshot source input:",
+	} {
+		if strings.Contains(prompt, unexpected) {
+			t.Fatalf("executor follow-up should not include world-state screenshot text %q:\n%s", unexpected, prompt)
+		}
+	}
+}
+
 func TestWorldStateUpdatesFromPostActionScreenshot(t *testing.T) {
 	jpegBytes := []byte("post-action-jpeg")
 	state := worldState{}
@@ -949,6 +1016,19 @@ func hasImageURL(messages []llms.MessageContent, want string) bool {
 		}
 	}
 	return false
+}
+
+func imageURLCount(messages []llms.MessageContent, want string) int {
+	count := 0
+	for _, msg := range messages {
+		for _, part := range msg.Parts {
+			image, ok := part.(llms.ImageURLContent)
+			if ok && image.URL == want {
+				count++
+			}
+		}
+	}
+	return count
 }
 
 func finalHumanMessageHasTextBeforeImage(messages []llms.MessageContent, imageURL string) bool {

--- a/src/agent/internal/agent/role_profile_test.go
+++ b/src/agent/internal/agent/role_profile_test.go
@@ -785,7 +785,7 @@ func TestRoleCollaborativeExecutorSharesScreenshotWorldStateAcrossRoles(t *testi
 	}
 }
 
-func TestRoleCollaborativeExecutorOmitsWorldStateLatestScreenshotWhenExecutorScratchpadHasIt(t *testing.T) {
+func TestRoleCollaborativeExecutorOmitsWorldStateLatestScreenshotWhenLatestExecutorToolResultIsScreenshot(t *testing.T) {
 	jpegBytes := []byte("executor-scratchpad-jpeg")
 	encodedImage := base64.StdEncoding.EncodeToString(jpegBytes)
 	imageURL := "data:image/jpeg;base64," + encodedImage
@@ -849,6 +849,169 @@ func TestRoleCollaborativeExecutorOmitsWorldStateLatestScreenshotWhenExecutorScr
 		if strings.Contains(prompt, unexpected) {
 			t.Fatalf("executor follow-up should not include world-state screenshot text %q:\n%s", unexpected, prompt)
 		}
+	}
+}
+
+func TestExecutorLatestToolResultHasScreenshotObservation(t *testing.T) {
+	screenshotStep := func(tool string) schema.AgentStep {
+		return testScreenshotObservationStep(tool, []byte(tool+"-screenshot"))
+	}
+	plainStep := schema.AgentStep{
+		Action:      schema.AgentAction{Tool: "echo"},
+		Observation: "ok",
+	}
+
+	for _, tc := range []struct {
+		name  string
+		state roleLoopState
+		want  bool
+	}{
+		{
+			name:  "no current executor tool steps",
+			state: roleLoopState{},
+			want:  false,
+		},
+		{
+			name: "last result is screenshot observation",
+			state: roleLoopState{
+				StepToolSteps: []schema.AgentStep{screenshotStep("screenshot")},
+			},
+			want: true,
+		},
+		{
+			name: "last result is post action screenshot observation",
+			state: roleLoopState{
+				StepToolSteps: []schema.AgentStep{screenshotStep("keyboard_tap")},
+			},
+			want: true,
+		},
+		{
+			name: "earlier screenshot but last result is not screenshot",
+			state: roleLoopState{
+				StepToolSteps: []schema.AgentStep{screenshotStep("screenshot"), plainStep},
+			},
+			want: false,
+		},
+		{
+			name: "last result is not parseable as screenshot",
+			state: roleLoopState{
+				StepToolSteps: []schema.AgentStep{{
+					Action:      schema.AgentAction{Tool: "screenshot"},
+					Observation: `{"width":320,"height":240,"format":"jpeg","data":"not-base64"}`,
+				}},
+			},
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := executorLatestToolResultHasScreenshotObservation(tc.state); got != tc.want {
+				t.Fatalf("executorLatestToolResultHasScreenshotObservation() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRoleMessagesOmitWorldScreenshotWhenLatestExecutorToolResultIsScreenshotEvenIfWorldDiffers(t *testing.T) {
+	worldBytes := []byte("stale-world-screenshot")
+	stepBytes := []byte("latest-tool-screenshot")
+	state := roleLoopState{
+		World:         worldState{LatestScreenshot: testWorldScreenshot(worldBytes)},
+		StepToolSteps: []schema.AgentStep{testScreenshotObservationStep("keyboard_tap", stepBytes)},
+	}
+	executor := &roleCollaborativeExecutor{
+		Tools: []langtools.Tool{&stubTool{name: "keyboard_tap", visual: true}},
+	}
+
+	messages := executor.roleMessages(RoleProfile{Name: RoleExecutor, SystemPrompt: "executor"}, map[string]string{"input": "inspect"}, state, "Executor task.")
+	prompt := messageText(messages)
+	worldImageURL := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(worldBytes)
+	stepImageURL := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(stepBytes)
+
+	if strings.Contains(prompt, "Latest screenshot:") ||
+		strings.Contains(prompt, "The current screenshot image is attached to this message.") {
+		t.Fatalf("executor prompt should omit world latest screenshot when latest tool result is a screenshot:\n%s", prompt)
+	}
+	if hasImageURL(messages, worldImageURL) {
+		t.Fatalf("executor messages should not attach stale world screenshot: %#v", messages)
+	}
+	if !hasImageURL(messages, stepImageURL) {
+		t.Fatalf("executor messages should still include latest tool-result screenshot: %#v", messages)
+	}
+}
+
+func TestRoleMessagesKeepWorldScreenshotWhenLatestExecutorToolResultIsNotScreenshot(t *testing.T) {
+	screenshotBytes := []byte("executor-current-step-screenshot")
+	state := roleLoopState{
+		World: worldState{LatestScreenshot: testWorldScreenshot(screenshotBytes)},
+		StepToolSteps: []schema.AgentStep{
+			testScreenshotObservationStep("screenshot", screenshotBytes),
+			{
+				Action:      schema.AgentAction{Tool: "echo", ToolInput: `{"message":"ok"}`},
+				Observation: "ok",
+			},
+		},
+	}
+	executor := &roleCollaborativeExecutor{
+		Tools: []langtools.Tool{
+			&stubTool{name: "screenshot", visual: true},
+			&stubTool{name: "echo"},
+		},
+	}
+
+	messages := executor.roleMessages(RoleProfile{Name: RoleExecutor, SystemPrompt: "executor"}, map[string]string{"input": "inspect"}, state, "Executor task.")
+	prompt := messageText(messages)
+	imageURL := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(screenshotBytes)
+
+	for _, want := range []string{
+		"Latest screenshot:",
+		"The current screenshot image is attached to this message.",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("executor prompt should keep world latest screenshot text %q:\n%s", want, prompt)
+		}
+	}
+	if got := imageURLCount(messages, imageURL); got != 2 {
+		t.Fatalf("executor messages should include scratchpad and world screenshots, got %d copies", got)
+	}
+}
+
+func TestRoleMessagesKeepWorldScreenshotWithoutLatestExecutorScreenshotObservation(t *testing.T) {
+	worldBytes := []byte("world-screenshot")
+	imageURL := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(worldBytes)
+	for _, tc := range []struct {
+		name          string
+		stepToolSteps []schema.AgentStep
+	}{
+		{
+			name: "no current executor tool steps",
+		},
+		{
+			name: "latest observation is not parseable as screenshot",
+			stepToolSteps: []schema.AgentStep{{
+				Action:      schema.AgentAction{Tool: "keyboard_tap"},
+				Observation: `{"width":320,"height":240,"format":"jpeg","data":"not-base64"}`,
+			}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			state := roleLoopState{
+				World:         worldState{LatestScreenshot: testWorldScreenshot(worldBytes)},
+				StepToolSteps: tc.stepToolSteps,
+			}
+			executor := &roleCollaborativeExecutor{
+				Tools: []langtools.Tool{&stubTool{name: "keyboard_tap", visual: true}},
+			}
+
+			messages := executor.roleMessages(RoleProfile{Name: RoleExecutor, SystemPrompt: "executor"}, map[string]string{"input": "inspect"}, state, "Executor task.")
+			prompt := messageText(messages)
+
+			if !strings.Contains(prompt, "Latest screenshot:") {
+				t.Fatalf("executor prompt should keep world latest screenshot:\n%s", prompt)
+			}
+			if !hasImageURL(messages, imageURL) {
+				t.Fatalf("executor messages should attach world latest screenshot: %#v", messages)
+			}
+		})
 	}
 }
 
@@ -995,6 +1158,34 @@ func messageText(messages []llms.MessageContent) string {
 		}
 	}
 	return builder.String()
+}
+
+func testWorldScreenshot(data []byte) *worldScreenshot {
+	return &worldScreenshot{
+		SourceTool: "screenshot",
+		Width:      320,
+		Height:     240,
+		Format:     "jpeg",
+		Size:       len(data),
+		Data:       data,
+		StepNumber: 1,
+	}
+}
+
+func testScreenshotObservationStep(tool string, data []byte) schema.AgentStep {
+	observation, _ := json.Marshal(postActionScreenshotResult{
+		screenshotResult: screenshotResult{
+			Width:  320,
+			Height: 240,
+			Format: "jpeg",
+			Size:   len(data),
+			Data:   base64.StdEncoding.EncodeToString(data),
+		},
+	})
+	return schema.AgentStep{
+		Action:      schema.AgentAction{Tool: tool},
+		Observation: string(observation),
+	}
 }
 
 func hasMessageRole(messages []llms.MessageContent, role llms.ChatMessageType) bool {

--- a/src/agent/internal/agent/role_profile_test.go
+++ b/src/agent/internal/agent/role_profile_test.go
@@ -709,9 +709,10 @@ func TestRoleCollaborativeExecutorReplansAfterRepeatedVerifierFailures(t *testin
 	}
 }
 
-func TestRoleCollaborativeExecutorSharesScreenshotWorldStateAcrossRoles(t *testing.T) {
+func TestRoleCollaborativeExecutorSharesScreenshotWorldStateOnlyWithVerifier(t *testing.T) {
 	jpegBytes := []byte("world-state-jpeg")
 	encodedImage := base64.StdEncoding.EncodeToString(jpegBytes)
+	imageURL := "data:image/jpeg;base64," + encodedImage
 	model := &scriptedModel{
 		responses: roleCommittedExecutionResponses(
 			[]string{"inspect screen", "answer from current screen"},
@@ -748,7 +749,7 @@ func TestRoleCollaborativeExecutorSharesScreenshotWorldStateAcrossRoles(t *testi
 		t.Fatalf("model call count = %d, want 7", model.callCount)
 	}
 
-	for _, idx := range []int{4, 5, 6} {
+	for _, idx := range []int{4, 6} {
 		prompt := messageText(model.messages[idx])
 		for _, want := range []string{
 			"World State (shared across planner, executor, and verifier):",
@@ -756,15 +757,30 @@ func TestRoleCollaborativeExecutorSharesScreenshotWorldStateAcrossRoles(t *testi
 			"The current screenshot image is attached to this message.",
 		} {
 			if !strings.Contains(prompt, want) {
-				t.Fatalf("model call %d missing world state %q:\n%s", idx, want, prompt)
+				t.Fatalf("verifier model call %d missing world-state screenshot text %q:\n%s", idx, want, prompt)
 			}
 		}
-		if !hasImageURL(model.messages[idx], "data:image/jpeg;base64,"+encodedImage) {
-			t.Fatalf("model call %d missing world-state screenshot image: %#v", idx, model.messages[idx])
+		if got := imageURLCount(model.messages[idx], imageURL); got != 1 {
+			t.Fatalf("verifier model call %d should receive one world-state screenshot image, got %d", idx, got)
 		}
-		if !finalHumanMessageHasTextBeforeImage(model.messages[idx], "data:image/jpeg;base64,"+encodedImage) {
-			t.Fatalf("model call %d should place text before world-state screenshot image: %#v", idx, model.messages[idx])
+		if !finalHumanMessageHasTextBeforeImage(model.messages[idx], imageURL) {
+			t.Fatalf("verifier model call %d should place text before world-state screenshot image: %#v", idx, model.messages[idx])
 		}
+	}
+
+	executorPrompt := messageText(model.messages[5])
+	for _, unexpected := range []string{
+		"Latest screenshot:",
+		"The current screenshot image is attached to this message.",
+		"Screenshot source input:",
+		"Post-action output before screenshot:",
+	} {
+		if strings.Contains(executorPrompt, unexpected) {
+			t.Fatalf("executor should not receive world-state screenshot text %q:\n%s", unexpected, executorPrompt)
+		}
+	}
+	if got := imageURLCount(model.messages[5], imageURL); got != 0 {
+		t.Fatalf("executor should not receive world-state screenshot image, got %d copies", got)
 	}
 
 	secondExecutorPrompt := messageText(model.messages[5])
@@ -852,66 +868,7 @@ func TestRoleCollaborativeExecutorOmitsWorldStateLatestScreenshotWhenLatestExecu
 	}
 }
 
-func TestExecutorLatestToolResultHasScreenshotObservation(t *testing.T) {
-	screenshotStep := func(tool string) schema.AgentStep {
-		return testScreenshotObservationStep(tool, []byte(tool+"-screenshot"))
-	}
-	plainStep := schema.AgentStep{
-		Action:      schema.AgentAction{Tool: "echo"},
-		Observation: "ok",
-	}
-
-	for _, tc := range []struct {
-		name  string
-		state roleLoopState
-		want  bool
-	}{
-		{
-			name:  "no current executor tool steps",
-			state: roleLoopState{},
-			want:  false,
-		},
-		{
-			name: "last result is screenshot observation",
-			state: roleLoopState{
-				StepToolSteps: []schema.AgentStep{screenshotStep("screenshot")},
-			},
-			want: true,
-		},
-		{
-			name: "last result is post action screenshot observation",
-			state: roleLoopState{
-				StepToolSteps: []schema.AgentStep{screenshotStep("keyboard_tap")},
-			},
-			want: true,
-		},
-		{
-			name: "earlier screenshot but last result is not screenshot",
-			state: roleLoopState{
-				StepToolSteps: []schema.AgentStep{screenshotStep("screenshot"), plainStep},
-			},
-			want: false,
-		},
-		{
-			name: "last result is not parseable as screenshot",
-			state: roleLoopState{
-				StepToolSteps: []schema.AgentStep{{
-					Action:      schema.AgentAction{Tool: "screenshot"},
-					Observation: `{"width":320,"height":240,"format":"jpeg","data":"not-base64"}`,
-				}},
-			},
-			want: false,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := executorLatestToolResultHasScreenshotObservation(tc.state); got != tc.want {
-				t.Fatalf("executorLatestToolResultHasScreenshotObservation() = %t, want %t", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestRoleMessagesOmitWorldScreenshotWhenLatestExecutorToolResultIsScreenshotEvenIfWorldDiffers(t *testing.T) {
+func TestRoleMessagesAttachCurrentStepScreenshotOnlyFromScratchpad(t *testing.T) {
 	worldBytes := []byte("stale-world-screenshot")
 	stepBytes := []byte("latest-tool-screenshot")
 	state := roleLoopState{
@@ -932,86 +889,44 @@ func TestRoleMessagesOmitWorldScreenshotWhenLatestExecutorToolResultIsScreenshot
 		t.Fatalf("executor prompt should omit world latest screenshot when latest tool result is a screenshot:\n%s", prompt)
 	}
 	if hasImageURL(messages, worldImageURL) {
-		t.Fatalf("executor messages should not attach stale world screenshot: %#v", messages)
+		t.Fatalf("executor messages should not attach world-state screenshot: %#v", messages)
 	}
-	if !hasImageURL(messages, stepImageURL) {
-		t.Fatalf("executor messages should still include latest tool-result screenshot: %#v", messages)
+	if got := imageURLCount(messages, stepImageURL); got != 1 {
+		t.Fatalf("executor messages should include latest tool-result screenshot once, got %d", got)
 	}
 }
 
-func TestRoleMessagesKeepWorldScreenshotWhenLatestExecutorToolResultIsNotScreenshot(t *testing.T) {
-	screenshotBytes := []byte("executor-current-step-screenshot")
+func TestRoleMessagesAttachWorldScreenshotOnlyForVerifier(t *testing.T) {
+	worldBytes := []byte("verifier-world-screenshot")
 	state := roleLoopState{
-		World: worldState{LatestScreenshot: testWorldScreenshot(screenshotBytes)},
-		StepToolSteps: []schema.AgentStep{
-			testScreenshotObservationStep("screenshot", screenshotBytes),
-			{
-				Action:      schema.AgentAction{Tool: "echo", ToolInput: `{"message":"ok"}`},
-				Observation: "ok",
-			},
-		},
+		World: worldState{LatestScreenshot: testWorldScreenshot(worldBytes)},
 	}
-	executor := &roleCollaborativeExecutor{
-		Tools: []langtools.Tool{
-			&stubTool{name: "screenshot", visual: true},
-			&stubTool{name: "echo"},
-		},
-	}
+	executor := &roleCollaborativeExecutor{}
+	imageURL := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(worldBytes)
 
-	messages := executor.roleMessages(RoleProfile{Name: RoleExecutor, SystemPrompt: "executor"}, map[string]string{"input": "inspect"}, state, "Executor task.")
-	prompt := messageText(messages)
-	imageURL := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(screenshotBytes)
+	plannerMessages := executor.roleMessages(RoleProfile{Name: RolePlanner, SystemPrompt: "planner"}, map[string]string{"input": "inspect"}, state, "Planner task.")
+	executorMessages := executor.roleMessages(RoleProfile{Name: RoleExecutor, SystemPrompt: "executor"}, map[string]string{"input": "inspect"}, state, "Executor task.")
+	verifierMessages := executor.roleMessages(RoleProfile{Name: RoleVerifier, SystemPrompt: "verifier"}, map[string]string{"input": "inspect"}, state, "Verifier task.")
 
-	for _, want := range []string{
-		"Latest screenshot:",
-		"The current screenshot image is attached to this message.",
+	for role, messages := range map[string][]llms.MessageContent{
+		"planner":  plannerMessages,
+		"executor": executorMessages,
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("executor prompt should keep world latest screenshot text %q:\n%s", want, prompt)
+		prompt := messageText(messages)
+		if strings.Contains(prompt, "Latest screenshot:") {
+			t.Fatalf("%s should not receive world-state latest screenshot text:\n%s", role, prompt)
+		}
+		if hasImageURL(messages, imageURL) {
+			t.Fatalf("%s should not receive world-state latest screenshot image: %#v", role, messages)
 		}
 	}
-	if got := imageURLCount(messages, imageURL); got != 2 {
-		t.Fatalf("executor messages should include scratchpad and world screenshots, got %d copies", got)
+
+	verifierPrompt := messageText(verifierMessages)
+	if !strings.Contains(verifierPrompt, "Latest screenshot: step=1 source_tool=screenshot size=320x240 format=jpeg bytes=25") {
+		t.Fatalf("verifier should receive world-state latest screenshot text:\n%s", verifierPrompt)
 	}
-}
-
-func TestRoleMessagesKeepWorldScreenshotWithoutLatestExecutorScreenshotObservation(t *testing.T) {
-	worldBytes := []byte("world-screenshot")
-	imageURL := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(worldBytes)
-	for _, tc := range []struct {
-		name          string
-		stepToolSteps []schema.AgentStep
-	}{
-		{
-			name: "no current executor tool steps",
-		},
-		{
-			name: "latest observation is not parseable as screenshot",
-			stepToolSteps: []schema.AgentStep{{
-				Action:      schema.AgentAction{Tool: "keyboard_tap"},
-				Observation: `{"width":320,"height":240,"format":"jpeg","data":"not-base64"}`,
-			}},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			state := roleLoopState{
-				World:         worldState{LatestScreenshot: testWorldScreenshot(worldBytes)},
-				StepToolSteps: tc.stepToolSteps,
-			}
-			executor := &roleCollaborativeExecutor{
-				Tools: []langtools.Tool{&stubTool{name: "keyboard_tap", visual: true}},
-			}
-
-			messages := executor.roleMessages(RoleProfile{Name: RoleExecutor, SystemPrompt: "executor"}, map[string]string{"input": "inspect"}, state, "Executor task.")
-			prompt := messageText(messages)
-
-			if !strings.Contains(prompt, "Latest screenshot:") {
-				t.Fatalf("executor prompt should keep world latest screenshot:\n%s", prompt)
-			}
-			if !hasImageURL(messages, imageURL) {
-				t.Fatalf("executor messages should attach world latest screenshot: %#v", messages)
-			}
-		})
+	if !hasImageURL(verifierMessages, imageURL) {
+		t.Fatalf("verifier should receive world-state latest screenshot image: %#v", verifierMessages)
 	}
 }
 
@@ -1025,7 +940,7 @@ func TestWorldStateUpdatesFromPostActionScreenshot(t *testing.T) {
 		},
 		Observation: `{"action_output":"ok","width":640,"height":480,"format":"jpeg","size":16,"data":"` +
 			base64.StdEncoding.EncodeToString(jpegBytes) + `"}`,
-	}, 3)
+	}, 3, []langtools.Tool{&stubTool{name: "keyboard_tap", visual: true}})
 
 	if state.LatestScreenshot == nil {
 		t.Fatal("expected world state screenshot")
@@ -1038,7 +953,7 @@ func TestWorldStateUpdatesFromPostActionScreenshot(t *testing.T) {
 	}
 
 	var builder strings.Builder
-	writeWorldState(&builder, state)
+	writeWorldStateWithOptions(&builder, state, worldStatePromptOptions{IncludeLatestScreenshot: true})
 	text := builder.String()
 	for _, want := range []string{
 		"source_tool=keyboard_tap",
@@ -1046,8 +961,33 @@ func TestWorldStateUpdatesFromPostActionScreenshot(t *testing.T) {
 		"Post-action output before screenshot: ok",
 	} {
 		if !strings.Contains(text, want) {
-			t.Fatalf("world state text missing %q:\n%s", want, text)
+			t.Fatalf("verifier world state text missing %q:\n%s", want, text)
 		}
+	}
+}
+
+func TestDefaultWorldStateDoesNotRenderLatestScreenshot(t *testing.T) {
+	state := worldState{LatestScreenshot: testWorldScreenshot([]byte("default-hidden-screenshot"))}
+
+	var builder strings.Builder
+	writeWorldState(&builder, state)
+	text := builder.String()
+	if strings.Contains(text, "Latest screenshot:") ||
+		strings.Contains(text, "The current screenshot image is attached to this message.") {
+		t.Fatalf("world state should not render latest screenshot fields:\n%s", text)
+	}
+}
+
+func TestWorldStateIgnoresScreenshotShapedObservationFromNonVisualTool(t *testing.T) {
+	worldBytes := []byte("previous-world-screenshot")
+	state := worldState{LatestScreenshot: testWorldScreenshot(worldBytes)}
+	state.UpdateFromStep(testScreenshotObservationStep("metadata_dump", []byte("metadata-image-shaped-payload")), 3, []langtools.Tool{&stubTool{name: "metadata_dump"}})
+
+	if state.LatestScreenshot == nil {
+		t.Fatal("expected previous world screenshot to remain")
+	}
+	if string(state.LatestScreenshot.Data) != string(worldBytes) {
+		t.Fatalf("world screenshot was overwritten by non visual tool: %#v", state.LatestScreenshot)
 	}
 }
 
@@ -1132,7 +1072,7 @@ func TestRoleCollaborativeExecutorUpdatesWorldStateFromObservedState(t *testing.
 
 	secondPlannerPrompt := messageText(model.messages[5])
 	for _, want := range []string{
-		"Observed app/page: 微信 / 聊天列表 platform=android confidence=0.82 source_role=verifier screenshot_step=3",
+		"Observed app/page: 微信 / 聊天列表 platform=android confidence=0.82 source_role=verifier",
 		"Visible text: 微信 | 通讯录",
 		"Dialogs: 权限提示",
 	} {
@@ -1141,9 +1081,16 @@ func TestRoleCollaborativeExecutorUpdatesWorldStateFromObservedState(t *testing.
 		}
 	}
 
-	secondExecutorPrompt := messageText(model.messages[7])
+	secondExecutorPrompt := messageText(model.messages[6])
 	if !strings.Contains(secondExecutorPrompt, "Observed app/page: 微信 / 聊天列表 platform=android") {
 		t.Fatalf("executor should receive structured observed world state:\n%s", secondExecutorPrompt)
+	}
+	if strings.Contains(secondPlannerPrompt, "screenshot_step=") || strings.Contains(secondExecutorPrompt, "screenshot_step=") {
+		t.Fatalf("planner/executor should not receive screenshot_step from verifier-only screenshot state:\nplanner:\n%s\nexecutor:\n%s", secondPlannerPrompt, secondExecutorPrompt)
+	}
+	finalVerifierPrompt := messageText(model.messages[7])
+	if !strings.Contains(finalVerifierPrompt, "screenshot_step=3") {
+		t.Fatalf("verifier should receive screenshot_step with verifier-only screenshot state:\n%s", finalVerifierPrompt)
 	}
 }
 

--- a/src/agent_toml.h
+++ b/src/agent_toml.h
@@ -118,7 +118,7 @@ struct AgentToml {
     int max_iterations = -1;
     bool force_simple_loop = false;
     int screenshot_keep_n = 3;
-    int screenshot_prune_interval = 25;
+    int screenshot_prune_interval = 5;
     int screen_stable_timeout_ms = 3500;
     int screen_stable_ms = 500;
     double screen_stable_diff_threshold = 2.0;

--- a/src/agent_toml.h
+++ b/src/agent_toml.h
@@ -118,7 +118,7 @@ struct AgentToml {
     int max_iterations = -1;
     bool force_simple_loop = false;
     int screenshot_keep_n = 3;
-    int screenshot_prune_interval = 5;
+    int screenshot_prune_interval = 2;
     int screen_stable_timeout_ms = 3500;
     int screen_stable_ms = 500;
     double screen_stable_diff_threshold = 2.0;

--- a/tests/agent_stub_main.cpp
+++ b/tests/agent_stub_main.cpp
@@ -79,7 +79,7 @@ const char* kDefaultConfig =
     "\"voice_speech_summary_enabled\":true,"
     "\"voice_max_response_tokens\":300,\"max_iterations\":-1,\"force_simple_loop\":false,"
     "\"screenshot_keep_n\":3,"
-    "\"screenshot_prune_interval\":5,\"screen_stable_timeout_ms\":3500,"
+    "\"screenshot_prune_interval\":2,\"screen_stable_timeout_ms\":3500,"
     "\"screen_stable_ms\":500,\"screen_stable_diff_threshold\":2}"
     "}\n";
 

--- a/tests/agent_stub_main.cpp
+++ b/tests/agent_stub_main.cpp
@@ -79,7 +79,7 @@ const char* kDefaultConfig =
     "\"voice_speech_summary_enabled\":true,"
     "\"voice_max_response_tokens\":300,\"max_iterations\":-1,\"force_simple_loop\":false,"
     "\"screenshot_keep_n\":3,"
-    "\"screenshot_prune_interval\":25,\"screen_stable_timeout_ms\":3500,"
+    "\"screenshot_prune_interval\":5,\"screen_stable_timeout_ms\":3500,"
     "\"screen_stable_ms\":500,\"screen_stable_diff_threshold\":2}"
     "}\n";
 

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -197,7 +197,7 @@ std::string resolved_config_json(const std::string& search_provider, bool search
         "\"voice_speech_summary_enabled\":true,"
         "\"voice_max_response_tokens\":300,\"max_iterations\":-1,\"force_simple_loop\":false,"
         "\"screenshot_keep_n\":3,"
-        "\"screenshot_prune_interval\":25,\"screen_stable_timeout_ms\":3500,"
+        "\"screenshot_prune_interval\":5,\"screen_stable_timeout_ms\":3500,"
         "\"screen_stable_ms\":500,\"screen_stable_diff_threshold\":2}"
         "}\n";
 }

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -197,7 +197,7 @@ std::string resolved_config_json(const std::string& search_provider, bool search
         "\"voice_speech_summary_enabled\":true,"
         "\"voice_max_response_tokens\":300,\"max_iterations\":-1,\"force_simple_loop\":false,"
         "\"screenshot_keep_n\":3,"
-        "\"screenshot_prune_interval\":5,\"screen_stable_timeout_ms\":3500,"
+        "\"screenshot_prune_interval\":2,\"screen_stable_timeout_ms\":3500,"
         "\"screen_stable_ms\":500,\"screen_stable_diff_threshold\":2}"
         "}\n";
 }


### PR DESCRIPTION
## Summary
- Keep `WorldState.LatestScreenshot` as verifier-only visual evidence so planner and executor world-state prompts stay stable and do not receive duplicate screenshot attachments.
- Preserve executor access to current screenshot observations through the tool scratchpad while validating visual observations by tool capability, dimensions, format, and image payload.
- Lower the default screenshot prune interval from 25 to 2 across Go defaults, C++ TOML defaults, overlay config, docs, and tests.
- Update context lifecycle and configuration docs to match the new screenshot visibility and pruning behavior.

## Tests
- `git diff --check main...HEAD`
- `cd src/agent && go test -count=1 ./...`
- `cmake --build build-host`
- `ctest --test-dir build-host --output-on-failure`