### PR TITLE
fix(agent): clarify and scope memory save tool usage

### DIFF
--- a/src/agent/internal/agent/memory_tools.go
+++ b/src/agent/internal/agent/memory_tools.go
@@ -136,10 +136,15 @@ func (t *SaveMemoryTool) Name() string { return "save_memory" }
 func (t *SaveMemoryTool) Description() string {
 	return strings.Join([]string{
 		"Save a long-term memory for future recall.",
-		"Use when user explicitly asks to remember something, or when you observe a stable user preference, rule, or procedure worth persisting.",
+		"Mandatory use: when the user explicitly asks you to remember, save, record, keep in mind, or use something as a future default, call save_memory before saying it is remembered or saved.",
+		"Do not claim a memory was remembered or saved until this tool returns saved or ignored as a duplicate.",
+		"Also use when you observe a stable user preference, rule, or procedure worth persisting.",
 		`Input JSON: {"type":"preference","title":"short title","content":"what to remember","tags":["tag1"],"entities":["AppName"],"evidence":["exact user quote"],"priority":80}`,
 		"How to choose fields:",
 		"  - type: preference (user likes/dislikes), rule (must/must-not), procedure (how-to steps), fact (stable info), profile (user role/background).",
+		"  - Use type=profile for durable user profile facts such as name, nickname, location, home city, timezone, role, or background so they appear in the synthesized user profile.",
+		"  - Use type=preference or type=rule for future defaults such as the user's default city for weather queries.",
+		"  - Use type=fact only for stable facts that should be recalled but do not need to appear in the synthesized user profile.",
 		"  - tags: TOPIC/DOMAIN keywords for future search (e.g., 'verification', 'payment', 'expense'). NOT time words or vague terms.",
 		"  - entities: Specific named things mentioned (apps, accounts, services, people).",
 		"  - evidence: Original user quotes or context that led to this memory. Helps verify relevance later.",

--- a/src/agent/internal/agent/memory_tools_test.go
+++ b/src/agent/internal/agent/memory_tools_test.go
@@ -179,4 +179,20 @@ func TestRecallToolDescriptionsGuideAgentUsage(t *testing.T) {
 			t.Fatalf("recall_memory description missing %q:\n%s", want, memoryDescription)
 		}
 	}
+
+	saveDescription := NewSaveMemoryTool(NewLongTermMemoryStore(t.TempDir())).Description()
+	for _, want := range []string{
+		"Mandatory use",
+		"call save_memory before saying it is remembered or saved",
+		"Do not claim a memory was remembered or saved until this tool returns saved or ignored as a duplicate",
+		"type=profile",
+		"location, home city, timezone",
+		"future defaults",
+		"type=fact only",
+		"synthesized user profile",
+	} {
+		if !strings.Contains(saveDescription, want) {
+			t.Fatalf("save_memory description missing %q:\n%s", want, saveDescription)
+		}
+	}
 }

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -226,7 +226,8 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 		}
 	}
 
-	toolSpecs := NewToolSpecs(e.Tools)
+	plannerToolSpecs := toolSpecsForRole(RolePlanner, e.Tools)
+	executorToolSpecs := toolSpecsForRole(RoleExecutor, e.Tools)
 	initialPhase := phaseDecision
 	if e.ForceSimpleLoop {
 		initialPhase = phaseDefault
@@ -248,7 +249,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 		}
 		switch state.Phase {
 		case phaseDecision, phaseDefault, phasePlan:
-			turn, err := e.callPlannerTurn(ctx, inputs, &state, toolSpecs, options...)
+			turn, err := e.callPlannerTurn(ctx, inputs, &state, plannerToolSpecs, options...)
 			if err != nil {
 				return nil, err
 			}
@@ -370,7 +371,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					e.emitTodoUpdate(ctx, todo, todo.CurrentSpeech(), true)
 				}
 			}
-			turn, err := e.callExecutorTurn(ctx, inputs, &state, toolSpecs, options...)
+			turn, err := e.callExecutorTurn(ctx, inputs, &state, executorToolSpecs, options...)
 			if err != nil {
 				return nil, err
 			}
