### PR TITLE
feat(agent): enhance LLM HTTP logging with JSONL format and session organization

### DIFF
--- a/docs/08-reference/paths-and-artifacts.md
+++ b/docs/08-reference/paths-and-artifacts.md
@@ -121,13 +121,13 @@ LLM HTTP 请求/响应日志（JSONL 格式），每个 session 独立文件。
 
 **格式**：
 ```json
-{"ts":"15:00:00","kind":"http_request","status":0,"body":"{\"model\":\"...\",\"messages\":[...]}"}
-{"ts":"15:00:00","kind":"http_response","status":200,"body":"{\"choices\":[...]}"}
+{"ts":"15:00:00","kind":"request","status":0,"body":"{\"model\":\"...\",\"messages\":[...]}"}
+{"ts":"15:00:00","kind":"response","status":200,"body":"{\"choices\":[...]}"}
 ```
 
 **字段**：
 - `ts` - 时间戳（HH:MM:SS）
-- `kind` - `http_request`, `http_response`, `http_stream`, `http_error`
+- `kind` - `request`, `response`, `stream`, `error`
 - `status` - HTTP 状态码（请求为 0）
 - `body` - 请求/响应体（JSON 字符串）
 

--- a/docs/08-reference/paths-and-artifacts.md
+++ b/docs/08-reference/paths-and-artifacts.md
@@ -44,6 +44,8 @@
 | `/var/log/frame_service/frame_service.log` | Frame Service 日志 |
 | `/var/log/audio_service/audio_service.log` | Audio Service 日志 |
 | `/var/log/agent/agent.log` | Agent init 脚本日志 |
+| `/userdata/agent/log/agent-YYYYMMDD.log` | Agent runtime 日志（按日期）|
+| `/userdata/agent/log/llm-http-YYYYMMDD-{session_id}.log` | LLM HTTP 请求/响应日志（JSONL 格式，按 session 组织）|
 
 ## 配置文件
 
@@ -94,6 +96,74 @@ curl http://<device-ip>:8080/api/tools
 /oem/usr/bin/ota status
 /oem/usr/bin/ota update
 /oem/usr/bin/abctl read /dev/block/by-name/misc
+
+# 日志查看
+tail -f /userdata/agent/log/agent-$(date +%Y%m%d).log
+jq . /userdata/agent/log/llm-http-$(date +%Y%m%d)-*.log
+```
+
+## Agent 日志
+
+### agent-YYYYMMDD.log
+
+Agent runtime 主日志，包含：
+- Session 启动标记（带 session ID）
+- Agent 运行状态
+- 工具调用信息
+- 错误和警告
+
+**Session 分隔格式**：
+```
+2026/06/20 15:06:16 [INFO] ========================================
+2026/06/20 15:06:16 [INFO] NEW SESSION STARTED
+2026/06/20 15:06:16 [INFO] Session ID: abc123def456
+2026/06/20 15:06:16 [INFO] ========================================
+```
+
+### llm-http-YYYYMMDD-{session_id}.log
+
+LLM HTTP 请求/响应原始日志（JSONL 格式），每个 session 独立文件。
+
+**格式示例**：
+```json
+{"ts":"15:00:00","kind":"http_request","status":0,"body":"{\"model\":\"test-model\",\"messages\":[...]}"}
+{"ts":"15:00:00","kind":"http_response","status":200,"body":"{\"choices\":[...]}"}
+```
+
+**字段说明**：
+- `ts` - 时间戳（HH:MM:SS）
+- `kind` - 类型：`http_request`, `http_response`, `http_stream`, `http_error`
+- `status` - HTTP 状态码（请求为 0）
+- `body` - 请求/响应体（JSON 字符串）
+
+**常用查询**：
+```bash
+# 查看特定 session 的所有调用
+jq . /userdata/agent/log/llm-http-20260620-abc123def.log
+
+# 只看响应
+jq 'select(.kind | test("response|stream"))' llm-http-*.log
+
+# 提取响应内容
+jq -r 'select(.kind == "http_response") | .body' llm-http-*.log
+
+# 按时间过滤
+jq 'select(.ts >= "14:00:00" and .ts <= "15:00:00")' llm-http-*.log
+
+# 统计请求类型
+jq -r '.kind' llm-http-20260620-*.log | sort | uniq -c
+```
+
+**日志管理**：
+```bash
+# 查看某天所有 session
+ls -lh /userdata/agent/log/llm-http-20260620-*.log
+
+# 删除特定 session
+rm /userdata/agent/log/llm-http-*-abc123def.log
+
+# 删除 7 天前的日志
+find /userdata/agent/log -name "llm-http-*.log" -mtime +7 -delete
 ```
 
 ## EDID 文件

--- a/docs/08-reference/paths-and-artifacts.md
+++ b/docs/08-reference/paths-and-artifacts.md
@@ -103,19 +103,11 @@ jq . /userdata/agent/log/llm-http-$(date +%Y%m%d)-*.log
 
 ## Agent 日志
 
-### agent.log
+### /var/log/agent/agent.log
 
-**位置**: `/var/log/agent/agent.log`
+Agent 主日志，包含 init 脚本和 runtime 的所有输出。
 
-Agent 主日志，包含 init 脚本和 runtime 的所有输出，包括：
-- Session 启动标记（带 session ID）
-- Agent 运行状态
-- 工具调用信息
-- 错误和警告
-
-**输出方式**: Init 脚本 (`/etc/init.d/S53agent`) 通过重定向将 agent 进程的 stdout/stderr 写入此文件。
-
-**Session 分隔格式**：
+**Session 分隔标记**：
 ```
 2026/06/20 15:06:16 [INFO] ========================================
 2026/06/20 15:06:16 [INFO] NEW SESSION STARTED
@@ -123,62 +115,35 @@ Agent 主日志，包含 init 脚本和 runtime 的所有输出，包括：
 2026/06/20 15:06:16 [INFO] ========================================
 ```
 
-**查看日志**：
-```bash
-# 实时追踪
-tail -f /var/log/agent/agent.log
+### /userdata/agent/log/llm-http-{YYYYMMDD}-{session_id}.log
 
-# 查看最近的日志
-tail -100 /var/log/agent/agent.log
+LLM HTTP 请求/响应日志（JSONL 格式），每个 session 独立文件。
 
-# 搜索特定 session
-grep "abc123def456" /var/log/agent/agent.log
-```
-
-### llm-http-YYYYMMDD-{session_id}.log
-
-LLM HTTP 请求/响应原始日志（JSONL 格式），每个 session 独立文件。
-
-**格式示例**：
+**格式**：
 ```json
-{"ts":"15:00:00","kind":"http_request","status":0,"body":"{\"model\":\"test-model\",\"messages\":[...]}"}
+{"ts":"15:00:00","kind":"http_request","status":0,"body":"{\"model\":\"...\",\"messages\":[...]}"}
 {"ts":"15:00:00","kind":"http_response","status":200,"body":"{\"choices\":[...]}"}
 ```
 
-**字段说明**：
+**字段**：
 - `ts` - 时间戳（HH:MM:SS）
-- `kind` - 类型：`http_request`, `http_response`, `http_stream`, `http_error`
+- `kind` - `http_request`, `http_response`, `http_stream`, `http_error`
 - `status` - HTTP 状态码（请求为 0）
 - `body` - 请求/响应体（JSON 字符串）
 
 **常用查询**：
 ```bash
-# 查看特定 session 的所有调用
+# 查看特定 session
 jq . /userdata/agent/log/llm-http-20260620-abc123def.log
 
 # 只看响应
 jq 'select(.kind | test("response|stream"))' llm-http-*.log
 
 # 提取响应内容
-jq -r 'select(.kind == "http_response") | .body' llm-http-*.log
-
-# 按时间过滤
-jq 'select(.ts >= "14:00:00" and .ts <= "15:00:00")' llm-http-*.log
+jq -r 'select(.kind == "http_response") | .body | fromjson' llm-http-*.log
 
 # 统计请求类型
-jq -r '.kind' llm-http-20260620-*.log | sort | uniq -c
-```
-
-**日志管理**：
-```bash
-# 查看某天所有 session
-ls -lh /userdata/agent/log/llm-http-20260620-*.log
-
-# 删除特定 session
-rm /userdata/agent/log/llm-http-*-abc123def.log
-
-# 删除 7 天前的日志
-find /userdata/agent/log -name "llm-http-*.log" -mtime +7 -delete
+jq -r '.kind' llm-http-*.log | sort | uniq -c
 ```
 
 ## EDID 文件

--- a/docs/08-reference/paths-and-artifacts.md
+++ b/docs/08-reference/paths-and-artifacts.md
@@ -97,7 +97,7 @@ curl http://<device-ip>:8080/api/tools
 /oem/usr/bin/abctl read /dev/block/by-name/misc
 
 # 日志查看
-tail -f /userdata/agent/log/agent-$(date +%Y%m%d).log
+tail -f /var/log/agent/agent.log
 jq . /userdata/agent/log/llm-http-$(date +%Y%m%d)-*.log
 ```
 
@@ -139,8 +139,8 @@ jq . /userdata/agent/log/llm-http-20260620-abc123def.log
 # 只看响应
 jq 'select(.kind | test("response|stream"))' llm-http-*.log
 
-# 提取响应内容
-jq -r 'select(.kind == "http_response") | .body | fromjson' llm-http-*.log
+# 提取非流式响应内容
+jq -r 'select(.kind == "response") | .body | fromjson' llm-http-*.log
 
 # 统计请求类型
 jq -r '.kind' llm-http-*.log | sort | uniq -c

--- a/docs/08-reference/paths-and-artifacts.md
+++ b/docs/08-reference/paths-and-artifacts.md
@@ -43,8 +43,7 @@
 | `/run/audio_service/audio_service.sock` | Audio Service socket |
 | `/var/log/frame_service/frame_service.log` | Frame Service 日志 |
 | `/var/log/audio_service/audio_service.log` | Audio Service 日志 |
-| `/var/log/agent/agent.log` | Agent init 脚本日志 |
-| `/userdata/agent/log/agent-YYYYMMDD.log` | Agent runtime 日志（按日期）|
+| `/var/log/agent/agent.log` | Agent 日志（包含 init 脚本和 runtime 输出）|
 | `/userdata/agent/log/llm-http-YYYYMMDD-{session_id}.log` | LLM HTTP 请求/响应日志（JSONL 格式，按 session 组织）|
 
 ## 配置文件
@@ -104,13 +103,17 @@ jq . /userdata/agent/log/llm-http-$(date +%Y%m%d)-*.log
 
 ## Agent 日志
 
