### PR TITLE
fix(agent): omit tool-call content from persisted context

### DIFF
--- a/src/agent/internal/agent/chat_history.go
+++ b/src/agent/internal/agent/chat_history.go
@@ -137,6 +137,9 @@ func (s *ChatHistoryStore) eventsPath() string {
 }
 
 func compactMessageForChatHistory(message Message) Message {
+	if message.Type == runEventToolCall {
+		message.Content = ""
+	}
 	if message.Type == "tool_result" {
 		message.Content = compactToolResultForChatHistory(message.Content)
 	}

--- a/src/agent/internal/agent/chat_history.go
+++ b/src/agent/internal/agent/chat_history.go
@@ -137,6 +137,7 @@ func (s *ChatHistoryStore) eventsPath() string {
 }
 
 func compactMessageForChatHistory(message Message) Message {
+	message.Type = strings.TrimSpace(message.Type)
 	if message.Type == runEventToolCall {
 		message.Content = ""
 	}

--- a/src/agent/internal/agent/chat_history_test.go
+++ b/src/agent/internal/agent/chat_history_test.go
@@ -45,3 +45,40 @@ func TestChatHistoryStorePersistsLightweightMessages(t *testing.T) {
 		t.Fatalf("tool result screenshot data should be omitted: %s", messages[1].Content)
 	}
 }
+
+func TestChatHistoryStoreOmitsToolCallContentBeforePersistence(t *testing.T) {
+	store := NewChatHistoryStore(t.TempDir())
+	ctx := context.Background()
+
+	var callbackMessages []Message
+	store.SetOnNewMessage(func(message Message) {
+		callbackMessages = append(callbackMessages, message)
+	})
+
+	if err := store.Append(ctx, Message{
+		Type:      runEventToolCall,
+		Content:   "我先查一下。",
+		ToolName:  "weather",
+		ToolInput: `{"location":"Shanghai"}`,
+		Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("Append tool call: %v", err)
+	}
+
+	messages, err := store.Load(ctx)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("messages = %d, want 1", len(messages))
+	}
+	if messages[0].Content != "" {
+		t.Fatalf("persisted tool_call content = %q, want empty", messages[0].Content)
+	}
+	if messages[0].ToolName != "weather" || messages[0].ToolInput != `{"location":"Shanghai"}` {
+		t.Fatalf("tool metadata was not preserved: %#v", messages[0])
+	}
+	if len(callbackMessages) != 1 || callbackMessages[0].Content != "" {
+		t.Fatalf("callback should receive sanitized persisted message, got %#v", callbackMessages)
+	}
+}

--- a/src/agent/internal/agent/chat_history_test.go
+++ b/src/agent/internal/agent/chat_history_test.go
@@ -82,3 +82,30 @@ func TestChatHistoryStoreOmitsToolCallContentBeforePersistence(t *testing.T) {
 		t.Fatalf("callback should receive sanitized persisted message, got %#v", callbackMessages)
 	}
 }
+
+func TestChatHistoryStoreNormalizesMessageTypeBeforeToolCallPersistence(t *testing.T) {
+	store := NewChatHistoryStore(t.TempDir())
+	ctx := context.Background()
+
+	if err := store.Append(ctx, Message{
+		Type:     " \t" + runEventToolCall + " \n",
+		Content:  "我先查一下。",
+		ToolName: "weather",
+	}); err != nil {
+		t.Fatalf("Append tool call: %v", err)
+	}
+
+	messages, err := store.Load(ctx)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("messages = %d, want 1", len(messages))
+	}
+	if messages[0].Type != runEventToolCall {
+		t.Fatalf("persisted message type = %q, want %q", messages[0].Type, runEventToolCall)
+	}
+	if messages[0].Content != "" {
+		t.Fatalf("persisted tool_call content = %q, want empty", messages[0].Content)
+	}
+}

--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -198,10 +198,7 @@ func (a *FunctionAgent) constructFunctionScratchPad(steps []schema.AgentStep) []
 			groupEnd++
 		}
 
