### PR TITLE
chore(agent): trim redundant current date prompt

### DIFF
--- a/src/agent/internal/agent/prompt.go
+++ b/src/agent/internal/agent/prompt.go
@@ -75,7 +75,7 @@ func hostInfoValue(value string) string {
 
 func formatCurrentDate(t time.Time) string {
 	weekdays := []string{"星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"}
-	return "Current date: " + t.Format("2006-01-02") + " (" + t.Format("2006年01月02日") + " " + weekdays[t.Weekday()] + ")"
+	return "Current date: " + t.Format("2006-01-02") + " (" + weekdays[t.Weekday()] + ")"
 }
 
 func combinedAgentInstruction(cfg AgentConfig) string {

--- a/src/agent/internal/agent/prompt_test.go
+++ b/src/agent/internal/agent/prompt_test.go
@@ -15,7 +15,7 @@ func TestRolePromptsIncludeCurrentDate(t *testing.T) {
 	}
 	t.Cleanup(func() { promptNow = originalNow })
 
-	want := "Current date: 2026-06-01 (2026年06月01日 星期一)"
+	want := "Current date: 2026-06-01 (星期一)"
 	profiles := buildRoleProfiles(AgentConfig{}, ResolvedSkills{}, nil, MemoryContext{})
 	for _, profile := range []RoleProfile{profiles.Planner, profiles.Executor, profiles.Verifier} {
 		if !strings.Contains(profile.SystemPrompt, want) {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -189,7 +189,7 @@ func TestRuntimeRunInjectsCurrentDateIntoPlannerPrompt(t *testing.T) {
 		t.Fatalf("expected model to receive planner prompt")
 	}
 	systemPrompt := messageText(model.messages[0][:1])
-	want := "Current date: 2026-06-15 (2026年06月15日 星期一)"
+	want := "Current date: 2026-06-15 (星期一)"
 	if !strings.Contains(systemPrompt, want) {
 		t.Fatalf("planner system prompt missing current date %q:\n%s", want, systemPrompt)
 	}


### PR DESCRIPTION
Summary: Remove duplicate localized date text from the current-date prompt while keeping the ISO date and weekday. Tests: go test ./internal/agent