### PR TITLE
refactor(agent): consolidate tool call content metadata

### DIFF
--- a/docs/04-agent/audio-features.md
+++ b/docs/04-agent/audio-features.md
@@ -109,9 +109,9 @@ speed = 1.0
 
 ### 工具调用口播
 
-`voice_tool_call_speech = true` 时，运行时会把工具 schema 中可选的 `speech` 参数暴露给 LLM，并在工具调用事件到达时异步 TTS 播放该字段。`speech` 是运行时元字段，不会传给真实工具。
+`voice_tool_call_speech = true` 时，运行时会在工具调用事件到达时异步 TTS 播放该事件的 `content`。这个 `content` 只来自同一次 LLM tool-call 响应中的 assistant content，不来自工具参数。
 
-如果 LLM 没有生成 `speech`，该工具调用保持静默。运行时不会从工具 `description`、assistant text 或其他上下文字段派生短口播；`description` 只用于 UI、trace、memory 和调试上下文。
+如果 LLM 没有在 tool call 同一响应中生成 assistant content，该工具调用保持静默。运行时不会从工具参数里的 `speech`、`description` 或其他上下文字段派生短口播。
 
 ## TTS provider 使用方式
 

--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -121,7 +121,7 @@ frame_socket = "/run/frame_service/frame_service.sock"
 | `voice_max_turns` | `0` | 单个 wakeup session 最大轮数；`0` 表示不限制 |
 | `voice_interrupt_on_wakeup` | `true` | session 内再次收到 wakeup 时取消 thinking/TTS 并重新听音；监听或录音阶段的重复 wakeup 会被合并或忽略 |
 | `voice_streaming_tts_enabled` | `true` | LLM 流式输出时按句送入 TTS，降低首句播放等待 |
-| `voice_tool_call_speech` | `true` | 是否异步朗读 LLM 在工具参数中显式生成的 `speech`；缺少 `speech` 时保持静默，不会从工具 `description` 派生口播 |
+| `voice_tool_call_speech` | `true` | 是否异步朗读 tool-call event 的 `content`；该内容只来自同一次 LLM tool-call 响应中的 assistant content，缺少时保持静默 |
 | `voice_progress_speech_enabled` | `true` | 是否在 todo item 进入 `in_progress` 时播报短进度；todo 状态仍会发送给 UI/trace |
 | `voice_max_response_tokens` | `400` | 语音回复的单次输出 token 上限（需 `>= 0`） |
 | `todo_reminder_tool_calls` | `3` | single-agent/default mode 中连续多少次工具调用后提醒模型更新 todo；设为 `0` 使用默认值 |

--- a/docs/04-agent/memory-plane.md
+++ b/docs/04-agent/memory-plane.md
@@ -595,7 +595,7 @@ The planner prompt receives `memory.Planner` plus `memory.Common`. The verifier 
 
 **3. Procedure（增强版）**  
 - **动作详情存储**：新增 `ProcedureStep` 结构，记录每步的：
-  - 工具名、description（从 tool_call arguments 自动提取）
+  - 工具名、content（来自 tool_call event 的 `content`）
   - 坐标（`x=500,y=850`）、输入文本
   - app_name、page_name、outcome_note
 - **按页面索引**：procedure ID 改为 `proc_<hash(app, page, goal)>`，page_name 进入 entities/tags
@@ -603,7 +603,7 @@ The planner prompt receives `memory.Planner` plus `memory.Common`. The verifier 
 
 **4. Navigation Memory（新增）**  
 - 抽取**页面间转移规则**：`美团/首页 → 美团/购物车`
-- 记录工具、坐标、描述，与具体任务目标解耦
+- 记录工具、坐标、tool-call content，与具体任务目标解耦
 - 与 procedure 同级路由到 Planner
 
 **5. Calibration Memory**  
@@ -619,7 +619,6 @@ The planner prompt receives `memory.Planner` plus `memory.Common`. The verifier 
 新增 `episode_extraction.go`，提供完整的 episode 事件解析：
 
 - **工具调用解析**：
-  - `extractToolCallDescription`：从 JSON 提取 description 字段
   - `extractToolCallCoords`：解析 tap/swipe 坐标
   - `extractToolCallText`：提取输入文本参数
 
@@ -660,7 +659,7 @@ memory/episodes/
 #### 测试覆盖
 
 新增 `device_memory_enhancements_test.go`，覆盖：
-- ✅ Procedure Steps 提取、坐标解析、description 保留
+- ✅ Procedure Steps 提取、坐标解析、tool-call content 保留
 - ✅ Page_name 索引和 entities 包含 page
 - ✅ Navigation 规则抽取
 - ✅ App profile 跨 episode 累积
@@ -690,7 +689,7 @@ memory/episodes/
 |------|---------|
 | `device_memory.go` | 扩展 `DeviceMemoryItem`（Steps、AppName、PageName、PagesSeen、ToolsUsed、KnownIssues）；新增 `ProcedureStep`；新增 `Get()` 方法；支持 navigation/ui_anchor 目录 |
 | `memory_plane.go` | 重写 `extractDeviceLessons`，新增 6 个辅助函数；扩展 `routeHit` 和 `renderMemoryHitLine`；新增 `mergeUniqueStrings`、`appendUniqueMemoryRef` |
