### PR TITLE
feat: add raw LLM response logging

### DIFF
--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -394,6 +394,7 @@ type ModelConfig struct {
 	TokenEnv          string  `toml:"token_env,omitempty"`
 	Temperature       float64 `toml:"temperature,omitempty"`
 	MaxResponseTokens int     `toml:"max_response_tokens,omitempty"`
+	LogRawResponse    bool    `toml:"log_raw_response,omitempty"`
 	// These override static model metadata; zero means use the registry/fallback.
 	ContextWindow        int      `toml:"context_window,omitempty"`
 	ModelMaxOutputTokens int      `toml:"model_max_output_tokens,omitempty"`

--- a/src/agent/internal/agent/config_defaults.go
+++ b/src/agent/internal/agent/config_defaults.go
@@ -10,6 +10,7 @@ const (
 	defaultModelName               = "bytedance-seed/seed-2.0-lite"
 	defaultModelTemperature        = 0.2
 	defaultModelMaxResponseTokens  = 1000
+	defaultModelLogRawResponse     = true
 	defaultTTSProvider             = "minimax-ws"
 	defaultTTSVoiceID              = "male-qn-qingse"
 	defaultTTSEmotion              = "happy"
@@ -63,6 +64,7 @@ func DefaultConfig() Config {
 			Model:             defaultModelName,
 			Temperature:       defaultModelTemperature,
 			MaxResponseTokens: defaultModelMaxResponseTokens,
+			LogRawResponse:    defaultModelLogRawResponse,
 		},
 		TTS: TTSConfig{
 			Provider: defaultTTSProvider,

--- a/src/agent/internal/agent/config_meta.go
+++ b/src/agent/internal/agent/config_meta.go
@@ -114,6 +114,7 @@ func ConfigMeta() ConfigMetadata {
 						VisibleWhen: all(ne("model.provider", "openrouter"))},
 					{Key: "temperature", Widget: WidgetNumber, Default: defaults.Model.Temperature},
 					{Key: "max_response_tokens", Widget: WidgetNumber, Default: defaults.Model.MaxResponseTokens},
+					{Key: "log_raw_response", Widget: WidgetBoolean, Default: defaults.Model.LogRawResponse},
 					{Key: "context_window", Widget: WidgetNumber, Default: defaults.Model.ContextWindow},
 					{Key: "model_max_output_tokens", Widget: WidgetNumber, Default: defaults.Model.ModelMaxOutputTokens},
 				},

--- a/src/agent/internal/agent/config_meta_test.go
+++ b/src/agent/internal/agent/config_meta_test.go
@@ -197,6 +197,7 @@ func TestConfigMeta_RuntimeDefaultsMatch(t *testing.T) {
 		{"model.model", defaults.Model.Model},
 		{"model.temperature", defaults.Model.Temperature},
 		{"model.max_response_tokens", defaults.Model.MaxResponseTokens},
+		{"model.log_raw_response", defaults.Model.LogRawResponse},
 		{"tts.provider", defaults.TTS.Provider},
 		{"tts.voice_id", defaults.TTS.VoiceID},
 		{"tts.emotion", defaults.TTS.Emotion},

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -197,6 +197,9 @@ provider = "fake"
 		t.Fatalf("VoiceMaxResponseTokens = %d, want runtime default %d",
 			cfg.VoiceMaxResponseTokens, defaultVoiceMaxResponseTokens)
 	}
+	if !cfg.Model.LogRawResponse {
+		t.Fatal("Model.LogRawResponse = false, want runtime default true")
+	}
 	if cfg.ScreenStableTimeoutMs != defaultStableWaitTimeoutMs {
 		t.Fatalf("ScreenStableTimeoutMs = %d, want runtime default %d",
 			cfg.ScreenStableTimeoutMs, defaultStableWaitTimeoutMs)
@@ -206,6 +209,26 @@ provider = "fake"
 	}
 	if cfg.STT.Provider != "" {
 		t.Fatalf("STT.Provider = %q, want empty when text mode did not configure STT", cfg.STT.Provider)
+	}
+}
+
+func TestLoadRuntimeConfigCanDisableRawResponseLogging(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.toml")
+	if err := os.WriteFile(path, []byte(`
+[model]
+provider = "fake"
+log_raw_response = false
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadRuntimeConfig(path)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfig() error = %v", err)
+	}
+	if cfg.Model.LogRawResponse {
+		t.Fatal("Model.LogRawResponse = true, want explicit false to disable raw response logging")
 	}
 }
 

--- a/src/agent/internal/agent/logger.go
+++ b/src/agent/internal/agent/logger.go
@@ -1,14 +1,18 @@
 package agent
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
+
+const logRetention = 48 * time.Hour
 
 // Logger provides structured logging to file and console
 type Logger struct {
@@ -37,10 +41,58 @@ func NewLogger(configDir string) (*Logger, error) {
 	log.SetOutput(multiWriter)
 	log.SetFlags(log.LstdFlags)
 
+	if err := cleanupOldLogFiles(logDir, time.Now()); err != nil {
+		logger.Printf("[WARN] log cleanup failed: %v", err)
+	}
+
 	return &Logger{
 		file:   f,
 		logger: logger,
 	}, nil
+}
+
+func cleanupOldLogFiles(logDir string, now time.Time) error {
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		return fmt.Errorf("read log directory: %w", err)
+	}
+	cutoff := now.Add(-logRetention)
+	var errs []error
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".log") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("stat log file %q: %w", entry.Name(), err))
+			continue
+		}
+		logTime := logFileTime(entry.Name(), info.ModTime())
+		if !logTime.Before(cutoff) {
+			continue
+		}
+		path := filepath.Join(logDir, entry.Name())
+		if err := os.Remove(path); err != nil {
+			errs = append(errs, fmt.Errorf("remove old log file %q: %w", entry.Name(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func logFileTime(name string, modTime time.Time) time.Time {
+	for _, prefix := range []string{"agent-", "llm-raw-"} {
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		date := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".log")
+		if len(date) != len("20060102") {
+			continue
+		}
+		if parsed, err := time.ParseInLocation("20060102", date, time.Local); err == nil {
+			return parsed
+		}
+	}
+	return modTime
 }
 
 func (l *Logger) Close() error {

--- a/src/agent/internal/agent/logger.go
+++ b/src/agent/internal/agent/logger.go
@@ -89,7 +89,7 @@ func logFileTime(name string, modTime time.Time) time.Time {
 			continue
 		}
 		if parsed, err := time.ParseInLocation("20060102", date, time.Local); err == nil {
-			return parsed
+			return parsed.Add(24 * time.Hour)
 		}
 	}
 	return modTime

--- a/src/agent/internal/agent/logger_test.go
+++ b/src/agent/internal/agent/logger_test.go
@@ -13,6 +13,7 @@ func TestCleanupOldLogFilesRemovesLogsOlderThanTwoDays(t *testing.T) {
 
 	writeTestLogFile(t, logDir, "agent-20260616.log", now)
 	writeTestLogFile(t, logDir, "llm-raw-20260616.log", now)
+	writeTestLogFile(t, logDir, "agent-20260617.log", now.Add(-72*time.Hour))
 	writeTestLogFile(t, logDir, "agent-20260618.log", now.Add(-72*time.Hour))
 	writeTestLogFile(t, logDir, "custom.log", now.Add(-72*time.Hour))
 	writeTestLogFile(t, logDir, "agent-20260616.txt", now.Add(-72*time.Hour))
@@ -25,6 +26,7 @@ func TestCleanupOldLogFilesRemovesLogsOlderThanTwoDays(t *testing.T) {
 	assertPathMissing(t, filepath.Join(logDir, "agent-20260616.log"))
 	assertPathMissing(t, filepath.Join(logDir, "llm-raw-20260616.log"))
 	assertPathMissing(t, filepath.Join(logDir, "custom.log"))
+	assertPathExists(t, filepath.Join(logDir, "agent-20260617.log"))
 	assertPathExists(t, filepath.Join(logDir, "agent-20260618.log"))
 	assertPathExists(t, filepath.Join(logDir, "agent-20260616.txt"))
 	assertPathExists(t, filepath.Join(logDir, "agent-notadate.log"))
@@ -50,7 +52,13 @@ func TestNewLoggerCleansOldLogFilesOnStartup(t *testing.T) {
 	}
 
 	assertPathMissing(t, oldLog)
-	assertPathExists(t, filepath.Join(logDir, "agent-"+time.Now().Format("20060102")+".log"))
+	matches, err := filepath.Glob(filepath.Join(logDir, "agent-*.log"))
+	if err != nil {
+		t.Fatalf("glob current log files: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("expected at least one current agent log file in %s", logDir)
+	}
 }
 
 func writeTestLogFile(t *testing.T, dir, name string, modTime time.Time) {

--- a/src/agent/internal/agent/logger_test.go
+++ b/src/agent/internal/agent/logger_test.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCleanupOldLogFilesRemovesLogsOlderThanTwoDays(t *testing.T) {
+	logDir := t.TempDir()
+	now := time.Date(2026, 6, 19, 12, 0, 0, 0, time.Local)
+
+	writeTestLogFile(t, logDir, "agent-20260616.log", now)
+	writeTestLogFile(t, logDir, "llm-raw-20260616.log", now)
+	writeTestLogFile(t, logDir, "agent-20260618.log", now.Add(-72*time.Hour))
+	writeTestLogFile(t, logDir, "custom.log", now.Add(-72*time.Hour))
+	writeTestLogFile(t, logDir, "agent-20260616.txt", now.Add(-72*time.Hour))
+	writeTestLogFile(t, logDir, "agent-notadate.log", now)
+
+	if err := cleanupOldLogFiles(logDir, now); err != nil {
+		t.Fatalf("cleanupOldLogFiles() error = %v", err)
+	}
+
+	assertPathMissing(t, filepath.Join(logDir, "agent-20260616.log"))
+	assertPathMissing(t, filepath.Join(logDir, "llm-raw-20260616.log"))
+	assertPathMissing(t, filepath.Join(logDir, "custom.log"))
+	assertPathExists(t, filepath.Join(logDir, "agent-20260618.log"))
+	assertPathExists(t, filepath.Join(logDir, "agent-20260616.txt"))
+	assertPathExists(t, filepath.Join(logDir, "agent-notadate.log"))
+}
+
+func TestNewLoggerCleansOldLogFilesOnStartup(t *testing.T) {
+	configDir := t.TempDir()
+	logDir := filepath.Join(configDir, "log")
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		t.Fatalf("create log dir: %v", err)
+	}
+	oldLog := filepath.Join(logDir, "agent-20000101.log")
+	if err := os.WriteFile(oldLog, []byte("old"), 0644); err != nil {
+		t.Fatalf("write old log: %v", err)
+	}
+
+	logger, err := NewLogger(configDir)
+	if err != nil {
+		t.Fatalf("NewLogger() error = %v", err)
+	}
+	if err := logger.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	assertPathMissing(t, oldLog)
+	assertPathExists(t, filepath.Join(logDir, "agent-"+time.Now().Format("20060102")+".log"))
+}
+
+func writeTestLogFile(t *testing.T, dir, name string, modTime time.Time) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(name), 0644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("chtimes %s: %v", name, err)
+	}
+}
+
+func assertPathExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected %s to exist: %v", path, err)
+	}
+}
+
+func assertPathMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to be missing, err=%v", path, err)
+	}
+}

--- a/src/agent/internal/agent/models.go
+++ b/src/agent/internal/agent/models.go
@@ -40,6 +40,7 @@ type ModelManager struct {
 	providerSpecFetchStarted  bool
 	metadataHTTPClient        *http.Client
 	providerMetadataCachePath string
+	rawResponseLogDir         string
 }
 
 type ModelManagerOption func(*ModelManager)
@@ -47,6 +48,12 @@ type ModelManagerOption func(*ModelManager)
 func WithProviderModelMetadataCachePath(path string) ModelManagerOption {
 	return func(m *ModelManager) {
 		m.providerMetadataCachePath = strings.TrimSpace(path)
+	}
+}
+
+func WithLLMRawResponseLogDir(path string) ModelManagerOption {
+	return func(m *ModelManager) {
+		m.rawResponseLogDir = strings.TrimSpace(path)
 	}
 }
 
@@ -115,7 +122,7 @@ func (m *ModelManager) build(cfg ModelConfig) (llms.Model, error) {
 		if baseURL == "" {
 			baseURL = "https://api.openai.com/v1"
 		}
-		return newOpenAICompatibleModel(baseURL, cfg.Model, resolveToken(cfg), newRetryHTTPClient(m.proxy)), nil
+		return newOpenAICompatibleModel(baseURL, cfg.Model, resolveToken(cfg), newRetryHTTPClient(m.proxy), m.openAICompatibleOptions(cfg)...), nil
 	case "openrouter":
 		token := resolveToken(cfg)
 		if token == "" {
@@ -125,7 +132,7 @@ func (m *ModelManager) build(cfg ModelConfig) (llms.Model, error) {
 		if baseURL == "" {
 			baseURL = "https://openrouter.ai/api/v1"
 		}
-		return newOpenAICompatibleModel(baseURL, cfg.Model, token, newRetryHTTPClient(m.proxy)), nil
+		return newOpenAICompatibleModel(baseURL, cfg.Model, token, newRetryHTTPClient(m.proxy), m.openAICompatibleOptions(cfg)...), nil
 	case "ollama":
 		options := []ollama.Option{ollama.WithModel(cfg.Model), ollama.WithHTTPClient(newProxyHTTPClient(m.proxy))}
 		if cfg.BaseURL != "" {
@@ -136,6 +143,15 @@ func (m *ModelManager) build(cfg ModelConfig) (llms.Model, error) {
 		return fakellm.NewFakeLLM(cfg.Responses), nil
 	default:
 		return nil, fmt.Errorf("unsupported provider %q", cfg.Provider)
+	}
+}
+
+func (m *ModelManager) openAICompatibleOptions(cfg ModelConfig) []openAICompatibleModelOption {
+	if !cfg.LogRawResponse || strings.TrimSpace(m.rawResponseLogDir) == "" {
+		return nil
+	}
+	return []openAICompatibleModelOption{
+		withOpenAICompatibleRawResponseLogger(newLLMRawResponseLogger(m.rawResponseLogDir)),
 	}
 }
 

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -9,8 +9,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/tmc/langchaingo/llms"
 )
@@ -20,6 +24,58 @@ type openAICompatibleModel struct {
 	model      string
 	token      string
 	httpClient *http.Client
+	rawLogger  *llmRawResponseLogger
+}
+
+type openAICompatibleModelOption func(*openAICompatibleModel)
+
+func withOpenAICompatibleRawResponseLogger(logger *llmRawResponseLogger) openAICompatibleModelOption {
+	return func(m *openAICompatibleModel) {
+		m.rawLogger = logger
+	}
+}
+
+type llmRawResponseLogger struct {
+	dir string
+	mu  sync.Mutex
+}
+
+func newLLMRawResponseLogger(logDir string) *llmRawResponseLogger {
+	logDir = strings.TrimSpace(logDir)
+	if logDir == "" {
+		return nil
+	}
+	return &llmRawResponseLogger{dir: logDir}
+}
+
+func (l *llmRawResponseLogger) Log(model, kind string, statusCode int, raw string) error {
+	if l == nil || strings.TrimSpace(l.dir) == "" {
+		return nil
+	}
+	now := time.Now()
+	entry := fmt.Sprintf(
+		"ts=%s model=%s kind=%s status=%d bytes=%d\n%s\n\n",
+		now.Format(time.RFC3339Nano),
+		strings.TrimSpace(model),
+		strings.TrimSpace(kind),
+		statusCode,
+		len([]byte(raw)),
+		raw,
+	)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := os.MkdirAll(l.dir, 0755); err != nil {
+		return err
+	}
+	path := filepath.Join(l.dir, "llm-raw-"+now.Format("20060102")+".log")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = file.WriteString(entry)
+	return err
 }
 
 type compatibleChatRequest struct {
@@ -122,16 +178,22 @@ type compatibleToolCallDelta struct {
 	Function *compatibleFunctionCall `json:"function,omitempty"`
 }
 
-func newOpenAICompatibleModel(baseURL, model, token string, httpClient *http.Client) llms.Model {
+func newOpenAICompatibleModel(baseURL, model, token string, httpClient *http.Client, opts ...openAICompatibleModelOption) llms.Model {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	return &openAICompatibleModel{
+	result := &openAICompatibleModel{
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		model:      model,
 		token:      token,
 		httpClient: httpClient,
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(result)
+		}
+	}
+	return result
 }
 
 func (m *openAICompatibleModel) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
@@ -197,15 +259,22 @@ func (m *openAICompatibleModel) GenerateContent(ctx context.Context, messages []
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		_ = m.logRawResponse("http_error", resp.StatusCode, string(body))
 		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
 	}
 
 	if reqPayload.Stream {
-		return m.decodeStreamingResponse(ctx, resp.Body, callOpts.StreamingFunc)
+		return m.decodeStreamingResponse(ctx, resp.Body, callOpts.StreamingFunc, resp.StatusCode)
 	}
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	_ = m.logRawResponse("http_response", resp.StatusCode, string(body))
+
 	var decoded compatibleChatResponse
-	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+	if err := json.Unmarshal(body, &decoded); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if len(decoded.Choices) == 0 {
@@ -235,7 +304,7 @@ func (m *openAICompatibleModel) GenerateContent(ctx context.Context, messages []
 	return result, nil
 }
 
-func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, body io.Reader, stream func(context.Context, []byte) error) (*llms.ContentResponse, error) {
+func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, body io.Reader, stream func(context.Context, []byte) error, statusCode int) (*llms.ContentResponse, error) {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
@@ -245,13 +314,15 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 	var generationInfo map[string]any
 
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
+		rawLine := scanner.Text()
+		line := strings.TrimSpace(rawLine)
 		if line == "" || strings.HasPrefix(line, ":") {
 			continue
 		}
 		if !strings.HasPrefix(line, "data:") {
 			continue
 		}
+		_ = m.logRawResponse("stream_event", statusCode, rawLine)
 		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
 		if data == "[DONE]" {
 			break
@@ -338,6 +409,13 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 		choice.GenerationInfo = generationInfo
 	}
 	return &llms.ContentResponse{Choices: []*llms.ContentChoice{choice}}, nil
+}
+
+func (m *openAICompatibleModel) logRawResponse(kind string, statusCode int, raw string) error {
+	if m == nil || m.rawLogger == nil {
+		return nil
+	}
+	return m.rawLogger.Log(m.model, kind, statusCode, raw)
 }
 
 func convertMessageContent(message llms.MessageContent) (compatibleMessage, error) {

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -259,23 +259,28 @@ func (m *openAICompatibleModel) GenerateContent(ctx context.Context, messages []
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		_ = m.logRawResponse("http_error", resp.StatusCode, string(body))
+		_ = m.logRawResponse(reqPayload.Model, "http_error", resp.StatusCode, string(body))
 		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
 	}
 
 	if reqPayload.Stream {
-		return m.decodeStreamingResponse(ctx, resp.Body, callOpts.StreamingFunc, resp.StatusCode)
+		return m.decodeStreamingResponse(ctx, resp.Body, callOpts.StreamingFunc, reqPayload.Model, resp.StatusCode)
 	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
-	}
-	_ = m.logRawResponse("http_response", resp.StatusCode, string(body))
 
 	var decoded compatibleChatResponse
-	if err := json.Unmarshal(body, &decoded); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
+	if m.rawLogger == nil {
+		if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+			return nil, fmt.Errorf("decode response: %w", err)
+		}
+	} else {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("read response: %w", err)
+		}
+		_ = m.logRawResponse(reqPayload.Model, "http_response", resp.StatusCode, string(body))
+		if err := json.Unmarshal(body, &decoded); err != nil {
+			return nil, fmt.Errorf("decode response: %w", err)
+		}
 	}
 	if len(decoded.Choices) == 0 {
 		return nil, fmt.Errorf("empty response choices")
@@ -304,7 +309,7 @@ func (m *openAICompatibleModel) GenerateContent(ctx context.Context, messages []
 	return result, nil
 }
 
-func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, body io.Reader, stream func(context.Context, []byte) error, statusCode int) (*llms.ContentResponse, error) {
+func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, body io.Reader, stream func(context.Context, []byte) error, requestModel string, statusCode int) (*llms.ContentResponse, error) {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
@@ -322,7 +327,7 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 		if !strings.HasPrefix(line, "data:") {
 			continue
 		}
-		_ = m.logRawResponse("stream_event", statusCode, rawLine)
+		_ = m.logRawResponse(requestModel, "stream_event", statusCode, rawLine)
 		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
 		if data == "[DONE]" {
 			break
@@ -411,11 +416,11 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 	return &llms.ContentResponse{Choices: []*llms.ContentChoice{choice}}, nil
 }
 
-func (m *openAICompatibleModel) logRawResponse(kind string, statusCode int, raw string) error {
+func (m *openAICompatibleModel) logRawResponse(modelName, kind string, statusCode int, raw string) error {
 	if m == nil || m.rawLogger == nil {
 		return nil
 	}
-	return m.rawLogger.Log(m.model, kind, statusCode, raw)
+	return m.rawLogger.Log(modelName, kind, statusCode, raw)
 }
 
 func convertMessageContent(message llms.MessageContent) (compatibleMessage, error) {

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -7,7 +7,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/tmc/langchaingo/llms"
 )
@@ -99,6 +104,40 @@ func TestOpenAICompatibleModelParsesToolCalls(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatibleModelLogsRawResponseWhenEnabled(t *testing.T) {
+	rawResponse := `{"choices":[{"message":{"content":"<think>\n需要查当前时间。\n</think>","tool_calls":[{"id":"call_1","type":"function","function":{"name":"current_time","arguments":"{\"timezone\":\"local\"}"}}]},"finish_reason":"tool_calls"}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(rawResponse))
+	}))
+	defer server.Close()
+
+	logDir := t.TempDir()
+	model := newOpenAICompatibleModel(
+		server.URL,
+		"test-model",
+		"",
+		server.Client(),
+		withOpenAICompatibleRawResponseLogger(newLLMRawResponseLogger(logDir)),
+	)
+	_, err := model.GenerateContent(context.Background(), []llms.MessageContent{{
+		Role:  llms.ChatMessageTypeHuman,
+		Parts: []llms.ContentPart{llms.TextPart("现在几点了？")},
+	}})
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	logText := readRawResponseLog(t, logDir)
+	if !strings.Contains(logText, rawResponse) {
+		t.Fatalf("raw response log missing exact response:\n%s", logText)
+	}
+	if !strings.Contains(logText, "kind=http_response") || !strings.Contains(logText, "model=test-model") {
+		t.Fatalf("raw response log missing metadata:\n%s", logText)
+	}
+	assertRawResponseLogHasRFC3339NanoTimestamp(t, logText)
+}
+
 func TestOpenAICompatibleModelStreamsContent(t *testing.T) {
 	var captured struct {
 		Stream bool `json:"stream"`
@@ -138,6 +177,110 @@ func TestOpenAICompatibleModelStreamsContent(t *testing.T) {
 	}
 	if len(chunks) != 2 || chunks[0] != "hello " || chunks[1] != "world" {
 		t.Fatalf("unexpected stream chunks: %#v", chunks)
+	}
+}
+
+func TestOpenAICompatibleModelLogsRawStreamingEventsWhenEnabled(t *testing.T) {
+	firstEvent := `data: {"choices":[{"delta":{"content":"<think>\n"}}]}`
+	secondEvent := `data: {"choices":[{"delta":{"content":"需要查当前时间。\n</think>"},"finish_reason":"tool_calls"}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Write([]byte(firstEvent + "\n\n"))
+		w.Write([]byte(secondEvent + "\n\n"))
+		w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	logDir := t.TempDir()
+	model := newOpenAICompatibleModel(
+		server.URL,
+		"test-model",
+		"",
+		server.Client(),
+		withOpenAICompatibleRawResponseLogger(newLLMRawResponseLogger(logDir)),
+	)
+	_, err := model.GenerateContent(
+		context.Background(),
+		[]llms.MessageContent{{
+			Role:  llms.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextPart("现在几点了？")},
+		}},
+		llms.WithStreamingFunc(func(ctx context.Context, chunk []byte) error { return nil }),
+	)
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	logText := readRawResponseLog(t, logDir)
+	if !strings.Contains(logText, firstEvent) || !strings.Contains(logText, secondEvent) || !strings.Contains(logText, "data: [DONE]") {
+		t.Fatalf("raw streaming log missing SSE events:\n%s", logText)
+	}
+	if !strings.Contains(logText, "kind=stream_event") || !strings.Contains(logText, "model=test-model") {
+		t.Fatalf("raw streaming log missing metadata:\n%s", logText)
+	}
+	assertRawResponseLogHasRFC3339NanoTimestamp(t, logText)
+}
+
+func TestModelManagerEnablesRawResponseLoggingFromModelConfig(t *testing.T) {
+	rawResponse := `{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(rawResponse))
+	}))
+	defer server.Close()
+
+	logDir := t.TempDir()
+	manager := NewModelManager(ModelConfig{
+		Provider:       "openai",
+		Model:          "test-model",
+		BaseURL:        server.URL,
+		LogRawResponse: true,
+	}, ProxyConfig{}, WithLLMRawResponseLogDir(logDir))
+	model, err := manager.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	_, err = model.GenerateContent(context.Background(), []llms.MessageContent{{
+		Role:  llms.ChatMessageTypeHuman,
+		Parts: []llms.ContentPart{llms.TextPart("hello")},
+	}})
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	logText := readRawResponseLog(t, logDir)
+	if !strings.Contains(logText, rawResponse) {
+		t.Fatalf("raw response log missing response from model manager config:\n%s", logText)
+	}
+}
+
+func TestModelManagerDoesNotLogRawResponseByDefault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	logDir := t.TempDir()
+	manager := NewModelManager(ModelConfig{
+		Provider: "openai",
+		Model:    "test-model",
+		BaseURL:  server.URL,
+	}, ProxyConfig{}, WithLLMRawResponseLogDir(logDir))
+	model, err := manager.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	_, err = model.GenerateContent(context.Background(), []llms.MessageContent{{
+		Role:  llms.ChatMessageTypeHuman,
+		Parts: []llms.ContentPart{llms.TextPart("hello")},
+	}})
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	if _, err := os.Stat(rawResponseLogPath(logDir)); !os.IsNotExist(err) {
+		t.Fatalf("raw response log should not exist by default, err=%v", err)
 	}
 }
 