@@ -524,15 +525,15 @@ func (e *roleCollaborativeExecutor) callPlannerTurn(
 	task := plannerTaskForPhase(state.Phase, *state, e.ForceSimpleLoop)
 	messages := e.roleMessages(e.Profiles.Planner, inputs, *state, task)
 	state.PendingTodoReminder = ""
-	plannerTools := e.Tools
+	plannerTools := toolsForRole(RolePlanner, e.Tools)
 	if e.ForceSimpleLoop {
-		plannerTools = appendSimpleTodoMetaTools(e.Tools)
+		plannerTools = appendSimpleTodoMetaTools(plannerTools)
 	} else {
 		switch state.Phase {
 		case phasePlan:
-			plannerTools = appendPlannerReadOnlyTools(loopMetaTools(), e.Tools)
+			plannerTools = appendPlannerReadOnlyTools(loopMetaTools(), plannerTools)
 		default:
-			plannerTools = appendDefaultLoopMetaTools(e.Tools)
+			plannerTools = appendDefaultLoopMetaTools(plannerTools)
 		}
 	}
 	parser := &FunctionAgent{
@@ -664,7 +665,7 @@ func (e *roleCollaborativeExecutor) callRouteTurn(
 		return plannerTurnResult{Kind: plannerTurnSteer}, nil
 	}
 
-	parser := &FunctionAgent{Tools: appendLoopMetaTools(e.Tools), OutputKey: e.OutputKey, ToolCallSpeech: e.ToolCallSpeech}
+	parser := &FunctionAgent{Tools: appendLoopMetaTools(toolsForRole(RolePlanner, e.Tools)), OutputKey: e.OutputKey, ToolCallSpeech: e.ToolCallSpeech}
 	actions, _, parseErr := parser.ParseOutput(res)
 	if parseErr != nil && !errors.Is(parseErr, agents.ErrUnableToParseOutput) {
 		return plannerTurnResult{}, parseErr
@@ -949,7 +950,7 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 	options ...chains.ChainCallOption,
 ) (executorTurnResult, error) {
 	messages := e.roleMessages(e.Profiles.Executor, inputs, *state, "Executor task: work on the current next_step across multiple tool calls if needed, then call finish_step when the step is ready for verification or abort_step if blocked.")
-	executorTools := appendExecutorMetaTools(e.Tools)
+	executorTools := appendExecutorMetaTools(toolsForRole(RoleExecutor, e.Tools))
 	parser := &FunctionAgent{
 		Tools:          executorTools,
 		OutputKey:      e.OutputKey,
@@ -1096,10 +1097,10 @@ func (e *roleCollaborativeExecutor) roleMessages(profile RoleProfile, inputs map
 	}
 
 	if profile.Name == RoleExecutor && len(state.StepToolSteps) > 0 {
-		scratchpad := (&FunctionAgent{Tools: appendExecutorMetaTools(e.Tools), ScreenshotPruning: e.ScreenshotPruning, ToolCallSpeech: e.ToolCallSpeech}).constructFunctionScratchPad(state.StepToolSteps)
+		scratchpad := (&FunctionAgent{Tools: appendExecutorMetaTools(toolsForRole(RoleExecutor, e.Tools)), ScreenshotPruning: e.ScreenshotPruning, ToolCallSpeech: e.ToolCallSpeech}).constructFunctionScratchPad(state.StepToolSteps)
 		messages = append(messages, scratchpad...)
 	} else if roleSeesToolScratchpad(profile.Name) && len(state.ToolSteps) > 0 {
-		scratchpad := (&FunctionAgent{Tools: e.Tools, ScreenshotPruning: e.ScreenshotPruning, ToolCallSpeech: e.ToolCallSpeech}).constructFunctionScratchPad(state.ToolSteps)
+		scratchpad := (&FunctionAgent{Tools: toolsForRole(profile.Name, e.Tools), ScreenshotPruning: e.ScreenshotPruning, ToolCallSpeech: e.ToolCallSpeech}).constructFunctionScratchPad(state.ToolSteps)
 		messages = append(messages, scratchpad...)
 	}
 

--- a/src/agent/internal/agent/role_profile.go
+++ b/src/agent/internal/agent/role_profile.go
@@ -53,7 +53,7 @@ func buildRoleProfiles(cfg AgentConfig, skills ResolvedSkills, availableTools []
 			RoleExecutor,
 			cfg,
 			skills,
-			executorToolsForConfig(availableTools),
+			appendExecutorMetaTools(toolsForRole(RoleExecutor, availableTools)),
 			"",
 			RoleCapabilities{CanExecuteStep: true, CanUseTools: true},
 			[]string{
@@ -128,21 +128,29 @@ func verifierRoleRules(cfg AgentConfig, openAppAvailable bool) []string {
 }
 
 func plannerToolsForConfig(cfg AgentConfig, tools []langtools.Tool) []langtools.Tool {
+	tools = toolsForRole(RolePlanner, tools)
 	if cfg.ForceSimpleLoop {
 		return appendSimpleTodoMetaTools(tools)
 	}
 	return appendDefaultLoopMetaTools(tools)
 }
 
-func executorToolsForConfig(tools []langtools.Tool) []langtools.Tool {
+func toolsForRole(role RoleName, tools []langtools.Tool) []langtools.Tool {
 	filtered := make([]langtools.Tool, 0, len(tools))
 	for _, tool := range tools {
-		if tool != nil && strings.EqualFold(tool.Name(), "save_memory") {
+		if tool == nil {
+			continue
+		}
+		if !NewToolSpec(tool).AgentExposedToRole(role) {
 			continue
 		}
 		filtered = append(filtered, tool)
 	}
-	return appendExecutorMetaTools(filtered)
+	return filtered
+}
+
+func toolSpecsForRole(role RoleName, tools []langtools.Tool) *ToolSpecs {
+	return NewToolSpecs(toolsForRole(role, tools))
 }
 
 func plannerRoleRules(cfg AgentConfig, openAppAvailable bool) []string {

--- a/src/agent/internal/agent/role_profile.go
+++ b/src/agent/internal/agent/role_profile.go
@@ -53,7 +53,7 @@ func buildRoleProfiles(cfg AgentConfig, skills ResolvedSkills, availableTools []
 			RoleExecutor,
 			cfg,
 			skills,
-			appendExecutorMetaTools(availableTools),
+			executorToolsForConfig(availableTools),
 			"",
 			RoleCapabilities{CanExecuteStep: true, CanUseTools: true},
 			[]string{
@@ -132,6 +132,17 @@ func plannerToolsForConfig(cfg AgentConfig, tools []langtools.Tool) []langtools.
 		return appendSimpleTodoMetaTools(tools)
 	}
 	return appendDefaultLoopMetaTools(tools)
+}
+
+func executorToolsForConfig(tools []langtools.Tool) []langtools.Tool {
+	filtered := make([]langtools.Tool, 0, len(tools))
+	for _, tool := range tools {
+		if tool != nil && strings.EqualFold(tool.Name(), "save_memory") {
+			continue
+		}
+		filtered = append(filtered, tool)
+	}
+	return appendExecutorMetaTools(filtered)
 }
 
 func plannerRoleRules(cfg AgentConfig, openAppAvailable bool) []string {

--- a/src/agent/internal/agent/role_profile_test.go
+++ b/src/agent/internal/agent/role_profile_test.go
@@ -17,7 +17,10 @@ func TestBuildRoleProfilesInjectsSkillsAndCapabilities(t *testing.T) {
 		Names:        []string{"ui"},
 		Instructions: []string{"[ui] inspect before acting"},
 	}
-	tools := []langtools.Tool{&stubTool{name: "screenshot", description: "Capture screen."}}
+	tools := []langtools.Tool{
+		&stubTool{name: "screenshot", description: "Capture screen."},
+		&stubTool{name: "save_memory", description: "Save memory."},
+	}
 
 	profiles := buildRoleProfiles(
 		AgentConfig{Instruction: "base", AdditionalPrompt: "extra"},
@@ -102,6 +105,12 @@ func TestBuildRoleProfilesInjectsSkillsAndCapabilities(t *testing.T) {
 	}
 	if !hasProfileTool(profiles.Planner, "screenshot") || !hasProfileTool(profiles.Planner, "enter_plan_mode") {
 		t.Fatalf("planner profile should retain callable tools and loop meta tools: %#v", profiles.Planner.Tools)
+	}
+	if !hasProfileTool(profiles.Planner, "save_memory") {
+		t.Fatalf("planner profile should retain save_memory: %#v", profiles.Planner.Tools)
+	}
+	if hasProfileTool(profiles.Executor, "save_memory") {
+		t.Fatalf("executor profile should not expose save_memory by default: %#v", profiles.Executor.Tools)
 	}
 	if !strings.Contains(profiles.Planner.SystemPrompt, "Route phase chooses direct_answer, simple, or plan") {
 		t.Fatalf("planner prompt should describe route-selected execution:\n%s", profiles.Planner.SystemPrompt)

--- a/src/agent/internal/agent/role_profile_test.go
+++ b/src/agent/internal/agent/role_profile_test.go
@@ -327,6 +327,58 @@ func TestRoleCollaborativeExecutorPassesToolsViaWithTools(t *testing.T) {
 	}
 }
 
+func TestExecutorRoleDoesNotExposePlannerOnlySaveMemoryTool(t *testing.T) {
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			toolCallResponse("save_1", "save_memory", `{"type":"profile","title":"Location","content":"The user is in Shanghai."}`),
+		},
+	}
+	executor := newRoleCollaborativeExecutor(
+		model,
+		RoleProfiles{
+			Executor: RoleProfile{Name: RoleExecutor, SystemPrompt: "executor"},
+		},
+		[]langtools.Tool{
+			&stubTool{name: "screenshot", description: "Capture screen."},
+			&stubTool{name: "save_memory", description: "Save memory.", output: `{"status":"saved"}`},
+		},
+		nil,
+		10,
+		nil,
+		nil,
+		nil,
+		ScreenshotPruningConfig{},
+		nil,
+	)
+	state := &roleLoopState{
+		Phase:               phaseExecution,
+		PlanCommitted:       true,
+		StepExecutionActive: true,
+		NextStep:            "remember the user's location",
+	}
+	inputs := map[string]string{"input": "remember that my location is Shanghai", "history": ""}
+
+	turn, err := executor.callExecutorTurn(context.Background(), inputs, state, toolSpecsForRole(RoleExecutor, executor.Tools))
+	if err != nil {
+		t.Fatalf("executor turn error: %v", err)
+	}
+	if len(model.tools) != 1 {
+		t.Fatalf("expected one executor model call, got %d", len(model.tools))
+	}
+	if !llmToolsContain(model.tools[0], "screenshot") || !llmToolsContain(model.tools[0], toolFinishStep) {
+		t.Fatalf("executor should receive ordinary executor tools and step meta tools: %#v", model.tools[0])
+	}
+	if llmToolsContain(model.tools[0], "save_memory") {
+		t.Fatalf("executor received planner-only save_memory tool: %#v", model.tools[0])
+	}
+	if turn.Kind != executorTurnTool || turn.Step == nil {
+		t.Fatalf("executor turn = %#v, want invalid tool step", turn)
+	}
+	if !strings.Contains(turn.Step.Observation, "save_memory is not a valid tool") {
+		t.Fatalf("executor should reject planner-only save_memory at execution time: %q", turn.Step.Observation)
+	}
+}
+
 func TestForceSimpleLoopOmitsPlanMetaTools(t *testing.T) {
 	tools := []langtools.Tool{&stubTool{name: "audio_volume", description: "Get or set audio playback volume."}}
 	profiles := buildRoleProfiles(

--- a/src/agent/internal/agent/tool_spec.go
+++ b/src/agent/internal/agent/tool_spec.go
@@ -24,6 +24,7 @@ type ToolSpec struct {
 	ExampleInput string
 	HTTPExposed  bool
 	AgentExposed bool
+	AgentRoles   []RoleName
 }
 
 type ToolSpecs struct {
@@ -58,6 +59,7 @@ type toolSpecMetadata struct {
 	ExampleInput string
 	HTTPExposed  *bool
 	AgentExposed *bool
+	AgentRoles   []RoleName
 }
 
 var builtInToolSpecMetadata = map[string]toolSpecMetadata{
@@ -130,6 +132,7 @@ var builtInToolSpecMetadata = map[string]toolSpecMetadata{
 		Category:     "memory",
 		InputMode:    toolInputModeJSON,
 		ExampleInput: `{"type":"procedure","title":"Login flow","content":"...","tags":["login"]}`,
+		AgentRoles:   []RoleName{RolePlanner},
 	},
 	"forget_memory": {
 		Category:     "memory",
@@ -293,7 +296,23 @@ func NewToolSpec(tool langtools.Tool) ToolSpec {
 		ExampleInput: meta.ExampleInput,
 		HTTPExposed:  httpExposed,
 		AgentExposed: agentExposed,
+		AgentRoles:   append([]RoleName{}, meta.AgentRoles...),
 	}
+}
+
+func (spec ToolSpec) AgentExposedToRole(role RoleName) bool {
+	if !spec.AgentExposed {
+		return false
+	}
+	if len(spec.AgentRoles) == 0 {
+		return true
+	}
+	for _, allowed := range spec.AgentRoles {
+		if strings.EqualFold(string(allowed), string(role)) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *ToolSpecs) Lookup(name string) (ToolSpec, bool) {


### PR DESCRIPTION
## Summary
- Strengthen save_memory tool guidance for explicit memory requests and profile-relevant facts.
- Keep planner role rules free of an extra hard-coded save_memory rule.
- Hide save_memory from executor tools by default so memory writes stay planner-scoped.
- Cover the tool guidance and role tool exposure with focused tests.

## Tests
- go test ./internal/agent -run "TestRecallToolDescriptionsGuideAgentUsage|TestBuildRoleProfilesInjectsSkillsAndCapabilities"