-| `task_episode.go` | `TaskEpisodeEvent` 新增 `ToolDescription`；`RecordExecution` 提取 description |
+| `task_episode.go` | `TaskEpisodeEvent` 记录 tool-call content；`RecordExecution` 从 action log 写入 content |
 | `episode_extraction.go` | **新文件**：完整的工具调用解析、步骤抽取、页面/工具统计、转移规则抽取 |
 | `device_memory_enhancements_test.go` | **新文件**：5 个测试用例覆盖全部增强点 |
 

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	toolDescriptionSpeechTimeout = 15 * time.Second
-	outputInterruptWaitTimeout   = 250 * time.Millisecond
+	toolContentSpeechTimeout   = 15 * time.Second
+	outputInterruptWaitTimeout = 250 * time.Millisecond
 )
 
 var (
@@ -814,14 +814,13 @@ func (d *AudioDialog) HandleRunEvent(ctx context.Context, event RunEvent) {
 	if event.Type != runEventToolCall || !d.config.VoiceToolCallSpeechOrDefault() || event.ToolName == toolWaitForWakeup {
 		return
 	}
-	// Tool-call speech is only explicit LLM-generated event content; do not
-	// synthesize speech from the description when it is missing.
-	go d.SpeakToolDescription(event.Content)
+	// Tool-call speech is only explicit LLM-generated event content.
+	go d.SpeakToolContent(event.Content)
 }
 
 func (d *AudioDialog) newRunProgressSpeaker() *progressSpeaker {
 	return newProgressSpeaker(func(ctx context.Context, text string) error {
-		return d.speak(ctx, text, nil, toolDescriptionSpeechTimeout)
+		return d.speak(ctx, text, nil, toolContentSpeechTimeout)
 	}, progressSpeakerConfig{})
 }
 
@@ -840,15 +839,15 @@ func (d *AudioDialog) currentProgressSpeaker() *progressSpeaker {
 	return d.progress
 }
 
-func (d *AudioDialog) SpeakToolDescription(description string) {
-	description = strings.TrimSpace(description)
-	if description == "" {
+func (d *AudioDialog) SpeakToolContent(content string) {
+	content = strings.TrimSpace(content)
+	if content == "" {
 		return
 	}
 	// Detached from the agent turn context so tool TTS is not cut off when
 	// runtime.Run returns or the parent context is cancelled.
-	if err := d.speak(context.Background(), description, nil, toolDescriptionSpeechTimeout); err != nil {
-		log.Printf("[error] Tool description TTS failed: %v", err)
+	if err := d.speak(context.Background(), content, nil, toolContentSpeechTimeout); err != nil {
+		log.Printf("[error] Tool content TTS failed: %v", err)
 	}
 }
 

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -286,7 +286,7 @@ func TestProcessUtteranceSpeaksFullOutputWhenSpeechMissing(t *testing.T) {
 	}
 }
 
-func TestAudioDialogSpeaksToolDescriptionAsynchronously(t *testing.T) {
+func TestAudioDialogSpeaksToolContentAsynchronously(t *testing.T) {
 	toolSpeech := true
 	model := &scriptedModel{
 		responses: []*llms.ContentResponse{
@@ -331,14 +331,14 @@ func TestAudioDialogSpeaksToolDescriptionAsynchronously(t *testing.T) {
 	waitForProviderTextCount(t, provider, 2)
 	texts := provider.texts()
 	if len(texts) != 2 {
-		t.Fatalf("expected tool description and final answer TTS, got %#v", texts)
+		t.Fatalf("expected tool content and final answer TTS, got %#v", texts)
 	}
 	if !containsString(texts, "检查音量。") || !containsString(texts, "当前音量是 42。") {
 		t.Fatalf("unexpected TTS texts: %#v", texts)
 	}
 }
 
-func TestAudioDialogDoesNotSpeakWaitForWakeupToolDescription(t *testing.T) {
+func TestAudioDialogDoesNotSpeakWaitForWakeupToolContent(t *testing.T) {
 	toolSpeech := true
 	provider := &recordingTTSProvider{name: "dialog-provider"}
 	dialog := &AudioDialog{
@@ -350,10 +350,9 @@ func TestAudioDialogDoesNotSpeakWaitForWakeupToolDescription(t *testing.T) {
 	}
 
 	dialog.HandleRunEvent(context.Background(), RunEvent{
-		Type:        runEventToolCall,
-		ToolName:    toolWaitForWakeup,
-		Description: "用户让我休息，我准备回到等待唤醒状态。",
-		Content:     "我准备回到等待唤醒状态。",
+		Type:     runEventToolCall,
+		ToolName: toolWaitForWakeup,
+		Content:  "我准备回到等待唤醒状态。",
 	})
 
 	assertNoProviderTextWithin(t, provider, 200*time.Millisecond)
@@ -371,10 +370,9 @@ func TestAudioDialogSpeaksToolCallContent(t *testing.T) {
 	}
 
 	dialog.HandleRunEvent(context.Background(), RunEvent{
-		Type:        runEventToolCall,
-		ToolName:    "audio_volume",
-		Description: "完整工具描述保留给事件和上下文，不应该直接播报。",
-		Content:     "读取当前音量。",
+		Type:     runEventToolCall,
+		ToolName: "audio_volume",
+		Content:  "读取当前音量。",
 	})
 
 	waitForProviderTextCount(t, provider, 1)
@@ -383,7 +381,7 @@ func TestAudioDialogSpeaksToolCallContent(t *testing.T) {
 	}
 }
 
-func TestAudioDialogDoesNotFallbackToToolCallDescriptionForSpeech(t *testing.T) {
+func TestAudioDialogDoesNotSpeakToolCallWithoutContent(t *testing.T) {
 	toolSpeech := true
 	provider := &recordingTTSProvider{name: "dialog-provider"}
 	dialog := &AudioDialog{
@@ -395,9 +393,8 @@ func TestAudioDialogDoesNotFallbackToToolCallDescriptionForSpeech(t *testing.T) 
 	}
 
 	dialog.HandleRunEvent(context.Background(), RunEvent{
-		Type:        runEventToolCall,
-		ToolName:    "audio_volume",
-		Description: "完整工具描述保留给事件和上下文。",
+		Type:     runEventToolCall,
+		ToolName: "audio_volume",
 	})
 
 	assertNoProviderTextWithin(t, provider, 200*time.Millisecond)

--- a/src/agent/internal/agent/chat_history.go
+++ b/src/agent/internal/agent/chat_history.go
@@ -145,7 +145,6 @@ func compactMessageForChatHistory(message Message) Message {
 	message.Content = truncateChatHistoryRunes(message.Content, maxChatHistoryContentRunes)
 	message.OriginalText = truncateChatHistoryRunes(message.OriginalText, maxChatHistoryContentRunes)
 	message.ToolInput = truncateChatHistoryRunes(message.ToolInput, maxChatHistoryContentRunes)
-	message.Description = truncateChatHistoryRunes(message.Description, maxChatHistoryContentRunes)
 	return message
 }
 

--- a/src/agent/internal/agent/device_memory_enhancements_test.go
+++ b/src/agent/internal/agent/device_memory_enhancements_test.go
@@ -31,10 +31,10 @@ func TestDeviceMemoryProcedureStepsExtraction(t *testing.T) {
 		},
 		Events: []TaskEpisodeEvent{
 			{
-				Type:            runEventToolCall,
-				ToolName:        "launch_app",
-				ToolInput:       `{"app_name":"美团"}`,
-				ToolDescription: "打开美团App",
+				Type:      runEventToolCall,
+				ToolName:  "launch_app",
+				ToolInput: `{"app_name":"美团"}`,
+				Content:   "打开美团App",
 			},
 			{
 				Type:        "tool_result",
@@ -49,10 +49,10 @@ func TestDeviceMemoryProcedureStepsExtraction(t *testing.T) {
 				},
 			},
 			{
-				Type:            runEventToolCall,
-				ToolName:        "touch_gesture",
-				ToolInput:       `{"__arg1":"{\"type\":\"tap\",\"point\":{\"x\":500,\"y\":850},\"description\":\"点击购物车按钮\"}"}`,
-				ToolDescription: "点击购物车按钮",
+				Type:      runEventToolCall,
+				ToolName:  "touch_gesture",
+				ToolInput: `{"__arg1":"{\"type\":\"tap\",\"point\":{\"x\":500,\"y\":850},\"description\":\"点击购物车按钮\"}"}`,
+				Content:   "点击购物车按钮",
 			},
 			{
 				Type:        "tool_result",
@@ -67,10 +67,10 @@ func TestDeviceMemoryProcedureStepsExtraction(t *testing.T) {
 				},
 			},
 			{
-				Type:            runEventToolCall,
-				ToolName:        "ui_query",
-				ToolInput:       `{"text":"蜜雪冰城"}`,
-				ToolDescription: "搜索蜜雪冰城",
+				Type:      runEventToolCall,
+				ToolName:  "ui_query",
+				ToolInput: `{"text":"蜜雪冰城"}`,
+				Content:   "搜索蜜雪冰城",
 			},
 			{
 				Type:        "tool_result",
@@ -105,7 +105,7 @@ func TestDeviceMemoryProcedureStepsExtraction(t *testing.T) {
 	}
 	// 验证 description 被保留
 	if !strings.Contains(content, "点击购物车按钮") {
-		t.Errorf("procedure steps should contain tool description\n%s", content)
+		t.Errorf("procedure steps should contain tool content\n%s", content)
 	}
 	// 验证 page_name 被记录
 	if !strings.Contains(content, "page_name: 购物车") || !strings.Contains(content, "page_name: 首页") {
@@ -194,10 +194,10 @@ func TestDeviceMemoryNavigationFacts(t *testing.T) {
 				},
 			},
 			{
-				Type:            runEventToolCall,
-				ToolName:        "touch_gesture",
-				ToolInput:       `{"__arg1":"{\"type\":\"tap\",\"point\":{\"x\":800,\"y\":900},\"description\":\"点击购物车\"}"}`,
-				ToolDescription: "点击购物车",
+				Type:      runEventToolCall,
+				ToolName:  "touch_gesture",
+				ToolInput: `{"__arg1":"{\"type\":\"tap\",\"point\":{\"x\":800,\"y\":900},\"description\":\"点击购物车\"}"}`,
+				Content:   "点击购物车",
 			},
 			{Type: "tool_result", ToolName: "touch_gesture"},
 			{

--- a/src/agent/internal/agent/device_memory_review_fixes_test.go
+++ b/src/agent/internal/agent/device_memory_review_fixes_test.go
@@ -45,18 +45,17 @@ func TestEpisodeRecorderFinishAcceptsVerifierApproval(t *testing.T) {
 	}
 }
 
-func TestEpisodeRecorderDoesNotPersistToolSpeechAsEventField(t *testing.T) {
+func TestEpisodeRecorderPersistsToolContent(t *testing.T) {
 	action := schema.AgentAction{
 		Tool:      "echo",
 		ToolInput: "hello",
-		Log:       formatToolActionLog("echo", `{"input":"hello","speech":"Saying hi."}`, "I will echo.", "Saying hi.", "\n"),
+		Log:       formatToolActionLog("echo", `{"input":"hello","speech":"Saying hi."}`, "I will echo.", "\n"),
 	}
 
-	enabled := NewEpisodeRecorder(MemoryRetrieveRequest{Input: "test"}, MemoryContext{})
-	enabled.ToolCallSpeech = true
-	enabled.RecordExecution(roleExecutionResult{Action: &action})
-	enabledEpisode := enabled.Finish("", nil, nil, nil, nil)
-	if got := firstToolCallEventContent(enabledEpisode.Events); got != "Saying hi." {
+	recorder := NewEpisodeRecorder(MemoryRetrieveRequest{Input: "test"}, MemoryContext{})
+	recorder.RecordExecution(roleExecutionResult{Action: &action})
+	episode := recorder.Finish("", nil, nil, nil, nil)
+	if got := firstToolCallEventContent(episode.Events); got != "I will echo." {
 		t.Fatalf("tool event content = %q", got)
 	}
 }

--- a/src/agent/internal/agent/episode_exporter.go
+++ b/src/agent/internal/agent/episode_exporter.go
@@ -467,12 +467,11 @@ func (e *EpisodeExporter) buildLangfuseBatch(ctx context.Context, episode TaskEp
 				end = pair.ResultTime
 			}
 			metadata := map[string]interface{}{
-				"event_id":         event.EventID,
-				"tool_name":        event.ToolName,
-				"tool_description": event.ToolDescription,
-				"has_tool_result":  paired && pair.HasResult,
-				"role":             event.Role,
-				"phase":            currentPhase,
+				"event_id":        event.EventID,
+				"tool_name":       event.ToolName,
+				"has_tool_result": paired && pair.HasResult,
+				"role":            event.Role,
+				"phase":           currentPhase,
 			}
 			if paired && pair.ResultEventID != "" {
 				metadata["result_event_id"] = pair.ResultEventID
@@ -1371,8 +1370,8 @@ func toolCallInput(event TaskEpisodeEvent) map[string]interface{} {
 	if strings.TrimSpace(event.ToolInput) != "" {
 		input["tool_input"] = event.ToolInput
 	}
-	if strings.TrimSpace(event.ToolDescription) != "" {
-		input["description"] = event.ToolDescription
+	if strings.TrimSpace(event.Content) != "" {
+		input["content"] = event.Content
 	}
 	return input
 }

--- a/src/agent/internal/agent/episode_extraction.go
+++ b/src/agent/internal/agent/episode_extraction.go
@@ -8,27 +8,6 @@ import (
 	"strings"
 )
 
-// extractToolCallDescription 从工具调用的 ToolInput JSON 中尽力提取出可读的 description
-// 字段。不同模型/工具会把它放在 top-level 或包在 __arg1 这样的字符串里，这里尝试两层。
-func extractToolCallDescription(toolInput string) string {
-	input := strings.TrimSpace(toolInput)
-	if input == "" || input[0] != '{' {
-		return ""
-	}
-	if desc := lookupStringField(input, "description"); desc != "" {
-		return desc
-	}
-	// __arg1 通常是又一个 JSON 字符串 — 解一层再找。
-	if arg := lookupStringField(input, "__arg1"); arg != "" {
-		if strings.HasPrefix(strings.TrimSpace(arg), "{") {
-			if desc := lookupStringField(arg, "description"); desc != "" {
-				return desc
-			}
-		}
-	}
-	return ""
-}
-
 func lookupStringField(jsonText, field string) string {
 	var probe map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(jsonText), &probe); err != nil {
@@ -148,7 +127,7 @@ func episodeProcedureSteps(events []TaskEpisodeEvent) []ProcedureStep {
 		}
 		step := ProcedureStep{
 			Tool:        evt.ToolName,
-			Description: evt.ToolDescription,
+			Description: strings.TrimSpace(evt.Content),
 			Coords:      extractToolCallCoords(evt.ToolInput),
 			Text:        extractToolCallText(evt.ToolInput),
 			AppName:     pendingApp,
@@ -348,7 +327,7 @@ func pageTransitions(events []TaskEpisodeEvent) []pageTransition {
 						ToApp:       nextApp,
 						ToPage:      nextPage,
 						Tool:        pending.ToolName,
-						Description: pending.ToolDescription,
+						Description: strings.TrimSpace(pending.Content),
 						Coords:      extractToolCallCoords(pending.ToolInput),
 						Text:        extractToolCallText(pending.ToolInput),
 					})

--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -15,7 +15,6 @@ type FunctionAgent struct {
 	Tools             []langtools.Tool
 	OutputKey         string
 	ScreenshotPruning ScreenshotPruningConfig
-	ToolCallSpeech    bool
 }
 
 type visualObservationTool interface {
@@ -34,8 +33,6 @@ type structuredInputTool interface {
 
 const toolActionLogVersion = 1
 const maxToolObservationRunes = 4000
-const toolCallSpeechField = "speech"
-const toolCallDescriptionField = "description"
 
 type ScreenshotPruningConfig struct {
 	KeepN    int
@@ -65,16 +62,13 @@ func (c ScreenshotPruningConfig) PrunedCount(total int) int {
 }
 
 type toolActionLog struct {
-	Version         int    `json:"aiden_action_log_version"`
-	Message         string `json:"message"`
-	ToolDescription string `json:"tool_description,omitempty"`
-	ToolSpeech      string `json:"tool_speech,omitempty"`
+	Version     int    `json:"aiden_action_log_version"`
+	Message     string `json:"message"`
+	ToolContent string `json:"tool_content,omitempty"`
 }
 
 type toolInvocation struct {
-	Input       string
-	Description string
-	Speech      string
+	Input string
 }
 
 func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema.AgentAction, *schema.AgentFinish, error) {
@@ -92,16 +86,12 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 			}
 			functionName := toolCall.FunctionCall.Name
 			toolInputStr := toolCall.FunctionCall.Arguments
-			invocation := extractToolInvocation(toolInputStr, false)
+			invocation := extractToolInvocation(toolInputStr)
 			toolCallContent := ""
 			if !contentConsumed {
-				toolCallContent = choice.Content
+				toolCallContent = strings.TrimSpace(choice.Content)
 				contentConsumed = true
 			}
-			if speech := a.toolSpeechFromChoiceContent(toolCallContent); speech != "" {
-				invocation.Speech = speech
-			}
-			invocation.Description = toolCallDescriptionText(toolCallContent, invocation.Description)
 
 			contentMsg := "\n"
 			if toolCallContent != "" {
@@ -111,7 +101,7 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 			actions = append(actions, schema.AgentAction{
 				Tool:      functionName,
 				ToolInput: invocation.Input,
-				Log:       formatToolActionLog(functionName, toolInputStr, invocation.Description, invocation.Speech, contentMsg),
+				Log:       formatToolActionLog(functionName, toolInputStr, toolCallContent, contentMsg),
 				ToolID:    ensureToolCallID(toolCall.ID, len(actions)),
 			})
 		}
@@ -121,21 +111,18 @@ func (a *FunctionAgent) ParseOutput(contentResp *llms.ContentResponse) ([]schema
 	if choice.FuncCall != nil {
 		functionName := choice.FuncCall.Name
 		toolInputStr := choice.FuncCall.Arguments
-		invocation := extractToolInvocation(toolInputStr, false)
-		if speech := a.toolSpeechFromChoiceContent(choice.Content); speech != "" {
-			invocation.Speech = speech
-		}
-		invocation.Description = toolCallDescriptionText(choice.Content, invocation.Description)
+		invocation := extractToolInvocation(toolInputStr)
+		toolCallContent := strings.TrimSpace(choice.Content)
 
 		contentMsg := "\n"
-		if choice.Content != "" {
-			contentMsg = fmt.Sprintf("responded: %s\n", choice.Content)
+		if toolCallContent != "" {
+			contentMsg = fmt.Sprintf("responded: %s\n", toolCallContent)
 		}
 
 		return []schema.AgentAction{{
 			Tool:      functionName,
 			ToolInput: invocation.Input,
-			Log:       formatToolActionLog(functionName, toolInputStr, invocation.Description, invocation.Speech, contentMsg),
+			Log:       formatToolActionLog(functionName, toolInputStr, toolCallContent, contentMsg),
 			ToolID:    ensureToolCallID("", 0),
 		}}, nil, nil
 	}
@@ -157,13 +144,6 @@ func (a *FunctionAgent) toolsAsLLM() []llms.Tool {
 		result = append(result, NewToolSpec(tool).LLMTool())
 	}
 	return result
-}
-
-func (a *FunctionAgent) toolSpeechFromChoiceContent(content string) string {
-	if a == nil || !a.ToolCallSpeech {
-		return ""
-	}
-	return strings.TrimSpace(content)
 }
 
 func genericToolParameters() map[string]any {
@@ -219,8 +199,8 @@ func (a *FunctionAgent) constructFunctionScratchPad(steps []schema.AgentStep) []
 		}
 
 		toolCallParts := make([]llms.ContentPart, 0, groupEnd-i+1)
-		if description := toolDescriptionFromAction(steps[i].Action); description != "" {
-			toolCallParts = append(toolCallParts, llms.TextPart(description))
+		if content := toolContentFromAction(steps[i].Action); content != "" {
+			toolCallParts = append(toolCallParts, llms.TextPart(content))
 		}
 		for j := i; j < groupEnd; j++ {
 			toolCallParts = append(toolCallParts, llms.ToolCall{
@@ -468,7 +448,7 @@ func attachmentAwarePrompt(text string, attachments []InputAttachment, descripti
 	return text + "\n\nAttached content:\n- " + strings.Join(descriptions, "\n- ")
 }
 
-func extractToolInvocation(raw string, includeSpeech bool) toolInvocation {
+func extractToolInvocation(raw string) toolInvocation {
 	var toolInputMap map[string]any
 	if err := json.Unmarshal([]byte(raw), &toolInputMap); err != nil {
 		return toolInvocation{Input: raw}
@@ -476,25 +456,13 @@ func extractToolInvocation(raw string, includeSpeech bool) toolInvocation {
 	invocation := toolInvocation{Input: raw}
 	_, hasLegacyArg := toolInputMap["__arg1"]
 	hasGenericInput := false
-	if includeSpeech {
-		if speech, ok := toolInputMap[toolCallSpeechField].(string); ok {
-			invocation.Speech = strings.TrimSpace(speech)
-		}
-	}
 	if arg1, ok := toolInputMap["__arg1"].(string); ok {
 		invocation.Input = arg1
-	} else if input, ok := toolInputMap["input"].(string); ok && isGenericStringInputWrapper(toolInputMap, includeSpeech) {
+	} else if input, ok := toolInputMap["input"].(string); ok && isGenericStringInputWrapper(toolInputMap) {
 		invocation.Input = input
 		hasGenericInput = true
 	}
-	if description, ok := toolInputMap[toolCallDescriptionField].(string); ok {
-		invocation.Description = strings.TrimSpace(description)
-	}
 	if !hasLegacyArg && !hasGenericInput {
-		delete(toolInputMap, toolCallDescriptionField)
-		if includeSpeech {
-			delete(toolInputMap, toolCallSpeechField)
-		}
 		if encoded, err := json.Marshal(toolInputMap); err == nil {
 			invocation.Input = string(encoded)
 		}
@@ -502,18 +470,12 @@ func extractToolInvocation(raw string, includeSpeech bool) toolInvocation {
 	return invocation
 }
 
-func isGenericStringInputWrapper(fields map[string]any, includeSpeech bool) bool {
+func isGenericStringInputWrapper(fields map[string]any) bool {
 	if _, ok := fields["input"]; !ok {
 		return false
 	}
 	for key := range fields {
-		switch key {
-		case "input", toolCallDescriptionField:
-		case toolCallSpeechField:
-			if !includeSpeech {
-				return false
-			}
-		default:
+		if key != "input" {
 			return false
 		}
 	}
@@ -521,7 +483,7 @@ func isGenericStringInputWrapper(fields map[string]any, includeSpeech bool) bool
 }
 
 func extractToolInput(raw string) string {
-	return extractToolInvocation(raw, false).Input
+	return extractToolInvocation(raw).Input
 }
 
 func encodeToolArguments(input string) string {
@@ -545,13 +507,12 @@ func encodeToolArguments(input string) string {
 	return string(encoded)
 }
 
-func formatToolActionLog(name, arguments, description, speech, contentMsg string) string {
+func formatToolActionLog(name, arguments, content, contentMsg string) string {
 	message := fmt.Sprintf("Invoking: %s with %s %s", name, arguments, contentMsg)
 	metadata := toolActionLog{
-		Version:         toolActionLogVersion,
-		Message:         message,
-		ToolDescription: strings.TrimSpace(description),
-		ToolSpeech:      strings.TrimSpace(speech),
+		Version:     toolActionLogVersion,
+		Message:     message,
+		ToolContent: strings.TrimSpace(content),
 	}
 	encoded, err := json.Marshal(metadata)
 	if err != nil {
@@ -560,7 +521,7 @@ func formatToolActionLog(name, arguments, description, speech, contentMsg string
 	return string(encoded)
 }
 
-func toolDescriptionFromAction(action schema.AgentAction) string {
+func toolContentFromAction(action schema.AgentAction) string {
 	var metadata toolActionLog
 	if err := json.Unmarshal([]byte(action.Log), &metadata); err != nil {
 		return ""
@@ -568,25 +529,7 @@ func toolDescriptionFromAction(action schema.AgentAction) string {
 	if metadata.Version != toolActionLogVersion {
 		return ""
 	}
-	return strings.TrimSpace(metadata.ToolDescription)
-}
-
-func toolSpeechFromAction(action schema.AgentAction) string {
-	var metadata toolActionLog
-	if err := json.Unmarshal([]byte(action.Log), &metadata); err != nil {
-		return ""
-	}
-	if metadata.Version != toolActionLogVersion {
-		return ""
-	}
-	return strings.TrimSpace(metadata.ToolSpeech)
-}
-
-func toolCallDescriptionText(content, legacyDescription string) string {
-	if content = strings.TrimSpace(content); content != "" {
-		return content
-	}
-	return strings.TrimSpace(legacyDescription)
+	return strings.TrimSpace(metadata.ToolContent)
 }
 
 func extractFinalAnswer(content string) string {

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -45,8 +45,8 @@ func TestFunctionAgentParseOutputSkipsNilToolCalls(t *testing.T) {
 	}
 }
 
-func TestFunctionAgentParseOutputUsesChoiceContentAsToolSpeech(t *testing.T) {
-	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
+func TestFunctionAgentParseOutputUsesChoiceContentAsToolContent(t *testing.T) {
+	agent := &FunctionAgent{OutputKey: "output"}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
@@ -73,24 +73,21 @@ func TestFunctionAgentParseOutputUsesChoiceContentAsToolSpeech(t *testing.T) {
 	if actions[0].ToolInput != "hello" {
 		t.Fatalf("ToolInput = %q, want stripped tool input", actions[0].ToolInput)
 	}
-	if got := toolDescriptionFromAction(actions[0]); got != "发送测试文本。" {
-		t.Fatalf("tool description = %q", got)
-	}
-	if got := toolSpeechFromAction(actions[0]); got != "发送测试文本。" {
-		t.Fatalf("tool speech = %q", got)
+	if got := toolContentFromAction(actions[0]); got != "发送测试文本。" {
+		t.Fatalf("tool content = %q", got)
 	}
 
 	var log toolActionLog
 	if err := json.Unmarshal([]byte(actions[0].Log), &log); err != nil {
 		t.Fatalf("action log should be structured JSON: %v", err)
 	}
-	if log.Version != toolActionLogVersion || log.ToolDescription != "发送测试文本。" || log.ToolSpeech != "发送测试文本。" {
+	if log.Version != toolActionLogVersion || log.ToolContent != "发送测试文本。" {
 		t.Fatalf("unexpected action log metadata: %#v", log)
 	}
 }
 
 func TestFunctionAgentParseOutputBindsChoiceContentToFirstValidToolCall(t *testing.T) {
-	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
+	agent := &FunctionAgent{OutputKey: "output"}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
@@ -131,17 +128,11 @@ func TestFunctionAgentParseOutputBindsChoiceContentToFirstValidToolCall(t *testi
 	if actions[1].ToolInput != "second" || actions[1].ToolID != "call_2" {
 		t.Fatalf("unexpected second action: %#v", actions[1])
 	}
-	if got := toolDescriptionFromAction(actions[0]); got != "先检查。" {
-		t.Fatalf("first tool description = %q", got)
+	if got := toolContentFromAction(actions[0]); got != "先检查。" {
+		t.Fatalf("first tool content = %q", got)
 	}
-	if got := toolSpeechFromAction(actions[0]); got != "先检查。" {
-		t.Fatalf("first tool speech = %q", got)
-	}
-	if got := toolDescriptionFromAction(actions[1]); got != "" {
-		t.Fatalf("second tool description = %q, want empty", got)
-	}
-	if got := toolSpeechFromAction(actions[1]); got != "" {
-		t.Fatalf("second tool speech = %q, want empty", got)
+	if got := toolContentFromAction(actions[1]); got != "" {
+		t.Fatalf("second tool content = %q, want empty", got)
 	}
 
 	var secondLog toolActionLog
@@ -154,7 +145,7 @@ func TestFunctionAgentParseOutputBindsChoiceContentToFirstValidToolCall(t *testi
 }
 
 func TestFunctionAgentParseOutputExtractsGenericInputWrapper(t *testing.T) {
-	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
+	agent := &FunctionAgent{OutputKey: "output"}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
@@ -181,16 +172,13 @@ func TestFunctionAgentParseOutputExtractsGenericInputWrapper(t *testing.T) {
 	if actions[0].ToolInput != "hello" {
 		t.Fatalf("ToolInput = %q, want generic input wrapper", actions[0].ToolInput)
 	}
-	if got := toolDescriptionFromAction(actions[0]); got != "Echoing text." {
-		t.Fatalf("tool description = %q", got)
-	}
-	if got := toolSpeechFromAction(actions[0]); got != "Echoing text." {
-		t.Fatalf("tool speech = %q", got)
+	if got := toolContentFromAction(actions[0]); got != "Echoing text." {
+		t.Fatalf("tool content = %q", got)
 	}
 }
 
 func TestFunctionAgentParseOutputPassesStructuredToolArguments(t *testing.T) {
-	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
+	agent := &FunctionAgent{OutputKey: "output"}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
@@ -217,16 +205,13 @@ func TestFunctionAgentParseOutputPassesStructuredToolArguments(t *testing.T) {
 	if actions[0].ToolInput != `{"keys":["enter"]}` {
 		t.Fatalf("ToolInput = %q, want structured args without description", actions[0].ToolInput)
 	}
-	if got := toolDescriptionFromAction(actions[0]); got != "按回车。" {
-		t.Fatalf("tool description = %q", got)
-	}
-	if got := toolSpeechFromAction(actions[0]); got != "按回车。" {
-		t.Fatalf("tool speech = %q", got)
+	if got := toolContentFromAction(actions[0]); got != "按回车。" {
+		t.Fatalf("tool content = %q", got)
 	}
 }
 
-func TestFunctionAgentParseOutputKeepsLegacyArg1CompatibilityWithoutSpeechFallback(t *testing.T) {
-	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
+func TestFunctionAgentParseOutputKeepsLegacyArg1CompatibilityWithoutContentFallback(t *testing.T) {
+	agent := &FunctionAgent{OutputKey: "output"}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
@@ -252,16 +237,13 @@ func TestFunctionAgentParseOutputKeepsLegacyArg1CompatibilityWithoutSpeechFallba
 	if actions[0].ToolInput != `{"keys":["enter"]}` {
 		t.Fatalf("ToolInput = %q, want legacy __arg1", actions[0].ToolInput)
 	}
-	if got := toolDescriptionFromAction(actions[0]); got != "我会按下回车键。" {
-		t.Fatalf("tool description = %q", got)
-	}
-	if got := toolSpeechFromAction(actions[0]); got != "" {
-		t.Fatalf("tool speech = %q, want empty without assistant content", got)
+	if got := toolContentFromAction(actions[0]); got != "" {
+		t.Fatalf("tool content = %q, want empty without assistant content", got)
 	}
 }
 
 func TestFunctionAgentParseOutputDoesNotConsumeSpeechArgumentAsMetadata(t *testing.T) {
-	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
+	agent := &FunctionAgent{OutputKey: "output"}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
@@ -291,13 +273,13 @@ func TestFunctionAgentParseOutputDoesNotConsumeSpeechArgumentAsMetadata(t *testi
 	if _, ok := input["keys"]; !ok || input["speech"] != "按回车。" {
 		t.Fatalf("ToolInput should preserve speech as an ordinary tool argument: %#v", input)
 	}
-	if got := toolSpeechFromAction(actions[0]); got != "" {
-		t.Fatalf("tool speech = %q, want empty without assistant content", got)
+	if got := toolContentFromAction(actions[0]); got != "" {
+		t.Fatalf("tool content = %q, want empty without assistant content", got)
 	}
 }
 
-func TestFunctionAgentParseOutputDoesNotSynthesizeMissingToolSpeech(t *testing.T) {
-	agent := &FunctionAgent{OutputKey: "output", ToolCallSpeech: true}
+func TestFunctionAgentParseOutputDoesNotSynthesizeMissingToolContent(t *testing.T) {
+	agent := &FunctionAgent{OutputKey: "output"}
 
 	actions, finish, err := agent.ParseOutput(&llms.ContentResponse{
 		Choices: []*llms.ContentChoice{{
@@ -320,8 +302,8 @@ func TestFunctionAgentParseOutputDoesNotSynthesizeMissingToolSpeech(t *testing.T
 	if len(actions) != 1 {
 		t.Fatalf("expected 1 action, got %#v", actions)
 	}
-	if got := toolSpeechFromAction(actions[0]); got != "" {
-		t.Fatalf("tool speech = %q, want empty", got)
+	if got := toolContentFromAction(actions[0]); got != "" {
+		t.Fatalf("tool content = %q, want empty", got)
 	}
 }
 
@@ -356,16 +338,14 @@ func TestFunctionAgentParseOutputPreservesSpeechArgumentWhenDisabled(t *testing.
 	if input["speech"] != "hello" || input["volume"] != float64(1) {
 		t.Fatalf("ToolInput lost real speech argument: %#v", input)
 	}
-	if got := toolSpeechFromAction(actions[0]); got != "" {
-		t.Fatalf("tool speech metadata = %q, want empty", got)
+	if got := toolContentFromAction(actions[0]); got != "" {
+		t.Fatalf("tool content = %q, want empty", got)
 	}
 }
 
 func TestFunctionAgentParseOutputPreservesRealSpeechArgumentWhenSchemaDefinesIt(t *testing.T) {
 	agent := &FunctionAgent{
-		OutputKey:      "output",
-		ToolCallSpeech: true,
-		Tools: []langtools.Tool{&structuredStubTool{
+		OutputKey: "output", Tools: []langtools.Tool{&structuredStubTool{
 			stubTool: stubTool{name: "say", description: "Speak text."},
 			schema: map[string]any{
 				"type": "object",
@@ -406,32 +386,31 @@ func TestFunctionAgentParseOutputPreservesRealSpeechArgumentWhenSchemaDefinesIt(
 	if input["speech"] != "hello" || input["volume"] != float64(1) {
 		t.Fatalf("ToolInput lost real speech argument: %#v", input)
 	}
-	if got := toolSpeechFromAction(actions[0]); got != "准备播报。" {
-		t.Fatalf("tool speech metadata = %q", got)
+	if got := toolContentFromAction(actions[0]); got != "准备播报。" {
+		t.Fatalf("tool content = %q", got)
 	}
 }
 
-func TestFunctionAgentToolDescriptionIgnoresLogTextCollisions(t *testing.T) {
+func TestFunctionAgentToolContentIgnoresLogTextCollisions(t *testing.T) {
 	log := formatToolActionLog(
 		"echo",
-		"{\"__arg1\":\"payload\\nTool description: injected\"}",
-		"",
+		"{\"__arg1\":\"payload\\nTool content: injected\"}",
 		"",
 		"\n",
 	)
 
-	if got := toolDescriptionFromAction(schema.AgentAction{Log: log}); got != "" {
-		t.Fatalf("tool description = %q, want empty", got)
+	if got := toolContentFromAction(schema.AgentAction{Log: log}); got != "" {
+		t.Fatalf("tool content = %q, want empty", got)
 	}
 }
 
-func TestFunctionAgentScratchpadDoesNotReplayToolSpeechAsArgument(t *testing.T) {
+func TestFunctionAgentScratchpadDoesNotReplaySpeechArgument(t *testing.T) {
 	agent := &FunctionAgent{}
 	messages := agent.constructFunctionScratchPad([]schema.AgentStep{{
 		Action: schema.AgentAction{
 			Tool:      "echo",
 			ToolInput: "hello",
-			Log:       formatToolActionLog("echo", `{"input":"hello","speech":"Echoing text."}`, "", "Echoing text.", "\n"),
+			Log:       formatToolActionLog("echo", `{"input":"hello","speech":"Echoing text."}`, "", "\n"),
 			ToolID:    "call_1",
 		},
 		Observation: "ok",
@@ -462,13 +441,13 @@ func TestFunctionAgentScratchpadDoesNotReplayToolSpeechAsArgument(t *testing.T) 
 	}
 }
 
-func TestFunctionAgentScratchpadDoesNotReplayToolSpeechWhenEnabled(t *testing.T) {
-	agent := &FunctionAgent{ToolCallSpeech: true}
+func TestFunctionAgentScratchpadDoesNotReplaySpeechArgumentAsContent(t *testing.T) {
+	agent := &FunctionAgent{}
 	messages := agent.constructFunctionScratchPad([]schema.AgentStep{{
 		Action: schema.AgentAction{
 			Tool:      "echo",
 			ToolInput: "hello",
-			Log:       formatToolActionLog("echo", `{"input":"hello","speech":"Echoing text."}`, "", "Echoing text.", "\n"),
+			Log:       formatToolActionLog("echo", `{"input":"hello","speech":"Echoing text."}`, "", "\n"),
 			ToolID:    "call_1",
 		},
 		Observation: "ok",
@@ -499,13 +478,13 @@ func TestFunctionAgentScratchpadDoesNotReplayToolSpeechWhenEnabled(t *testing.T)
 	}
 }
 
-func TestFunctionAgentScratchpadReplaysToolDescriptionAsAssistantText(t *testing.T) {
+func TestFunctionAgentScratchpadReplaysToolContentAsAssistantText(t *testing.T) {
 	agent := &FunctionAgent{}
 	messages := agent.constructFunctionScratchPad([]schema.AgentStep{{
 		Action: schema.AgentAction{
 			Tool:      "echo",
 			ToolInput: "hello",
-			Log:       formatToolActionLog("echo", `{"input":"hello"}`, "I will echo text.", "", "responded: I will echo text.\n"),
+			Log:       formatToolActionLog("echo", `{"input":"hello"}`, "I will echo text.", "responded: I will echo text.\n"),
 			ToolID:    "call_1",
 		},
 		Observation: "ok",
@@ -720,7 +699,6 @@ func scratchpadToolResponseCount(messages []llms.MessageContent) int {
 
 func TestFunctionAgentToolsAsLLMUsesGenericInputFallback(t *testing.T) {
 	agent := &FunctionAgent{
-		ToolCallSpeech: true,
 		Tools: []langtools.Tool{&stubTool{
 			name:        "echo",
 			description: "Echo text.",
@@ -772,7 +750,7 @@ func TestFunctionAgentToolsAsLLMUsesGenericInputFallback(t *testing.T) {
 	}
 }
 
-func TestFunctionAgentToolsAsLLMOmitsSpeechWhenToolCallSpeechDisabled(t *testing.T) {
+func TestFunctionAgentToolsAsLLMOmitsSpeechMetadata(t *testing.T) {
 	agent := &FunctionAgent{
 		Tools: []langtools.Tool{&stubTool{
 			name:        "echo",
@@ -791,7 +769,7 @@ func TestFunctionAgentToolsAsLLMOmitsSpeechWhenToolCallSpeechDisabled(t *testing
 		t.Fatalf("unexpected properties: %#v", params["properties"])
 	}
 	if _, ok := props["speech"]; ok {
-		t.Fatalf("schema should not expose speech when tool-call speech is disabled: %#v", props)
+		t.Fatalf("schema should not expose speech metadata: %#v", props)
 	}
 }
 
@@ -804,7 +782,6 @@ func (t *structuredStubTool) ArgsSchema() map[string]any { return t.schema }
 
 func TestFunctionAgentToolsAsLLMUsesStructuredSchema(t *testing.T) {
 	agent := &FunctionAgent{
-		ToolCallSpeech: true,
 		Tools: []langtools.Tool{&structuredStubTool{
 			stubTool: stubTool{name: "structured", description: "Structured input."},
 			schema: map[string]any{

--- a/src/agent/internal/agent/live_activity.go
+++ b/src/agent/internal/agent/live_activity.go
@@ -215,7 +215,6 @@ func (m *LiveActivityManager) UpdateFromRunEvent(requestID string, event RunEven
 			state.CurrentApp = truncateLiveActivityText(app, 40)
 		}
 		state.CurrentStep = truncateLiveActivityText(firstNonEmptyString([]string{
-			event.Description,
 			event.Content,
 			toolStatus.step,
 			formatToolStep("Using", event.ToolName),

--- a/src/agent/internal/agent/live_activity_test.go
+++ b/src/agent/internal/agent/live_activity_test.go
@@ -25,10 +25,10 @@ func TestLiveActivityManagerLifecycle(t *testing.T) {
 	}
 
 	state = manager.UpdateFromRunEvent("req-1", RunEvent{
-		Type:        runEventToolCall,
-		ToolName:    "screenshot",
-		Description: "Checking the current screen",
-		Timestamp:   time.Now(),
+		Type:      runEventToolCall,
+		ToolName:  "screenshot",
+		Content:   "Checking the current screen",
+		Timestamp: time.Now(),
 	})
 	if state == nil || state.LastToolName != "screenshot" || !strings.Contains(state.CurrentStep, "Checking") {
 		t.Fatalf("unexpected tool update state: %#v", state)

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -109,7 +109,6 @@ type SessionEvent struct {
 	ToolCallID         string          `json:"tool_call_id,omitempty"`
 	ToolName           string          `json:"tool_name,omitempty"`
 	ToolInput          string          `json:"tool_input,omitempty"`
-	Description        string          `json:"description,omitempty"`
 	Objective          string          `json:"objective,omitempty"`
 	CompletionCriteria []string        `json:"completion_criteria,omitempty"`
 	Plan               []string        `json:"plan,omitempty"`
@@ -1741,7 +1740,7 @@ func messageRecordFromSessionEvent(event SessionEvent) (MessageRecord, bool) {
 	case "system_event":
 		return MessageRecord{Role: string(llms.ChatMessageTypeSystem), Content: event.Content}, true
 	case "tool_result":
-		if event.ToolName == "" && event.ToolInput == "" && event.Description == "" {
+		if event.ToolName == "" && event.ToolInput == "" {
 			return MessageRecord{Role: string(llms.ChatMessageTypeTool), Content: event.Content}, true
 		}
 		return MessageRecord{}, false

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -535,10 +535,10 @@ func (e *roleCollaborativeExecutor) callPlannerTurn(
 			plannerTools = appendDefaultLoopMetaTools(plannerTools)
 		}
 	}
-		parser := &FunctionAgent{
-			Tools:     plannerTools,
-			OutputKey: e.OutputKey,
-		}
+	parser := &FunctionAgent{
+		Tools:     plannerTools,
+		OutputKey: e.OutputKey,
+	}
 	baseOptions := append(chains.GetLLMCallOptions(options...), llms.WithTools(parser.toolsAsLLM()))
 	finalStreaming := state.Phase == phaseDefault || e.ForceSimpleLoop
 	callOptions := baseOptions
@@ -949,10 +949,10 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 ) (executorTurnResult, error) {
 	messages := e.roleMessages(e.Profiles.Executor, inputs, *state, "Executor task: work on the current next_step across multiple tool calls if needed, then call finish_step when the step is ready for verification or abort_step if blocked.")
 	executorTools := appendExecutorMetaTools(toolsForRole(RoleExecutor, e.Tools))
-		parser := &FunctionAgent{
-			Tools:     executorTools,
-			OutputKey: e.OutputKey,
-		}
+	parser := &FunctionAgent{
+		Tools:     executorTools,
+		OutputKey: e.OutputKey,
+	}
 	callOptions := append(chains.GetLLMCallOptions(options...), llms.WithTools(parser.toolsAsLLM()))
 	res, err := e.generateRoleContent(ctx, RoleExecutor, messages, callOptions...)
 	if err != nil {

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -34,7 +34,6 @@ type roleCollaborativeExecutor struct {
 	ScreenshotPruning     ScreenshotPruningConfig
 	InitialWorldState     worldState
 	ForceSimpleLoop       bool
-	ToolCallSpeech        bool
 	SteerProvider         func(context.Context) (RunSteerMessage, bool)
 	FinalSteerProvider    func(context.Context) (RunSteerMessage, bool)
 	SteerInterrupt        func() <-chan struct{}
@@ -536,11 +535,10 @@ func (e *roleCollaborativeExecutor) callPlannerTurn(
 			plannerTools = appendDefaultLoopMetaTools(plannerTools)
 		}
 	}
-	parser := &FunctionAgent{
-		Tools:          plannerTools,
-		OutputKey:      e.OutputKey,
-		ToolCallSpeech: e.ToolCallSpeech,
-	}
+		parser := &FunctionAgent{
+			Tools:     plannerTools,
+			OutputKey: e.OutputKey,
+		}
 	baseOptions := append(chains.GetLLMCallOptions(options...), llms.WithTools(parser.toolsAsLLM()))
 	finalStreaming := state.Phase == phaseDefault || e.ForceSimpleLoop
 	callOptions := baseOptions
@@ -665,7 +663,7 @@ func (e *roleCollaborativeExecutor) callRouteTurn(
 		return plannerTurnResult{Kind: plannerTurnSteer}, nil
 	}
 
-	parser := &FunctionAgent{Tools: appendLoopMetaTools(toolsForRole(RolePlanner, e.Tools)), OutputKey: e.OutputKey, ToolCallSpeech: e.ToolCallSpeech}
+	parser := &FunctionAgent{Tools: appendLoopMetaTools(toolsForRole(RolePlanner, e.Tools)), OutputKey: e.OutputKey}
 	actions, _, parseErr := parser.ParseOutput(res)
 	if parseErr != nil && !errors.Is(parseErr, agents.ErrUnableToParseOutput) {
 		return plannerTurnResult{}, parseErr
@@ -951,11 +949,10 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 ) (executorTurnResult, error) {
 	messages := e.roleMessages(e.Profiles.Executor, inputs, *state, "Executor task: work on the current next_step across multiple tool calls if needed, then call finish_step when the step is ready for verification or abort_step if blocked.")
 	executorTools := appendExecutorMetaTools(toolsForRole(RoleExecutor, e.Tools))
-	parser := &FunctionAgent{
-		Tools:          executorTools,
-		OutputKey:      e.OutputKey,
-		ToolCallSpeech: e.ToolCallSpeech,
-	}
+		parser := &FunctionAgent{
+			Tools:     executorTools,
+			OutputKey: e.OutputKey,
+		}
 	callOptions := append(chains.GetLLMCallOptions(options...), llms.WithTools(parser.toolsAsLLM()))
 	res, err := e.generateRoleContent(ctx, RoleExecutor, messages, callOptions...)
 	if err != nil {
@@ -1097,10 +1094,10 @@ func (e *roleCollaborativeExecutor) roleMessages(profile RoleProfile, inputs map
 	}
 
 	if profile.Name == RoleExecutor && len(state.StepToolSteps) > 0 {
-		scratchpad := (&FunctionAgent{Tools: appendExecutorMetaTools(toolsForRole(RoleExecutor, e.Tools)), ScreenshotPruning: e.ScreenshotPruning, ToolCallSpeech: e.ToolCallSpeech}).constructFunctionScratchPad(state.StepToolSteps)
+		scratchpad := (&FunctionAgent{Tools: appendExecutorMetaTools(toolsForRole(RoleExecutor, e.Tools)), ScreenshotPruning: e.ScreenshotPruning}).constructFunctionScratchPad(state.StepToolSteps)
 		messages = append(messages, scratchpad...)
 	} else if roleSeesToolScratchpad(profile.Name) && len(state.ToolSteps) > 0 {
-		scratchpad := (&FunctionAgent{Tools: toolsForRole(profile.Name, e.Tools), ScreenshotPruning: e.ScreenshotPruning, ToolCallSpeech: e.ToolCallSpeech}).constructFunctionScratchPad(state.ToolSteps)
+		scratchpad := (&FunctionAgent{Tools: toolsForRole(profile.Name, e.Tools), ScreenshotPruning: e.ScreenshotPruning}).constructFunctionScratchPad(state.ToolSteps)
 		messages = append(messages, scratchpad...)
 	}
 

--- a/src/agent/internal/agent/role_loop.go
+++ b/src/agent/internal/agent/role_loop.go
@@ -116,11 +116,8 @@ func isWaitForWakeupTool(name string) bool {
 
 func waitForWakeupFinalAnswer(step *schema.AgentStep) string {
 	if step != nil {
-		if speech := toolSpeechFromAction(step.Action); speech != "" {
-			return speech
-		}
-		if description := toolDescriptionFromAction(step.Action); description != "" {
-			return description
+		if content := toolContentFromAction(step.Action); content != "" {
+			return content
 		}
 		if message := toolObservationMessage(step.Observation); message != "" {
 			return message

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -71,7 +71,7 @@ func TestEnterPlanModePreservesToolSteps(t *testing.T) {
 	}
 }
 
-func TestExecutorScratchpadDoesNotReplayToolSpeechWhenEnabled(t *testing.T) {
+func TestExecutorScratchpadDoesNotReplaySpeechArgumentAsContent(t *testing.T) {
 	executor := newRoleCollaborativeExecutor(
 		&scriptedModel{},
 		RoleProfiles{},
@@ -84,13 +84,12 @@ func TestExecutorScratchpadDoesNotReplayToolSpeechWhenEnabled(t *testing.T) {
 		ScreenshotPruningConfig{},
 		nil,
 	)
-	executor.ToolCallSpeech = true
 	state := roleLoopState{
 		StepToolSteps: []schema.AgentStep{{
 			Action: schema.AgentAction{
 				Tool:      "mouse_click",
 				ToolInput: `{"button":"left","x":500,"y":850}`,
-				Log:       formatToolActionLog("mouse_click", `{"button":"left","speech":"点击支付按钮","x":500,"y":850}`, "", "点击支付按钮", "\n"),
+				Log:       formatToolActionLog("mouse_click", `{"button":"left","speech":"点击支付按钮","x":500,"y":850}`, "", "\n"),
 				ToolID:    "call_1",
 			},
 			Observation: "ok",

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -164,7 +164,6 @@ type RunEvent struct {
 	EpisodeID      string     `json:"episode_id,omitempty"`
 	ToolName       string     `json:"tool_name,omitempty"`
 	ToolInput      string     `json:"tool_input,omitempty"`
-	Description    string     `json:"description,omitempty"`
 	Content        string     `json:"content,omitempty"`
 	Todo           *TodoState `json:"todo,omitempty"`
 	SpeechEligible bool       `json:"speech_eligible,omitempty"`
@@ -586,7 +585,6 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if r.memoryPlane != nil {
 		episodeRecorder = r.memoryPlane.NewEpisodeRecorder(retrieveReq, memoryContext)
 		if episodeRecorder != nil {
-			episodeRecorder.ToolCallSpeech = r.config.VoiceToolCallSpeechOrDefault()
 			retrieveReq.EpisodeID = episodeRecorder.ID()
 			if err := episodeRecorder.Start(ctx); err != nil && r.logger != nil {
 				r.logger.Warn("[memory] start episode failed: %v", err)
@@ -617,7 +615,6 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			sessionID:              r.telemetrySessionID,
 			requestID:              req.RequestID,
 			runID:                  runID,
-			toolCallSpeechEnabled:  r.config.VoiceToolCallSpeechOrDefault(),
 		}
 		if persistRuntimeSessionEvents {
 			streamCallbackHandler.sessionEventAppender = func(ctx context.Context, event SessionEvent) error {
@@ -660,7 +657,6 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	executor := newRoleCollaborativeExecutor(model, profiles, availableTools, plannerMemory, maxIterations, turnInput.Attachments, executorHandler, episodeRecorder, r.config.ScreenshotPruningOrDefault(), req.DeviceEnvironment, req.SteerProvider)
 	executor.ConversationHistory = conversationHistory
 	executor.TodoReminderToolCalls = r.config.TodoReminderToolCallsOrDefault()
-	executor.ToolCallSpeech = r.config.VoiceToolCallSpeechOrDefault()
 	executor.SteerInterrupt = req.SteerInterrupt
 	executor.SteerWaiter = req.SteerWaiter
 	executor.FinalSteerProvider = req.FinalSteerProvider
@@ -1167,7 +1163,6 @@ type runtimeCallbackHandler struct {
 	requestID              string
 	runID                  string
 	sessionEventAppender   func(context.Context, SessionEvent) error
-	toolCallSpeechEnabled  bool
 	mu                     sync.Mutex
 	pendingActions         []schema.AgentAction
 }
@@ -1328,31 +1323,23 @@ func (h *runtimeCallbackHandler) HandleNamedToolError(ctx context.Context, name,
 }
 
 func (h *runtimeCallbackHandler) HandleToolCallStart(ctx context.Context, call ToolCall) {
-	description := call.Description
-	speech := call.Speech
+	content := strings.TrimSpace(call.Content)
 	if h.logger != nil {
-		if description != "" && speech != "" {
-			h.logger.Info("Tool call: name=%s input=%s description=%s speech=%s",
-				call.Spec.Name, truncateForLog(call.Input, 240), truncateForLog(description, 240), truncateForLog(speech, 120))
-		} else if description != "" {
-			h.logger.Info("Tool call: name=%s input=%s description=%s",
-				call.Spec.Name, truncateForLog(call.Input, 240), truncateForLog(description, 240))
-		} else if speech != "" {
-			h.logger.Info("Tool call: name=%s input=%s speech=%s",
-				call.Spec.Name, truncateForLog(call.Input, 240), truncateForLog(speech, 120))
+		if content != "" {
+			h.logger.Info("Tool call: name=%s input=%s content=%s",
+				call.Spec.Name, truncateForLog(call.Input, 240), truncateForLog(content, 240))
 		} else {
 			h.logger.Info("Tool call: name=%s input=%s",
 				call.Spec.Name, truncateForLog(call.Input, 240))
 		}
 	}
 	h.emitRunEvent(ctx, RunEvent{
-		Type:        runEventToolCall,
-		EpisodeID:   h.episodeID,
-		ToolName:    call.Spec.Name,
-		ToolInput:   call.Input,
-		Description: description,
-		Content:     h.toolCallContent(speech),
-		Timestamp:   time.Now(),
+		Type:      runEventToolCall,
+		EpisodeID: h.episodeID,
+		ToolName:  call.Spec.Name,
+		ToolInput: call.Input,
+		Content:   content,
+		Timestamp: time.Now(),
 	})
 }
 
@@ -1385,18 +1372,11 @@ func (h *runtimeCallbackHandler) HandleToolCallResult(ctx context.Context, call 
 }
 
 func (h *runtimeCallbackHandler) HandleAgentAction(ctx context.Context, action schema.AgentAction) {
-	description := toolDescriptionFromAction(action)
-	speech := toolSpeechFromAction(action)
+	content := toolContentFromAction(action)
 	if h.logger != nil {
-		if description != "" && speech != "" {
-			h.logger.Info("Tool call: name=%s input=%s description=%s speech=%s",
-				action.Tool, truncateForLog(action.ToolInput, 240), truncateForLog(description, 240), truncateForLog(speech, 120))
-		} else if description != "" {
-			h.logger.Info("Tool call: name=%s input=%s description=%s",
-				action.Tool, truncateForLog(action.ToolInput, 240), truncateForLog(description, 240))
-		} else if speech != "" {
-			h.logger.Info("Tool call: name=%s input=%s speech=%s",
-				action.Tool, truncateForLog(action.ToolInput, 240), truncateForLog(speech, 120))
+		if content != "" {
+			h.logger.Info("Tool call: name=%s input=%s content=%s",
+				action.Tool, truncateForLog(action.ToolInput, 240), truncateForLog(content, 240))
 		} else {
 			h.logger.Info("Tool call: name=%s input=%s",
 				action.Tool, truncateForLog(action.ToolInput, 240))
@@ -1406,13 +1386,12 @@ func (h *runtimeCallbackHandler) HandleAgentAction(ctx context.Context, action s
 		h.pushPendingAction(action)
 	}
 	h.emitRunEvent(ctx, RunEvent{
-		Type:        runEventToolCall,
-		EpisodeID:   h.episodeID,
-		ToolName:    action.Tool,
-		ToolInput:   action.ToolInput,
-		Description: description,
-		Content:     h.toolCallContent(speech),
-		Timestamp:   time.Now(),
+		Type:      runEventToolCall,
+		EpisodeID: h.episodeID,
+		ToolName:  action.Tool,
+		ToolInput: action.ToolInput,
+		Content:   content,
+		Timestamp: time.Now(),
 	})
 }
 
@@ -1494,18 +1473,17 @@ func sessionEventFromRunEvent(event RunEvent, h *runtimeCallbackHandler) Session
 		ts = time.Now()
 	}
 	sessionEvent := SessionEvent{
-		Ts:          ts.UTC().Format(time.RFC3339Nano),
-		Type:        event.Type,
-		Role:        role,
-		SessionID:   h.sessionID,
-		EpisodeID:   firstNonEmptyString([]string{event.EpisodeID, h.episodeID}),
-		RequestID:   h.requestID,
-		RunID:       h.runID,
-		Content:     event.Content,
-		ToolName:    event.ToolName,
-		ToolInput:   event.ToolInput,
-		Description: event.Description,
-		IsError:     event.IsError,
+		Ts:        ts.UTC().Format(time.RFC3339Nano),
+		Type:      event.Type,
+		Role:      role,
+		SessionID: h.sessionID,
+		EpisodeID: firstNonEmptyString([]string{event.EpisodeID, h.episodeID}),
+		RequestID: h.requestID,
+		RunID:     h.runID,
+		Content:   event.Content,
+		ToolName:  event.ToolName,
+		ToolInput: event.ToolInput,
+		IsError:   event.IsError,
 	}
 	return sessionEvent
 }
@@ -1679,13 +1657,6 @@ func (h *runtimeCallbackHandler) recordFinalStreamError(err error) {
 }
 
 var _ callbacks.Handler = (*runtimeCallbackHandler)(nil)
-
-func (h *runtimeCallbackHandler) toolCallContent(speech string) string {
-	if h == nil || !h.toolCallSpeechEnabled {
-		return ""
-	}
-	return strings.TrimSpace(speech)
-}
 
 func (h *runtimeCallbackHandler) pushPendingAction(action schema.AgentAction) {
 	h.mu.Lock()

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -2165,7 +2165,7 @@ func TestRuntimeAllowsRepeatedKeyboardText(t *testing.T) {
 	}
 }
 
-func TestRuntimeRunEmitsToolDescriptionEventAndStripsToolInput(t *testing.T) {
+func TestRuntimeRunStripsLegacyToolInputWithoutDerivingContent(t *testing.T) {
 	model := &scriptedModel{
 		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我先读取当前音量。","speech":"读取音量。"}`, "The current audio volume is 42."),
 	}
@@ -2207,9 +2207,6 @@ func TestRuntimeRunEmitsToolDescriptionEventAndStripsToolInput(t *testing.T) {
 	toolCall, ok := firstRunEventOfType(events, runEventToolCall)
 	if !ok {
 		t.Fatalf("expected tool_call event, got %#v", events)
-	}
-	if toolCall.Description != "我先读取当前音量。" {
-		t.Fatalf("unexpected tool description event: %#v", toolCall)
 	}
 	if toolCall.Content != "" {
 		t.Fatalf("tool_call content = %q, want empty without assistant content", toolCall.Content)
@@ -2261,15 +2258,12 @@ func TestRuntimeRunEmitsToolContentForToolCallSpeech(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected tool_call event, got %#v", events)
 	}
-	if toolCall.Description != speech {
-		t.Fatalf("tool_call description changed: %q", toolCall.Description)
-	}
 	if toolCall.Content != speech {
 		t.Fatalf("tool_call content = %q, want assistant content", toolCall.Content)
 	}
 }
 
-func TestRuntimeRunDoesNotDeriveToolSpeechWhenMissing(t *testing.T) {
+func TestRuntimeRunDoesNotDeriveToolContentFromDescriptionArgument(t *testing.T) {
 	description := "我先读取当前音量并检查当前播放设备、音量状态、静音状态、输出通道以及系统返回结果是否一致。然后继续回答。"
 	model := &scriptedModel{
 		responses: roleToolResponses("audio_volume", fmt.Sprintf(`{"__arg1":"{}","description":%q}`, description), "The current audio volume is 42."),
@@ -2307,9 +2301,6 @@ func TestRuntimeRunDoesNotDeriveToolSpeechWhenMissing(t *testing.T) {
 	toolCall, ok := firstRunEventOfType(events, runEventToolCall)
 	if !ok {
 		t.Fatalf("expected tool_call event, got %#v", events)
-	}
-	if toolCall.Description != description {
-		t.Fatalf("tool_call description changed: %q", toolCall.Description)
 	}
 	if toolCall.Content != "" {
 		t.Fatalf("tool_call content = %q, want empty without assistant content", toolCall.Content)

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -112,7 +112,6 @@ type Message struct {
 	SpeechEligible  bool                `json:"speech_eligible,omitempty"`
 	ToolName        string              `json:"tool_name,omitempty"`
 	ToolInput       string              `json:"tool_input,omitempty"`
-	Description     string              `json:"description,omitempty"`
 	Attachments     []MessageAttachment `json:"attachments,omitempty"`
 	Artifacts       []InputArtifact     `json:"artifacts,omitempty"`
 	Source          string              `json:"source,omitempty"`
@@ -145,7 +144,6 @@ func messageFromRunEvent(event RunEvent, fallbackEpisodeID string, requestID str
 		SpeechEligible: event.SpeechEligible,
 		ToolName:       event.ToolName,
 		ToolInput:      event.ToolInput,
-		Description:    event.Description,
 		Timestamp:      event.Timestamp,
 		IsError:        event.IsError,
 	}
@@ -827,7 +825,7 @@ func (s *Server) handleChatAsync(
 			}
 
 			if s.shouldSpeakToolCall(event) {
-				go s.speakToolDescription(runCtx, event.Content)
+				go s.speakToolContent(runCtx, event.Content)
 			}
 			if event.Type == runEventTodoUpdate && s.runtime.config.VoiceProgressSpeechEnabledOrDefault() {
 				if text, ok := progressSpeechTextForEvent(event); ok {
@@ -1093,7 +1091,7 @@ func (s *Server) handleChatSync(
 		EventHandler: func(event RunEvent) {
 			s.appendHistory(messageFromRunEvent(event, episodeID, ""))
 			if s.shouldSpeakToolCall(event) {
-				go s.speakToolDescription(r.Context(), event.Content)
+				go s.speakToolContent(r.Context(), event.Content)
 			}
 			if event.Type == runEventTodoUpdate && s.runtime.config.VoiceProgressSpeechEnabledOrDefault() {
 				if text, ok := progressSpeechTextForEvent(event); ok {
@@ -1272,7 +1270,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 				s.liveActivity.UpdateFromRunEvent(req.RequestID, event)
 			}
 			if s.shouldSpeakToolCall(event) {
-				go s.speakToolDescription(ctx, event.Content)
+				go s.speakToolContent(ctx, event.Content)
 			}
 			if event.Type == runEventTodoUpdate && s.runtime.config.VoiceProgressSpeechEnabledOrDefault() {
 				if text, ok := progressSpeechTextForEvent(event); ok {
@@ -1589,22 +1587,22 @@ func (w *finalStreamFanoutWriter) StreamEmitted() bool {
 	return false
 }
 
-func (s *Server) speakToolDescription(ctx context.Context, description string) {
-	description = strings.TrimSpace(description)
-	if description == "" || s.audioClient == nil {
+func (s *Server) speakToolContent(ctx context.Context, content string) {
+	content = strings.TrimSpace(content)
+	if content == "" || s.audioClient == nil {
 		return
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	ttsCtx, cancel := context.WithTimeout(ctx, toolDescriptionSpeechTimeout)
+	ttsCtx, cancel := context.WithTimeout(ctx, toolContentSpeechTimeout)
 	defer cancel()
 	if s.logger != nil {
-		s.logger.Info("Tool description TTS playback: %q", description)
+		s.logger.Info("Tool content TTS playback: %q", content)
 	}
-	if err := s.speakText(ttsCtx, description, 0); err != nil {
+	if err := s.speakText(ttsCtx, content, 0); err != nil {
 		if s.logger != nil {
-			s.logger.Error("Tool description TTS playback failed: %v", err)
+			s.logger.Error("Tool content TTS playback failed: %v", err)
 		}
 	}
 }
@@ -1630,7 +1628,7 @@ func (s *Server) newRunProgressSpeaker() *progressSpeaker {
 		if ctx == nil {
 			ctx = context.Background()
 		}
-		ttsCtx, cancel := context.WithTimeout(ctx, toolDescriptionSpeechTimeout)
+		ttsCtx, cancel := context.WithTimeout(ctx, toolContentSpeechTimeout)
 		defer cancel()
 		if s.logger != nil {
 			s.logger.Info("Progress TTS playback: %q", text)

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -47,7 +47,10 @@ func firstMessageOfType(messages []Message, messageType string) (Message, bool) 
 
 func TestServerHandleChatReturnsToolHistory(t *testing.T) {
 	model := &scriptedModel{
-		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我先读取当前音量。","speech":"读取音量。"}`, "The current audio volume is 42."),
+		responses: []*llms.ContentResponse{
+			toolCallResponseWithContent("call_1", "audio_volume", `{"__arg1":"{}"}`, "我先读取当前音量。"),
+			contentResponse("The current audio volume is 42."),
+		},
 	}
 	tool := &stubTool{
 		name:        "audio_volume",
@@ -104,11 +107,8 @@ func TestServerHandleChatReturnsToolHistory(t *testing.T) {
 	if !ok || toolCall.ToolName != "audio_volume" || toolCall.ToolInput != "{}" {
 		t.Fatalf("unexpected tool_call message: %#v", resp.History)
 	}
-	if toolCall.Description != "我先读取当前音量。" {
-		t.Fatalf("unexpected tool_call description: %#v", toolCall)
-	}
-	if toolCall.Content != "" {
-		t.Fatalf("tool_call content = %q, want empty without assistant content", toolCall.Content)
+	if toolCall.Content != "我先读取当前音量。" {
+		t.Fatalf("unexpected tool_call content: %#v", toolCall)
 	}
 	toolResult, ok := firstMessageOfType(resp.History, "tool_result")
 	if !ok || toolResult.ToolName != "audio_volume" || toolResult.Content != `{"volume":42}` {
@@ -776,7 +776,7 @@ func TestHandleCoordinateDebugTapRecapturesUncroppedScreenshot(t *testing.T) {
 	}
 }
 
-func TestServerSpeakToolDescriptionUsesTTS(t *testing.T) {
+func TestServerSpeakToolContentUsesTTS(t *testing.T) {
 	provider := &recordingTTSProvider{name: "server-provider"}
 	server := &Server{
 		runtime: NewRuntimeWithDeps(
@@ -790,14 +790,14 @@ func TestServerSpeakToolDescriptionUsesTTS(t *testing.T) {
 		audioClient: NewAudioServiceClient(startTTSPlaybackAudioSocket(t)),
 	}
 
-	server.speakToolDescription(context.Background(), " 我先读取当前音量。 ")
+	server.speakToolContent(context.Background(), " 我先读取当前音量。 ")
 
 	if got := provider.texts(); len(got) != 1 || got[0] != "我先读取当前音量。" {
 		t.Fatalf("unexpected TTS texts: %#v", got)
 	}
 }
 
-func TestServerHandleChatDoesNotWaitForToolDescriptionTTSWhenEnabled(t *testing.T) {
+func TestServerHandleChatDoesNotWaitForToolContentTTSWhenEnabled(t *testing.T) {
 	speech := "读取音量。"
 	model := &scriptedModel{
 		responses: []*llms.ContentResponse{
@@ -847,12 +847,12 @@ func TestServerHandleChatDoesNotWaitForToolDescriptionTTSWhenEnabled(t *testing.
 	case <-time.After(500 * time.Millisecond):
 		cancel()
 		<-done
-		t.Fatal("handleChat waited for tool description TTS")
+		t.Fatal("handleChat waited for tool content TTS")
 	}
 	select {
 	case <-provider.started:
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("tool description TTS was not started")
+		t.Fatal("tool content TTS was not started")
 	}
 	if rec.Code != http.StatusOK {
 		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
@@ -899,9 +899,12 @@ func TestServerHandleChatDoesNotSpeakWaitForWakeup(t *testing.T) {
 	assertNoProviderTextWithin(t, provider, 200*time.Millisecond)
 }
 
-func TestServerHandleChatSkipsToolDescriptionTTSWhenDisabled(t *testing.T) {
+func TestServerHandleChatSkipsToolContentTTSWhenDisabled(t *testing.T) {
 	model := &scriptedModel{
-		responses: roleToolResponses("audio_volume", `{"__arg1":"{}","description":"我先读取当前音量。","speech":"读取音量。"}`, "The current audio volume is 42."),
+		responses: []*llms.ContentResponse{
+			toolCallResponseWithContent("call_1", "audio_volume", `{"__arg1":"{}"}`, "我先读取当前音量。"),
+			contentResponse("The current audio volume is 42."),
+		},
 	}
 	streamingDisabled := false
 	toolSpeechDisabled := false
@@ -939,7 +942,7 @@ func TestServerHandleChatSkipsToolDescriptionTTSWhenDisabled(t *testing.T) {
 	}
 	select {
 	case <-provider.started:
-		t.Fatal("tool description TTS started despite voice_tool_call_speech=false")
+		t.Fatal("tool content TTS started despite voice_tool_call_speech=false")
 	case <-time.After(50 * time.Millisecond):
 	}
 }
@@ -1148,7 +1151,7 @@ func TestServerHandleChatStreamDuplicateRequestIDDoesNotAppendHistory(t *testing
 	}
 }
 
-func TestServerSpeakToolDescriptionUsesCallerContext(t *testing.T) {
+func TestServerSpeakToolContentUsesCallerContext(t *testing.T) {
 	provider := &blockingTTSProvider{started: make(chan struct{}), blockText: "我先读取当前音量。"}
 	server := &Server{
 		ttsManager:  ttsmodule.NewProviderManager(provider, nil),
@@ -1158,7 +1161,7 @@ func TestServerSpeakToolDescriptionUsesCallerContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		server.speakToolDescription(ctx, "我先读取当前音量。")
+		server.speakToolContent(ctx, "我先读取当前音量。")
 		close(done)
 	}()
 
@@ -1166,13 +1169,13 @@ func TestServerSpeakToolDescriptionUsesCallerContext(t *testing.T) {
 	case <-provider.started:
 	case <-time.After(500 * time.Millisecond):
 		cancel()
-		t.Fatal("tool description TTS was not started")
+		t.Fatal("tool content TTS was not started")
 	}
 	cancel()
 	select {
 	case <-done:
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("tool description TTS did not stop after caller context cancellation")
+		t.Fatal("tool content TTS did not stop after caller context cancellation")
 	}
 }
 

--- a/src/agent/internal/agent/task_episode.go
+++ b/src/agent/internal/agent/task_episode.go
@@ -69,7 +69,6 @@ type TaskEpisodeEvent struct {
 	NextStep           string              `json:"next_step,omitempty" yaml:"next_step,omitempty"`
 	ToolName           string              `json:"tool_name,omitempty" yaml:"tool_name,omitempty"`
 	ToolInput          string              `json:"tool_input,omitempty" yaml:"tool_input,omitempty"`
-	ToolDescription    string              `json:"tool_description,omitempty" yaml:"tool_description,omitempty"`
 	Content            string              `json:"content,omitempty" yaml:"content,omitempty"`
 	Todo               *TodoState          `json:"todo,omitempty" yaml:"todo,omitempty"`
 	SpeechEligible     bool                `json:"speech_eligible,omitempty" yaml:"speech_eligible,omitempty"`
@@ -125,8 +124,6 @@ type EpisodeRecorder struct {
 	store     *TaskEpisodeStore
 	started   bool
 	startErr  error
-	// ToolCallSpeech gates persistence of LLM-generated tool-call content.
-	ToolCallSpeech bool
 }
 
 func NewTaskEpisodeStore(rootDir string) *TaskEpisodeStore {
@@ -298,21 +295,12 @@ func (r *EpisodeRecorder) recordExecutionForRole(result roleExecutionResult, rol
 	}
 	if result.Action != nil {
 		input := normalizeToolInput(result.Action.ToolInput)
-		description := toolDescriptionFromAction(*result.Action)
-		if description == "" {
-			description = extractToolCallDescription(input)
-		}
 		event := TaskEpisodeEvent{
-			Type:            runEventToolCall,
-			Role:            string(role),
-			ToolName:        result.Action.Tool,
-			ToolInput:       input,
-			ToolDescription: description,
-		}
-		if r.ToolCallSpeech {
-			// Persist only explicit LLM-generated tool-call content. Missing
-			// content is intentionally left empty rather than derived.
-			event.Content = toolSpeechFromAction(*result.Action)
+			Type:      runEventToolCall,
+			Role:      string(role),
+			ToolName:  result.Action.Tool,
+			ToolInput: input,
+			Content:   toolContentFromAction(*result.Action),
 		}
 		r.append(event)
 	}

--- a/src/agent/internal/agent/tool_execution.go
+++ b/src/agent/internal/agent/tool_execution.go
@@ -13,12 +13,11 @@ import (
 )
 
 type ToolCall struct {
-	Spec        ToolSpec
-	Action      schema.AgentAction
-	Input       string
-	Description string
-	Speech      string
-	StartedAt   time.Time
+	Spec      ToolSpec
+	Action    schema.AgentAction
+	Input     string
+	Content   string
+	StartedAt time.Time
 }
 
 type ToolResult struct {
@@ -77,12 +76,11 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 	action.Tool = spec.Name
 	action.ToolInput = input
 	call := ToolCall{
-		Spec:        spec,
-		Action:      action,
-		Input:       input,
-		Description: toolDescriptionFromAction(action),
-		Speech:      toolSpeechFromAction(action),
-		StartedAt:   startedAt,
+		Spec:      spec,
+		Action:    action,
+		Input:     input,
+		Content:   toolContentFromAction(action),
+		StartedAt: startedAt,
 	}
 
 	emitToolStart(ctx, execution.Callback, call)
@@ -131,12 +129,11 @@ func invalidToolCall(action schema.AgentAction, startedAt time.Time) ToolCall {
 	action.ToolInput = normalizeToolInput(action.ToolInput)
 	toolName := strings.TrimSpace(action.Tool)
 	return ToolCall{
-		Spec:        ToolSpec{Name: toolName},
-		Action:      action,
-		Input:       action.ToolInput,
-		Description: toolDescriptionFromAction(action),
-		Speech:      toolSpeechFromAction(action),
-		StartedAt:   startedAt,
+		Spec:      ToolSpec{Name: toolName},
+		Action:    action,
+		Input:     action.ToolInput,
+		Content:   toolContentFromAction(action),
+		StartedAt: startedAt,
 	}
 }
 

--- a/src/agent/internal/agent/tool_schema_test.go
+++ b/src/agent/internal/agent/tool_schema_test.go
@@ -45,10 +45,10 @@ func TestAgentExposedToolsDoNotExposeLegacyArg1Schema(t *testing.T) {
 				t.Fatalf("schema missing properties: %#v", schema)
 			}
 			if _, ok := props["description"]; ok {
-				t.Fatalf("schema exposes tool-call speech description property: %#v", schema)
+				t.Fatalf("schema exposes tool-call metadata description property: %#v", schema)
 			}
 			if _, ok := props["speech"]; ok {
-				t.Fatalf("schema exposes speech while tool-call speech is disabled: %#v", schema)
+				t.Fatalf("schema exposes tool-call speech metadata: %#v", schema)
 			}
 		})
 	}

--- a/src/agent/internal/agent/tts_provider_integration_test.go
+++ b/src/agent/internal/agent/tts_provider_integration_test.go
@@ -393,7 +393,7 @@ func TestAudioDialogInterruptOutputStopsBackgroundToolSpeech(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		dialog.SpeakToolDescription("tool is running")
+		dialog.SpeakToolContent("tool is running")
 		close(done)
 	}()
 


### PR DESCRIPTION
## Summary
- Replace ToolCall Description/Speech metadata with a single Content field sourced from assistant content
- Emit tool-call content through RunEvent.Content and remove RunEvent.Description from chat/session/episode paths
- Update tool-call TTS, memory extraction, Langfuse export, tests, and docs for the new content semantics

## Tests
- go test ./...