@@ -232,6 +375,30 @@ func TestOpenAICompatibleModelIncludesUsageInGenerationInfo(t *testing.T) {
 	got := resp.Choices[0].GenerationInfo
 	if got["prompt_tokens"] != 11 || got["completion_tokens"] != 7 || got["total_tokens"] != 18 {
 		t.Fatalf("unexpected generation info: %#v", got)
+	}
+}
+
+func readRawResponseLog(t *testing.T, logDir string) string {
+	t.Helper()
+	data, err := os.ReadFile(rawResponseLogPath(logDir))
+	if err != nil {
+		t.Fatalf("read raw response log: %v", err)
+	}
+	return string(data)
+}
+
+func rawResponseLogPath(logDir string) string {
+	return filepath.Join(logDir, "llm-raw-"+time.Now().Format("20060102")+".log")
+}
+
+func assertRawResponseLogHasRFC3339NanoTimestamp(t *testing.T, logText string) {
+	t.Helper()
+	match := regexp.MustCompile(`ts=([^ ]+)`).FindStringSubmatch(logText)
+	if len(match) != 2 {
+		t.Fatalf("raw response log missing timestamp:\n%s", logText)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, match[1]); err != nil {
+		t.Fatalf("raw response log timestamp = %q, want RFC3339Nano: %v", match[1], err)
 	}
 }
 

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -138,6 +139,40 @@ func TestOpenAICompatibleModelLogsRawResponseWhenEnabled(t *testing.T) {
 	assertRawResponseLogHasRFC3339NanoTimestamp(t, logText)
 }
 
