### PR TITLE
fix(agent): use assistant content for tool speech

### DIFF
--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -812,7 +812,7 @@ func (d *AudioDialog) HandleRunEvent(ctx context.Context, event RunEvent) {
 	if event.Type != runEventToolCall || !d.config.VoiceToolCallSpeechOrDefault() || event.ToolName == toolWaitForWakeup {
 		return
 	}
-	// Tool-call speech is only the explicit LLM-generated speech field; do not
+	// Tool-call speech is only the explicit LLM-generated event speech; do not
 	// synthesize speech from the description when it is missing.
 	go d.SpeakToolDescription(event.Speech)
 }

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -812,9 +812,9 @@ func (d *AudioDialog) HandleRunEvent(ctx context.Context, event RunEvent) {
 	if event.Type != runEventToolCall || !d.config.VoiceToolCallSpeechOrDefault() || event.ToolName == toolWaitForWakeup {
 		return
 	}
-	// Tool-call speech is only the explicit LLM-generated event speech; do not
+	// Tool-call speech is only explicit LLM-generated event content; do not
 	// synthesize speech from the description when it is missing.
-	go d.SpeakToolDescription(event.Speech)
+	go d.SpeakToolDescription(event.Content)
 }
 
 func (d *AudioDialog) newRunProgressSpeaker() *progressSpeaker {

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -290,7 +290,10 @@ func TestProcessUtteranceSpeaksFullOutputWhenSpeechMissing(t *testing.T) {
 func TestAudioDialogSpeaksToolDescriptionAsynchronously(t *testing.T) {
 	toolSpeech := true
 	model := &scriptedModel{
-		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我会检查当前音量。","speech":"检查音量。"}`, "当前音量是 42。"),
+		responses: []*llms.ContentResponse{
+			toolCallResponseWithContent("call_1", "audio_volume", `{"__arg1":"{}"}`, "检查音量。"),
+			contentResponse("当前音量是 42。"),
+		},
 	}
 	runtime := NewRuntimeWithDeps(
 		Config{

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -354,13 +354,13 @@ func TestAudioDialogDoesNotSpeakWaitForWakeupToolDescription(t *testing.T) {
 		Type:        runEventToolCall,
 		ToolName:    toolWaitForWakeup,
 		Description: "用户让我休息，我准备回到等待唤醒状态。",
-		Speech:      "我准备回到等待唤醒状态。",
+		Content:     "我准备回到等待唤醒状态。",
 	})
 
 	assertNoProviderTextWithin(t, provider, 200*time.Millisecond)
 }
 
-func TestAudioDialogSpeaksToolCallSpeechField(t *testing.T) {
+func TestAudioDialogSpeaksToolCallContent(t *testing.T) {
 	toolSpeech := true
 	provider := &recordingTTSProvider{name: "dialog-provider"}
 	dialog := &AudioDialog{
@@ -375,7 +375,7 @@ func TestAudioDialogSpeaksToolCallSpeechField(t *testing.T) {
 		Type:        runEventToolCall,
 		ToolName:    "audio_volume",
 		Description: "完整工具描述保留给事件和上下文，不应该直接播报。",
-		Speech:      "读取当前音量。",
+		Content:     "读取当前音量。",
 	})
 
 	waitForProviderTextCount(t, provider, 1)

--- a/src/agent/internal/agent/device_memory_review_fixes_test.go
+++ b/src/agent/internal/agent/device_memory_review_fixes_test.go
@@ -45,33 +45,26 @@ func TestEpisodeRecorderFinishAcceptsVerifierApproval(t *testing.T) {
 	}
 }
 
-func TestEpisodeRecorderPersistsToolSpeechOnlyWhenEnabled(t *testing.T) {
+func TestEpisodeRecorderDoesNotPersistToolSpeechAsEventField(t *testing.T) {
 	action := schema.AgentAction{
 		Tool:      "echo",
 		ToolInput: "hello",
 		Log:       formatToolActionLog("echo", `{"input":"hello","speech":"Saying hi."}`, "I will echo.", "Saying hi.", "\n"),
 	}
 
-	disabled := NewEpisodeRecorder(MemoryRetrieveRequest{Input: "test"}, MemoryContext{})
-	disabled.RecordExecution(roleExecutionResult{Action: &action})
-	disabledEpisode := disabled.Finish("", nil, nil, nil, nil)
-	if got := firstToolCallEventSpeech(disabledEpisode.Events); got != "" {
-		t.Fatalf("disabled recorder speech = %q, want empty", got)
-	}
-
 	enabled := NewEpisodeRecorder(MemoryRetrieveRequest{Input: "test"}, MemoryContext{})
 	enabled.ToolCallSpeech = true
 	enabled.RecordExecution(roleExecutionResult{Action: &action})
 	enabledEpisode := enabled.Finish("", nil, nil, nil, nil)
-	if got := firstToolCallEventSpeech(enabledEpisode.Events); got != "Saying hi." {
-		t.Fatalf("enabled recorder speech = %q", got)
+	if got := firstToolCallEventContent(enabledEpisode.Events); got != "Saying hi." {
+		t.Fatalf("tool event content = %q", got)
 	}
 }
 
-func firstToolCallEventSpeech(events []TaskEpisodeEvent) string {
+func firstToolCallEventContent(events []TaskEpisodeEvent) string {
 	for _, event := range events {
 		if event.Type == runEventToolCall {
-			return event.Speech
+			return event.Content
 		}
 	}
 	return ""

--- a/src/agent/internal/agent/episode_exporter.go
+++ b/src/agent/internal/agent/episode_exporter.go
@@ -470,7 +470,6 @@ func (e *EpisodeExporter) buildLangfuseBatch(ctx context.Context, episode TaskEp
 				"event_id":         event.EventID,
 				"tool_name":        event.ToolName,
 				"tool_description": event.ToolDescription,
-				"speech":           event.Speech,
 				"has_tool_result":  paired && pair.HasResult,
 				"role":             event.Role,
 				"phase":            currentPhase,
@@ -1374,9 +1373,6 @@ func toolCallInput(event TaskEpisodeEvent) map[string]interface{} {
 	}
 	if strings.TrimSpace(event.ToolDescription) != "" {
 		input["description"] = event.ToolDescription
-	}
-	if strings.TrimSpace(event.Speech) != "" {
-		input["speech"] = event.Speech
 	}
 	return input
 }

--- a/src/agent/internal/agent/episode_exporter_test.go
+++ b/src/agent/internal/agent/episode_exporter_test.go
@@ -122,7 +122,7 @@ func TestBuildLangfuseBatchMapsPlannerToolVerifier(t *testing.T) {
 				Type:      runEventToolCall,
 				ToolName:  "mouse_click",
 				ToolInput: `{"x":100,"y":200}`,
-				Speech:    "点击设置。",
+				Content:   "点击设置。",
 			},
 			{
 				EventID:       "evt3",
@@ -232,15 +232,15 @@ func TestBuildLangfuseBatchMapsPlannerToolVerifier(t *testing.T) {
 	if !ok {
 		t.Fatalf("tool span input missing: %#v", toolBody["input"])
 	}
-	if toolInput["speech"] != "点击设置。" {
-		t.Fatalf("tool span speech input = %#v", toolInput["speech"])
+	if _, ok := toolInput["speech"]; ok {
+		t.Fatalf("tool span should not include speech input: %#v", toolInput)
 	}
 	toolMetadata, ok := toolBody["metadata"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("tool span metadata missing: %#v", toolBody["metadata"])
 	}
-	if toolMetadata["speech"] != "点击设置。" {
-		t.Fatalf("tool span speech metadata = %#v", toolMetadata["speech"])
+	if _, ok := toolMetadata["speech"]; ok {
+		t.Fatalf("tool span should not include speech metadata: %#v", toolMetadata)
 	}
 	if names["verifier"] != 1 {
 		t.Fatalf("verifier span count = %d, want 1", names["verifier"])

--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -85,6 +85,7 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 
 	if len(choice.ToolCalls) > 0 {
 		actions := make([]schema.AgentAction, 0, len(choice.ToolCalls))
+		contentConsumed := false
 		for _, toolCall := range choice.ToolCalls {
 			if toolCall.FunctionCall == nil {
 				continue
@@ -92,14 +93,19 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 			functionName := toolCall.FunctionCall.Name
 			toolInputStr := toolCall.FunctionCall.Arguments
 			invocation := extractToolInvocation(toolInputStr, false)
-			if speech := a.toolSpeechFromChoiceContent(choice.Content); speech != "" {
+			toolCallContent := ""
+			if !contentConsumed {
+				toolCallContent = choice.Content
+				contentConsumed = true
+			}
+			if speech := a.toolSpeechFromChoiceContent(toolCallContent); speech != "" {
 				invocation.Speech = speech
 			}
-			invocation.Description = toolCallDescriptionText(choice.Content, invocation.Description)
+			invocation.Description = toolCallDescriptionText(toolCallContent, invocation.Description)
 
 			contentMsg := "\n"
-			if choice.Content != "" {
-				contentMsg = fmt.Sprintf("responded: %s\n", choice.Content)
+			if toolCallContent != "" {
+				contentMsg = fmt.Sprintf("responded: %s\n", toolCallContent)
 			}
 
 			actions = append(actions, schema.AgentAction{

--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -91,7 +91,10 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 			}
 			functionName := toolCall.FunctionCall.Name
 			toolInputStr := toolCall.FunctionCall.Arguments
-			invocation := extractToolInvocation(toolInputStr, a.ToolCallSpeech)
+			invocation := extractToolInvocation(toolInputStr, false)
+			if speech := a.toolSpeechFromChoiceContent(choice.Content); speech != "" {
+				invocation.Speech = speech
+			}
 			invocation.Description = toolCallDescriptionText(choice.Content, invocation.Description)
 
 			contentMsg := "\n"
@@ -112,7 +115,10 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 	if choice.FuncCall != nil {
 		functionName := choice.FuncCall.Name
 		toolInputStr := choice.FuncCall.Arguments
-		invocation := extractToolInvocation(toolInputStr, a.ToolCallSpeech)
+		invocation := extractToolInvocation(toolInputStr, false)
+		if speech := a.toolSpeechFromChoiceContent(choice.Content); speech != "" {
+			invocation.Speech = speech
+		}
 		invocation.Description = toolCallDescriptionText(choice.Content, invocation.Description)
 
 		contentMsg := "\n"
@@ -142,13 +148,20 @@ func (a *FunctionAgent) toolsAsLLM() []llms.Tool {
 		if tool == nil {
 			continue
 		}
-		result = append(result, NewToolSpec(tool).LLMToolWithSpeech(a.ToolCallSpeech))
+		result = append(result, NewToolSpec(tool).LLMTool())
 	}
 	return result
 }
 
-func genericToolParameters(includeSpeech bool) map[string]any {
-	return addToolSpeechParameter(map[string]any{
+func (a *FunctionAgent) toolSpeechFromChoiceContent(content string) string {
+	if a == nil || !a.ToolCallSpeech {
+		return ""
+	}
+	return strings.TrimSpace(content)
+}
+
+func genericToolParameters() map[string]any {
+	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"input": map[string]string{
@@ -158,38 +171,15 @@ func genericToolParameters(includeSpeech bool) map[string]any {
 			},
 		},
 		"required": []string{"input"},
-	}, includeSpeech)
+	}
 }
 
-func toolParametersSchema(schema map[string]any, includeSpeech bool) map[string]any {
+func toolParametersSchema(schema map[string]any) map[string]any {
 	parameters := make(map[string]any, len(schema))
 	for key, value := range schema {
 		parameters[key] = value
 	}
 	parameters["type"] = "object"
-	return addToolSpeechParameter(parameters, includeSpeech)
-}
-
-func addToolSpeechParameter(parameters map[string]any, includeSpeech bool) map[string]any {
-	if parameters == nil {
-		parameters = map[string]any{}
-	}
-	if !includeSpeech {
-		return parameters
-	}
-	properties, _ := parameters["properties"].(map[string]any)
-	copiedProperties := make(map[string]any, len(properties)+1)
-	for key, value := range properties {
-		copiedProperties[key] = value
-	}
-	if _, exists := copiedProperties[toolCallSpeechField]; !exists {
-		copiedProperties[toolCallSpeechField] = map[string]string{
-			"title":       "speech",
-			"type":        "string",
-			"description": "Optional short spoken status before this tool call. Write natural TTS text directly; use the user's language, avoid implementation details, and keep it under 20 Chinese characters or 8 English words.",
-		}
-	}
-	parameters["properties"] = copiedProperties
 	return parameters
 }
 
@@ -231,12 +221,8 @@ func (a *FunctionAgent) constructFunctionScratchPad(steps []schema.AgentStep) []
 				ID:   scratchpadToolCallID(steps[j].Action, i, j),
 				Type: "function",
 				FunctionCall: &llms.FunctionCall{
-					Name: steps[j].Action.Tool,
-					Arguments: encodeToolArgumentsWithSpeech(
-						steps[j].Action.ToolInput,
-						toolSpeechFromAction(steps[j].Action),
-						a.ToolCallSpeech,
-					),
+					Name:      steps[j].Action.Tool,
+					Arguments: encodeToolArguments(steps[j].Action.ToolInput),
 				},
 			})
 		}
@@ -533,10 +519,6 @@ func extractToolInput(raw string) string {
 }
 
 func encodeToolArguments(input string) string {
-	return encodeToolArgumentsWithSpeech(input, "", false)
-}
-
-func encodeToolArgumentsWithSpeech(input string, speech string, includeSpeech bool) string {
 	args := map[string]any{}
 	trimmed := strings.TrimSpace(input)
 	if strings.HasPrefix(trimmed, "{") {
@@ -549,11 +531,6 @@ func encodeToolArgumentsWithSpeech(input string, speech string, includeSpeech bo
 	}
 	if len(args) == 0 && trimmed != "" {
 		args["input"] = input
-	}
-	if includeSpeech {
-		if speech = strings.TrimSpace(speech); speech != "" {
-			args[toolCallSpeechField] = speech
-		}
 	}
 	encoded, err := json.Marshal(args)
 	if err != nil {

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -89,6 +89,70 @@ func TestFunctionAgentParseOutputUsesChoiceContentAsToolSpeech(t *testing.T) {
 	}
 }
 
+func TestFunctionAgentParseOutputBindsChoiceContentToFirstValidToolCall(t *testing.T) {
+	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
+
+	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
+		Choices: []*llms.ContentChoice{{
+			Content: "先检查。",
+			ToolCalls: []llms.ToolCall{
+				{ID: "ignored", Type: "function"},
+				{
+					ID:   "call_1",
+					Type: "function",
+					FunctionCall: &llms.FunctionCall{
+						Name:      "echo",
+						Arguments: `{"input":"first"}`,
+					},
+				},
+				{
+					ID:   "call_2",
+					Type: "function",
+					FunctionCall: &llms.FunctionCall{
+						Name:      "echo",
+						Arguments: `{"input":"second"}`,
+					},
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ParseOutput() error = %v", err)
+	}
+	if finish != nil {
+		t.Fatalf("expected no finish, got %#v", finish)
+	}
+	if len(actions) != 2 {
+		t.Fatalf("expected 2 actions, got %#v", actions)
+	}
+	if actions[0].ToolInput != "first" || actions[0].ToolID != "call_1" {
+		t.Fatalf("unexpected first action: %#v", actions[0])
+	}
+	if actions[1].ToolInput != "second" || actions[1].ToolID != "call_2" {
+		t.Fatalf("unexpected second action: %#v", actions[1])
+	}
+	if got := toolDescriptionFromAction(actions[0]); got != "先检查。" {
+		t.Fatalf("first tool description = %q", got)
+	}
+	if got := toolSpeechFromAction(actions[0]); got != "先检查。" {
+		t.Fatalf("first tool speech = %q", got)
+	}
+	if got := toolDescriptionFromAction(actions[1]); got != "" {
+		t.Fatalf("second tool description = %q, want empty", got)
+	}
+	if got := toolSpeechFromAction(actions[1]); got != "" {
+		t.Fatalf("second tool speech = %q, want empty", got)
+	}
+
+	var secondLog toolActionLog
+	if err := json.Unmarshal([]byte(actions[1].Log), &secondLog); err != nil {
+		t.Fatalf("second action log should be structured JSON: %v", err)
+	}
+	if strings.Contains(secondLog.Message, "先检查。") {
+		t.Fatalf("second action log repeated assistant content: %#v", secondLog)
+	}
+}
+
 func TestFunctionAgentParseOutputExtractsGenericInputWrapper(t *testing.T) {
 	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
 

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -45,18 +45,18 @@ func TestFunctionAgentParseOutputSkipsNilToolCalls(t *testing.T) {
 	}
 }
 
-func TestFunctionAgentParseOutputUsesLLMToolSpeechArgument(t *testing.T) {
+func TestFunctionAgentParseOutputUsesChoiceContentAsToolSpeech(t *testing.T) {
 	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
-			Content: "我会发送一段测试文本。",
+			Content: "发送测试文本。",
 			ToolCalls: []llms.ToolCall{{
 				ID:   "call_1",
 				Type: "function",
 				FunctionCall: &llms.FunctionCall{
 					Name:      "echo",
-					Arguments: `{"input":"hello","speech":"发送测试文本。"}`,
+					Arguments: `{"input":"hello"}`,
 				},
 			}},
 		}},
@@ -73,7 +73,7 @@ func TestFunctionAgentParseOutputUsesLLMToolSpeechArgument(t *testing.T) {
 	if actions[0].ToolInput != "hello" {
 		t.Fatalf("ToolInput = %q, want stripped tool input", actions[0].ToolInput)
 	}
-	if got := toolDescriptionFromAction(actions[0]); got != "我会发送一段测试文本。" {
+	if got := toolDescriptionFromAction(actions[0]); got != "发送测试文本。" {
 		t.Fatalf("tool description = %q", got)
 	}
 	if got := toolSpeechFromAction(actions[0]); got != "发送测试文本。" {
@@ -84,7 +84,7 @@ func TestFunctionAgentParseOutputUsesLLMToolSpeechArgument(t *testing.T) {
 	if err := json.Unmarshal([]byte(actions[0].Log), &log); err != nil {
 		t.Fatalf("action log should be structured JSON: %v", err)
 	}
-	if log.Version != toolActionLogVersion || log.ToolDescription != "我会发送一段测试文本。" || log.ToolSpeech != "发送测试文本。" {
+	if log.Version != toolActionLogVersion || log.ToolDescription != "发送测试文本。" || log.ToolSpeech != "发送测试文本。" {
 		t.Fatalf("unexpected action log metadata: %#v", log)
 	}
 }
@@ -94,12 +94,13 @@ func TestFunctionAgentParseOutputExtractsGenericInputWrapper(t *testing.T) {
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
+			Content: "Echoing text.",
 			ToolCalls: []llms.ToolCall{{
 				ID:   "call_1",
 				Type: "function",
 				FunctionCall: &llms.FunctionCall{
 					Name:      "echo",
-					Arguments: `{"input":"hello","speech":"Echoing text."}`,
+					Arguments: `{"input":"hello"}`,
 				},
 			}},
 		}},
@@ -116,8 +117,8 @@ func TestFunctionAgentParseOutputExtractsGenericInputWrapper(t *testing.T) {
 	if actions[0].ToolInput != "hello" {
 		t.Fatalf("ToolInput = %q, want generic input wrapper", actions[0].ToolInput)
 	}
-	if got := toolDescriptionFromAction(actions[0]); got != "" {
-		t.Fatalf("tool description = %q, want empty", got)
+	if got := toolDescriptionFromAction(actions[0]); got != "Echoing text." {
+		t.Fatalf("tool description = %q", got)
 	}
 	if got := toolSpeechFromAction(actions[0]); got != "Echoing text." {
 		t.Fatalf("tool speech = %q", got)
@@ -129,13 +130,13 @@ func TestFunctionAgentParseOutputPassesStructuredToolArguments(t *testing.T) {
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
-			Content: "我会按下回车键。",
+			Content: "按回车。",
 			ToolCalls: []llms.ToolCall{{
 				ID:   "call_1",
 				Type: "function",
 				FunctionCall: &llms.FunctionCall{
 					Name:      "keyboard_tap",
-					Arguments: `{"keys":["enter"],"speech":"按回车。"}`,
+					Arguments: `{"keys":["enter"]}`,
 				},
 			}},
 		}},
@@ -152,7 +153,7 @@ func TestFunctionAgentParseOutputPassesStructuredToolArguments(t *testing.T) {
 	if actions[0].ToolInput != `{"keys":["enter"]}` {
 		t.Fatalf("ToolInput = %q, want structured args without description", actions[0].ToolInput)
 	}
-	if got := toolDescriptionFromAction(actions[0]); got != "我会按下回车键。" {
+	if got := toolDescriptionFromAction(actions[0]); got != "按回车。" {
 		t.Fatalf("tool description = %q", got)
 	}
 	if got := toolSpeechFromAction(actions[0]); got != "按回车。" {
@@ -160,7 +161,7 @@ func TestFunctionAgentParseOutputPassesStructuredToolArguments(t *testing.T) {
 	}
 }
 
-func TestFunctionAgentParseOutputKeepsLegacyArg1Compatibility(t *testing.T) {
+func TestFunctionAgentParseOutputKeepsLegacyArg1CompatibilityWithoutSpeechFallback(t *testing.T) {
 	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
@@ -190,8 +191,44 @@ func TestFunctionAgentParseOutputKeepsLegacyArg1Compatibility(t *testing.T) {
 	if got := toolDescriptionFromAction(actions[0]); got != "我会按下回车键。" {
 		t.Fatalf("tool description = %q", got)
 	}
-	if got := toolSpeechFromAction(actions[0]); got != "按回车。" {
-		t.Fatalf("tool speech = %q", got)
+	if got := toolSpeechFromAction(actions[0]); got != "" {
+		t.Fatalf("tool speech = %q, want empty without assistant content", got)
+	}
+}
+
+func TestFunctionAgentParseOutputDoesNotConsumeSpeechArgumentAsMetadata(t *testing.T) {
+	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
+
+	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
+		Choices: []*llms.ContentChoice{{
+			ToolCalls: []llms.ToolCall{{
+				ID:   "call_1",
+				Type: "function",
+				FunctionCall: &llms.FunctionCall{
+					Name:      "keyboard_tap",
+					Arguments: `{"keys":["enter"],"speech":"按回车。"}`,
+				},
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ParseOutput() error = %v", err)
+	}
+	if finish != nil {
+		t.Fatalf("expected no finish, got %#v", finish)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %#v", actions)
+	}
+	var input map[string]any
+	if err := json.Unmarshal([]byte(actions[0].ToolInput), &input); err != nil {
+		t.Fatalf("ToolInput is not JSON: %q err=%v", actions[0].ToolInput, err)
+	}
+	if _, ok := input["keys"]; !ok || input["speech"] != "按回车。" {
+		t.Fatalf("ToolInput should preserve speech as an ordinary tool argument: %#v", input)
+	}
+	if got := toolSpeechFromAction(actions[0]); got != "" {
+		t.Fatalf("tool speech = %q, want empty without assistant content", got)
 	}
 }
 
@@ -260,6 +297,56 @@ func TestFunctionAgentParseOutputPreservesSpeechArgumentWhenDisabled(t *testing.
 	}
 }
 
+func TestFunctionAgentParseOutputPreservesRealSpeechArgumentWhenSchemaDefinesIt(t *testing.T) {
+	agent := &FunctionAgent{
+		OutputKey:      "output",
+		ToolCallSpeech: true,
+		Tools: []langtools.Tool{&structuredStubTool{
+			stubTool: stubTool{name: "say", description: "Speak text."},
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"speech": map[string]any{"type": "string"},
+					"volume": map[string]any{"type": "number"},
+				},
+			},
+		}},
+	}
+
+	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
+		Choices: []*llms.ContentChoice{{
+			Content: "准备播报。",
+			ToolCalls: []llms.ToolCall{{
+				ID:   "call_1",
+				Type: "function",
+				FunctionCall: &llms.FunctionCall{
+					Name:      "say",
+					Arguments: `{"speech":"hello","volume":1}`,
+				},
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ParseOutput() error = %v", err)
+	}
+	if finish != nil {
+		t.Fatalf("expected no finish, got %#v", finish)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %#v", actions)
+	}
+	var input map[string]any
+	if err := json.Unmarshal([]byte(actions[0].ToolInput), &input); err != nil {
+		t.Fatalf("ToolInput is not JSON: %q err=%v", actions[0].ToolInput, err)
+	}
+	if input["speech"] != "hello" || input["volume"] != float64(1) {
+		t.Fatalf("ToolInput lost real speech argument: %#v", input)
+	}
+	if got := toolSpeechFromAction(actions[0]); got != "准备播报。" {
+		t.Fatalf("tool speech metadata = %q", got)
+	}
+}
+
 func TestFunctionAgentToolDescriptionIgnoresLogTextCollisions(t *testing.T) {
 	log := formatToolActionLog(
 		"echo",
@@ -311,7 +398,7 @@ func TestFunctionAgentScratchpadDoesNotReplayToolSpeechAsArgument(t *testing.T) 
 	}
 }
 
-func TestFunctionAgentScratchpadReplaysToolSpeechWhenEnabled(t *testing.T) {
+func TestFunctionAgentScratchpadDoesNotReplayToolSpeechWhenEnabled(t *testing.T) {
 	agent := &FunctionAgent{ToolCallSpeech: true}
 	messages := agent.constructFunctionScratchPad([]schema.AgentStep{{
 		Action: schema.AgentAction{
@@ -337,8 +424,8 @@ func TestFunctionAgentScratchpadReplaysToolSpeechWhenEnabled(t *testing.T) {
 	if args["input"] != "hello" {
 		t.Fatalf("scratchpad input = %q", args["input"])
 	}
-	if args["speech"] != "Echoing text." {
-		t.Fatalf("scratchpad speech = %q, want LLM tool-call speech", args["speech"])
+	if _, ok := args["speech"]; ok {
+		t.Fatalf("scratchpad should not replay speech argument when tool-call speech is enabled: %#v", args)
 	}
 	if _, ok := args["description"]; ok {
 		t.Fatalf("scratchpad should not replay description argument: %#v", args)
@@ -597,12 +684,8 @@ func TestFunctionAgentToolsAsLLMUsesGenericInputFallback(t *testing.T) {
 	if _, ok := props["__arg1"]; ok {
 		t.Fatalf("generic fallback schema should not expose __arg1: %#v", props)
 	}
-	speech, ok := props["speech"].(map[string]string)
-	if !ok {
-		t.Fatalf("generic fallback schema missing speech property: %#v", props)
-	}
-	if !strings.Contains(speech["description"], "spoken") {
-		t.Fatalf("speech description does not explain spoken text: %q", speech["description"])
+	if _, ok := props["speech"]; ok {
+		t.Fatalf("generic fallback schema should not expose speech metadata: %#v", props)
 	}
 	input, ok := props["input"].(map[string]string)
 	if !ok {
@@ -688,8 +771,8 @@ func TestFunctionAgentToolsAsLLMUsesStructuredSchema(t *testing.T) {
 	if _, ok := props["description"]; ok {
 		t.Fatalf("structured schema should not expose description property: %#v", props)
 	}
-	if _, ok := props["speech"]; !ok {
-		t.Fatalf("structured schema missing speech property: %#v", props)
+	if _, ok := props["speech"]; ok {
+		t.Fatalf("structured schema should not expose speech metadata: %#v", props)
 	}
 }
 

--- a/src/agent/internal/agent/prompt.go
+++ b/src/agent/internal/agent/prompt.go
@@ -95,7 +95,7 @@ func combinedAgentInstruction(cfg AgentConfig) string {
 func defaultAgentBehavior(cfg AgentConfig) string {
 	toolCallSpeechRule := "- When calling a tool, do not add speech or description arguments to tool inputs."
 	if cfg.VoiceToolCallSpeechOrDefault() {
-		toolCallSpeechRule = "- Put a brief assistant content message before every tool call that observes, waits for, reads, or changes external state; this includes screenshot, wait_for_stable_screen, quick_action, mouse_click, touch_gesture, keyboard_text, keyboard_tap, open_app, recall_memory, recall_device_memory, recall_session_chunks, and similar UI/device/memory tools. Use assistant content (choice.Content) for the spoken status; assistant content is spoken by the runtime, so keep it as short as possible, under 20 Chinese characters or 8 English words, in the user's language. Do not add speech or description arguments to tool inputs."
+		toolCallSpeechRule = "- Put a brief assistant content message before every tool call that observes, waits for, reads, or changes external state; this includes screenshot, wait_for_stable_screen, quick_action, mouse_click, touch_gesture, keyboard_text, keyboard_tap, open_app, recall_memory, recall_device_memory, recall_session_chunks, and similar UI/device/memory tools. Use assistant content (choice.Content) for the spoken status; assistant content is spoken by the runtime, so keep it as short as possible, under 20 Chinese characters or 8 English words, in the user's language."
 	}
 	return strings.Join([]string{
 		"### Environment",

--- a/src/agent/internal/agent/prompt.go
+++ b/src/agent/internal/agent/prompt.go
@@ -95,7 +95,7 @@ func combinedAgentInstruction(cfg AgentConfig) string {
 func defaultAgentBehavior(cfg AgentConfig) string {
 	toolCallSpeechRule := "- When calling a tool, do not add speech or description arguments to tool inputs."
 	if cfg.VoiceToolCallSpeechOrDefault() {
-		toolCallSpeechRule = "- Include the speech argument on every tool call that observes, waits for, reads, or changes external state; this includes screenshot, wait_for_stable_screen, quick_action, mouse_click, touch_gesture, keyboard_text, keyboard_tap, open_app, recall_memory, recall_device_memory, recall_session_chunks, and similar UI/device/memory tools. Assistant text before a tool call is not a substitute for the speech argument; put the spoken status in speech on the tool call itself. Keep speech under 20 Chinese characters or 8 English words, in the user's language. Do not add a description argument; speech is consumed by the runtime and is not passed to the real tool."
+		toolCallSpeechRule = "- Put a brief assistant content message before every tool call that observes, waits for, reads, or changes external state; this includes screenshot, wait_for_stable_screen, quick_action, mouse_click, touch_gesture, keyboard_text, keyboard_tap, open_app, recall_memory, recall_device_memory, recall_session_chunks, and similar UI/device/memory tools. Use assistant content (choice.Content) for the spoken status; assistant content is spoken by the runtime, so keep it as short as possible, under 20 Chinese characters or 8 English words, in the user's language. Do not add speech or description arguments to tool inputs."
 	}
 	return strings.Join([]string{
 		"### Environment",

--- a/src/agent/internal/agent/prompt_test.go
+++ b/src/agent/internal/agent/prompt_test.go
@@ -159,9 +159,10 @@ func TestRolePromptsRequireToolCallSpeechForExternalStateTools(t *testing.T) {
 
 	for _, profile := range []RoleProfile{profiles.Planner, profiles.Executor} {
 		for _, want := range []string{
-			"Include the speech argument on every tool call that observes, waits for, reads, or changes external state",
+			"Put a brief assistant content message before every tool call that observes, waits for, reads, or changes external state",
 			"screenshot, wait_for_stable_screen, quick_action, mouse_click, touch_gesture, keyboard_text, keyboard_tap, open_app, recall_memory",
-			"Assistant text before a tool call is not a substitute for the speech argument",
+			"assistant content is spoken by the runtime",
+			"Do not add speech or description arguments to tool inputs",
 		} {
 			if !strings.Contains(profile.SystemPrompt, want) {
 				t.Fatalf("%s prompt missing tool-call speech requirement %q:\n%s", profile.Name, want, profile.SystemPrompt)

--- a/src/agent/internal/agent/prompt_test.go
+++ b/src/agent/internal/agent/prompt_test.go
@@ -162,7 +162,6 @@ func TestRolePromptsRequireToolCallSpeechForExternalStateTools(t *testing.T) {
 			"Put a brief assistant content message before every tool call that observes, waits for, reads, or changes external state",
 			"screenshot, wait_for_stable_screen, quick_action, mouse_click, touch_gesture, keyboard_text, keyboard_tap, open_app, recall_memory",
 			"assistant content is spoken by the runtime",
-			"Do not add speech or description arguments to tool inputs",
 		} {
 			if !strings.Contains(profile.SystemPrompt, want) {
 				t.Fatalf("%s prompt missing tool-call speech requirement %q:\n%s", profile.Name, want, profile.SystemPrompt)

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -71,7 +71,7 @@ func TestEnterPlanModePreservesToolSteps(t *testing.T) {
 	}
 }
 
-func TestExecutorScratchpadReplaysToolSpeechWhenEnabled(t *testing.T) {
+func TestExecutorScratchpadDoesNotReplayToolSpeechWhenEnabled(t *testing.T) {
 	executor := newRoleCollaborativeExecutor(
 		&scriptedModel{},
 		RoleProfiles{},
@@ -113,8 +113,8 @@ func TestExecutorScratchpadReplaysToolSpeechWhenEnabled(t *testing.T) {
 			if err := json.Unmarshal([]byte(toolCall.FunctionCall.Arguments), &args); err != nil {
 				t.Fatalf("decode scratchpad tool arguments: %v", err)
 			}
-			if args["speech"] != "点击支付按钮" {
-				t.Fatalf("scratchpad speech = %#v, want previous tool-call speech; args=%#v", args["speech"], args)
+			if _, ok := args["speech"]; ok {
+				t.Fatalf("scratchpad should not replay previous tool-call speech as an argument; args=%#v", args)
 			}
 			return
 		}

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -182,7 +182,6 @@ type RunEvent struct {
 	ToolName       string     `json:"tool_name,omitempty"`
 	ToolInput      string     `json:"tool_input,omitempty"`
 	Description    string     `json:"description,omitempty"`
-	Speech         string     `json:"speech,omitempty"`
 	Content        string     `json:"content,omitempty"`
 	Todo           *TodoState `json:"todo,omitempty"`
 	SpeechEligible bool       `json:"speech_eligible,omitempty"`
@@ -1372,8 +1371,7 @@ func (h *runtimeCallbackHandler) HandleToolCallStart(ctx context.Context, call T
 		ToolName:    call.Spec.Name,
 		ToolInput:   call.Input,
 		Description: description,
-		Speech:      h.toolCallSpeech(speech),
-		Content:     description,
+		Content:     h.toolCallContent(speech),
 		Timestamp:   time.Now(),
 	})
 }
@@ -1433,8 +1431,7 @@ func (h *runtimeCallbackHandler) HandleAgentAction(ctx context.Context, action s
 		ToolName:    action.Tool,
 		ToolInput:   action.ToolInput,
 		Description: description,
-		Speech:      h.toolCallSpeech(speech),
-		Content:     description,
+		Content:     h.toolCallContent(speech),
 		Timestamp:   time.Now(),
 	})
 }
@@ -1706,12 +1703,10 @@ func (h *runtimeCallbackHandler) recordFinalStreamError(err error) {
 
 var _ callbacks.Handler = (*runtimeCallbackHandler)(nil)
 
-func (h *runtimeCallbackHandler) toolCallSpeech(speech string) string {
+func (h *runtimeCallbackHandler) toolCallContent(speech string) string {
 	if h == nil || !h.toolCallSpeechEnabled {
 		return ""
 	}
-	// Intentionally do not derive speech from the tool description. Missing
-	// LLM-generated tool-call speech means this tool call stays silent.
 	return strings.TrimSpace(speech)
 }
 

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -2171,18 +2171,18 @@ func TestRuntimeRunEmitsToolDescriptionEventAndStripsToolInput(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected tool_call event, got %#v", events)
 	}
-	if toolCall.Description != "我先读取当前音量。" || toolCall.Content != toolCall.Description {
+	if toolCall.Description != "我先读取当前音量。" {
 		t.Fatalf("unexpected tool description event: %#v", toolCall)
 	}
-	if toolCall.Speech != "" {
-		t.Fatalf("tool_call speech = %q, want empty when voice_tool_call_speech is disabled", toolCall.Speech)
+	if toolCall.Content != "" {
+		t.Fatalf("tool_call content = %q, want empty without assistant content", toolCall.Content)
 	}
 	if toolCall.ToolInput != "{}" {
 		t.Fatalf("tool_call event input = %q, want stripped input", toolCall.ToolInput)
 	}
 }
 
-func TestRuntimeRunEmitsToolSpeechOnlyWhenToolCallSpeechEnabled(t *testing.T) {
+func TestRuntimeRunEmitsToolContentForToolCallSpeech(t *testing.T) {
 	speech := "读取音量。"
 	model := &scriptedModel{
 		responses: []*llms.ContentResponse{
@@ -2230,12 +2230,6 @@ func TestRuntimeRunEmitsToolSpeechOnlyWhenToolCallSpeechEnabled(t *testing.T) {
 	if toolCall.Content != speech {
 		t.Fatalf("tool_call content = %q, want assistant content", toolCall.Content)
 	}
-	if toolCall.Speech == "" {
-		t.Fatal("tool_call speech is empty when voice_tool_call_speech is enabled")
-	}
-	if toolCall.Speech != speech {
-		t.Fatalf("tool_call speech = %q, want LLM speech %q", toolCall.Speech, speech)
-	}
 }
 
 func TestRuntimeRunDoesNotDeriveToolSpeechWhenMissing(t *testing.T) {
@@ -2280,8 +2274,8 @@ func TestRuntimeRunDoesNotDeriveToolSpeechWhenMissing(t *testing.T) {
 	if toolCall.Description != description {
 		t.Fatalf("tool_call description changed: %q", toolCall.Description)
 	}
-	if toolCall.Speech != "" {
-		t.Fatalf("tool_call speech = %q, want empty when LLM omitted speech", toolCall.Speech)
+	if toolCall.Content != "" {
+		t.Fatalf("tool_call content = %q, want empty without assistant content", toolCall.Content)
 	}
 }
 

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1596,8 +1596,13 @@ func verifierStepContinueResponse(reason string) *llms.ContentResponse {
 }
 
 func toolCallResponse(id, name, arguments string) *llms.ContentResponse {
+	return toolCallResponseWithContent(id, name, arguments, "")
+}
+
+func toolCallResponseWithContent(id, name, arguments, content string) *llms.ContentResponse {
 	return &llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
+			Content: content,
 			ToolCalls: []llms.ToolCall{{
 				ID:   id,
 				Type: "function",
@@ -2178,10 +2183,12 @@ func TestRuntimeRunEmitsToolDescriptionEventAndStripsToolInput(t *testing.T) {
 }
 
 func TestRuntimeRunEmitsToolSpeechOnlyWhenToolCallSpeechEnabled(t *testing.T) {
-	description := "我先读取当前音量并检查当前播放设备、音量状态、静音状态、输出通道以及系统返回结果是否一致。然后继续回答。"
 	speech := "读取音量。"
 	model := &scriptedModel{
-		responses: roleToolResponses("audio_volume", fmt.Sprintf(`{"__arg1":"{}","description":%q,"speech":%q}`, description, speech), "The current audio volume is 42."),
+		responses: []*llms.ContentResponse{
+			toolCallResponseWithContent("call_1", "audio_volume", `{"__arg1":"{}"}`, speech),
+			contentResponse("The current audio volume is 42."),
+		},
 	}
 	tool := &stubTool{
 		name:        "audio_volume",
@@ -2217,11 +2224,11 @@ func TestRuntimeRunEmitsToolSpeechOnlyWhenToolCallSpeechEnabled(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected tool_call event, got %#v", events)
 	}
-	if toolCall.Description != description {
+	if toolCall.Description != speech {
 		t.Fatalf("tool_call description changed: %q", toolCall.Description)
 	}
-	if toolCall.Content != description {
-		t.Fatalf("tool_call content = %q, want full description", toolCall.Content)
+	if toolCall.Content != speech {
+		t.Fatalf("tool_call content = %q, want assistant content", toolCall.Content)
 	}
 	if toolCall.Speech == "" {
 		t.Fatal("tool_call speech is empty when voice_tool_call_speech is enabled")

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -110,7 +110,6 @@ type Message struct {
 	Content         string              `json:"content"`
 	Todo            *TodoState          `json:"todo,omitempty"`
 	SpeechEligible  bool                `json:"speech_eligible,omitempty"`
-	Speech          string              `json:"speech,omitempty"`
 	ToolName        string              `json:"tool_name,omitempty"`
 	ToolInput       string              `json:"tool_input,omitempty"`
 	Description     string              `json:"description,omitempty"`
@@ -144,7 +143,6 @@ func messageFromRunEvent(event RunEvent, fallbackEpisodeID string, requestID str
 		Content:        event.Content,
 		Todo:           cloneTodoStatePtr(event.Todo),
 		SpeechEligible: event.SpeechEligible,
-		Speech:         event.Speech,
 		ToolName:       event.ToolName,
 		ToolInput:      event.ToolInput,
 		Description:    event.Description,
@@ -829,7 +827,7 @@ func (s *Server) handleChatAsync(
 			}
 
 			if s.shouldSpeakToolCall(event) {
-				go s.speakToolDescription(runCtx, event.Speech)
+				go s.speakToolDescription(runCtx, event.Content)
 			}
 			if event.Type == runEventTodoUpdate && s.runtime.config.VoiceProgressSpeechEnabledOrDefault() {
 				if text, ok := progressSpeechTextForEvent(event); ok {
@@ -1095,7 +1093,7 @@ func (s *Server) handleChatSync(
 		EventHandler: func(event RunEvent) {
 			s.appendHistory(messageFromRunEvent(event, episodeID, ""))
 			if s.shouldSpeakToolCall(event) {
-				go s.speakToolDescription(r.Context(), event.Speech)
+				go s.speakToolDescription(r.Context(), event.Content)
 			}
 			if event.Type == runEventTodoUpdate && s.runtime.config.VoiceProgressSpeechEnabledOrDefault() {
 				if text, ok := progressSpeechTextForEvent(event); ok {
@@ -1274,7 +1272,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 				s.liveActivity.UpdateFromRunEvent(req.RequestID, event)
 			}
 			if s.shouldSpeakToolCall(event) {
-				go s.speakToolDescription(ctx, event.Speech)
+				go s.speakToolDescription(ctx, event.Content)
 			}
 			if event.Type == runEventTodoUpdate && s.runtime.config.VoiceProgressSpeechEnabledOrDefault() {
 				if text, ok := progressSpeechTextForEvent(event); ok {

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -104,11 +104,11 @@ func TestServerHandleChatReturnsToolHistory(t *testing.T) {
 	if !ok || toolCall.ToolName != "audio_volume" || toolCall.ToolInput != "{}" {
 		t.Fatalf("unexpected tool_call message: %#v", resp.History)
 	}
-	if toolCall.Description != "我先读取当前音量。" || toolCall.Content != "我先读取当前音量。" {
+	if toolCall.Description != "我先读取当前音量。" {
 		t.Fatalf("unexpected tool_call description: %#v", toolCall)
 	}
-	if toolCall.Speech != "" {
-		t.Fatalf("tool_call speech = %q, want empty when voice_tool_call_speech is disabled", toolCall.Speech)
+	if toolCall.Content != "" {
+		t.Fatalf("tool_call content = %q, want empty without assistant content", toolCall.Content)
 	}
 	toolResult, ok := firstMessageOfType(resp.History, "tool_result")
 	if !ok || toolResult.ToolName != "audio_volume" || toolResult.Content != `{"volume":42}` {

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -798,10 +798,12 @@ func TestServerSpeakToolDescriptionUsesTTS(t *testing.T) {
 }
 
 func TestServerHandleChatDoesNotWaitForToolDescriptionTTSWhenEnabled(t *testing.T) {
-	description := "我先读取当前音量并检查当前播放设备、音量状态、静音状态、输出通道以及系统返回结果是否一致。然后继续回答。"
 	speech := "读取音量。"
 	model := &scriptedModel{
-		responses: roleToolResponses("audio_volume", fmt.Sprintf(`{"__arg1":"{}","description":%q,"speech":%q}`, description, speech), "The current audio volume is 42."),
+		responses: []*llms.ContentResponse{
+			toolCallResponseWithContent("call_1", "audio_volume", `{"__arg1":"{}"}`, speech),
+			contentResponse("The current audio volume is 42."),
+		},
 	}
 	streamingDisabled := false
 	toolSpeechEnabled := true

--- a/src/agent/internal/agent/task_episode.go
+++ b/src/agent/internal/agent/task_episode.go
@@ -70,7 +70,6 @@ type TaskEpisodeEvent struct {
 	ToolName           string              `json:"tool_name,omitempty" yaml:"tool_name,omitempty"`
 	ToolInput          string              `json:"tool_input,omitempty" yaml:"tool_input,omitempty"`
 	ToolDescription    string              `json:"tool_description,omitempty" yaml:"tool_description,omitempty"`
-	Speech             string              `json:"speech,omitempty" yaml:"speech,omitempty"`
 	Content            string              `json:"content,omitempty" yaml:"content,omitempty"`
 	Todo               *TodoState          `json:"todo,omitempty" yaml:"todo,omitempty"`
 	SpeechEligible     bool                `json:"speech_eligible,omitempty" yaml:"speech_eligible,omitempty"`
@@ -126,7 +125,7 @@ type EpisodeRecorder struct {
 	store     *TaskEpisodeStore
 	started   bool
 	startErr  error
-	// ToolCallSpeech gates persistence of LLM-generated tool-call speech.
+	// ToolCallSpeech gates persistence of LLM-generated tool-call content.
 	ToolCallSpeech bool
 }
 
@@ -311,9 +310,9 @@ func (r *EpisodeRecorder) recordExecutionForRole(result roleExecutionResult, rol
 			ToolDescription: description,
 		}
 		if r.ToolCallSpeech {
-			// Persist only explicit LLM-generated tool-call speech. Missing
-			// speech is intentionally left empty rather than derived.
-			event.Speech = toolSpeechFromAction(*result.Action)
+			// Persist only explicit LLM-generated tool-call content. Missing
+			// content is intentionally left empty rather than derived.
+			event.Content = toolSpeechFromAction(*result.Action)
 		}
 		r.append(event)
 	}

--- a/src/agent/internal/agent/tool_schema_test.go
+++ b/src/agent/internal/agent/tool_schema_test.go
@@ -55,8 +55,8 @@ func TestAgentExposedToolsDoNotExposeLegacyArg1Schema(t *testing.T) {
 			if !ok {
 				t.Fatalf("enabled schema missing properties: %#v", enabledSchema)
 			}
-			if _, ok := enabledProps["speech"]; !ok {
-				t.Fatalf("enabled schema missing speech property: %#v", enabledSchema)
+			if _, ok := enabledProps["speech"]; ok {
+				t.Fatalf("enabled schema exposes speech metadata as a tool argument: %#v", enabledSchema)
 			}
 		})
 	}

--- a/src/agent/internal/agent/tool_schema_test.go
+++ b/src/agent/internal/agent/tool_schema_test.go
@@ -50,14 +50,6 @@ func TestAgentExposedToolsDoNotExposeLegacyArg1Schema(t *testing.T) {
 			if _, ok := props["speech"]; ok {
 				t.Fatalf("schema exposes speech while tool-call speech is disabled: %#v", schema)
 			}
-			enabledSchema := NewToolSpec(tool).LLMSchemaWithSpeech(true)
-			enabledProps, ok := enabledSchema["properties"].(map[string]any)
-			if !ok {
-				t.Fatalf("enabled schema missing properties: %#v", enabledSchema)
-			}
-			if _, ok := enabledProps["speech"]; ok {
-				t.Fatalf("enabled schema exposes speech metadata as a tool argument: %#v", enabledSchema)
-			}
 		})
 	}
 }

--- a/src/agent/internal/agent/tool_spec.go
+++ b/src/agent/internal/agent/tool_spec.go
@@ -354,10 +354,6 @@ func (spec ToolSpec) Descriptor() ToolDescriptor {
 }
 
 func (spec ToolSpec) LLMTool() llms.Tool {
-	return spec.LLMToolWithSpeech(false)
-}
-
-func (spec ToolSpec) LLMToolWithSpeech(_ bool) llms.Tool {
 	return llms.Tool{
 		Type: "function",
 		Function: &llms.FunctionDefinition{
@@ -375,10 +371,6 @@ func (spec ToolSpec) LLMSchema() map[string]any {
 		}
 	}
 	return genericToolParameters()
-}
-
-func (spec ToolSpec) LLMSchemaWithSpeech(_ bool) map[string]any {
-	return spec.LLMSchema()
 }
 
 func (spec ToolSpec) NormalizeInput(input string) string {

--- a/src/agent/internal/agent/tool_spec.go
+++ b/src/agent/internal/agent/tool_spec.go
@@ -357,28 +357,28 @@ func (spec ToolSpec) LLMTool() llms.Tool {
 	return spec.LLMToolWithSpeech(false)
 }
 
-func (spec ToolSpec) LLMToolWithSpeech(includeSpeech bool) llms.Tool {
+func (spec ToolSpec) LLMToolWithSpeech(_ bool) llms.Tool {
 	return llms.Tool{
 		Type: "function",
 		Function: &llms.FunctionDefinition{
 			Name:        spec.Name,
 			Description: strings.TrimSpace(spec.Description),
-			Parameters:  spec.LLMSchemaWithSpeech(includeSpeech),
+			Parameters:  spec.LLMSchema(),
 		},
 	}
 }
 
 func (spec ToolSpec) LLMSchema() map[string]any {
-	return spec.LLMSchemaWithSpeech(false)
-}
-
-func (spec ToolSpec) LLMSchemaWithSpeech(includeSpeech bool) map[string]any {
 	if structured, ok := spec.Tool.(structuredInputTool); ok {
 		if schema := structured.ArgsSchema(); len(schema) > 0 {
-			return toolParametersSchema(schema, includeSpeech)
+			return toolParametersSchema(schema)
 		}
 	}
-	return genericToolParameters(includeSpeech)
+	return genericToolParameters()
+}
+
+func (spec ToolSpec) LLMSchemaWithSpeech(_ bool) map[string]any {
+	return spec.LLMSchema()
 }
 
 func (spec ToolSpec) NormalizeInput(input string) string {


### PR DESCRIPTION
## Summary
- Remove tool-call speech metadata from LLM tool schemas and scratchpad tool arguments.
- Use assistant choice content as the tool-call speech source when voice tool-call speech is enabled.
- Treat arguments.speech as ordinary tool input instead of a legacy speech fallback.

## Tests
- go test ./...