-		toolCallParts := make([]llms.ContentPart, 0, groupEnd-i+1)
-		if content := toolContentFromAction(steps[i].Action); content != "" {
-			toolCallParts = append(toolCallParts, llms.TextPart(content))
-		}
+		toolCallParts := make([]llms.ContentPart, 0, groupEnd-i)
 		for j := i; j < groupEnd; j++ {
 			toolCallParts = append(toolCallParts, llms.ToolCall{
 				ID:   scratchpadToolCallID(steps[j].Action, i, j),

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -478,7 +478,7 @@ func TestFunctionAgentScratchpadDoesNotReplaySpeechArgumentAsContent(t *testing.
 	}
 }
 
-func TestFunctionAgentScratchpadReplaysToolContentAsAssistantText(t *testing.T) {
+func TestFunctionAgentScratchpadOmitsToolContentFromModelContext(t *testing.T) {
 	agent := &FunctionAgent{}
 	messages := agent.constructFunctionScratchPad([]schema.AgentStep{{
 		Action: schema.AgentAction{
@@ -490,15 +490,11 @@ func TestFunctionAgentScratchpadReplaysToolContentAsAssistantText(t *testing.T) 
 		Observation: "ok",
 	}})
 
-	if len(messages) == 0 || len(messages[0].Parts) != 2 {
+	if len(messages) == 0 || len(messages[0].Parts) != 1 {
 		t.Fatalf("unexpected scratchpad messages: %#v", messages)
 	}
-	text, ok := messages[0].Parts[0].(llms.TextContent)
-	if !ok || text.Text != "I will echo text." {
-		t.Fatalf("expected assistant text before tool call, got %#v", messages[0].Parts[0])
-	}
-	if _, ok := messages[0].Parts[1].(llms.ToolCall); !ok {
-		t.Fatalf("expected tool call after assistant text, got %#v", messages[0].Parts[1])
+	if _, ok := messages[0].Parts[0].(llms.ToolCall); !ok {
+		t.Fatalf("expected tool call without assistant text content, got %#v", messages[0].Parts[0])
 	}
 }
 

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -1695,10 +1695,17 @@ func normalizeSessionEventForAppend(event SessionEvent, ts time.Time, sequence i
 	if event.Role == "" {
 		event.Role = "system"
 	}
-	event.Content = stripScreenshotData(event.Content)
+	event.Content = sanitizePersistentEventContent(event.Type, event.Content)
 	event.ToolInput = stripScreenshotData(event.ToolInput)
 	event.Artifacts = sanitizeInputArtifacts(event.Artifacts)
 	return event
+}
+
+func sanitizePersistentEventContent(eventType string, content string) string {
+	if strings.TrimSpace(eventType) == runEventToolCall {
+		return ""
+	}
+	return stripScreenshotData(content)
 }
 
 func sessionEventFromTurnInput(input TurnInput) SessionEvent {

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -206,6 +206,35 @@ func TestSessionMemoryAppendEventStripsScreenshotData(t *testing.T) {
 	}
 }
 
+func TestSessionMemoryAppendEventOmitsToolCallContentBeforePersistence(t *testing.T) {
+	ctx := context.Background()
+	session := NewSessionMemoryStore(t.TempDir())
+
+	if _, err := session.AppendEvent(ctx, SessionEvent{
+		Type:      runEventToolCall,
+		Role:      "assistant",
+		Content:   "我先查一下。",
+		ToolName:  "weather",
+		ToolInput: `{"location":"Shanghai"}`,
+	}); err != nil {
+		t.Fatalf("AppendEvent() error = %v", err)
+	}
+
+	events, err := session.readEvents(session.eventsPath())
+	if err != nil {
+		t.Fatalf("ReadEvents() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Content != "" {
+		t.Fatalf("persisted tool_call content = %q, want empty", events[0].Content)
+	}
+	if events[0].ToolName != "weather" || events[0].ToolInput != `{"location":"Shanghai"}` {
+		t.Fatalf("tool metadata was not preserved: %#v", events[0])
+	}
+}
+
 func TestMemoryManagerRestoresFromSessionEventsWhenSnapshotMissing(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()
@@ -337,6 +366,33 @@ func TestMemoryManagerSaveDoesNotRegressEventCountWithRuntimeEvents(t *testing.T
 		if event.Sequence != want {
 			t.Fatalf("event %d sequence = %d, want %d; events=%#v", i, event.Sequence, want, events)
 		}
+	}
+}
+
+func TestMemoryManagerAppendSessionEventOmitsToolCallContentBeforePersistence(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	manager := NewMemoryManager(storageDir)
+
+	if err := manager.AppendSessionEvent(ctx, "default", SessionEvent{
+		Type:      runEventToolCall,
+		Role:      "assistant",
+		Content:   "我先查一下。",
+		ToolName:  "weather",
+		ToolInput: `{"location":"Shanghai"}`,
+	}, SessionEventMetadata{}); err != nil {
+		t.Fatalf("AppendSessionEvent() error = %v", err)
+	}
+
+	events := readSessionEvents(t, filepath.Join(storageDir, "session", "events.jsonl"))
+	if len(events) != 1 {
+		t.Fatalf("expected 1 session event, got %d: %#v", len(events), events)
+	}
+	if events[0].Content != "" {
+		t.Fatalf("persisted tool_call content = %q, want empty", events[0].Content)
+	}
+	if events[0].ToolName != "weather" || events[0].ToolInput != `{"location":"Shanghai"}` {
+		t.Fatalf("tool metadata was not preserved: %#v", events[0])
 	}
 }
 

--- a/src/agent/internal/agent/session_memory.go
+++ b/src/agent/internal/agent/session_memory.go
@@ -181,13 +181,11 @@ func (s *SessionMemoryStore) AppendEvent(ctx context.Context, event SessionEvent
 	if event.Role == "" {
 		event.Role = "system"
 	}
-	// Strip screenshot base64 payloads at the write boundary, regardless of
-	// origin (direct AppendEvent calls or sessionEventFromRecord). This is the
-	// second line of defense: sessionEventFromRecord already strips when
-	// converting from MessageRecord (the langchain path); AppendEvent handles
-	// direct writes. stripScreenshotData is idempotent—calling it twice on
-	// already-stripped content is safe—so we can sanitize here unconditionally.
-	event.Content = stripScreenshotData(event.Content)
+	// Sanitize content at the write boundary regardless of origin (direct
+	// AppendEvent calls or sessionEventFromRecord). This keeps replay-only
+	// tool-call speech out of persistent context and strips large screenshot
+	// payloads before compression/token accounting sees them.
+	event.Content = sanitizePersistentEventContent(event.Type, event.Content)
 	event.Artifacts = sanitizeInputArtifacts(event.Artifacts)
 
 	if err := os.MkdirAll(s.rootDir, 0o755); err != nil {

--- a/src/agent/internal/agent/task_episode.go
+++ b/src/agent/internal/agent/task_episode.go
@@ -589,7 +589,7 @@ func (s *TaskEpisodeStore) AppendEpisodeEvent(ctx context.Context, episode TaskE
 	if err := s.materializeEventArtifact(dir, &event, step); err != nil {
 		return err
 	}
-	event.RawObservation = ""
+	event = sanitizeTaskEpisodeEventForPersistence(event)
 	file, err := os.OpenFile(filepath.Join(dir, "events.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		return fmt.Errorf("open episode events: %w", err)
@@ -993,12 +993,18 @@ func writeEpisodeEventsJSONL(path string, events []TaskEpisodeEvent) error {
 	defer file.Close()
 	encoder := json.NewEncoder(file)
 	for _, event := range events {
-		event.RawObservation = ""
+		event = sanitizeTaskEpisodeEventForPersistence(event)
 		if err := encoder.Encode(event); err != nil {
 			return fmt.Errorf("encode episode event: %w", err)
 		}
 	}
 	return nil
+}
+
+func sanitizeTaskEpisodeEventForPersistence(event TaskEpisodeEvent) TaskEpisodeEvent {
+	event.Content = sanitizePersistentEventContent(event.Type, event.Content)
+	event.RawObservation = ""
+	return event
 }
 
 func readEpisodeEvents(path string) ([]TaskEpisodeEvent, error) {

--- a/src/agent/internal/agent/task_episode_test.go
+++ b/src/agent/internal/agent/task_episode_test.go
@@ -1,0 +1,88 @@
+package agent
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestTaskEpisodeStoreAddEpisodeOmitsToolCallContentBeforePersistence(t *testing.T) {
+	ctx := context.Background()
+	rootDir := t.TempDir()
+	store := NewTaskEpisodeStore(rootDir)
+
+	if _, err := store.AddEpisode(ctx, TaskEpisode{
+		ID:        "ep_tool_call_content",
+		Status:    "active",
+		StartedAt: "2026-06-19T12:45:00Z",
+		EndedAt:   "2026-06-19T12:45:10Z",
+		UserGoal:  "记住我在上海",
+		Outcome:   TaskEpisodeOutcome{Success: true},
+		Events: []TaskEpisodeEvent{
+			{
+				EventID:   "evt_tool",
+				Type:      runEventToolCall,
+				Role:      "assistant",
+				ToolName:  "save_memory",
+				ToolInput: `{"memory":"用户住在上海"}`,
+				Content:   "好的，已经记下来了，你住在上海。",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("AddEpisode() error = %v", err)
+	}
+
+	events, err := readEpisodeEvents(filepath.Join(rootDir, "2026", "ep_tool_call_content", "events.jsonl"))
+	if err != nil {
+		t.Fatalf("readEpisodeEvents() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Content != "" {
+		t.Fatalf("persisted tool_call content = %q, want empty", events[0].Content)
+	}
+	if events[0].ToolName != "save_memory" || events[0].ToolInput != `{"memory":"用户住在上海"}` {
+		t.Fatalf("tool metadata was not preserved: %#v", events[0])
+	}
+}
+
+func TestTaskEpisodeStoreAppendEpisodeEventOmitsToolCallContentBeforePersistence(t *testing.T) {
+	ctx := context.Background()
+	rootDir := t.TempDir()
+	store := NewTaskEpisodeStore(rootDir)
+	episode := TaskEpisode{
+		ID:        "ep_running_tool_call_content",
+		Status:    "running",
+		StartedAt: "2026-06-19T12:45:00Z",
+		UserGoal:  "查询天气",
+	}
+
+	if _, err := store.StartEpisode(ctx, episode); err != nil {
+		t.Fatalf("StartEpisode() error = %v", err)
+	}
+	if err := store.AppendEpisodeEvent(ctx, episode, TaskEpisodeEvent{
+		EventID:   "evt_tool",
+		Type:      runEventToolCall,
+		Role:      "assistant",
+		ToolName:  "weather",
+		ToolInput: `{"location":"Shanghai"}`,
+		Content:   "我先查一下。",
+	}, 1); err != nil {
+		t.Fatalf("AppendEpisodeEvent() error = %v", err)
+	}
+
+	events, err := readEpisodeEvents(filepath.Join(rootDir, "2026", "ep_running_tool_call_content", "events.jsonl"))
+	if err != nil {
+		t.Fatalf("readEpisodeEvents() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Content != "" {
+		t.Fatalf("persisted tool_call content = %q, want empty", events[0].Content)
+	}
+	if events[0].ToolName != "weather" || events[0].ToolInput != `{"location":"Shanghai"}` {
+		t.Fatalf("tool metadata was not preserved: %#v", events[0])
+	}
+}


### PR DESCRIPTION
## Summary
- Stop replaying tool-call content as assistant text in the function-agent scratchpad
- Clear tool-call speech before chat history, session memory, and task episode persistence
- Add regression coverage for model context and persistence boundaries

## Tests
- go test ./internal/agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined tool-call message persistence handling in conversation memory storage systems to improve metadata consistency across chat history, sessions, and activity tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->