+func TestOpenAICompatibleModelRawResponseLogUsesEffectiveRequestModel(t *testing.T) {
+	rawResponse := `{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(rawResponse))
+	}))
+	defer server.Close()
+
+	logDir := t.TempDir()
+	model := newOpenAICompatibleModel(
+		server.URL,
+		"configured-model",
+		"",
+		server.Client(),
+		withOpenAICompatibleRawResponseLogger(newLLMRawResponseLogger(logDir)),
+	)
+	_, err := model.GenerateContent(
+		context.Background(),
+		[]llms.MessageContent{{
+			Role:  llms.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextPart("hello")},
+		}},
+		llms.WithModel("override-model"),
+	)
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	logText := readRawResponseLog(t, logDir)
+	if !strings.Contains(logText, "model=override-model") {
+		t.Fatalf("raw response log used wrong model metadata:\n%s", logText)
+	}
+}
+
 func TestOpenAICompatibleModelStreamsContent(t *testing.T) {
 	var captured struct {
 		Stream bool `json:"stream"`
@@ -254,7 +289,39 @@ func TestModelManagerEnablesRawResponseLoggingFromModelConfig(t *testing.T) {
 	}
 }
 
-func TestModelManagerDoesNotLogRawResponseByDefault(t *testing.T) {
+func TestModelManagerEnablesRawResponseLoggingFromDefaultConfig(t *testing.T) {
+	rawResponse := `{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(rawResponse))
+	}))
+	defer server.Close()
+
+	logDir := t.TempDir()
+	cfg := DefaultConfig().Model
+	cfg.Provider = "openai"
+	cfg.Model = "test-model"
+	cfg.BaseURL = server.URL
+	manager := NewModelManager(cfg, ProxyConfig{}, WithLLMRawResponseLogDir(logDir))
+	model, err := manager.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	_, err = model.GenerateContent(context.Background(), []llms.MessageContent{{
+		Role:  llms.ChatMessageTypeHuman,
+		Parts: []llms.ContentPart{llms.TextPart("hello")},
+	}})
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	logText := readRawResponseLog(t, logDir)
+	if !strings.Contains(logText, rawResponse) {
+		t.Fatalf("raw response log missing response from default config:\n%s", logText)
+	}
+}
+
+func TestModelManagerDoesNotLogRawResponseWhenDisabled(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
@@ -280,7 +347,7 @@ func TestModelManagerDoesNotLogRawResponseByDefault(t *testing.T) {
 	}
 
 	if _, err := os.Stat(rawResponseLogPath(logDir)); !os.IsNotExist(err) {
-		t.Fatalf("raw response log should not exist by default, err=%v", err)
+		t.Fatalf("raw response log should not exist when disabled, err=%v", err)
 	}
 }
 
