### PR TITLE
fix(agent): refine follow-up relation classification

### DIFF
--- a/src/agent/internal/agent/session_boundary_test.go
+++ b/src/agent/internal/agent/session_boundary_test.go
@@ -45,6 +45,59 @@ func TestClassifyFollowUpRelation_RootRequestOnNewBoundary(t *testing.T) {
 	}
 }
 
+func TestClassifyFollowUpRelation_ContextReferenceOverridesActionVerb(t *testing.T) {
+	prev := []SessionEvent{{Type: "user_input", Role: "user", Content: "打开相册找到最新照片"}}
+	cases := []string{
+		"帮我把它保存下来",
+		"发给刚才那个人",
+		"open the same page again",
+		"send that to Alex",
+	}
+	for _, input := range cases {
+		if got := ClassifyFollowUpRelation(prev, input, BoundaryContinue); got != FollowUpContinuation {
+			t.Errorf("input %q relation = %q, want %q", input, got, FollowUpContinuation)
+		}
+	}
+}
+
+func TestClassifyFollowUpRelation_DistinguishesReplacementFromCancelTask(t *testing.T) {
+	prev := []SessionEvent{{Type: "user_input", Role: "user", Content: "查天气"}}
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{input: "取消刚才那个", want: FollowUpReplacement},
+		{input: "不用打开微信了", want: FollowUpReplacement},
+		{input: "重新打开支付宝", want: FollowUpReplacement},
+		{input: "取消订单", want: FollowUpNewTask},
+		{input: "cancel the order", want: FollowUpNewTask},
+	}
+	for _, tc := range cases {
+		if got := ClassifyFollowUpRelation(prev, tc.input, BoundaryContinue); got != tc.want {
+			t.Errorf("input %q relation = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestClassifyFollowUpRelation_CorrectionCuePrecision(t *testing.T) {
+	prev := []SessionEvent{{Type: "user_input", Role: "user", Content: "打开微信发消息"}}
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{input: "群名你听错了，是 Aden AI agent", want: FollowUpCorrection},
+		{input: "不是 den，是 Aden AI agent", want: FollowUpCorrection},
+		{input: "actually it should be Aden AI agent", want: FollowUpCorrection},
+		{input: "是不是要登录一下", want: FollowUpContinuation},
+		{input: "今天是周五", want: FollowUpContinuation},
+	}
+	for _, tc := range cases {
+		if got := ClassifyFollowUpRelation(prev, tc.input, BoundaryContinue); got != tc.want {
+			t.Errorf("input %q relation = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
 func TestClassifyTurnBoundary_RunningEpisodeOverridesNoPrevEvents(t *testing.T) {
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()

--- a/src/agent/internal/agent/session_context_view.go
+++ b/src/agent/internal/agent/session_context_view.go
@@ -26,8 +26,12 @@ const (
 const maxSessionContextEvents = 200
 
 var (
-	correctionCueRe  = regexp.MustCompile(`(?i)(听错|看错|不是|应该是|是\s*[^，。,.!?！？]+$|改成|改为|更正|纠正|说错|写错|typo|correction|correct|actually|should be|not .+ but)`)
-	replacementCueRe = regexp.MustCompile(`(?i)^\s*(取消|不用|别|先别|算了|重新|从头|换成|改为新的|replace|instead|start over|new task)\b?`)
+	correctionExplicitCueRe        = regexp.MustCompile(`(?i)(听错|看错|说错|写错|更正|纠正|不对|应该是|应当是|应该为|应为|\btypo\b|\bcorrection\b|\bcorrect\b|\bactually\b|\bshould be\b)`)
+	correctionContrastCueRe        = regexp.MustCompile(`(?i)(^|[\s,，。.!?！？])不是[^，。,.!?！？]+[\s,，。.!?！？]*(是|而是)[^，。,.!?！？]+`)
+	correctionEnglishContrastCueRe = regexp.MustCompile(`(?i)\bnot\s+[^,.!?]+[\s,]+but\s+[^,.!?]+`)
+	replacementCueRe               = regexp.MustCompile(`(?i)^[\s,，。.!?！？]*(算了|重新|从头|换成|改为新的|replace\b|instead\b|start over\b|new task\b)`)
+	continuationReferenceRe        = regexp.MustCompile(`(?i)(刚才|刚刚|上一个|上一条|前面|之前|这个|那个|它|同一个|\b(it|this|that|same|previous)\b|\bthe\s+last\b|\blast\s+(one|message|page|thing|item)\b)`)
+	independentCancelActionRe      = regexp.MustCompile(`(?i)^[\s,，。.!?！？]*(取消|撤销|cancel\b)`)
 )
 
 type sessionContextView struct {
@@ -145,19 +149,103 @@ func ClassifyFollowUpRelation(prevEvents []SessionEvent, input string, boundary 
 	if trimmed == "" {
 		return FollowUpRootRequest
 	}
-	if boundary == BoundaryNew || len(prevEvents) == 0 {
+	if boundary == BoundaryNew || !hasPreviousUserInput(prevEvents) {
 		return FollowUpRootRequest
 	}
-	if replacementCueRe.MatchString(trimmed) {
+	if isReplacementFollowUp(trimmed) {
 		return FollowUpReplacement
 	}
-	if correctionCueRe.MatchString(trimmed) {
+	if isCorrectionFollowUp(trimmed) {
 		return FollowUpCorrection
 	}
-	if actionVerbStartRe.MatchString(trimmed) && !continuationMarkerRe.MatchString(trimmed) {
+	if hasContinuationReference(trimmed) {
+		return FollowUpContinuation
+	}
+	if actionVerbStartRe.MatchString(trimmed) || independentCancelActionRe.MatchString(trimmed) {
 		return FollowUpNewTask
 	}
 	return FollowUpContinuation
+}
+
+func hasPreviousUserInput(events []SessionEvent) bool {
+	for i := len(events) - 1; i >= 0; i-- {
+		event := events[i]
+		if event.Type == "user_input" && strings.TrimSpace(event.Content) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func isReplacementFollowUp(input string) bool {
+	if replacementCueRe.MatchString(input) {
+		return true
+	}
+	trimmed := strings.TrimLeft(input, " \t\r\n,，。.!?！？")
+	for _, prefix := range []string{"不用", "先别", "别"} {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	if rest, ok := strings.CutPrefix(trimmed, "取消"); ok {
+		return isContextualCancelTarget(rest)
+	}
+	lower := strings.ToLower(trimmed)
+	if rest, ok := strings.CutPrefix(lower, "cancel"); ok {
+		return isContextualCancelTarget(rest)
+	}
+	return false
+}
+
+func isContextualCancelTarget(target string) bool {
+	target = strings.TrimLeft(target, " \t\r\n,，。.!?！？")
+	if target == "" {
+		return true
+	}
+	for _, prefix := range []string{
+		"掉", "了", "吧", "这个", "那个", "它", "刚才", "刚刚", "上一个", "上一条", "前面", "之前", "当前", "这次", "本次",
+		"it", "this", "that", "same", "previous", "the previous", "the last",
+		"last one", "last message", "last page", "last thing", "last item",
+	} {
+		if strings.HasPrefix(target, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCorrectionFollowUp(input string) bool {
+	if correctionExplicitCueRe.MatchString(input) ||
+		correctionContrastCueRe.MatchString(input) ||
+		correctionEnglishContrastCueRe.MatchString(input) {
+		return true
+	}
+	trimmed := strings.TrimLeft(input, " \t\r\n,，。.!?！？")
+	for _, prefix := range []string{"是", "改成", "改为", "更正为", "纠正为"} {
+		if rest, ok := strings.CutPrefix(trimmed, prefix); ok {
+			return looksLikeCorrectionValue(rest)
+		}
+	}
+	return false
+}
+
+func looksLikeCorrectionValue(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	switch strings.ToLower(strings.Trim(value, " \t\r\n,，。.!?！？")) {
+	case "的", "的吧", "吧", "吗", "不是", "not":
+		return false
+	}
+	if strings.HasPrefix(value, "不是") {
+		return false
+	}
+	return len([]rune(value)) >= 2
+}
+
+func hasContinuationReference(input string) bool {
+	return continuationMarkerRe.MatchString(input) || continuationReferenceRe.MatchString(input)
 }
 
 func BuildSessionContextView(events []SessionEvent, currentInput string) sessionContextView {


### PR DESCRIPTION
## Summary
- refine follow-up relation classification with explicit helpers for replacement, correction, context references, and independent actions
- preserve continuation for contextual action phrases like "send that" while keeping standalone action verbs as new tasks
- add regression coverage for contextual actions, replacement vs cancel-task, and correction cue precision

## Tests
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests validating follow-up request classification behavior, including context reference handling and cancellation vs. replacement distinction

* **Improvements**
  * Enhanced system detection of user correction intents when providing follow-up requests or clarifications
  * Improved distinction between task replacement versus task cancellation request scenarios
  * Refined follow-up context recognition for better continuation reference detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->