### PR TITLE
fix(agent): clarify voice prompt speech behavior

### DIFF
--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -407,6 +407,7 @@ type AgentConfig struct {
 	RuntimeContext      string
 	ForceSimpleLoop     bool
 	VoiceToolCallSpeech *bool
+	TTSConfigured       bool
 }
 
 // MemoryConfig is used internally by the memory manager.

--- a/src/agent/internal/agent/prompt.go
+++ b/src/agent/internal/agent/prompt.go
@@ -105,10 +105,15 @@ func agentEnvironmentGuidance() string {
 func defaultAgentBehavior(cfg AgentConfig) string {
 	toolCallSpeechRule := "- When calling a tool, do not add speech or description arguments to tool inputs."
 	if cfg.VoiceToolCallSpeechOrDefault() {
-		toolCallSpeechRule = "- Put a brief assistant content message before every tool call that observes, waits for, reads, or changes external state; this includes screenshot, wait_for_stable_screen, quick_action, mouse_click, touch_gesture, keyboard_text, keyboard_tap, open_app, recall_memory, recall_device_memory, recall_session_chunks, and similar UI/device/memory tools. Use assistant content (choice.Content) for the spoken status; assistant content is spoken by the runtime, so keep it as short as possible, under 20 Chinese characters or 8 English words, in the user's language."
+		toolCallSpeechRule = "- Put a brief assistant content message before every tool call that observes, waits for, reads, or changes external state; this includes screenshot, wait_for_stable_screen, quick_action, mouse_click, touch_gesture, keyboard_text, keyboard_tap, open_app, recall_memory, recall_device_memory, recall_session_chunks, and similar UI/device/memory tools. Use assistant content (choice.Content) for the spoken status; assistant content is spoken aloud by the runtime before the tool runs, so keep it as short as possible, under 20 Chinese characters or 8 English words, in the user's language. Do not put the final answer in tool-call assistant content."
 	}
-	return strings.Join([]string{
+	ttsRule := ""
+	if cfg.TTSConfigured {
+		ttsRule = "- TTS is configured, so user-facing text output will be spoken aloud. Do not duplicate the same sentence in tool-call assistant content and the final answer; use tool-call assistant content only for brief progress, and put the actual answer only in the final response."
+	}
+	rules := []string{
 		"- Default to replying in Simplified Chinese; follow the user's language when they clearly use another language. Keep final replies short, natural, and suitable for TTS; avoid Markdown tables or long lists unless the user asks for them.",
+		"- The system prompt already includes the current date and weekday. Do not call current_time for ordinary date or weekday questions; answer from that prompt context. Call current_time only when a precise clock time, timezone conversion, offset, timestamp, or elapsed-time calculation is required.",
 		"- When an answer depends on saved long-term preferences, rules, procedures, or facts, call recall_memory first; do not answer from general knowledge alone. Do not use tools unnecessarily for ordinary questions. For text-only arithmetic, comparison, summarization, translation, or simple Q&A tasks, answer directly or use only the non-visual tool needed for the task; do not observe, wait on, or operate the connected display.",
 		"- When the user asks to inspect or operate a device, app, settings, contacts, messages, websites, TV UI, or other external state, you must use tools; do not claim state has changed without tool results or screenshot confirmation.",
 		"- When operating visible target UI, match device-operator in Available skills first; if relevant and not active, load it with skill_read before acting. Keep detailed UI playbooks in skills; do not copy them into the default prompt.",
@@ -120,5 +125,9 @@ func defaultAgentBehavior(cfg AgentConfig) string {
 		"- Picker/wheel controls (time, date, city pickers, etc.): recall_memory for similar control calibration first; without cache, probe once with medium, observe how many steps the value changed, then pick strength by remaining steps. Screenshot after each swipe to confirm the current value before the next step. On success, save_memory with app name, control location, direction, strength/distance, and delta (tags:[\"swipe\",\"picker\",\"calibration\"]).",
 		"- Before irreversible or sensitive actions—send message/email, place order, pay, delete data, change privacy/security settings, grant permissions, or start a call—request confirmation unless the user explicitly asks for that final action.",
 		toolCallSpeechRule,
-	}, "\n")
+	}
+	if ttsRule != "" {
+		rules = append(rules, ttsRule)
+	}
+	return strings.Join(rules, "\n")
 }

--- a/src/agent/internal/agent/prompt_test.go
+++ b/src/agent/internal/agent/prompt_test.go
@@ -191,7 +191,10 @@ func TestDefaultAgentBehaviorExcludesMigratedToolDetails(t *testing.T) {
 func TestRolePromptsRequireToolCallSpeechForExternalStateTools(t *testing.T) {
 	enabled := true
 	profiles := buildRoleProfiles(
-		AgentConfig{VoiceToolCallSpeech: &enabled},
+		AgentConfig{
+			VoiceToolCallSpeech: &enabled,
+			TTSConfigured:       true,
+		},
 		ResolvedSkills{},
 		nil,
 		MemoryContext{},
@@ -199,9 +202,15 @@ func TestRolePromptsRequireToolCallSpeechForExternalStateTools(t *testing.T) {
 
 	for _, profile := range []RoleProfile{profiles.Planner, profiles.Executor} {
 		for _, want := range []string{
+			"The system prompt already includes the current date and weekday",
+			"Do not call current_time for ordinary date or weekday questions",
+			"when a precise clock time, timezone conversion, offset, timestamp, or elapsed-time calculation is required",
 			"Put a brief assistant content message before every tool call that observes, waits for, reads, or changes external state",
 			"screenshot, wait_for_stable_screen, quick_action, mouse_click, touch_gesture, keyboard_text, keyboard_tap, open_app, recall_memory",
-			"assistant content is spoken by the runtime",
+			"assistant content is spoken aloud by the runtime before the tool runs",
+			"Do not put the final answer in tool-call assistant content",
+			"TTS is configured, so user-facing text output will be spoken aloud",
+			"Do not duplicate the same sentence in tool-call assistant content and the final answer",
 		} {
 			if !strings.Contains(profile.SystemPrompt, want) {
 				t.Fatalf("%s prompt missing tool-call speech requirement %q:\n%s", profile.Name, want, profile.SystemPrompt)

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1126,6 +1126,7 @@ func (r *Runtime) buildRoleProfiles(skills ResolvedSkills, availableTools []lang
 			RuntimeContext:      runtimeContext,
 			ForceSimpleLoop:     r.config.ForceSimpleLoop,
 			VoiceToolCallSpeech: r.config.VoiceToolCallSpeech,
+			TTSConfigured:       strings.TrimSpace(r.config.TTS.Provider) != "",
 		},
 		skills,
 		availableTools,

--- a/src/agent/internal/agent/tools_system.go
+++ b/src/agent/internal/agent/tools_system.go
@@ -34,7 +34,10 @@ func NewCurrentTimeTool() *CurrentTimeTool {
 func (t *CurrentTimeTool) Name() string { return "current_time" }
 
 func (t *CurrentTimeTool) Description() string {
-	return `Get the current date and time. Input JSON: {"timezone":"Asia/Shanghai"} or a bare timezone string. ` +
+	return `Get the precise current clock time, timezone data, UTC offset, Unix timestamp, or data needed for elapsed-time calculations. ` +
+		`Do not use this tool for ordinary date or weekday questions because the system prompt already provides today's date and weekday. ` +
+		`Use this tool only when a precise clock time, timezone conversion, UTC offset, Unix timestamp, or elapsed-time calculation is required. ` +
+		`Input JSON: {"timezone":"Asia/Shanghai"} or a bare timezone string. ` +
 		`The timezone may be an IANA name such as "America/New_York", "UTC", "local", or a UTC offset such as "+08:00".`
 }
 

--- a/src/agent/internal/agent/tools_system_test.go
+++ b/src/agent/internal/agent/tools_system_test.go
@@ -33,6 +33,20 @@ func TestCurrentTimeToolSupportsIANAAndOffsetTimezones(t *testing.T) {
 	}
 }
 
+func TestCurrentTimeToolDescriptionAvoidsOrdinaryDateQuestions(t *testing.T) {
+	description := NewCurrentTimeTool().Description()
+
+	for _, want := range []string{
+		"Do not use this tool for ordinary date or weekday questions",
+		"the system prompt already provides today's date and weekday",
+		"Use this tool only when a precise clock time, timezone conversion, UTC offset, Unix timestamp, or elapsed-time calculation is required",
+	} {
+		if !strings.Contains(description, want) {
+			t.Fatalf("current_time description missing %q:\n%s", want, description)
+		}
+	}
+}
+
 func TestBuiltinToolSetRegistersSystemTools(t *testing.T) {
 	tools := NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{})
 	for _, name := range []string{"current_time", "weather"} {


### PR DESCRIPTION
Summary:
- Tell the model to answer ordinary date and weekday questions from the system-provided current date instead of calling current_time.
- Clarify that tool-call assistant content is spoken aloud when voice_tool_call_speech is enabled.
- Add TTS-aware prompt guidance so final text is not duplicated with tool-call speech.

Tests:
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Text-to-Speech configuration detection for improved agent behavior when TTS is enabled.

* **Improvements**
  * Refined date and time question handling to avoid unnecessary tool calls for basic date/weekday inquiries.
  * Enhanced guidance to clarify when precise time tools should be used versus relying on system knowledge.

* **Tests**
  * Added test coverage for TTS-aware agent behavior and time tool guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->