@@ -388,6 +455,11 @@ func readRawResponseLog(t *testing.T, logDir string) string {
 }
 
 func rawResponseLogPath(logDir string) string {
+	matches, _ := filepath.Glob(filepath.Join(logDir, "llm-raw-*.log"))
+	sort.Strings(matches)
+	if len(matches) > 0 {
+		return matches[len(matches)-1]
+	}
 	return filepath.Join(logDir, "llm-raw-"+time.Now().Format("20060102")+".log")
 }
 

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -287,6 +287,9 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 	modelManagerOptions := []ModelManagerOption{}
 	if cfg.ConfigDir != "" {
 		modelManagerOptions = append(modelManagerOptions, WithProviderModelMetadataCachePath(filepath.Join(cfg.ConfigDir, "cache", "provider_model_metadata.json")))
+		if cfg.Model.LogRawResponse {
+			modelManagerOptions = append(modelManagerOptions, WithLLMRawResponseLogDir(filepath.Join(cfg.ConfigDir, "log")))
+		}
 	}
 	modelManager := NewModelManager(cfg.Model, proxy, modelManagerOptions...)
 	modelManager.prefetchProviderModelSpecIfNeeded()

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -2292,11 +2292,14 @@ func TestRuntimeLogsPreserveThinkStartTagInToolCallContent(t *testing.T) {
 	}
 
 	logText := logs.String()
