### PR TITLE
fix(agent): keep follow-up relation out of prompts

### DIFF
--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -220,7 +220,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 	if _, ok := inputs["history"]; !ok {
 		inputs["history"] = ""
 	}
-	for _, key := range []string{sessionContextInputKey, rootRequestInputKey, latestUserInputKey, followUpRelationKey} {
+	for _, key := range []string{sessionContextInputKey, rootRequestInputKey, latestUserInputKey} {
 		if _, ok := inputs[key]; !ok {
 			inputs[key] = ""
 		}
@@ -1575,11 +1575,6 @@ func writeRequestContextAndCriteria(builder *strings.Builder, inputs map[string]
 	if latestUserMessage != "" && latestUserMessage != rootRequest {
 		builder.WriteString("\n\nLatest user message:\n")
 		builder.WriteString(latestUserMessage)
-		if relation := strings.TrimSpace(inputs[followUpRelationKey]); relation != "" {
-			builder.WriteString("\n\nFollow-up classification:\n")
-			builder.WriteString(relation)
-			builder.WriteByte('\n')
-		}
 	}
 	if len(state.CompletionCriteria) == 0 {
 		return

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -862,10 +862,10 @@ func TestRecordPlanStepResultSurvivesStepClear(t *testing.T) {
 
 func TestRequestContextPromptDoesNotMarkRootRequestAuthoritative(t *testing.T) {
 	inputs := map[string]string{
-		"input":             "打开微信",
-		rootRequestInputKey: "查天气",
-		latestUserInputKey:  "打开微信",
-		followUpRelationKey: FollowUpContinuation,
+		"input":              "打开微信",
+		rootRequestInputKey:  "查天气",
+		latestUserInputKey:   "打开微信",
+		"follow_up_relation": FollowUpContinuation,
 	}
 	prompt := buildPlannerStatePrompt(inputs, roleLoopState{}, "Planner task.")
 
@@ -874,6 +874,8 @@ func TestRequestContextPromptDoesNotMarkRootRequestAuthoritative(t *testing.T) {
 		"authoritative; do not replace it with a subtask",
 		"Current objective:",
 		"Satisfy every explicit requirement in the original user request.",
+		"Follow-up classification:",
+		"follow_up_relation",
 	} {
 		if strings.Contains(prompt, unwanted) {
 			t.Fatalf("planner prompt should not contain %q:\n%s", unwanted, prompt)

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1001,14 +1001,21 @@ func TestRuntimeRunResumeCorrectionUsesRootRequestAndCommittedPlan(t *testing.T)
 		rootRequest,
 		"Latest user message",
 		correction,
-		"Follow-up classification:",
-		"correction",
 		"Latest committed plan",
 		"在微信群发送100块钱红包",
 		"发送100块钱红包",
 	} {
 		if !strings.Contains(resumePrompt, want) {
 			t.Fatalf("resume planner prompt missing %q:\n%s", want, resumePrompt)
+		}
+	}
+	for _, unwanted := range []string{
+		"Follow-up classification:",
+		"follow_up_relation",
+		"Latest correction",
+	} {
+		if strings.Contains(resumePrompt, unwanted) {
+			t.Fatalf("resume planner prompt should not expose follow-up relation judgement %q:\n%s", unwanted, resumePrompt)
 		}
 	}
 	if strings.Contains(resumePrompt, "发介绍") {
@@ -1081,12 +1088,18 @@ func TestRuntimeRunForcedFollowUpRelationMarksInterruptedCorrection(t *testing.T
 		rootRequest,
 		"Latest user message",
 		correction,
-		"Follow-up classification:",
-		FollowUpCorrection,
-		"Latest correction",
 	} {
 		if !strings.Contains(correctionPrompt, want) {
 			t.Fatalf("correction prompt missing %q:\n%s", want, correctionPrompt)
+		}
+	}
+	for _, unwanted := range []string{
+		"Follow-up classification:",
+		"follow_up_relation",
+		"Latest correction",
+	} {
+		if strings.Contains(correctionPrompt, unwanted) {
+			t.Fatalf("correction prompt should not expose follow-up relation judgement %q:\n%s", unwanted, correctionPrompt)
 		}
 	}
 

--- a/src/agent/internal/agent/session_context_view.go
+++ b/src/agent/internal/agent/session_context_view.go
@@ -20,7 +20,6 @@ const (
 	sessionContextInputKey = "session_context"
 	rootRequestInputKey    = "root_request"
 	latestUserInputKey     = "latest_user_message"
-	followUpRelationKey    = "follow_up_relation"
 )
 
 const maxSessionContextEvents = 200
@@ -37,10 +36,8 @@ var (
 type sessionContextView struct {
 	RootUserRequest       string
 	LatestUserMessage     string
-	FollowUpRelation      string
 	LatestCommittedPlan   *plannerDecision
 	LatestVerifierSummary string
-	LatestCorrection      string
 }
 
 type sessionContextPlannerMemory struct {
@@ -65,7 +62,7 @@ func (m *sessionContextPlannerMemory) GetMemoryKey(ctx context.Context) string {
 
 func (m *sessionContextPlannerMemory) MemoryVariables(ctx context.Context) []string {
 	variables := append([]string(nil), m.inner.MemoryVariables(ctx)...)
-	for _, key := range []string{sessionContextInputKey, rootRequestInputKey, latestUserInputKey, followUpRelationKey} {
+	for _, key := range []string{sessionContextInputKey, rootRequestInputKey, latestUserInputKey} {
 		if !slicesContainsString(variables, key) {
 			variables = append(variables, key)
 		}
@@ -96,9 +93,6 @@ func (m *sessionContextPlannerMemory) LoadMemoryVariables(ctx context.Context, i
 	}
 	if view.LatestUserMessage != "" {
 		values[latestUserInputKey] = view.LatestUserMessage
-	}
-	if view.FollowUpRelation != "" {
-		values[followUpRelationKey] = view.FollowUpRelation
 	}
 	return values, nil
 }
@@ -144,6 +138,12 @@ func normalizeFollowUpRelation(relation string) string {
 	}
 }
 
+// ClassifyFollowUpRelation is a local heuristic for session metadata only.
+// Keep its output out of LLM prompts and context-selection logic: the labels
+// are not semantic ground truth and should not decide the task root, restored
+// plan, verifier context, or any model-facing instruction. Runtime callers may
+// still pass an explicit FollowUpRelation when an external signal is stronger
+// than the text heuristic, such as a voice wakeup interrupt correction.
 func ClassifyFollowUpRelation(prevEvents []SessionEvent, input string, boundary string) string {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {
@@ -250,6 +250,7 @@ func hasContinuationReference(input string) bool {
 
 func BuildSessionContextView(events []SessionEvent, currentInput string) sessionContextView {
 	currentInput = strings.TrimSpace(currentInput)
+	events = runtimeSessionContextEvents(events)
 	if len(events) == 0 && currentInput == "" {
 		return sessionContextView{}
 	}
@@ -262,39 +263,44 @@ func BuildSessionContextView(events []SessionEvent, currentInput string) session
 	if latestContent == "" {
 		latestContent = currentInput
 	}
-	relation := strings.TrimSpace(latestUser.Relation)
-	if relation == "" {
-		relation = ClassifyFollowUpRelation(eventsBefore(events, latestUserIndex), latestContent, BoundaryContinue)
-	}
-	if relation == "" {
-		relation = FollowUpRootRequest
-	}
 
 	root := latestContent
-	taskRootIndex := latestUserIndex
-	if relation != FollowUpReplacement && relation != FollowUpNewTask {
-		if taskRoot, index := taskRootUserInput(events, latestUserIndex); taskRoot != "" {
-			root = taskRoot
-			taskRootIndex = index
-		}
+	rootIndex := latestUserIndex
+	if sessionRoot, index := activeSessionRootUserInput(events, latestUserIndex); sessionRoot != "" {
+		root = sessionRoot
+		rootIndex = index
 	}
 	view := sessionContextView{
 		RootUserRequest:   root,
 		LatestUserMessage: latestContent,
-		FollowUpRelation:  relation,
 	}
-	if relation == FollowUpCorrection {
-		view.LatestCorrection = latestContent
+	if decision, ok := latestCommittedPlan(events, rootIndex, latestUserIndex); ok {
+		view.LatestCommittedPlan = &decision
 	}
-	if relation != FollowUpReplacement && relation != FollowUpNewTask {
-		if decision, ok := latestCommittedPlan(events, taskRootIndex, latestUserIndex); ok {
-			view.LatestCommittedPlan = &decision
-		}
-		if summary := latestVerifierSummary(events, taskRootIndex, latestUserIndex); summary != "" {
-			view.LatestVerifierSummary = summary
-		}
+	if summary := latestVerifierSummary(events, rootIndex, latestUserIndex); summary != "" {
+		view.LatestVerifierSummary = summary
 	}
 	return view
+}
+
+func runtimeSessionContextEvents(events []SessionEvent) []SessionEvent {
+	hasRuntimeEvents := false
+	for _, event := range events {
+		if strings.TrimSpace(event.RunID) != "" {
+			hasRuntimeEvents = true
+			break
+		}
+	}
+	if !hasRuntimeEvents {
+		return events
+	}
+	scoped := make([]SessionEvent, 0, len(events))
+	for _, event := range events {
+		if strings.TrimSpace(event.RunID) != "" {
+			scoped = append(scoped, event)
+		}
+	}
+	return scoped
 }
 
 func latestUserEventIndex(events []SessionEvent, currentInput string) int {
@@ -314,51 +320,32 @@ func latestUserEventIndex(events []SessionEvent, currentInput string) int {
 	return -1
 }
 
-func eventsBefore(events []SessionEvent, index int) []SessionEvent {
-	if index <= 0 || index > len(events) {
-		return nil
-	}
-	return events[:index]
-}
-
-func taskRootUserInput(events []SessionEvent, latestUserIndex int) (string, int) {
+func activeSessionRootUserInput(events []SessionEvent, latestUserIndex int) (string, int) {
 	limit := len(events)
 	if latestUserIndex >= 0 && latestUserIndex < limit {
 		limit = latestUserIndex + 1
 	}
-	for i := limit - 1; i >= 0; i-- {
+	for i := 0; i < limit; i++ {
 		event := events[i]
 		if event.Type != "user_input" {
 			continue
 		}
 		content := strings.TrimSpace(event.Content)
-		if content == "" {
-			continue
-		}
-		relation := strings.TrimSpace(event.Relation)
-		switch relation {
-		case FollowUpRootRequest, FollowUpNewTask, FollowUpReplacement:
+		if content != "" {
 			return content, i
-		}
-	}
-	for i := 0; i < limit; i++ {
-		if events[i].Type == "user_input" {
-			if content := strings.TrimSpace(events[i].Content); content != "" {
-				return content, i
-			}
 		}
 	}
 	return "", -1
 }
 
-func latestCommittedPlan(events []SessionEvent, taskRootIndex, latestUserIndex int) (plannerDecision, bool) {
+func latestCommittedPlan(events []SessionEvent, rootIndex, latestUserIndex int) (plannerDecision, bool) {
 	limit := latestUserIndex
 	if limit < 0 || limit > len(events) {
 		limit = len(events)
 	}
 	start := 0
-	if taskRootIndex >= 0 && taskRootIndex < limit {
-		start = taskRootIndex + 1
+	if rootIndex >= 0 && rootIndex < limit {
+		start = rootIndex + 1
 	}
 	for i := limit - 1; i >= 0; i-- {
 		if i < start {
@@ -397,14 +384,14 @@ func plannerDecisionFromSessionEvent(event SessionEvent) (plannerDecision, bool)
 	return decision, len(decision.Plan) > 0 || decision.Objective != "" || decision.NextStep != ""
 }
 
-func latestVerifierSummary(events []SessionEvent, taskRootIndex, latestUserIndex int) string {
+func latestVerifierSummary(events []SessionEvent, rootIndex, latestUserIndex int) string {
 	limit := latestUserIndex
 	if limit < 0 || limit > len(events) {
 		limit = len(events)
 	}
 	start := 0
-	if taskRootIndex >= 0 && taskRootIndex < limit {
-		start = taskRootIndex + 1
+	if rootIndex >= 0 && rootIndex < limit {
+		start = rootIndex + 1
 	}
 	for i := limit - 1; i >= 0; i-- {
 		if i < start {
@@ -434,8 +421,6 @@ func latestVerifierSummary(events []SessionEvent, taskRootIndex, latestUserIndex
 
 func formatSessionContextView(view sessionContextView) string {
 	if strings.TrimSpace(view.LatestUserMessage) == "" &&
-		strings.TrimSpace(view.FollowUpRelation) == "" &&
-		strings.TrimSpace(view.LatestCorrection) == "" &&
 		view.LatestCommittedPlan == nil &&
 		strings.TrimSpace(view.LatestVerifierSummary) == "" {
 		return ""
@@ -445,16 +430,6 @@ func formatSessionContextView(view sessionContextView) string {
 	if latest := strings.TrimSpace(view.LatestUserMessage); latest != "" {
 		builder.WriteString("- Latest user message: ")
 		builder.WriteString(singleLineHistoryText(latest))
-		builder.WriteByte('\n')
-	}
-	if relation := strings.TrimSpace(view.FollowUpRelation); relation != "" {
-		builder.WriteString("- Follow-up classification: ")
-		builder.WriteString(relation)
-		builder.WriteByte('\n')
-	}
-	if correction := strings.TrimSpace(view.LatestCorrection); correction != "" {
-		builder.WriteString("- Latest correction: ")
-		builder.WriteString(singleLineHistoryText(correction))
 		builder.WriteByte('\n')
 	}
 	if view.LatestCommittedPlan != nil {

--- a/src/agent/internal/agent/session_context_view.go
+++ b/src/agent/internal/agent/session_context_view.go
@@ -338,19 +338,24 @@ func activeSessionRootUserInput(events []SessionEvent, latestUserIndex int) (str
 	return "", -1
 }
 
-func latestCommittedPlan(events []SessionEvent, rootIndex, latestUserIndex int) (plannerDecision, bool) {
+func sessionDecisionScanWindow(events []SessionEvent, rootIndex, latestUserIndex int) (int, int) {
 	limit := latestUserIndex
 	if limit < 0 || limit > len(events) {
 		limit = len(events)
 	}
 	start := 0
-	if rootIndex >= 0 && rootIndex < limit {
+	if rootIndex >= 0 && rootIndex < len(events) {
 		start = rootIndex + 1
 	}
-	for i := limit - 1; i >= 0; i-- {
-		if i < start {
-			break
-		}
+	if start > limit {
+		start = limit
+	}
+	return start, limit
+}
+
+func latestCommittedPlan(events []SessionEvent, rootIndex, latestUserIndex int) (plannerDecision, bool) {
+	start, limit := sessionDecisionScanWindow(events, rootIndex, latestUserIndex)
+	for i := limit - 1; i >= start; i-- {
 		event := events[i]
 		if event.Type != "planner_decision" {
 			continue
@@ -385,18 +390,8 @@ func plannerDecisionFromSessionEvent(event SessionEvent) (plannerDecision, bool)
 }
 
 func latestVerifierSummary(events []SessionEvent, rootIndex, latestUserIndex int) string {
-	limit := latestUserIndex
-	if limit < 0 || limit > len(events) {
-		limit = len(events)
-	}
-	start := 0
-	if rootIndex >= 0 && rootIndex < limit {
-		start = rootIndex + 1
-	}
-	for i := limit - 1; i >= 0; i-- {
-		if i < start {
-			break
-		}
+	start, limit := sessionDecisionScanWindow(events, rootIndex, latestUserIndex)
+	for i := limit - 1; i >= start; i-- {
 		event := events[i]
 		if event.Type != "verifier_decision" {
 			continue

--- a/src/agent/internal/agent/session_context_view_test.go
+++ b/src/agent/internal/agent/session_context_view_test.go
@@ -44,6 +44,26 @@ func TestBuildSessionContextViewIgnoresHotWindowEventsWhenRuntimeEventsExist(t *
 	}
 }
 
+func TestBuildSessionContextViewDoesNotLeakPreRootPlanWhenRootIsLatestUser(t *testing.T) {
+	canFinish := true
+	events := []SessionEvent{
+		{Type: "planner_decision", Role: string(RolePlanner), Objective: "old objective", Plan: []string{"old step"}, RunID: "run-old"},
+		{Type: "verifier_decision", Role: string(RoleVerifier), Reason: "old verifier", CanFinish: &canFinish, RunID: "run-old"},
+		{Type: "user_input", Role: "user", Content: "new root request", RunID: "run-new"},
+	}
+
+	view := BuildSessionContextView(events, "new root request")
+	if view.RootUserRequest != "new root request" {
+		t.Fatalf("root request = %q, want latest user as root", view.RootUserRequest)
+	}
+	if view.LatestCommittedPlan != nil {
+		t.Fatalf("latest committed plan should not leak from before root, got %#v", view.LatestCommittedPlan)
+	}
+	if view.LatestVerifierSummary != "" {
+		t.Fatalf("latest verifier summary should not leak from before root, got %q", view.LatestVerifierSummary)
+	}
+}
+
 func TestFormatSessionContextViewOmitsFollowUpRelationJudgement(t *testing.T) {
 	events := []SessionEvent{
 		{Type: "user_input", Role: "user", Content: "打开微信", Relation: FollowUpRootRequest},

--- a/src/agent/internal/agent/session_context_view_test.go
+++ b/src/agent/internal/agent/session_context_view_test.go
@@ -1,11 +1,14 @@
 package agent
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"github.com/tmc/langchaingo/memory"
 )
 
-func TestBuildSessionContextViewUsesLatestTaskRootForContinuation(t *testing.T) {
+func TestBuildSessionContextViewUsesActiveSessionScopeIgnoringRelation(t *testing.T) {
 	events := []SessionEvent{
 		{Type: "user_input", Role: "user", Content: "查天气", Relation: FollowUpRootRequest},
 		{Type: "planner_decision", Role: string(RolePlanner), Objective: "查询天气", Plan: []string{"打开天气"}},
@@ -15,15 +18,33 @@ func TestBuildSessionContextViewUsesLatestTaskRootForContinuation(t *testing.T) 
 	}
 
 	view := BuildSessionContextView(events, "然后给张三发消息")
-	if view.RootUserRequest != "打开微信" {
-		t.Fatalf("root request = %q, want latest new task root", view.RootUserRequest)
+	if view.RootUserRequest != "查天气" {
+		t.Fatalf("root request = %q, want first active-session user input", view.RootUserRequest)
 	}
-	if view.LatestCommittedPlan != nil {
-		t.Fatalf("latest committed plan should not cross task root, got %#v", view.LatestCommittedPlan)
+	if view.LatestCommittedPlan == nil || view.LatestCommittedPlan.Objective != "查询天气" {
+		t.Fatalf("latest committed plan should come from active session regardless of relation, got %#v", view.LatestCommittedPlan)
 	}
 }
 
-func TestFormatSessionContextViewOmitsFollowUpInterpretationText(t *testing.T) {
+func TestBuildSessionContextViewIgnoresHotWindowEventsWhenRuntimeEventsExist(t *testing.T) {
+	events := []SessionEvent{
+		{Type: "user_input", Role: "user", Content: "HOT_WINDOW_USER_ONLY_PLANNER"},
+		{Type: "assistant_output", Role: "assistant", Content: "HOT_WINDOW_ASSISTANT_ONLY_PLANNER"},
+		{Type: "user_input", Role: "user", Content: "打开微信", RunID: "run-1", Relation: FollowUpRootRequest},
+		{Type: "planner_decision", Role: string(RolePlanner), Objective: "打开微信", Plan: []string{"打开微信"}, RunID: "run-1"},
+		{Type: "user_input", Role: "user", Content: "继续当前任务", RunID: "run-2", Relation: FollowUpContinuation},
+	}
+
+	view := BuildSessionContextView(events, "继续当前任务")
+	if view.RootUserRequest != "打开微信" {
+		t.Fatalf("root request = %q, want first runtime user input", view.RootUserRequest)
+	}
+	if view.LatestCommittedPlan == nil || view.LatestCommittedPlan.Objective != "打开微信" {
+		t.Fatalf("latest committed plan should come from runtime events, got %#v", view.LatestCommittedPlan)
+	}
+}
+
+func TestFormatSessionContextViewOmitsFollowUpRelationJudgement(t *testing.T) {
 	events := []SessionEvent{
 		{Type: "user_input", Role: "user", Content: "打开微信", Relation: FollowUpRootRequest},
 		{Type: "assistant_output", Role: "assistant", Content: "正在打开微信"},
@@ -32,10 +53,14 @@ func TestFormatSessionContextViewOmitsFollowUpInterpretationText(t *testing.T) {
 
 	view := BuildSessionContextView(events, "我喜欢吃小龙虾")
 	formatted := formatSessionContextView(view)
-	if !strings.Contains(formatted, "- Follow-up classification: continuation") {
-		t.Fatalf("formatted context missing follow-up classification:\n%s", formatted)
-	}
 	for _, unwanted := range []string{
+		"Follow-up classification:",
+		"follow_up_relation",
+		"continuation",
+		"correction",
+		"replacement",
+		"new_task",
+		"Latest correction:",
 		"Interpretation:",
 		"Context priority:",
 		"Root request:",
@@ -45,5 +70,25 @@ func TestFormatSessionContextViewOmitsFollowUpInterpretationText(t *testing.T) {
 		if strings.Contains(formatted, unwanted) {
 			t.Fatalf("formatted context should not contain %q:\n%s", unwanted, formatted)
 		}
+	}
+}
+
+func TestSessionContextPlannerMemoryDoesNotExposeFollowUpRelationVariable(t *testing.T) {
+	ctx := context.Background()
+	manager := NewMemoryManager(t.TempDir())
+	mem := newSessionContextPlannerMemory(memory.NewSimple(), manager, "default")
+
+	for _, variable := range mem.MemoryVariables(ctx) {
+		if variable == "follow_up_relation" {
+			t.Fatalf("memory variables should not expose follow_up_relation: %#v", mem.MemoryVariables(ctx))
+		}
+	}
+
+	values, err := mem.LoadMemoryVariables(ctx, map[string]any{"input": "然后给张三发消息"})
+	if err != nil {
+		t.Fatalf("LoadMemoryVariables() error = %v", err)
+	}
+	if _, ok := values["follow_up_relation"]; ok {
+		t.Fatalf("memory values should not expose follow_up_relation: %#v", values)
 	}
 }


### PR DESCRIPTION
## Summary
- remove follow-up relation from session context memory variables and role prompts
- restore root request and latest plan from runtime-scoped session events instead of relation labels
- document that follow-up relation classification is heuristic session metadata only

## Tests
- go test ./internal/agent
- go test ./cmd/daemon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed follow-up classification from agent planning prompts to ensure accurate context handling and prevent incorrect authoritative marking.

* **Refactor**
  * Simplified session context management by removing follow-up relation and correction tracking.
  * Updated runtime event filtering logic for improved session continuity during agent resumption and correction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->