### PR TITLE
fix: stabilize wakeup prompt handling

### DIFF
--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 
 const (
 	wakeupListenTimeout                     = 10 * time.Second
+	wakeupDebounceInterval                  = 500 * time.Millisecond
 	defaultVoiceSteerListenTimeout          = 45 * time.Second
 	voiceTurnCancelWaitTimeout              = 2 * time.Second
 	voiceWakeupInterruptedCorrectionContext = "Voice interruption: the user pressed the physical wakeup button " +
@@ -28,6 +30,7 @@ const (
 )
 
 var voiceSteerListenTimeout = defaultVoiceSteerListenTimeout
+var wakeupDebounceNow = time.Now
 
 var wakeupGPIOPins = []int{33, 32}
 
@@ -245,10 +248,55 @@ func wakeupGPIOPinsLabel() string {
 }
 
 func startWakeupWatchers(newWatcher wakeupWatcherFactory, callback func()) ([]wakeupWatcher, error) {
+	return startWakeupWatchersWithDebounce(newWatcher, callback, wakeupDebounceInterval, wakeupDebounceNow)
+}
+
+type wakeupDebouncer struct {
+	mu       sync.Mutex
+	interval time.Duration
+	now      func() time.Time
+	last     time.Time
+}
+
+func newWakeupDebouncer(interval time.Duration, now func() time.Time) *wakeupDebouncer {
+	if now == nil {
+		now = time.Now
+	}
+	return &wakeupDebouncer{
+		interval: interval,
+		now:      now,
+	}
+}
+
+func (d *wakeupDebouncer) allow() bool {
+	if d == nil || d.interval <= 0 {
+		return true
+	}
+
+	now := d.now()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if !d.last.IsZero() {
+		elapsed := now.Sub(d.last)
+		if elapsed >= 0 && elapsed < d.interval {
+			return false
+		}
+	}
+	d.last = now
+	return true
+}
+
+func startWakeupWatchersWithDebounce(newWatcher wakeupWatcherFactory, callback func(), debounceInterval time.Duration, now func() time.Time) ([]wakeupWatcher, error) {
 	watchers := make([]wakeupWatcher, 0, len(wakeupGPIOPins))
+	debouncer := newWakeupDebouncer(debounceInterval, now)
 	for _, pin := range wakeupGPIOPins {
 		pin := pin
 		watcher, err := newWatcher(pin, func() {
+			if !debouncer.allow() {
+				log.Printf("[wakeup] GPIO %d wakeup event ignored by %s debounce", pin, debounceInterval)
+				return
+			}
 			log.Printf("[wakeup] GPIO %d wakeup event", pin)
 			callback()
 		})

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -376,6 +376,26 @@ type fakeWakeupWatcher struct {
 	stopCount    int
 }
 
+func withWakeupDebounceClock(t *testing.T, start time.Time) func(time.Duration) {
+	t.Helper()
+	var mu sync.Mutex
+	current := start
+	originalNow := wakeupDebounceNow
+	wakeupDebounceNow = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return current
+	}
+	t.Cleanup(func() {
+		wakeupDebounceNow = originalNow
+	})
+	return func(delta time.Duration) {
+		mu.Lock()
+		current = current.Add(delta)
+		mu.Unlock()
+	}
+}
+
 func newTestAudioVAD(t *testing.T, alwaysBuffer bool, probabilities []float64) *agent.AudioVAD {
 	t.Helper()
 	vad, err := agent.NewAudioVADWithScorer(agent.AudioVADConfig{
@@ -433,6 +453,7 @@ func (w *fakeWakeupWatcher) Stop() {
 }
 
 func TestStartWakeupWatchersRegistersGPIO32And33Callbacks(t *testing.T) {
+	advanceWakeup := withWakeupDebounceClock(t, time.Unix(0, 0))
 	watchersByPin := map[int]*fakeWakeupWatcher{}
 	eventCount := 0
 
@@ -457,10 +478,37 @@ func TestStartWakeupWatchersRegistersGPIO32And33Callbacks(t *testing.T) {
 			t.Fatalf("GPIO %d watcher was not started", pin)
 		}
 		watcher.callback()
+		advanceWakeup(wakeupDebounceInterval + time.Millisecond)
 	}
 
 	if eventCount != 2 {
 		t.Fatalf("event count = %d, want one wakeup event per GPIO callback", eventCount)
+	}
+}
+
+func TestStartWakeupWatchersDebouncesImmediateGPIOBurst(t *testing.T) {
+	withWakeupDebounceClock(t, time.Unix(0, 0))
+	watchersByPin := map[int]*fakeWakeupWatcher{}
+	eventCount := 0
+
+	watchers, err := startWakeupWatchers(func(pin int, callback func()) (wakeupWatcher, error) {
+		watcher := &fakeWakeupWatcher{callback: callback}
+		watchersByPin[pin] = watcher
+		return watcher, nil
+	}, func() {
+		eventCount++
+	})
+	if err != nil {
+		t.Fatalf("startWakeupWatchers() error = %v", err)
+	}
+	defer stopWakeupWatchers(watchers)
+
+	watchersByPin[33].callback()
+	watchersByPin[32].callback()
+	watchersByPin[33].callback()
+
+	if eventCount != 1 {
+		t.Fatalf("event count = %d, want one wakeup event after immediate GPIO burst", eventCount)
 	}
 }
 
@@ -883,6 +931,7 @@ func TestRunWakeupModeBuffersSpeechDetectedByRKNNAfterInitialNonSpeech(t *testin
 }
 
 func TestRunWakeupModeStartsNewRecordingForNextWakeup(t *testing.T) {
+	advanceWakeup := withWakeupDebounceClock(t, time.Unix(0, 0))
 	sigChan := make(chan os.Signal, 1)
 	watcher := &fakeWakeupWatcher{fireOnStart: true}
 	voiceSessionDisabled := false
@@ -903,6 +952,7 @@ func TestRunWakeupModeStartsNewRecordingForNextWakeup(t *testing.T) {
 			} else if watcher.callback != nil {
 				go func() {
 					time.Sleep(10 * time.Millisecond)
+					advanceWakeup(wakeupDebounceInterval + time.Millisecond)
 					watcher.callback()
 				}()
 			}
@@ -936,6 +986,7 @@ func TestRunWakeupModeStartsNewRecordingForNextWakeup(t *testing.T) {
 }
 
 func TestRunWakeupModeSTTWakeupQueuesCorrectionWhileRunActive(t *testing.T) {
+	advanceWakeup := withWakeupDebounceClock(t, time.Unix(0, 0))
 	sigChan := make(chan os.Signal, 1)
 	watcher := &fakeWakeupWatcher{fireOnStart: true}
 	firstRunStarted := make(chan struct{})
@@ -1008,6 +1059,7 @@ func TestRunWakeupModeSTTWakeupQueuesCorrectionWhileRunActive(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("STT wakeup mode did not start the first voice run")
 	}
+	advanceWakeup(wakeupDebounceInterval + time.Millisecond)
 	watcher.callback()
 
 	select {
@@ -2058,6 +2110,7 @@ func TestRunVoiceSessionSpeakingInterruptMarksNextUtteranceCorrection(t *testing
 }
 
 func TestRunWakeupModeSTTSpeakingInterruptMarksNextTurnCorrection(t *testing.T) {
+	advanceWakeup := withWakeupDebounceClock(t, time.Unix(0, 0))
 	sigChan := make(chan os.Signal, 1)
 	watcher := &fakeWakeupWatcher{fireOnStart: true}
 	speakStarted := make(chan struct{})
@@ -2108,6 +2161,7 @@ func TestRunWakeupModeSTTSpeakingInterruptMarksNextTurnCorrection(t *testing.T) 
 	case <-time.After(2 * time.Second):
 		t.Fatal("runWakeupMode did not start speaking")
 	}
+	advanceWakeup(wakeupDebounceInterval + time.Millisecond)
 	watcher.callback()
 
 	select {

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -927,6 +927,11 @@ func (d *AudioDialog) playPromptSoundAsync(kind promptSoundKind, label string) {
 }
 
 func (d *AudioDialog) playPromptSound(kind promptSoundKind, label string, wait bool) {
+	if kind == promptSoundRecordingStart {
+		d.playPromptSoundUninterruptible(kind, label, wait)
+		return
+	}
+
 	outputCtx, cancelOutput := context.WithCancel(context.Background())
 	output := newActiveTTSOutput(cancelOutput)
 	unregisterOutput := d.registerActiveOutput(output)
@@ -938,6 +943,14 @@ func (d *AudioDialog) playPromptSound(kind promptSoundKind, label string, wait b
 	d.speechMu.Lock()
 	defer d.speechMu.Unlock()
 	if err := playPromptSound(outputCtx, d.audioClient, kind, wait); err != nil {
+		log.Printf("[audio] %s prompt sound failed: %v\n", label, err)
+	}
+}
+
+func (d *AudioDialog) playPromptSoundUninterruptible(kind promptSoundKind, label string, wait bool) {
+	d.speechMu.Lock()
+	defer d.speechMu.Unlock()
+	if err := playPromptSound(context.Background(), d.audioClient, kind, wait); err != nil {
 		log.Printf("[audio] %s prompt sound failed: %v\n", label, err)
 	}
 }

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -394,6 +394,9 @@ func (d *AudioDialog) InterruptOutput() {
 	}
 
 	outputs := d.snapshotActiveOutputs()
+	if progress != nil || len(outputs) > 0 {
+		log.Printf("[audio] interrupt output requested: active_outputs=%d progress_active=%t\n", len(outputs), progress != nil)
+	}
 	for _, output := range outputs {
 		output.interrupt()
 	}
@@ -948,11 +951,15 @@ func (d *AudioDialog) playPromptSound(kind promptSoundKind, label string, wait b
 }
 
 func (d *AudioDialog) playPromptSoundUninterruptible(kind promptSoundKind, label string, wait bool) {
+	startedAt := time.Now()
+	log.Printf("[audio] %s prompt sound requested (uninterruptible)\n", label)
 	d.speechMu.Lock()
 	defer d.speechMu.Unlock()
 	if err := playPromptSound(context.Background(), d.audioClient, kind, wait); err != nil {
-		log.Printf("[audio] %s prompt sound failed: %v\n", label, err)
+		log.Printf("[audio] %s prompt sound failed after %s: %v\n", label, time.Since(startedAt).Round(time.Millisecond), err)
+		return
 	}
+	log.Printf("[audio] %s prompt sound completed in %s\n", label, time.Since(startedAt).Round(time.Millisecond))
 }
 
 // ProcessTextInput processes text input and speaks the response

--- a/src/agent/internal/agent/tts_test.go
+++ b/src/agent/internal/agent/tts_test.go
@@ -102,9 +102,38 @@ func TestPlayPromptSoundReturnsContextErrorWhenCanceledBeforeRetry(t *testing.T)
 	}
 }
 
-func TestAudioDialogInterruptOutputStopsPromptSound(t *testing.T) {
+func TestAudioDialogInterruptOutputStopsAgentSendPromptSound(t *testing.T) {
 	audioServer := newTestAudioService(t)
 	audioServer.healthPlaybackSessions = []uint32{1}
+	firstStart := make(chan struct{})
+	var once sync.Once
+	audioServer.onStartPlayback = func() {
+		once.Do(func() {
+			close(firstStart)
+		})
+	}
+	dialog := &AudioDialog{
+		audioClient: NewAudioServiceClient(audioServer.socketPath),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		dialog.playPromptSound(promptSoundAgentSend, "agent send", true)
+		close(done)
+	}()
+
+	waitForTestSignal(t, firstStart, "prompt sound playback to start")
+	dialog.InterruptOutput()
+	waitForTestSignal(t, done, "prompt sound to stop")
+
+	if got := audioServer.countOp("stop_playback"); got != 1 {
+		t.Fatalf("stop_playback count = %d, want 1", got)
+	}
+}
+
+func TestAudioDialogInterruptOutputDoesNotStopRecordingPromptSound(t *testing.T) {
+	audioServer := newTestAudioService(t)
+	audioServer.healthPlaybackSessions = []uint32{0}
 	firstStart := make(chan struct{})
 	var once sync.Once
 	audioServer.onStartPlayback = func() {
@@ -122,12 +151,12 @@ func TestAudioDialogInterruptOutputStopsPromptSound(t *testing.T) {
 		close(done)
 	}()
 
-	waitForTestSignal(t, firstStart, "prompt sound playback to start")
+	waitForTestSignal(t, firstStart, "recording prompt sound playback to start")
 	dialog.InterruptOutput()
-	waitForTestSignal(t, done, "prompt sound to stop")
+	waitForTestSignal(t, done, "recording prompt sound to finish")
 
-	if got := audioServer.countOp("stop_playback"); got != 1 {
-		t.Fatalf("stop_playback count = %d, want 1", got)
+	if got := audioServer.countOp("stop_playback"); got != 0 {
+		t.Fatalf("stop_playback count = %d, want recording prompt to ignore InterruptOutput", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Debounce GPIO wakeup bursts across both physical wakeup pins before they enter the voice state machine.
- Keep recording-start prompt sounds out of interruptible active outputs so wakeup interrupts do not cancel the listen cue.
- Add regression coverage for wakeup debounce and prompt interruption behavior.

## Tests
- go test ./cmd/daemon -count=1
- go test ./internal/agent -count=1
- go test ./...