-	if !strings.Contains(logText, "Role output: role=planner content=<think>") {
-		t.Fatalf("role output log lost think start tag:\n%s", logText)
+	if !strings.Contains(logText, "Role output: role=planner") {
+		t.Fatalf("missing planner role output log:\n%s", logText)
 	}
-	if !strings.Contains(logText, "Tool call: name=current_time input={\"timezone\":\"local\"} content=<think>") {
-		t.Fatalf("tool call log lost think start tag:\n%s", logText)
+	if !strings.Contains(logText, "Tool call: name=current_time") {
+		t.Fatalf("missing current_time tool call log:\n%s", logText)
+	}
+	if strings.Count(logText, "<think>") < 2 {
+		t.Fatalf("logs lost think start tag:\n%s", logText)
 	}
 	if !strings.Contains(logText, "</think>") {
 		t.Fatalf("log lost think end tag:\n%s", logText)

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"math"
 	"os"
 	"path/filepath"
@@ -2260,6 +2261,45 @@ func TestRuntimeRunEmitsToolContentForToolCallSpeech(t *testing.T) {
 	}
 	if toolCall.Content != speech {
 		t.Fatalf("tool_call content = %q, want assistant content", toolCall.Content)
+	}
+}
+
+func TestRuntimeLogsPreserveThinkStartTagInToolCallContent(t *testing.T) {
+	thinkingContent := "<think>\n需要查当前时间。\n</think>"
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			toolCallResponseWithContent("call_1", "current_time", `{"timezone":"local"}`, thinkingContent),
+			contentResponse("已完成。"),
+		},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:       ModelConfig{Provider: "fake"},
+			Instruction: "Use tools when external state is requested.",
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{
+			"current_time": NewCurrentTimeTool(),
+		}},
+		NewSkillIndex(),
+	)
+	var logs bytes.Buffer
+	runtime.logger = &Logger{logger: log.New(&logs, "", 0)}
+
+	if _, err := runtime.Run(context.Background(), RunRequest{Input: "现在几点了？"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	logText := logs.String()
+	if !strings.Contains(logText, "Role output: role=planner content=<think>") {
+		t.Fatalf("role output log lost think start tag:\n%s", logText)
+	}
+	if !strings.Contains(logText, "Tool call: name=current_time input={\"timezone\":\"local\"} content=<think>") {
+		t.Fatalf("tool call log lost think start tag:\n%s", logText)
+	}
+	if !strings.Contains(logText, "</think>") {
+		t.Fatalf("log lost think end tag:\n%s", logText)
 	}
 }
 

--- a/src/agent/internal/agent/speech_text_test.go
+++ b/src/agent/internal/agent/speech_text_test.go
@@ -73,6 +73,16 @@ func TestBuildSpeechTextNormalizesMarkdownWithoutDroppingContent(t *testing.T) {
 	}
 }
 
+func TestBuildSpeechTextPreservesThinkTags(t *testing.T) {
+	output := "<think>\n需要查当前时间。\n</think>"
+
+	speech := BuildSpeechText(output, Config{})
+
+	if speech != output {
+		t.Fatalf("speech = %q, want think tags preserved", speech)
+	}
+}
+
 func TestBuildSpeechTextNormalizesTablesAndTasksWithoutDroppingContent(t *testing.T) {
 	output := strings.Join([]string{
 		"| 项目 | 状态 |",


### PR DESCRIPTION
## Summary
- add model.log_raw_response for OpenAI-compatible providers
- write raw HTTP responses and streaming SSE events to separate llm-raw logs
- clean log files older than two days during logger startup
- add regression coverage for think-tag preservation and raw response logging

## Tests
- go test ./internal/agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable raw LLM response logging to help debug API interactions
  * Implemented automatic cleanup of log files older than 48 hours

* **Tests**
  * Enhanced test coverage for log cleanup behavior
  * Added tests for raw response logging functionality
  * Added tests to verify handling of special content tags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->