-### agent-YYYYMMDD.log
+### agent.log
 
-Agent runtime 主日志，包含：
+**位置**: `/var/log/agent/agent.log`
+
+Agent 主日志，包含 init 脚本和 runtime 的所有输出，包括：
 - Session 启动标记（带 session ID）
 - Agent 运行状态
 - 工具调用信息
 - 错误和警告
+
+**输出方式**: Init 脚本 (`/etc/init.d/S53agent`) 通过重定向将 agent 进程的 stdout/stderr 写入此文件。
 
 **Session 分隔格式**：
 ```
@@ -118,6 +121,18 @@ Agent runtime 主日志，包含：
 2026/06/20 15:06:16 [INFO] NEW SESSION STARTED
 2026/06/20 15:06:16 [INFO] Session ID: abc123def456
 2026/06/20 15:06:16 [INFO] ========================================
+```
+
+**查看日志**：
+```bash
+# 实时追踪
+tail -f /var/log/agent/agent.log
+
+# 查看最近的日志
+tail -100 /var/log/agent/agent.log
+
+# 搜索特定 session
+grep "abc123def456" /var/log/agent/agent.log
 ```
 
 ### llm-http-YYYYMMDD-{session_id}.log

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -394,7 +394,7 @@ type ModelConfig struct {
 	TokenEnv          string  `toml:"token_env,omitempty"`
 	Temperature       float64 `toml:"temperature,omitempty"`
 	MaxResponseTokens int     `toml:"max_response_tokens,omitempty"`
-	LogRawResponse    bool    `toml:"log_raw_response,omitempty"`
+	LogRawHTTP        bool    `toml:"log_raw_http,omitempty"`
 	// These override static model metadata; zero means use the registry/fallback.
 	ContextWindow        int      `toml:"context_window,omitempty"`
 	ModelMaxOutputTokens int      `toml:"model_max_output_tokens,omitempty"`

--- a/src/agent/internal/agent/config_defaults.go
+++ b/src/agent/internal/agent/config_defaults.go
@@ -10,7 +10,7 @@ const (
 	defaultModelName               = "bytedance-seed/seed-2.0-lite"
 	defaultModelTemperature        = 0.2
 	defaultModelMaxResponseTokens  = 1000
-	defaultModelLogRawResponse     = true
+	defaultModelLogRawHTTP         = true
 	defaultTTSProvider             = "minimax-ws"
 	defaultTTSVoiceID              = "male-qn-qingse"
 	defaultTTSEmotion              = "happy"
@@ -64,7 +64,7 @@ func DefaultConfig() Config {
 			Model:             defaultModelName,
 			Temperature:       defaultModelTemperature,
 			MaxResponseTokens: defaultModelMaxResponseTokens,
-			LogRawResponse:    defaultModelLogRawResponse,
+			LogRawHTTP:        defaultModelLogRawHTTP,
 		},
 		TTS: TTSConfig{
 			Provider: defaultTTSProvider,

--- a/src/agent/internal/agent/config_meta.go
+++ b/src/agent/internal/agent/config_meta.go
@@ -114,7 +114,7 @@ func ConfigMeta() ConfigMetadata {
 						VisibleWhen: all(ne("model.provider", "openrouter"))},
 					{Key: "temperature", Widget: WidgetNumber, Default: defaults.Model.Temperature},
 					{Key: "max_response_tokens", Widget: WidgetNumber, Default: defaults.Model.MaxResponseTokens},
-					{Key: "log_raw_response", Widget: WidgetBoolean, Default: defaults.Model.LogRawResponse},
+					{Key: "log_raw_http", Widget: WidgetBoolean, Default: defaults.Model.LogRawHTTP},
 					{Key: "context_window", Widget: WidgetNumber, Default: defaults.Model.ContextWindow},
 					{Key: "model_max_output_tokens", Widget: WidgetNumber, Default: defaults.Model.ModelMaxOutputTokens},
 				},

--- a/src/agent/internal/agent/config_meta_test.go
+++ b/src/agent/internal/agent/config_meta_test.go
@@ -197,7 +197,7 @@ func TestConfigMeta_RuntimeDefaultsMatch(t *testing.T) {
 		{"model.model", defaults.Model.Model},
 		{"model.temperature", defaults.Model.Temperature},
 		{"model.max_response_tokens", defaults.Model.MaxResponseTokens},
-		{"model.log_raw_response", defaults.Model.LogRawResponse},
+		{"model.log_raw_http", defaults.Model.LogRawHTTP},
 		{"tts.provider", defaults.TTS.Provider},
 		{"tts.voice_id", defaults.TTS.VoiceID},
 		{"tts.emotion", defaults.TTS.Emotion},

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -197,8 +197,8 @@ provider = "fake"
 		t.Fatalf("VoiceMaxResponseTokens = %d, want runtime default %d",
 			cfg.VoiceMaxResponseTokens, defaultVoiceMaxResponseTokens)
 	}
-	if !cfg.Model.LogRawResponse {
-		t.Fatal("Model.LogRawResponse = false, want runtime default true")
+	if !cfg.Model.LogRawHTTP {
+		t.Fatal("Model.LogRawHTTP = false, want runtime default true")
 	}
 	if cfg.ScreenStableTimeoutMs != defaultStableWaitTimeoutMs {
 		t.Fatalf("ScreenStableTimeoutMs = %d, want runtime default %d",
@@ -212,13 +212,13 @@ provider = "fake"
 	}
 }
 
-func TestLoadRuntimeConfigCanDisableRawResponseLogging(t *testing.T) {
+func TestLoadRuntimeConfigCanDisableRawHTTPLogging(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agent.toml")
 	if err := os.WriteFile(path, []byte(`
 [model]
 provider = "fake"
-log_raw_response = false
+log_raw_http = false
 `), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -227,8 +227,8 @@ log_raw_response = false
 	if err != nil {
 		t.Fatalf("LoadRuntimeConfig() error = %v", err)
 	}
-	if cfg.Model.LogRawResponse {
-		t.Fatal("Model.LogRawResponse = true, want explicit false to disable raw response logging")
+	if cfg.Model.LogRawHTTP {
+		t.Fatal("Model.LogRawHTTP = true, want explicit false to disable raw HTTP logging")
 	}
 }
 

--- a/src/agent/internal/agent/logger.go
+++ b/src/agent/internal/agent/logger.go
@@ -80,7 +80,7 @@ func cleanupOldLogFiles(logDir string, now time.Time) error {
 }
 
 func logFileTime(name string, modTime time.Time) time.Time {
-	for _, prefix := range []string{"agent-", "llm-raw-"} {
+	for _, prefix := range []string{"agent-", "llm-http-"} {
 		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".log") {
 			continue
 		}

--- a/src/agent/internal/agent/logger.go
+++ b/src/agent/internal/agent/logger.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -14,39 +13,29 @@ import (
 
 const logRetention = 48 * time.Hour
 
-// Logger provides structured logging to file and console
+// Logger provides structured logging to stdout/stderr
+// Output is captured by the init script and written to /var/log/agent/agent.log
 type Logger struct {
-	file   *os.File
 	logger *log.Logger
 	mu     sync.Mutex
 }
 
-// NewLogger creates a new logger that writes to config/log/agent-YYYYMMDD.log
+// NewLogger creates a new logger that writes to stdout/stderr
+// The init script redirects output to /var/log/agent/agent.log
 func NewLogger(configDir string) (*Logger, error) {
-	logDir := filepath.Join(configDir, "log")
-	if err := os.MkdirAll(logDir, 0755); err != nil {
-		return nil, fmt.Errorf("create log directory: %w", err)
-	}
-
-	// Create log file with date suffix
-	logFile := filepath.Join(logDir, fmt.Sprintf("agent-%s.log", time.Now().Format("20060102")))
-	f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	if err != nil {
-		return nil, fmt.Errorf("open log file: %w", err)
-	}
-
-	// Write to both file and stderr
-	multiWriter := io.MultiWriter(f, os.Stderr)
-	logger := log.New(multiWriter, "", log.LstdFlags)
-	log.SetOutput(multiWriter)
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	log.SetOutput(os.Stderr)
 	log.SetFlags(log.LstdFlags)
 
-	if err := cleanupOldLogFiles(logDir, time.Now()); err != nil {
-		logger.Printf("[WARN] log cleanup failed: %v", err)
+	// Cleanup old llm-http logs in configDir if set
+	if configDir != "" {
+		llmLogDir := filepath.Join(configDir, "log")
+		if err := cleanupOldLogFiles(llmLogDir, time.Now()); err != nil {
+			logger.Printf("[WARN] log cleanup failed: %v", err)
+		}
 	}
 
 	return &Logger{
-		file:   f,
 		logger: logger,
 	}, nil
 }
@@ -60,6 +49,10 @@ func cleanupOldLogFiles(logDir string, now time.Time) error {
 	var errs []error
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".log") {
+			continue
+		}
+		// Only clean up llm-http logs (not agent.log)
+		if !strings.HasPrefix(entry.Name(), "llm-http-") {
 			continue
 		}
 		info, err := entry.Info()
@@ -80,17 +73,19 @@ func cleanupOldLogFiles(logDir string, now time.Time) error {
 }
 
 func logFileTime(name string, modTime time.Time) time.Time {
-	for _, prefix := range []string{"agent-", "llm-http-"} {
-		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".log") {
-			continue
-		}
-		date := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".log")
-		if len(date) != len("20060102") {
-			continue
-		}
-		if parsed, err := time.ParseInLocation("20060102", date, time.Local); err == nil {
-			return parsed.Add(24 * time.Hour)
-		}
+	// Only parse llm-http logs
+	if !strings.HasPrefix(name, "llm-http-") || !strings.HasSuffix(name, ".log") {
+		return modTime
+	}
+	// Extract date from llm-http-YYYYMMDD-*.log
+	parts := strings.TrimPrefix(name, "llm-http-")
+	parts = strings.TrimSuffix(parts, ".log")
+	if len(parts) < 8 {
+		return modTime
+	}
+	dateStr := parts[:8]
+	if parsed, err := time.ParseInLocation("20060102", dateStr, time.Local); err == nil {
+		return parsed.Add(24 * time.Hour)
 	}
 	return modTime
 }
@@ -98,9 +93,6 @@ func logFileTime(name string, modTime time.Time) time.Time {
 func (l *Logger) Close() error {
 	log.SetOutput(os.Stderr)
 	log.SetFlags(log.LstdFlags)
-	if l.file != nil {
-		return l.file.Close()
-	}
 	return nil
 }
 

--- a/src/agent/internal/agent/logger_test.go
+++ b/src/agent/internal/agent/logger_test.go
@@ -12,7 +12,7 @@ func TestCleanupOldLogFilesRemovesLogsOlderThanTwoDays(t *testing.T) {
 	now := time.Date(2026, 6, 19, 12, 0, 0, 0, time.Local)
 
 	writeTestLogFile(t, logDir, "agent-20260616.log", now)
-	writeTestLogFile(t, logDir, "llm-raw-20260616.log", now)
+	writeTestLogFile(t, logDir, "llm-http-20260616.log", now)
 	writeTestLogFile(t, logDir, "agent-20260617.log", now.Add(-72*time.Hour))
 	writeTestLogFile(t, logDir, "agent-20260618.log", now.Add(-72*time.Hour))
 	writeTestLogFile(t, logDir, "custom.log", now.Add(-72*time.Hour))
@@ -24,7 +24,7 @@ func TestCleanupOldLogFilesRemovesLogsOlderThanTwoDays(t *testing.T) {
 	}
 
 	assertPathMissing(t, filepath.Join(logDir, "agent-20260616.log"))
-	assertPathMissing(t, filepath.Join(logDir, "llm-raw-20260616.log"))
+	assertPathMissing(t, filepath.Join(logDir, "llm-http-20260616.log"))
 	assertPathMissing(t, filepath.Join(logDir, "custom.log"))
 	assertPathExists(t, filepath.Join(logDir, "agent-20260617.log"))
 	assertPathExists(t, filepath.Join(logDir, "agent-20260618.log"))

--- a/src/agent/internal/agent/logger_test.go
+++ b/src/agent/internal/agent/logger_test.go
@@ -11,25 +11,31 @@ func TestCleanupOldLogFilesRemovesLogsOlderThanTwoDays(t *testing.T) {
 	logDir := t.TempDir()
 	now := time.Date(2026, 6, 19, 12, 0, 0, 0, time.Local)
 
+	// Only llm-http logs are cleaned up
+	writeTestLogFile(t, logDir, "llm-http-20260616-session1.log", now)
+	writeTestLogFile(t, logDir, "llm-http-20260617-session2.log", now.Add(-72*time.Hour))
+	writeTestLogFile(t, logDir, "llm-http-20260618-session3.log", now.Add(-72*time.Hour))
+
+	// These should not be touched
 	writeTestLogFile(t, logDir, "agent-20260616.log", now)
-	writeTestLogFile(t, logDir, "llm-http-20260616.log", now)
-	writeTestLogFile(t, logDir, "agent-20260617.log", now.Add(-72*time.Hour))
-	writeTestLogFile(t, logDir, "agent-20260618.log", now.Add(-72*time.Hour))
 	writeTestLogFile(t, logDir, "custom.log", now.Add(-72*time.Hour))
-	writeTestLogFile(t, logDir, "agent-20260616.txt", now.Add(-72*time.Hour))
-	writeTestLogFile(t, logDir, "agent-notadate.log", now)
+	writeTestLogFile(t, logDir, "llm-http-notadate.log", now)
 
 	if err := cleanupOldLogFiles(logDir, now); err != nil {
 		t.Fatalf("cleanupOldLogFiles() error = %v", err)
 	}
 
-	assertPathMissing(t, filepath.Join(logDir, "agent-20260616.log"))
-	assertPathMissing(t, filepath.Join(logDir, "llm-http-20260616.log"))
-	assertPathMissing(t, filepath.Join(logDir, "custom.log"))
-	assertPathExists(t, filepath.Join(logDir, "agent-20260617.log"))
-	assertPathExists(t, filepath.Join(logDir, "agent-20260618.log"))
-	assertPathExists(t, filepath.Join(logDir, "agent-20260616.txt"))
-	assertPathExists(t, filepath.Join(logDir, "agent-notadate.log"))
+	// Old llm-http logs should be removed
+	assertPathMissing(t, filepath.Join(logDir, "llm-http-20260616-session1.log"))
+
+	// Recent llm-http logs should remain
+	assertPathExists(t, filepath.Join(logDir, "llm-http-20260617-session2.log"))
+	assertPathExists(t, filepath.Join(logDir, "llm-http-20260618-session3.log"))
+
+	// Non-llm-http logs should not be touched
+	assertPathExists(t, filepath.Join(logDir, "agent-20260616.log"))
+	assertPathExists(t, filepath.Join(logDir, "custom.log"))
+	assertPathExists(t, filepath.Join(logDir, "llm-http-notadate.log"))
 }
 
 func TestNewLoggerCleansOldLogFilesOnStartup(t *testing.T) {
@@ -38,7 +44,8 @@ func TestNewLoggerCleansOldLogFilesOnStartup(t *testing.T) {
 	if err := os.MkdirAll(logDir, 0755); err != nil {
 		t.Fatalf("create log dir: %v", err)
 	}
-	oldLog := filepath.Join(logDir, "agent-20000101.log")
+	// Create old llm-http log
+	oldLog := filepath.Join(logDir, "llm-http-20000101-session1.log")
 	if err := os.WriteFile(oldLog, []byte("old"), 0644); err != nil {
 		t.Fatalf("write old log: %v", err)
 	}
@@ -51,14 +58,8 @@ func TestNewLoggerCleansOldLogFilesOnStartup(t *testing.T) {
 		t.Fatalf("Close() error = %v", err)
 	}
 
+	// Old llm-http log should be cleaned up
 	assertPathMissing(t, oldLog)
-	matches, err := filepath.Glob(filepath.Join(logDir, "agent-*.log"))
-	if err != nil {
-		t.Fatalf("glob current log files: %v", err)
-	}
-	if len(matches) == 0 {
-		t.Fatalf("expected at least one current agent log file in %s", logDir)
-	}
 }
 
 func writeTestLogFile(t *testing.T, dir, name string, modTime time.Time) {

--- a/src/agent/internal/agent/models.go
+++ b/src/agent/internal/agent/models.go
@@ -40,7 +40,7 @@ type ModelManager struct {
 	providerSpecFetchStarted  bool
 	metadataHTTPClient        *http.Client
 	providerMetadataCachePath string
-	rawResponseLogDir         string
+	rawHTTPLogDir             string
 }
 
 type ModelManagerOption func(*ModelManager)
@@ -51,9 +51,9 @@ func WithProviderModelMetadataCachePath(path string) ModelManagerOption {
 	}
 }
 
-func WithLLMRawResponseLogDir(path string) ModelManagerOption {
+func WithLLMRawHTTPLogDir(path string) ModelManagerOption {
 	return func(m *ModelManager) {
-		m.rawResponseLogDir = strings.TrimSpace(path)
+		m.rawHTTPLogDir = strings.TrimSpace(path)
 	}
 }
 
@@ -147,11 +147,11 @@ func (m *ModelManager) build(cfg ModelConfig) (llms.Model, error) {
 }
 
 func (m *ModelManager) openAICompatibleOptions(cfg ModelConfig) []openAICompatibleModelOption {
-	if !cfg.LogRawResponse || strings.TrimSpace(m.rawResponseLogDir) == "" {
+	if !cfg.LogRawHTTP || strings.TrimSpace(m.rawHTTPLogDir) == "" {
 		return nil
 	}
 	return []openAICompatibleModelOption{
-		withOpenAICompatibleRawResponseLogger(newLLMRawResponseLogger(m.rawResponseLogDir)),
+		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(m.rawHTTPLogDir)),
 	}
 }
 

--- a/src/agent/internal/agent/models.go
+++ b/src/agent/internal/agent/models.go
@@ -41,6 +41,7 @@ type ModelManager struct {
 	metadataHTTPClient        *http.Client
 	providerMetadataCachePath string
 	rawHTTPLogDir             string
+	sessionID                 string
 }
 
 type ModelManagerOption func(*ModelManager)
@@ -65,6 +66,10 @@ func NewModelManager(config ModelConfig, proxy ProxyConfig, opts ...ModelManager
 		}
 	}
 	return m
+}
+
+func (m *ModelManager) SetSessionID(sessionID string) {
+	m.sessionID = sessionID
 }
 
 func (m *ModelManager) Get() (llms.Model, error) {
@@ -151,7 +156,7 @@ func (m *ModelManager) openAICompatibleOptions(cfg ModelConfig) []openAICompatib
 		return nil
 	}
 	return []openAICompatibleModelOption{
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(m.rawHTTPLogDir)),
+		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(m.rawHTTPLogDir, m.sessionID)),
 	}
 }
 

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -272,7 +272,7 @@ func (m *openAICompatibleModel) GenerateContent(ctx context.Context, messages []
 	}
 
 	// Log HTTP request body
-	_ = m.logRawHTTP(reqPayload.Model, "request", "http_request", 0, string(payloadBytes))
+	_ = m.logRawHTTP(reqPayload.Model, "request", "request", 0, string(payloadBytes))
 
 	endpoint := m.baseURL + "/chat/completions"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payloadBytes))
@@ -292,7 +292,7 @@ func (m *openAICompatibleModel) GenerateContent(ctx context.Context, messages []
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		_ = m.logRawHTTP(reqPayload.Model, "response", "http_error", resp.StatusCode, string(body))
+		_ = m.logRawHTTP(reqPayload.Model, "response", "error", resp.StatusCode, string(body))
 		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -310,7 +310,7 @@ func (m *openAICompatibleModel) GenerateContent(ctx context.Context, messages []
 		if err != nil {
 			return nil, fmt.Errorf("read response: %w", err)
 		}
-		_ = m.logRawHTTP(reqPayload.Model, "response", "http_response", resp.StatusCode, string(body))
+		_ = m.logRawHTTP(reqPayload.Model, "response", "response", resp.StatusCode, string(body))
 		if err := json.Unmarshal(body, &decoded); err != nil {
 			return nil, fmt.Errorf("decode response: %w", err)
 		}
@@ -428,7 +428,7 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 
 	// Log the aggregated streaming response as a single line
 	if m.rawLogger != nil && len(rawStreamLines) > 0 {
-		_ = m.logRawHTTP(requestModel, "response", "http_stream", statusCode, strings.Join(rawStreamLines, "\n"))
+		_ = m.logRawHTTP(requestModel, "response", "stream", statusCode, strings.Join(rawStreamLines, "\n"))
 	}
 
 	orderedToolCalls := make([]compatibleToolCall, 0, len(toolCalls))

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -64,14 +64,18 @@ func (l *llmRawHTTPLogger) Log(model, dir, kind string, statusCode int, raw stri
 		raw = strings.ReplaceAll(raw, "\r", "\\r")
 	}
 
-	entry := fmt.Sprintf(
-		"ts=%s dir=%s kind=%s status=%d body=%s\n",
-		now.Format("15:04:05"),
-		strings.TrimSpace(dir),
-		strings.TrimSpace(kind),
-		statusCode,
-		raw,
-	)
+	// Create JSONL entry
+	entry := map[string]interface{}{
+		"ts":     now.Format("15:04:05"),
+		"dir":    strings.TrimSpace(dir),
+		"kind":   strings.TrimSpace(kind),
+		"status": statusCode,
+		"body":   raw,
+	}
+	entryBytes, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshal log entry: %w", err)
+	}
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -84,7 +88,7 @@ func (l *llmRawHTTPLogger) Log(model, dir, kind string, statusCode int, raw stri
 		return err
 	}
 	defer file.Close()
-	_, err = file.WriteString(entry)
+	_, err = file.Write(append(entryBytes, '\n'))
 	return err
 }
 

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -65,13 +65,11 @@ func (l *llmRawHTTPLogger) Log(model, dir, kind string, statusCode int, raw stri
 	}
 
 	entry := fmt.Sprintf(
-		"ts=%s model=%s dir=%s kind=%s status=%d bytes=%d body=%s\n",
-		now.Format(time.RFC3339Nano),
-		strings.TrimSpace(model),
+		"ts=%s dir=%s kind=%s status=%d body=%s\n",
+		now.Format("2006-01-02 15:04:05"),
 		strings.TrimSpace(dir),
 		strings.TrimSpace(kind),
 		statusCode,
-		len([]byte(raw)),
 		raw,
 	)
 

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -350,10 +350,11 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 	stopReason := ""
 	toolCalls := map[int]*compatibleToolCall{}
 	var generationInfo map[string]any
-	var rawStreamLines []string
+	var rawStream strings.Builder
+	hasRawStream := false
 	logRawStream := func() {
-		if m.rawLogger != nil && len(rawStreamLines) > 0 {
-			_ = m.logRawHTTP(requestModel, "response", "stream", statusCode, strings.Join(rawStreamLines, "\n"))
+		if m.rawLogger != nil && hasRawStream {
+			_ = m.logRawHTTP(requestModel, "response", "stream", statusCode, rawStream.String())
 		}
 	}
 	defer logRawStream()
@@ -361,7 +362,11 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 	for scanner.Scan() {
 		rawLine := scanner.Text()
 		if m.rawLogger != nil {
-			rawStreamLines = append(rawStreamLines, rawLine)
+			if hasRawStream {
+				rawStream.WriteByte('\n')
+			}
+			rawStream.WriteString(rawLine)
+			hasRawStream = true
 		}
 		line := strings.TrimSpace(rawLine)
 		if line == "" || strings.HasPrefix(line, ":") {

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -36,16 +36,20 @@ func withOpenAICompatibleRawHTTPLogger(logger *llmRawHTTPLogger) openAICompatibl
 }
 
 type llmRawHTTPLogger struct {
-	dir string
-	mu  sync.Mutex
+	dir       string
+	sessionID string
+	mu        sync.Mutex
 }
 
-func newLLMRawHTTPLogger(logDir string) *llmRawHTTPLogger {
+func newLLMRawHTTPLogger(logDir, sessionID string) *llmRawHTTPLogger {
 	logDir = strings.TrimSpace(logDir)
 	if logDir == "" {
 		return nil
 	}
-	return &llmRawHTTPLogger{dir: logDir}
+	return &llmRawHTTPLogger{
+		dir:       logDir,
+		sessionID: sessionID,
+	}
 }
 
 func (l *llmRawHTTPLogger) Log(model, dir, kind string, statusCode int, raw string) error {
@@ -86,7 +90,15 @@ func (l *llmRawHTTPLogger) Log(model, dir, kind string, statusCode int, raw stri
 	if err := os.MkdirAll(l.dir, 0755); err != nil {
 		return err
 	}
-	path := filepath.Join(l.dir, "llm-http-"+now.Format("20060102")+".log")
+
+	// File name includes both date and session ID
+	dateStr := now.Format("20060102")
+	fileName := "llm-http-" + dateStr + ".log"
+	if l.sessionID != "" {
+		fileName = "llm-http-" + dateStr + "-" + l.sessionID + ".log"
+	}
+
+	path := filepath.Join(l.dir, fileName)
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return err

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -24,39 +24,51 @@ type openAICompatibleModel struct {
 	model      string
 	token      string
 	httpClient *http.Client
-	rawLogger  *llmRawResponseLogger
+	rawLogger  *llmRawHTTPLogger
 }
 
 type openAICompatibleModelOption func(*openAICompatibleModel)
 
-func withOpenAICompatibleRawResponseLogger(logger *llmRawResponseLogger) openAICompatibleModelOption {
+func withOpenAICompatibleRawHTTPLogger(logger *llmRawHTTPLogger) openAICompatibleModelOption {
 	return func(m *openAICompatibleModel) {
 		m.rawLogger = logger
 	}
 }
 
-type llmRawResponseLogger struct {
+type llmRawHTTPLogger struct {
 	dir string
 	mu  sync.Mutex
 }
 
-func newLLMRawResponseLogger(logDir string) *llmRawResponseLogger {
+func newLLMRawHTTPLogger(logDir string) *llmRawHTTPLogger {
 	logDir = strings.TrimSpace(logDir)
 	if logDir == "" {
 		return nil
 	}
-	return &llmRawResponseLogger{dir: logDir}
+	return &llmRawHTTPLogger{dir: logDir}
 }
 
-func (l *llmRawResponseLogger) Log(model, kind string, statusCode int, raw string) error {
+func (l *llmRawHTTPLogger) Log(model, dir, kind string, statusCode int, raw string) error {
 	if l == nil || strings.TrimSpace(l.dir) == "" {
 		return nil
 	}
 	now := time.Now()
+
+	// Compact JSON bodies to single line if possible
+	compacted := new(bytes.Buffer)
+	if err := json.Compact(compacted, []byte(raw)); err == nil {
+		raw = compacted.String()
+	} else {
+		// Not JSON or malformed, escape newlines
+		raw = strings.ReplaceAll(raw, "\n", "\\n")
+		raw = strings.ReplaceAll(raw, "\r", "\\r")
+	}
+
 	entry := fmt.Sprintf(
-		"ts=%s model=%s kind=%s status=%d bytes=%d\n%s\n\n",
+		"ts=%s model=%s dir=%s kind=%s status=%d bytes=%d body=%s\n",
 		now.Format(time.RFC3339Nano),
 		strings.TrimSpace(model),
+		strings.TrimSpace(dir),
 		strings.TrimSpace(kind),
 		statusCode,
 		len([]byte(raw)),
@@ -68,7 +80,7 @@ func (l *llmRawResponseLogger) Log(model, kind string, statusCode int, raw strin
 	if err := os.MkdirAll(l.dir, 0755); err != nil {
 		return err
 	}
-	path := filepath.Join(l.dir, "llm-raw-"+now.Format("20060102")+".log")
+	path := filepath.Join(l.dir, "llm-http-"+now.Format("20060102")+".log")
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return err
@@ -241,6 +253,9 @@ func (m *openAICompatibleModel) GenerateContent(ctx context.Context, messages []
 		return nil, fmt.Errorf("marshal chat request: %w", err)
 	}
 
+	// Log HTTP request body
+	_ = m.logRawHTTP(reqPayload.Model, "request", "http_request", 0, string(payloadBytes))
+
 	endpoint := m.baseURL + "/chat/completions"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payloadBytes))
 	if err != nil {
@@ -259,7 +274,7 @@ func (m *openAICompatibleModel) GenerateContent(ctx context.Context, messages []
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		_ = m.logRawResponse(reqPayload.Model, "http_error", resp.StatusCode, string(body))
+		_ = m.logRawHTTP(reqPayload.Model, "response", "http_error", resp.StatusCode, string(body))
 		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -277,7 +292,7 @@ func (m *openAICompatibleModel) GenerateContent(ctx context.Context, messages []
 		if err != nil {
 			return nil, fmt.Errorf("read response: %w", err)
 		}
-		_ = m.logRawResponse(reqPayload.Model, "http_response", resp.StatusCode, string(body))
+		_ = m.logRawHTTP(reqPayload.Model, "response", "http_response", resp.StatusCode, string(body))
 		if err := json.Unmarshal(body, &decoded); err != nil {
 			return nil, fmt.Errorf("decode response: %w", err)
 		}
@@ -317,9 +332,13 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 	stopReason := ""
 	toolCalls := map[int]*compatibleToolCall{}
 	var generationInfo map[string]any
+	var rawStreamLines []string
 
 	for scanner.Scan() {
 		rawLine := scanner.Text()
+		if m.rawLogger != nil {
+			rawStreamLines = append(rawStreamLines, rawLine)
+		}
 		line := strings.TrimSpace(rawLine)
 		if line == "" || strings.HasPrefix(line, ":") {
 			continue
@@ -327,7 +346,6 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 		if !strings.HasPrefix(line, "data:") {
 			continue
 		}
-		_ = m.logRawResponse(requestModel, "stream_event", statusCode, rawLine)
 		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
 		if data == "[DONE]" {
 			break
@@ -390,6 +408,11 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 		return nil, fmt.Errorf("read stream response: %w", err)
 	}
 
+	// Log the aggregated streaming response as a single line
+	if m.rawLogger != nil && len(rawStreamLines) > 0 {
+		_ = m.logRawHTTP(requestModel, "response", "http_stream", statusCode, strings.Join(rawStreamLines, "\n"))
+	}
+
 	orderedToolCalls := make([]compatibleToolCall, 0, len(toolCalls))
 	toolCallIndexes := make([]int, 0, len(toolCalls))
 	for index := range toolCalls {
@@ -416,11 +439,11 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 	return &llms.ContentResponse{Choices: []*llms.ContentChoice{choice}}, nil
 }
 
-func (m *openAICompatibleModel) logRawResponse(modelName, kind string, statusCode int, raw string) error {
+func (m *openAICompatibleModel) logRawHTTP(modelName, dir, kind string, statusCode int, raw string) error {
 	if m == nil || m.rawLogger == nil {
 		return nil
 	}
-	return m.rawLogger.Log(modelName, kind, statusCode, raw)
+	return m.rawLogger.Log(modelName, dir, kind, statusCode, raw)
 }
 
 func convertMessageContent(message llms.MessageContent) (compatibleMessage, error) {

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -64,13 +64,17 @@ func (l *llmRawHTTPLogger) Log(model, dir, kind string, statusCode int, raw stri
 		raw = strings.ReplaceAll(raw, "\r", "\\r")
 	}
 
-	// Create JSONL entry
-	entry := map[string]interface{}{
-		"ts":     now.Format("15:04:05"),
-		"dir":    strings.TrimSpace(dir),
-		"kind":   strings.TrimSpace(kind),
-		"status": statusCode,
-		"body":   raw,
+	// Create JSONL entry with ordered fields
+	entry := struct {
+		TS     string `json:"ts"`
+		Kind   string `json:"kind"`
+		Status int    `json:"status"`
+		Body   string `json:"body"`
+	}{
+		TS:     now.Format("15:04:05"),
+		Kind:   strings.TrimSpace(kind),
+		Status: statusCode,
+		Body:   raw,
 	}
 	entryBytes, err := json.Marshal(entry)
 	if err != nil {

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -66,7 +66,7 @@ func (l *llmRawHTTPLogger) Log(model, dir, kind string, statusCode int, raw stri
 
 	entry := fmt.Sprintf(
 		"ts=%s dir=%s kind=%s status=%d body=%s\n",
-		now.Format("2006-01-02 15:04:05"),
+		now.Format("15:04:05"),
 		strings.TrimSpace(dir),
 		strings.TrimSpace(kind),
 		statusCode,

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -351,6 +351,12 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 	toolCalls := map[int]*compatibleToolCall{}
 	var generationInfo map[string]any
 	var rawStreamLines []string
+	logRawStream := func() {
+		if m.rawLogger != nil && len(rawStreamLines) > 0 {
+			_ = m.logRawHTTP(requestModel, "response", "stream", statusCode, strings.Join(rawStreamLines, "\n"))
+		}
+	}
+	defer logRawStream()
 
 	for scanner.Scan() {
 		rawLine := scanner.Text()
@@ -424,11 +430,6 @@ func (m *openAICompatibleModel) decodeStreamingResponse(ctx context.Context, bod
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("read stream response: %w", err)
-	}
-
-	// Log the aggregated streaming response as a single line
-	if m.rawLogger != nil && len(rawStreamLines) > 0 {
-		_ = m.logRawHTTP(requestModel, "response", "stream", statusCode, strings.Join(rawStreamLines, "\n"))
 	}
 
 	orderedToolCalls := make([]compatibleToolCall, 0, len(toolCalls))

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -105,7 +105,7 @@ func TestOpenAICompatibleModelParsesToolCalls(t *testing.T) {
 	}
 }
 
-func TestOpenAICompatibleModelLogsRawResponseWhenEnabled(t *testing.T) {
+func TestOpenAICompatibleModelLogsRawHTTPWhenEnabled(t *testing.T) {
 	rawResponse := `{"choices":[{"message":{"content":"<think>\n需要查当前时间。\n</think>","tool_calls":[{"id":"call_1","type":"function","function":{"name":"current_time","arguments":"{\"timezone\":\"local\"}"}}]},"finish_reason":"tool_calls"}]}`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -119,7 +119,7 @@ func TestOpenAICompatibleModelLogsRawResponseWhenEnabled(t *testing.T) {
 		"test-model",
 		"",
 		server.Client(),
-		withOpenAICompatibleRawResponseLogger(newLLMRawResponseLogger(logDir)),
+		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir)),
 	)
 	_, err := model.GenerateContent(context.Background(), []llms.MessageContent{{
 		Role:  llms.ChatMessageTypeHuman,
@@ -129,17 +129,26 @@ func TestOpenAICompatibleModelLogsRawResponseWhenEnabled(t *testing.T) {
 		t.Fatalf("GenerateContent() error = %v", err)
 	}
 
-	logText := readRawResponseLog(t, logDir)
+	logText := readRawHTTPLog(t, logDir)
 	if !strings.Contains(logText, rawResponse) {
-		t.Fatalf("raw response log missing exact response:\n%s", logText)
+		t.Fatalf("raw HTTP log missing exact response:\n%s", logText)
 	}
 	if !strings.Contains(logText, "kind=http_response") || !strings.Contains(logText, "model=test-model") {
-		t.Fatalf("raw response log missing metadata:\n%s", logText)
+		t.Fatalf("raw HTTP log missing metadata:\n%s", logText)
 	}
-	assertRawResponseLogHasRFC3339NanoTimestamp(t, logText)
+	if !strings.Contains(logText, "dir=response") {
+		t.Fatalf("raw HTTP log missing direction field:\n%s", logText)
+	}
+	if !strings.Contains(logText, "dir=request") || !strings.Contains(logText, "kind=http_request") {
+		t.Fatalf("raw HTTP log missing request record:\n%s", logText)
+	}
+	if !strings.Contains(logText, "现在几点了") {
+		t.Fatalf("raw HTTP log missing request content:\n%s", logText)
+	}
+	assertRawHTTPLogHasRFC3339NanoTimestamp(t, logText)
 }
 
-func TestOpenAICompatibleModelRawResponseLogUsesEffectiveRequestModel(t *testing.T) {
+func TestOpenAICompatibleModelRawHTTPLogUsesEffectiveRequestModel(t *testing.T) {
 	rawResponse := `{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -153,7 +162,7 @@ func TestOpenAICompatibleModelRawResponseLogUsesEffectiveRequestModel(t *testing
 		"configured-model",
 		"",
 		server.Client(),
-		withOpenAICompatibleRawResponseLogger(newLLMRawResponseLogger(logDir)),
+		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir)),
 	)
 	_, err := model.GenerateContent(
 		context.Background(),
@@ -167,9 +176,9 @@ func TestOpenAICompatibleModelRawResponseLogUsesEffectiveRequestModel(t *testing
 		t.Fatalf("GenerateContent() error = %v", err)
 	}
 
-	logText := readRawResponseLog(t, logDir)
+	logText := readRawHTTPLog(t, logDir)
 	if !strings.Contains(logText, "model=override-model") {
-		t.Fatalf("raw response log used wrong model metadata:\n%s", logText)
+		t.Fatalf("raw HTTP log used wrong model metadata:\n%s", logText)
 	}
 }
 
@@ -215,7 +224,7 @@ func TestOpenAICompatibleModelStreamsContent(t *testing.T) {
 	}
 }
 
-func TestOpenAICompatibleModelLogsRawStreamingEventsWhenEnabled(t *testing.T) {
+func TestOpenAICompatibleModelLogsRawStreamingHTTPWhenEnabled(t *testing.T) {
 	firstEvent := `data: {"choices":[{"delta":{"content":"<think>\n"}}]}`
 	secondEvent := `data: {"choices":[{"delta":{"content":"需要查当前时间。\n</think>"},"finish_reason":"tool_calls"}]}`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -232,7 +241,7 @@ func TestOpenAICompatibleModelLogsRawStreamingEventsWhenEnabled(t *testing.T) {
 		"test-model",
 		"",
 		server.Client(),
-		withOpenAICompatibleRawResponseLogger(newLLMRawResponseLogger(logDir)),
+		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir)),
 	)
 	_, err := model.GenerateContent(
 		context.Background(),
@@ -246,17 +255,28 @@ func TestOpenAICompatibleModelLogsRawStreamingEventsWhenEnabled(t *testing.T) {
 		t.Fatalf("GenerateContent() error = %v", err)
 	}
 
-	logText := readRawResponseLog(t, logDir)
-	if !strings.Contains(logText, firstEvent) || !strings.Contains(logText, secondEvent) || !strings.Contains(logText, "data: [DONE]") {
-		t.Fatalf("raw streaming log missing SSE events:\n%s", logText)
+	logText := readRawHTTPLog(t, logDir)
+	// Stream is aggregated into one line with escaped newlines
+	if !findLogLineContaining(logText, firstEvent) {
+		t.Fatalf("raw streaming HTTP log missing first SSE event:\n%s", logText)
 	}
-	if !strings.Contains(logText, "kind=stream_event") || !strings.Contains(logText, "model=test-model") {
-		t.Fatalf("raw streaming log missing metadata:\n%s", logText)
+	if !findLogLineContaining(logText, secondEvent) {
+		t.Fatalf("raw streaming HTTP log missing second SSE event:\n%s", logText)
 	}
-	assertRawResponseLogHasRFC3339NanoTimestamp(t, logText)
+	if !findLogLineContaining(logText, "data: [DONE]") {
+		t.Fatalf("raw streaming HTTP log missing [DONE] marker:\n%s", logText)
+	}
+	if !strings.Contains(logText, "kind=http_stream") || !strings.Contains(logText, "model=test-model") {
+		t.Fatalf("raw streaming HTTP log missing metadata:\n%s", logText)
+	}
+	if !strings.Contains(logText, "dir=response") {
+		t.Fatalf("raw streaming HTTP log missing direction field:\n%s", logText)
+	}
+	assertRawHTTPLogHasRFC3339NanoTimestamp(t, logText)
+	assertEveryLineIsCompleteRecord(t, logText)
 }
 
-func TestModelManagerEnablesRawResponseLoggingFromModelConfig(t *testing.T) {
+func TestModelManagerEnablesRawHTTPLoggingFromModelConfig(t *testing.T) {
 	rawResponse := `{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -266,11 +286,11 @@ func TestModelManagerEnablesRawResponseLoggingFromModelConfig(t *testing.T) {
 
 	logDir := t.TempDir()
 	manager := NewModelManager(ModelConfig{
-		Provider:       "openai",
-		Model:          "test-model",
-		BaseURL:        server.URL,
-		LogRawResponse: true,
-	}, ProxyConfig{}, WithLLMRawResponseLogDir(logDir))
+		Provider:   "openai",
+		Model:      "test-model",
+		BaseURL:    server.URL,
+		LogRawHTTP: true,
+	}, ProxyConfig{}, WithLLMRawHTTPLogDir(logDir))
 	model, err := manager.Get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
@@ -283,13 +303,13 @@ func TestModelManagerEnablesRawResponseLoggingFromModelConfig(t *testing.T) {
 		t.Fatalf("GenerateContent() error = %v", err)
 	}
 
-	logText := readRawResponseLog(t, logDir)
+	logText := readRawHTTPLog(t, logDir)
 	if !strings.Contains(logText, rawResponse) {
-		t.Fatalf("raw response log missing response from model manager config:\n%s", logText)
+		t.Fatalf("raw HTTP log missing response from model manager config:\n%s", logText)
 	}
 }
 
-func TestModelManagerEnablesRawResponseLoggingFromDefaultConfig(t *testing.T) {
+func TestModelManagerEnablesRawHTTPLoggingFromDefaultConfig(t *testing.T) {
 	rawResponse := `{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -302,7 +322,7 @@ func TestModelManagerEnablesRawResponseLoggingFromDefaultConfig(t *testing.T) {
 	cfg.Provider = "openai"
 	cfg.Model = "test-model"
 	cfg.BaseURL = server.URL
-	manager := NewModelManager(cfg, ProxyConfig{}, WithLLMRawResponseLogDir(logDir))
+	manager := NewModelManager(cfg, ProxyConfig{}, WithLLMRawHTTPLogDir(logDir))
 	model, err := manager.Get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
@@ -315,13 +335,13 @@ func TestModelManagerEnablesRawResponseLoggingFromDefaultConfig(t *testing.T) {
 		t.Fatalf("GenerateContent() error = %v", err)
 	}
 
-	logText := readRawResponseLog(t, logDir)
+	logText := readRawHTTPLog(t, logDir)
 	if !strings.Contains(logText, rawResponse) {
-		t.Fatalf("raw response log missing response from default config:\n%s", logText)
+		t.Fatalf("raw HTTP log missing response from default config:\n%s", logText)
 	}
 }
 
-func TestModelManagerDoesNotLogRawResponseWhenDisabled(t *testing.T) {
+func TestModelManagerDoesNotLogRawHTTPWhenDisabled(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
@@ -333,7 +353,7 @@ func TestModelManagerDoesNotLogRawResponseWhenDisabled(t *testing.T) {
 		Provider: "openai",
 		Model:    "test-model",
 		BaseURL:  server.URL,
-	}, ProxyConfig{}, WithLLMRawResponseLogDir(logDir))
+	}, ProxyConfig{}, WithLLMRawHTTPLogDir(logDir))
 	model, err := manager.Get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
@@ -346,8 +366,8 @@ func TestModelManagerDoesNotLogRawResponseWhenDisabled(t *testing.T) {
 		t.Fatalf("GenerateContent() error = %v", err)
 	}
 
-	if _, err := os.Stat(rawResponseLogPath(logDir)); !os.IsNotExist(err) {
-		t.Fatalf("raw response log should not exist when disabled, err=%v", err)
+	if _, err := os.Stat(rawHTTPLogPath(logDir)); !os.IsNotExist(err) {
+		t.Fatalf("raw HTTP log should not exist when disabled, err=%v", err)
 	}
 }
 
@@ -445,32 +465,56 @@ func TestOpenAICompatibleModelIncludesUsageInGenerationInfo(t *testing.T) {
 	}
 }
 
-func readRawResponseLog(t *testing.T, logDir string) string {
+func readRawHTTPLog(t *testing.T, logDir string) string {
 	t.Helper()
-	data, err := os.ReadFile(rawResponseLogPath(logDir))
+	data, err := os.ReadFile(rawHTTPLogPath(logDir))
 	if err != nil {
-		t.Fatalf("read raw response log: %v", err)
+		t.Fatalf("read raw HTTP log: %v", err)
 	}
 	return string(data)
 }
 
-func rawResponseLogPath(logDir string) string {
-	matches, _ := filepath.Glob(filepath.Join(logDir, "llm-raw-*.log"))
+func rawHTTPLogPath(logDir string) string {
+	matches, _ := filepath.Glob(filepath.Join(logDir, "llm-http-*.log"))
 	sort.Strings(matches)
 	if len(matches) > 0 {
 		return matches[len(matches)-1]
 	}
-	return filepath.Join(logDir, "llm-raw-"+time.Now().Format("20060102")+".log")
+	return filepath.Join(logDir, "llm-http-"+time.Now().Format("20060102")+".log")
 }
 
-func assertRawResponseLogHasRFC3339NanoTimestamp(t *testing.T, logText string) {
+func assertRawHTTPLogHasRFC3339NanoTimestamp(t *testing.T, logText string) {
 	t.Helper()
 	match := regexp.MustCompile(`ts=([^ ]+)`).FindStringSubmatch(logText)
 	if len(match) != 2 {
-		t.Fatalf("raw response log missing timestamp:\n%s", logText)
+		t.Fatalf("raw HTTP log missing timestamp:\n%s", logText)
 	}
 	if _, err := time.Parse(time.RFC3339Nano, match[1]); err != nil {
-		t.Fatalf("raw response log timestamp = %q, want RFC3339Nano: %v", match[1], err)
+		t.Fatalf("raw HTTP log timestamp = %q, want RFC3339Nano: %v", match[1], err)
+	}
+}
+
+func findLogLineContaining(logText, substring string) bool {
+	lines := strings.Split(logText, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, substring) {
+			return true
+		}
+	}
+	return false
+}
+
+func assertEveryLineIsCompleteRecord(t *testing.T, logText string) {
+	t.Helper()
+	lines := strings.Split(logText, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "ts=") {
+			t.Fatalf("log line does not start with timestamp: %s", line)
+		}
 	}
 }
 

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -485,14 +485,14 @@ func rawHTTPLogPath(logDir string) string {
 
 func assertRawHTTPLogHasSimpleTimestamp(t *testing.T, logText string) {
 	t.Helper()
-	// Match timestamp with space: ts=2006-01-02 15:04:05
-	match := regexp.MustCompile(`ts=([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})`).FindStringSubmatch(logText)
+	// Match timestamp: ts=15:04:05
+	match := regexp.MustCompile(`ts=([0-9]{2}:[0-9]{2}:[0-9]{2})`).FindStringSubmatch(logText)
 	if len(match) != 2 {
 		t.Fatalf("raw HTTP log missing timestamp:\n%s", logText)
 	}
-	// Format: 2006-01-02 15:04:05
-	if _, err := time.Parse("2006-01-02 15:04:05", match[1]); err != nil {
-		t.Fatalf("raw HTTP log timestamp = %q, want format '2006-01-02 15:04:05': %v", match[1], err)
+	// Format: 15:04:05
+	if _, err := time.Parse("15:04:05", match[1]); err != nil {
+		t.Fatalf("raw HTTP log timestamp = %q, want format '15:04:05': %v", match[1], err)
 	}
 }
 

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -133,7 +133,7 @@ func TestOpenAICompatibleModelLogsRawHTTPWhenEnabled(t *testing.T) {
 	if !strings.Contains(logText, rawResponse) {
 		t.Fatalf("raw HTTP log missing exact response:\n%s", logText)
 	}
-	if !strings.Contains(logText, "kind=http_response") || !strings.Contains(logText, "model=test-model") {
+	if !strings.Contains(logText, "kind=http_response") {
 		t.Fatalf("raw HTTP log missing metadata:\n%s", logText)
 	}
 	if !strings.Contains(logText, "dir=response") {
@@ -145,7 +145,7 @@ func TestOpenAICompatibleModelLogsRawHTTPWhenEnabled(t *testing.T) {
 	if !strings.Contains(logText, "现在几点了") {
 		t.Fatalf("raw HTTP log missing request content:\n%s", logText)
 	}
-	assertRawHTTPLogHasRFC3339NanoTimestamp(t, logText)
+	assertRawHTTPLogHasSimpleTimestamp(t, logText)
 }
 
 func TestOpenAICompatibleModelRawHTTPLogUsesEffectiveRequestModel(t *testing.T) {
@@ -177,8 +177,8 @@ func TestOpenAICompatibleModelRawHTTPLogUsesEffectiveRequestModel(t *testing.T) 
 	}
 
 	logText := readRawHTTPLog(t, logDir)
-	if !strings.Contains(logText, "model=override-model") {
-		t.Fatalf("raw HTTP log used wrong model metadata:\n%s", logText)
+	if !strings.Contains(logText, `"model":"override-model"`) {
+		t.Fatalf("raw HTTP log should use effective model in request body:\n%s", logText)
 	}
 }
 
@@ -266,13 +266,13 @@ func TestOpenAICompatibleModelLogsRawStreamingHTTPWhenEnabled(t *testing.T) {
 	if !findLogLineContaining(logText, "data: [DONE]") {
 		t.Fatalf("raw streaming HTTP log missing [DONE] marker:\n%s", logText)
 	}
-	if !strings.Contains(logText, "kind=http_stream") || !strings.Contains(logText, "model=test-model") {
+	if !strings.Contains(logText, "kind=http_stream") {
 		t.Fatalf("raw streaming HTTP log missing metadata:\n%s", logText)
 	}
 	if !strings.Contains(logText, "dir=response") {
 		t.Fatalf("raw streaming HTTP log missing direction field:\n%s", logText)
 	}
-	assertRawHTTPLogHasRFC3339NanoTimestamp(t, logText)
+	assertRawHTTPLogHasSimpleTimestamp(t, logText)
 	assertEveryLineIsCompleteRecord(t, logText)
 }
 
@@ -483,14 +483,16 @@ func rawHTTPLogPath(logDir string) string {
 	return filepath.Join(logDir, "llm-http-"+time.Now().Format("20060102")+".log")
 }
 
-func assertRawHTTPLogHasRFC3339NanoTimestamp(t *testing.T, logText string) {
+func assertRawHTTPLogHasSimpleTimestamp(t *testing.T, logText string) {
 	t.Helper()
-	match := regexp.MustCompile(`ts=([^ ]+)`).FindStringSubmatch(logText)
+	// Match timestamp with space: ts=2006-01-02 15:04:05
+	match := regexp.MustCompile(`ts=([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})`).FindStringSubmatch(logText)
 	if len(match) != 2 {
 		t.Fatalf("raw HTTP log missing timestamp:\n%s", logText)
 	}
-	if _, err := time.Parse(time.RFC3339Nano, match[1]); err != nil {
-		t.Fatalf("raw HTTP log timestamp = %q, want RFC3339Nano: %v", match[1], err)
+	// Format: 2006-01-02 15:04:05
+	if _, err := time.Parse("2006-01-02 15:04:05", match[1]); err != nil {
+		t.Fatalf("raw HTTP log timestamp = %q, want format '2006-01-02 15:04:05': %v", match[1], err)
 	}
 }
 

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -156,10 +156,7 @@ func TestOpenAICompatibleModelLogsRawHTTPWhenEnabled(t *testing.T) {
 	if !strings.Contains(logText, `"kind":"http_response"`) {
 		t.Fatalf("raw HTTP log missing response metadata:\n%s", logText)
 	}
-	if !strings.Contains(logText, `"dir":"response"`) {
-		t.Fatalf("raw HTTP log missing direction field:\n%s", logText)
-	}
-	if !strings.Contains(logText, `"dir":"request"`) || !strings.Contains(logText, `"kind":"http_request"`) {
+	if !strings.Contains(logText, `"kind":"http_request"`) {
 		t.Fatalf("raw HTTP log missing request record:\n%s", logText)
 	}
 	assertRawHTTPLogIsValidJSONL(t, logText)
@@ -321,9 +318,6 @@ func TestOpenAICompatibleModelLogsRawStreamingHTTPWhenEnabled(t *testing.T) {
 	}
 	if !strings.Contains(logText, `"kind":"http_stream"`) {
 		t.Fatalf("raw streaming HTTP log missing metadata:\n%s", logText)
-	}
-	if !strings.Contains(logText, `"dir":"response"`) {
-		t.Fatalf("raw streaming HTTP log missing direction field:\n%s", logText)
 	}
 	assertRawHTTPLogIsValidJSONL(t, logText)
 }
@@ -584,9 +578,6 @@ func assertRawHTTPLogIsValidJSONL(t *testing.T, logText string) {
 		// Check required fields
 		if _, ok := entry["ts"]; !ok {
 			t.Fatalf("line %d missing 'ts' field: %s", i+1, line)
-		}
-		if _, ok := entry["dir"]; !ok {
-			t.Fatalf("line %d missing 'dir' field: %s", i+1, line)
 		}
 		if _, ok := entry["kind"]; !ok {
 			t.Fatalf("line %d missing 'kind' field: %s", i+1, line)

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -130,22 +129,40 @@ func TestOpenAICompatibleModelLogsRawHTTPWhenEnabled(t *testing.T) {
 	}
 
 	logText := readRawHTTPLog(t, logDir)
-	if !strings.Contains(logText, rawResponse) {
-		t.Fatalf("raw HTTP log missing exact response:\n%s", logText)
+
+	// Parse JSONL and check for expected content
+	var foundResponse, foundRequest bool
+	lines := strings.Split(strings.TrimSpace(logText), "\n")
+	for _, line := range lines {
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		body, _ := entry["body"].(string)
+		if strings.Contains(body, "finish_reason") && strings.Contains(body, "tool_calls") {
+			foundResponse = true
+		}
+		if strings.Contains(body, "现在几点了") {
+			foundRequest = true
+		}
 	}
-	if !strings.Contains(logText, "kind=http_response") {
-		t.Fatalf("raw HTTP log missing metadata:\n%s", logText)
+
+	if !foundResponse {
+		t.Fatalf("raw HTTP log missing response:\n%s", logText)
 	}
-	if !strings.Contains(logText, "dir=response") {
+	if !foundRequest {
+		t.Fatalf("raw HTTP log missing request:\n%s", logText)
+	}
+	if !strings.Contains(logText, `"kind":"http_response"`) {
+		t.Fatalf("raw HTTP log missing response metadata:\n%s", logText)
+	}
+	if !strings.Contains(logText, `"dir":"response"`) {
 		t.Fatalf("raw HTTP log missing direction field:\n%s", logText)
 	}
-	if !strings.Contains(logText, "dir=request") || !strings.Contains(logText, "kind=http_request") {
+	if !strings.Contains(logText, `"dir":"request"`) || !strings.Contains(logText, `"kind":"http_request"`) {
 		t.Fatalf("raw HTTP log missing request record:\n%s", logText)
 	}
-	if !strings.Contains(logText, "现在几点了") {
-		t.Fatalf("raw HTTP log missing request content:\n%s", logText)
-	}
-	assertRawHTTPLogHasSimpleTimestamp(t, logText)
+	assertRawHTTPLogIsValidJSONL(t, logText)
 }
 
 func TestOpenAICompatibleModelRawHTTPLogUsesEffectiveRequestModel(t *testing.T) {
@@ -177,7 +194,23 @@ func TestOpenAICompatibleModelRawHTTPLogUsesEffectiveRequestModel(t *testing.T) 
 	}
 
 	logText := readRawHTTPLog(t, logDir)
-	if !strings.Contains(logText, `"model":"override-model"`) {
+
+	// Parse JSONL and check for model in request body
+	var foundModel bool
+	lines := strings.Split(strings.TrimSpace(logText), "\n")
+	for _, line := range lines {
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		body, _ := entry["body"].(string)
+		if strings.Contains(body, `"model":"override-model"`) {
+			foundModel = true
+			break
+		}
+	}
+
+	if !foundModel {
 		t.Fatalf("raw HTTP log should use effective model in request body:\n%s", logText)
 	}
 }
@@ -256,24 +289,43 @@ func TestOpenAICompatibleModelLogsRawStreamingHTTPWhenEnabled(t *testing.T) {
 	}
 
 	logText := readRawHTTPLog(t, logDir)
-	// Stream is aggregated into one line with escaped newlines
-	if !findLogLineContaining(logText, firstEvent) {
-		t.Fatalf("raw streaming HTTP log missing first SSE event:\n%s", logText)
+
+	// Parse JSONL and check stream body contains expected events
+	var foundStreamResponse bool
+	var streamBody string
+	lines := strings.Split(strings.TrimSpace(logText), "\n")
+	for _, line := range lines {
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry["kind"] == "http_stream" {
+			streamBody, _ = entry["body"].(string)
+			foundStreamResponse = true
+			break
+		}
 	}
-	if !findLogLineContaining(logText, secondEvent) {
-		t.Fatalf("raw streaming HTTP log missing second SSE event:\n%s", logText)
+
+	if !foundStreamResponse {
+		t.Fatalf("raw streaming HTTP log missing stream response:\n%s", logText)
 	}
-	if !findLogLineContaining(logText, "data: [DONE]") {
-		t.Fatalf("raw streaming HTTP log missing [DONE] marker:\n%s", logText)
+	// Check that stream body contains the SSE events (they are escaped in JSON)
+	if !strings.Contains(streamBody, firstEvent) {
+		t.Fatalf("raw streaming HTTP log missing first SSE event in body:\n%s", streamBody)
 	}
-	if !strings.Contains(logText, "kind=http_stream") {
+	if !strings.Contains(streamBody, secondEvent) {
+		t.Fatalf("raw streaming HTTP log missing second SSE event in body:\n%s", streamBody)
+	}
+	if !strings.Contains(streamBody, "data: [DONE]") {
+		t.Fatalf("raw streaming HTTP log missing [DONE] marker in body:\n%s", streamBody)
+	}
+	if !strings.Contains(logText, `"kind":"http_stream"`) {
 		t.Fatalf("raw streaming HTTP log missing metadata:\n%s", logText)
 	}
-	if !strings.Contains(logText, "dir=response") {
+	if !strings.Contains(logText, `"dir":"response"`) {
 		t.Fatalf("raw streaming HTTP log missing direction field:\n%s", logText)
 	}
-	assertRawHTTPLogHasSimpleTimestamp(t, logText)
-	assertEveryLineIsCompleteRecord(t, logText)
+	assertRawHTTPLogIsValidJSONL(t, logText)
 }
 
 func TestModelManagerEnablesRawHTTPLoggingFromModelConfig(t *testing.T) {
@@ -304,7 +356,23 @@ func TestModelManagerEnablesRawHTTPLoggingFromModelConfig(t *testing.T) {
 	}
 
 	logText := readRawHTTPLog(t, logDir)
-	if !strings.Contains(logText, rawResponse) {
+
+	// Parse JSONL and check for expected content
+	var foundResponse bool
+	lines := strings.Split(strings.TrimSpace(logText), "\n")
+	for _, line := range lines {
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		body, _ := entry["body"].(string)
+		if strings.Contains(body, "finish_reason") && strings.Contains(body, "ok") {
+			foundResponse = true
+			break
+		}
+	}
+
+	if !foundResponse {
 		t.Fatalf("raw HTTP log missing response from model manager config:\n%s", logText)
 	}
 }
@@ -336,7 +404,23 @@ func TestModelManagerEnablesRawHTTPLoggingFromDefaultConfig(t *testing.T) {
 	}
 
 	logText := readRawHTTPLog(t, logDir)
-	if !strings.Contains(logText, rawResponse) {
+
+	// Parse JSONL and check for expected content
+	var foundResponse bool
+	lines := strings.Split(strings.TrimSpace(logText), "\n")
+	for _, line := range lines {
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		body, _ := entry["body"].(string)
+		if strings.Contains(body, "finish_reason") && strings.Contains(body, "ok") {
+			foundResponse = true
+			break
+		}
+	}
+
+	if !foundResponse {
 		t.Fatalf("raw HTTP log missing response from default config:\n%s", logText)
 	}
 }
@@ -483,16 +567,44 @@ func rawHTTPLogPath(logDir string) string {
 	return filepath.Join(logDir, "llm-http-"+time.Now().Format("20060102")+".log")
 }
 
-func assertRawHTTPLogHasSimpleTimestamp(t *testing.T, logText string) {
+func assertRawHTTPLogIsValidJSONL(t *testing.T, logText string) {
 	t.Helper()
-	// Match timestamp: ts=15:04:05
-	match := regexp.MustCompile(`ts=([0-9]{2}:[0-9]{2}:[0-9]{2})`).FindStringSubmatch(logText)
-	if len(match) != 2 {
-		t.Fatalf("raw HTTP log missing timestamp:\n%s", logText)
+	lines := strings.Split(strings.TrimSpace(logText), "\n")
+	if len(lines) == 0 {
+		t.Fatal("raw HTTP log is empty")
 	}
-	// Format: 15:04:05
-	if _, err := time.Parse("15:04:05", match[1]); err != nil {
-		t.Fatalf("raw HTTP log timestamp = %q, want format '15:04:05': %v", match[1], err)
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("line %d is not valid JSON: %v\nline: %s", i+1, err, line)
+		}
+		// Check required fields
+		if _, ok := entry["ts"]; !ok {
+			t.Fatalf("line %d missing 'ts' field: %s", i+1, line)
+		}
+		if _, ok := entry["dir"]; !ok {
+			t.Fatalf("line %d missing 'dir' field: %s", i+1, line)
+		}
+		if _, ok := entry["kind"]; !ok {
+			t.Fatalf("line %d missing 'kind' field: %s", i+1, line)
+		}
+		if _, ok := entry["status"]; !ok {
+			t.Fatalf("line %d missing 'status' field: %s", i+1, line)
+		}
+		if _, ok := entry["body"]; !ok {
+			t.Fatalf("line %d missing 'body' field: %s", i+1, line)
+		}
+		// Validate timestamp format
+		ts, ok := entry["ts"].(string)
+		if !ok {
+			t.Fatalf("line %d 'ts' is not a string: %s", i+1, line)
+		}
+		if _, err := time.Parse("15:04:05", ts); err != nil {
+			t.Fatalf("line %d 'ts' format invalid (want HH:MM:SS): %v", i+1, err)
+		}
 	}
 }
 
@@ -507,17 +619,8 @@ func findLogLineContaining(logText, substring string) bool {
 }
 
 func assertEveryLineIsCompleteRecord(t *testing.T, logText string) {
+	// This is now covered by assertRawHTTPLogIsValidJSONL
 	t.Helper()
-	lines := strings.Split(logText, "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		if !strings.HasPrefix(line, "ts=") {
-			t.Fatalf("log line does not start with timestamp: %s", line)
-		}
-	}
 }
 
 func TestModelManagerOpenRouterRetriesEOFInModelCall(t *testing.T) {

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -611,10 +611,11 @@ func rawHTTPLogPath(logDir string) string {
 
 func assertRawHTTPLogIsValidJSONL(t *testing.T, logText string) {
 	t.Helper()
-	lines := strings.Split(strings.TrimSpace(logText), "\n")
-	if len(lines) == 0 {
+	trimmed := strings.TrimSpace(logText)
+	if trimmed == "" {
 		t.Fatal("raw HTTP log is empty")
 	}
+	lines := strings.Split(trimmed, "\n")
 	for i, line := range lines {
 		if strings.TrimSpace(line) == "" {
 			continue

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -153,10 +153,10 @@ func TestOpenAICompatibleModelLogsRawHTTPWhenEnabled(t *testing.T) {
 	if !foundRequest {
 		t.Fatalf("raw HTTP log missing request:\n%s", logText)
 	}
-	if !strings.Contains(logText, `"kind":"http_response"`) {
+	if !strings.Contains(logText, `"kind":"response"`) {
 		t.Fatalf("raw HTTP log missing response metadata:\n%s", logText)
 	}
-	if !strings.Contains(logText, `"kind":"http_request"`) {
+	if !strings.Contains(logText, `"kind":"request"`) {
 		t.Fatalf("raw HTTP log missing request record:\n%s", logText)
 	}
 	assertRawHTTPLogIsValidJSONL(t, logText)
@@ -296,7 +296,7 @@ func TestOpenAICompatibleModelLogsRawStreamingHTTPWhenEnabled(t *testing.T) {
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
 			continue
 		}
-		if entry["kind"] == "http_stream" {
+		if entry["kind"] == "stream" {
 			streamBody, _ = entry["body"].(string)
 			foundStreamResponse = true
 			break
@@ -316,7 +316,7 @@ func TestOpenAICompatibleModelLogsRawStreamingHTTPWhenEnabled(t *testing.T) {
 	if !strings.Contains(streamBody, "data: [DONE]") {
 		t.Fatalf("raw streaming HTTP log missing [DONE] marker in body:\n%s", streamBody)
 	}
-	if !strings.Contains(logText, `"kind":"http_stream"`) {
+	if !strings.Contains(logText, `"kind":"stream"`) {
 		t.Fatalf("raw streaming HTTP log missing metadata:\n%s", logText)
 	}
 	assertRawHTTPLogIsValidJSONL(t, logText)

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -118,7 +118,7 @@ func TestOpenAICompatibleModelLogsRawHTTPWhenEnabled(t *testing.T) {
 		"test-model",
 		"",
 		server.Client(),
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir)),
+		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir, "test-session-1")),
 	)
 	_, err := model.GenerateContent(context.Background(), []llms.MessageContent{{
 		Role:  llms.ChatMessageTypeHuman,
@@ -176,7 +176,7 @@ func TestOpenAICompatibleModelRawHTTPLogUsesEffectiveRequestModel(t *testing.T) 
 		"configured-model",
 		"",
 		server.Client(),
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir)),
+		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir, "test-session-1")),
 	)
 	_, err := model.GenerateContent(
 		context.Background(),
@@ -271,7 +271,7 @@ func TestOpenAICompatibleModelLogsRawStreamingHTTPWhenEnabled(t *testing.T) {
 		"test-model",
 		"",
 		server.Client(),
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir)),
+		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir, "test-session-1")),
 	)
 	_, err := model.GenerateContent(
 		context.Background(),

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -322,6 +322,54 @@ func TestOpenAICompatibleModelLogsRawStreamingHTTPWhenEnabled(t *testing.T) {
 	assertRawHTTPLogIsValidJSONL(t, logText)
 }
 
+func TestOpenAICompatibleModelLogsRawStreamingHTTPOnDecodeError(t *testing.T) {
+	validEvent := `data: {"choices":[{"delta":{"content":"hello"}}]}`
+	malformedEvent := `data: {"choices":[`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Write([]byte(validEvent + "\n\n"))
+		w.Write([]byte(malformedEvent + "\n\n"))
+	}))
+	defer server.Close()
+
+	logDir := t.TempDir()
+	model := newOpenAICompatibleModel(
+		server.URL,
+		"test-model",
+		"",
+		server.Client(),
+		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir, "test-session-1")),
+	)
+	_, err := model.GenerateContent(
+		context.Background(),
+		[]llms.MessageContent{{
+			Role:  llms.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextPart("stream please")},
+		}},
+		llms.WithStreamingFunc(func(ctx context.Context, chunk []byte) error { return nil }),
+	)
+	if err == nil || !strings.Contains(err.Error(), "decode stream event") {
+		t.Fatalf("GenerateContent() error = %v, want decode stream event", err)
+	}
+
+	logText := readRawHTTPLog(t, logDir)
+	var streamBody string
+	for _, line := range strings.Split(strings.TrimSpace(logText), "\n") {
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry["kind"] == "stream" {
+			streamBody, _ = entry["body"].(string)
+			break
+		}
+	}
+	if !strings.Contains(streamBody, validEvent) || !strings.Contains(streamBody, malformedEvent) {
+		t.Fatalf("raw streaming HTTP log missing failed SSE events:\nlog=%s\nstream=%s", logText, streamBody)
+	}
+	assertRawHTTPLogIsValidJSONL(t, logText)
+}
+
 func TestModelManagerEnablesRawHTTPLoggingFromModelConfig(t *testing.T) {
 	rawResponse := `{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -324,6 +324,14 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 	rt.waitForWakeup = waitForWakeupController
 	rt.mobileGym = mobileGymStore
 
+	// Log session start marker
+	if logger != nil {
+		logger.Info("========================================")
+		logger.Info("NEW SESSION STARTED")
+		logger.Info("Session ID: %s", rt.telemetrySessionID)
+		logger.Info("========================================")
+	}
+
 	if len(mergeNeeded) > 0 && cfg.SkillMergeModel != nil {
 		manifestPath := filepath.Join(cfg.ConfigDir, "skill-state", ".bundled_manifest.json")
 		worker := NewMergeWorker(cfg.SkillMergeModel, manifestPath)

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -364,6 +364,10 @@ func NewRuntimeWithDeps(cfg Config, models ModelResolver, memories *MemoryManage
 		telemetrySessionID: uuid.NewString(),
 		mobileGym:          &mobileGymSessionStore{},
 	}
+	// Set session ID for raw HTTP logging
+	if modelManager, ok := models.(*ModelManager); ok {
+		modelManager.SetSessionID(rt.telemetrySessionID)
+	}
 	if cfg.ConfigDir != "" {
 		rt.memoryPlane = NewFilesystemMemoryPlane(filepath.Join(cfg.ConfigDir, "memory"), LoadMemoryExtractionConfig(cfg.ConfigDir), nil)
 		rt.markInterruptedEpisodesBestEffort()

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -287,8 +287,8 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 	modelManagerOptions := []ModelManagerOption{}
 	if cfg.ConfigDir != "" {
 		modelManagerOptions = append(modelManagerOptions, WithProviderModelMetadataCachePath(filepath.Join(cfg.ConfigDir, "cache", "provider_model_metadata.json")))
-		if cfg.Model.LogRawResponse {
-			modelManagerOptions = append(modelManagerOptions, WithLLMRawResponseLogDir(filepath.Join(cfg.ConfigDir, "log")))
+		if cfg.Model.LogRawHTTP {
+			modelManagerOptions = append(modelManagerOptions, WithLLMRawHTTPLogDir(filepath.Join(cfg.ConfigDir, "log")))
 		}
 	}
 	modelManager := NewModelManager(cfg.Model, proxy, modelManagerOptions...)


### PR DESCRIPTION
## Overview

Enhance LLM HTTP logging with standardized JSONL format and session-based organization.

## Changes

### LLM HTTP Logs
- **Format**: Standard JSONL (one JSON object per line)
- **Location**: `/userdata/agent/log/llm-http-{YYYYMMDD}-{session_id}.log`
- **Organization**: Each session gets its own log file
- **Fields**: `ts`, `kind`, `status`, `body` (simplified and ordered)
- **Kind values**: `request`, `response`, `stream`, `error`

### Agent Log Improvements
- **Session separator**: Clear visual markers in `/var/log/agent/agent.log`
- **Session ID**: Displayed in session start marker
- **Simplified logger**: Uses stdout/stderr, init script handles redirection

### Example Log Format

```json
{"ts":"15:00:00","kind":"request","status":0,"body":"{...}"}
{"ts":"15:00:00","kind":"response","status":200,"body":"{...}"}
```

### Example Session Separator

```
[INFO] ========================================
[INFO] NEW SESSION STARTED
[INFO] Session ID: abc123def456
[INFO] ========================================
```

## Benefits

- **Standardized**: JSONL format works with jq and other standard tools
- **Organized**: Each session isolated in its own file
- **Simple**: No redundant fields or prefixes
- **Traceable**: Session ID links agent.log and llm-http logs
- **Clean**: Automatic cleanup of old logs (48 hour retention)

## Usage Examples

```bash
# View specific session
jq . /userdata/agent/log/llm-http-20260620-abc123def.log

# Filter by kind
jq 'select(.kind == "response")' llm-http-*.log

# Extract response content
jq -r 'select(.kind == "response") | .body | fromjson' llm-http-*.log
```

## Testing

✅ All tests pass (47s)
✅ Code builds successfully
✅ Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Raw HTTP request/response logging for language model interactions now available in structured JSONL format
  * Per-session log tracking for improved request/response correlation
  * Updated log cleanup to target dated HTTP logs

* **Documentation**
  * New log path documentation with viewing instructions and command-line query examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->