### PR TITLE
fix(agent): drop finished-episode signal from session boundary scoring

### DIFF
--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -380,8 +380,8 @@ func NewRuntimeWithDeps(cfg Config, models ModelResolver, memories *MemoryManage
 		rt.memoryPlane = NewFilesystemMemoryPlane(filepath.Join(cfg.ConfigDir, "memory"), LoadMemoryExtractionConfig(cfg.ConfigDir), nil)
 		rt.markInterruptedEpisodesBestEffort()
 	}
-	rt.sessionManager = newMemoryManagerSessionManager(memories, func(now time.Time, activeMaxAge time.Duration) BoundaryEpisodeContext {
-		return recentEpisodeContext(rt.memoryPlane, now, activeMaxAge)
+	rt.sessionManager = newMemoryManagerSessionManager(memories, func() BoundaryEpisodeContext {
+		return recentEpisodeContext(rt.memoryPlane)
 	})
 	rt.initRunGate()
 	return rt

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -3956,17 +3956,25 @@ func TestRuntimeRunKeepsSmallSessionOnUnrelatedInput(t *testing.T) {
 	}
 }
 
-func TestRuntimeRunKeepsNeutralFollowUpWithActiveEpisode(t *testing.T) {
+func TestRuntimeRunRotatesNeutralFollowUpAfterFinishedEpisode(t *testing.T) {
+	// A finished (non-running) episode must not, on its own, keep a stale
+	// session alive across a mid-range gap. The session here is large enough to
+	// defeat the small-session bias, and the input is neutral with no
+	// continuation marker, so the only thing that could force "continue" is a
+	// recently-finished episode — which is exactly the signal we removed.
 	configDir := t.TempDir()
 	storageDir := filepath.Join(configDir, "memory")
 	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
-	now := time.Now().UTC().Add(-6 * time.Minute)
-	for i, content := range []string{"查一下今天天气", "今天多云"} {
+	now := time.Now().UTC().Add(-8 * time.Minute)
+	const prevEventCount = 18 // > SmallSessionEventThreshold (16)
+	for i := 0; i < prevEventCount; i++ {
 		role := "user"
 		eventType := "user_input"
-		if i == 1 {
+		content := "查一下今天天气"
+		if i%2 == 1 {
 			role = "assistant"
 			eventType = "assistant_output"
+			content = "今天多云"
 		}
 		if _, err := session.AppendEvent(context.Background(), SessionEvent{
 			EventID: fmt.Sprintf("evt_prev_%d", i),
@@ -3984,7 +3992,7 @@ func TestRuntimeRunKeepsNeutralFollowUpWithActiveEpisode(t *testing.T) {
 		ID:        "ep_weather_done",
 		Status:    "active",
 		StartedAt: now.Add(-30 * time.Second).Format(time.RFC3339Nano),
-		EndedAt:   now.Add(time.Second).Format(time.RFC3339Nano),
+		EndedAt:   now.Add(prevEventCount * time.Second).Format(time.RFC3339Nano),
 		UserGoal:  "查一下今天天气",
 		Outcome:   TaskEpisodeOutcome{Success: true, FinalAnswer: "今天多云"},
 	}); err != nil {
@@ -4007,35 +4015,29 @@ func TestRuntimeRunKeepsNeutralFollowUpWithActiveEpisode(t *testing.T) {
 	)
 	runtime.memoryPlane = NewFilesystemMemoryPlane(storageDir, manager.extraction, nil)
 
-	result, err := runtime.Run(context.Background(), RunRequest{Input: "好的"})
+	result, err := runtime.Run(context.Background(), RunRequest{Input: "你有什么爱好？"})
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
-	}
-	if len(result.Memory) != 4 || result.Memory[0].Content != "查一下今天天气" {
-		t.Fatalf("neutral follow-up should keep previous session context, got %#v", result.Memory)
 	}
 
 	archiveDirs, err := filepath.Glob(filepath.Join(storageDir, "session_archive", "*"))
 	if err != nil {
 		t.Fatalf("Glob archived sessions: %v", err)
 	}
-	if len(archiveDirs) != 0 {
-		t.Fatalf("neutral follow-up with active episode rotated session: %v", archiveDirs)
+	if len(archiveDirs) != 1 {
+		t.Fatalf("neutral follow-up after a finished episode should rotate the session, got %d archives: %v", len(archiveDirs), archiveDirs)
 	}
 
 	episode, err := episodeStore.Get(context.Background(), result.EpisodeID)
 	if err != nil {
 		t.Fatalf("Get episode: %v", err)
 	}
-	if got := episode.Extra["session_boundary_decision"]; got != BoundaryContinue {
-		t.Fatalf("session_boundary_decision = %#v, want %q", got, BoundaryContinue)
-	}
-	if got := episode.Extra["session_boundary_reason"]; got != BoundaryReasonActiveEpisode {
-		t.Fatalf("session_boundary_reason = %#v, want %q", got, BoundaryReasonActiveEpisode)
+	if got := episode.Extra["session_boundary_decision"]; got != BoundaryNew {
+		t.Fatalf("session_boundary_decision = %#v, want %q", got, BoundaryNew)
 	}
 }
 
-func TestRecentEpisodeContextIncludesRunningAndRecentActiveEpisodes(t *testing.T) {
+func TestRecentEpisodeContextDetectsRunningEpisode(t *testing.T) {
 	storageDir := filepath.Join(t.TempDir(), "memory")
 	store := NewTaskEpisodeStore(filepath.Join(storageDir, "episodes"))
 	now := time.Now().UTC()
@@ -4047,6 +4049,7 @@ func TestRecentEpisodeContextIncludesRunningAndRecentActiveEpisodes(t *testing.T
 	}); err != nil {
 		t.Fatalf("StartEpisode() error = %v", err)
 	}
+	// A finished episode alongside the running one must not disturb detection.
 	if _, err := store.AddEpisode(context.Background(), TaskEpisode{
 		ID:        "ep_active_recent",
 		Status:    "active",
@@ -4059,25 +4062,22 @@ func TestRecentEpisodeContextIncludesRunningAndRecentActiveEpisodes(t *testing.T
 	}
 
 	plane := NewFilesystemMemoryPlane(storageDir, DefaultMemoryExtractionConfig(), nil)
-	ctx := recentEpisodeContext(plane, now, 5*time.Minute)
+	ctx := recentEpisodeContext(plane)
 	if !ctx.HasRunning {
 		t.Fatalf("expected running episode context")
 	}
-	if !ctx.HasActive {
-		t.Fatalf("expected recent active episode context")
-	}
 }
 
-func TestRecentEpisodeContextIgnoresOldActiveEpisode(t *testing.T) {
+func TestRecentEpisodeContextFinishedEpisodeIsNotASignal(t *testing.T) {
 	storageDir := filepath.Join(t.TempDir(), "memory")
 	store := NewTaskEpisodeStore(filepath.Join(storageDir, "episodes"))
 	now := time.Now().UTC()
 
 	if _, err := store.AddEpisode(context.Background(), TaskEpisode{
-		ID:        "ep_active_old",
+		ID:        "ep_active_recent",
 		Status:    "active",
-		StartedAt: now.Add(-10 * time.Minute).Format(time.RFC3339Nano),
-		EndedAt:   now.Add(-6 * time.Minute).Format(time.RFC3339Nano),
+		StartedAt: now.Add(-3 * time.Minute).Format(time.RFC3339Nano),
+		EndedAt:   now.Add(-time.Minute).Format(time.RFC3339Nano),
 		UserGoal:  "查天气",
 		Outcome:   TaskEpisodeOutcome{Success: true},
 	}); err != nil {
@@ -4085,9 +4085,9 @@ func TestRecentEpisodeContextIgnoresOldActiveEpisode(t *testing.T) {
 	}
 
 	plane := NewFilesystemMemoryPlane(storageDir, DefaultMemoryExtractionConfig(), nil)
-	ctx := recentEpisodeContext(plane, now, 5*time.Minute)
-	if ctx.HasActive {
-		t.Fatalf("old active episode should not bias session boundary")
+	ctx := recentEpisodeContext(plane)
+	if ctx.HasRunning {
+		t.Fatalf("a finished episode must not produce a running-episode signal")
 	}
 }
 

--- a/src/agent/internal/agent/session_boundary.go
+++ b/src/agent/internal/agent/session_boundary.go
@@ -22,7 +22,6 @@ const (
 	BoundaryReasonContinuationWord = "continuation_word"
 	BoundaryReasonActionVerb       = "action_verb"
 	BoundaryReasonRunningEpisode   = "running_episode"
-	BoundaryReasonActiveEpisode    = "active_episode"
 	BoundaryReasonSmallSession     = "small_session"
 	BoundaryReasonDefaultNew       = "default_new"
 	BoundaryReasonScoreContinue    = "score_continue"
@@ -66,12 +65,10 @@ func DefaultBoundaryConfig() BoundaryConfig {
 type BoundaryEpisodeContext struct {
 	// HasRunning is true when there is an in-flight TaskEpisode. It biases
 	// toward "continue" because the user is mid-task and is unlikely to be
-	// opening a new one.
+	// opening a new one. Unlike a finished episode, "running" is a genuine
+	// state signal that is independent of the time gap: a task is in-flight no
+	// matter how long the user paused before the next turn.
 	HasRunning bool
-	// HasActive is true when a TaskEpisode recently finished into the active
-	// episode index. Neutral confirmations after completion often refer back
-	// to the just-finished task.
-	HasActive bool
 }
 
 // continuationMarkerRe matches sentence-initial continuation cues.
@@ -161,18 +158,18 @@ func ClassifyTurnBoundary(
 			primaryReason = BoundaryReasonActionVerb
 		}
 	}
-	if episode.HasRunning || episode.HasActive {
-		// An in-flight or just-finished episode means a neutral utterance is
-		// overwhelmingly a continuation. Weight equals the continue threshold
-		// so this signal alone carries the decision when no other evidence
-		// contradicts it.
+	if episode.HasRunning {
+		// An in-flight episode means a neutral utterance is overwhelmingly a
+		// continuation. Weight equals the continue threshold so this signal
+		// alone carries the decision when no other evidence contradicts it.
+		// A *finished* episode is deliberately not used here: "recently
+		// finished" is just the time gap re-encoded (the episode's EndedAt is
+		// the most recent event), so it carries no information the gap shortcut
+		// hasn't already spent, and in the mid-range it is always true — which
+		// silently collapses the scoring into a 30-minute cliff.
 		score += 2
 		if primaryReason == BoundaryReasonDefaultNew {
-			if episode.HasRunning {
-				primaryReason = BoundaryReasonRunningEpisode
-			} else {
-				primaryReason = BoundaryReasonActiveEpisode
-			}
+			primaryReason = BoundaryReasonRunningEpisode
 		}
 	}
 	if smallSession {

--- a/src/agent/internal/agent/session_boundary_test.go
+++ b/src/agent/internal/agent/session_boundary_test.go
@@ -184,17 +184,26 @@ func TestClassifyTurnBoundary_RunningEpisodeBiasesContinue(t *testing.T) {
 	}
 }
 
-func TestClassifyTurnBoundary_ActiveEpisodeBiasesNeutralFollowUpContinue(t *testing.T) {
+func TestClassifyTurnBoundary_FinishedEpisodeDoesNotForceContinue(t *testing.T) {
+	// A finished episode is no longer a boundary signal: "recently finished" is
+	// just the time gap re-encoded, so in the mid-range a neutral follow-up in a
+	// large session must fall through to the default "new" decision. Only an
+	// in-flight (running) episode biases toward continue.
 	cfg := DefaultBoundaryConfig()
 	now := time.Now()
-	prev := eventsAt(now.Add(-6*time.Minute), cfg.SmallSessionEventThreshold+1, "user_input", "查一下今天天气")
+	// Large session (> SmallSessionEventThreshold) so the small-session bias
+	// can't mask the effect, and a mid-range gap (between short and long).
+	prev := eventsAt(now.Add(-8*time.Minute), cfg.SmallSessionEventThreshold+2, "user_input", "查一下今天天气")
 
-	boundary, reason := ClassifyTurnBoundary(prev, "确认", now, cfg, BoundaryEpisodeContext{HasActive: true})
-	if boundary != BoundaryContinue {
-		t.Fatalf("active episode + neutral confirmation should yield 'continue', got %q (reason=%s)", boundary, reason)
+	boundary, reason := ClassifyTurnBoundary(prev, "你有什么爱好？", now, cfg, BoundaryEpisodeContext{})
+	if boundary != BoundaryNew {
+		t.Fatalf("neutral mid-range follow-up with no running episode should yield 'new', got %q (reason=%s)", boundary, reason)
 	}
-	if reason != BoundaryReasonActiveEpisode {
-		t.Fatalf("expected reason %q, got %q", BoundaryReasonActiveEpisode, reason)
+
+	// Sanity: the same input flips to continue once a task is actually running.
+	boundary, _ = ClassifyTurnBoundary(prev, "你有什么爱好？", now, cfg, BoundaryEpisodeContext{HasRunning: true})
+	if boundary != BoundaryContinue {
+		t.Fatalf("running episode should still bias neutral follow-up to 'continue', got %q", boundary)
 	}
 }
 

--- a/src/agent/internal/agent/session_boundary_test.go
+++ b/src/agent/internal/agent/session_boundary_test.go
@@ -163,6 +163,24 @@ func TestClassifyTurnBoundary_SmallSessionContinuesUnrelatedMidGap(t *testing.T)
 	}
 }
 
+func TestClassifyTurnBoundary_SmallSessionContinuesNeutralMidGapWithoutEpisode(t *testing.T) {
+	// Regression guard for removing HasActive: the small-session bias is an
+	// independent continue path. A mid-range neutral follow-up (no marker, no
+	// action verb) in a small session, with no running/finished episode signal,
+	// must still continue purely on the small-session floor.
+	cfg := DefaultBoundaryConfig()
+	now := time.Now()
+	prev := eventsAt(now.Add(-8*time.Minute), cfg.SmallSessionEventThreshold, "user_input", "查一下今天天气")
+
+	boundary, reason := ClassifyTurnBoundary(prev, "你有什么爱好？", now, cfg, BoundaryEpisodeContext{})
+	if boundary != BoundaryContinue {
+		t.Fatalf("small session + neutral mid-range input should continue, got %q (reason=%s)", boundary, reason)
+	}
+	if reason != BoundaryReasonSmallSession {
+		t.Fatalf("expected reason %q, got %q", BoundaryReasonSmallSession, reason)
+	}
+}
+
 func TestClassifyTurnBoundary_RunningEpisodeBiasesContinue(t *testing.T) {
 	// Mid-range gap + neutral input + running episode → continue.
 	// Same input + no episode → new (default bias).

--- a/src/agent/internal/agent/session_manager.go
+++ b/src/agent/internal/agent/session_manager.go
@@ -130,6 +130,13 @@ func (m memoryManagerSessionManager) handleSessionBoundary(input string) session
 	telemetry.Reason = reason
 
 	if boundary != BoundaryNew || len(events) == 0 {
+		// No rotation happens here (either a "continue" decision, or "new" with
+		// no prior events to archive). Log at Debug so the decision and its
+		// reason are observable on every turn without spamming Info — otherwise
+		// a wrongly-kept session is silent and only diagnosable by code archaeology.
+		if m.memories.logger != nil {
+			m.memories.logger.Debug("[memory] session boundary: decision=%s reason=%s (no rotation)", boundary, reason)
+		}
 		return telemetry
 	}
 

--- a/src/agent/internal/agent/session_manager.go
+++ b/src/agent/internal/agent/session_manager.go
@@ -61,12 +61,12 @@ type SessionCommitResult struct {
 
 type memoryManagerSessionManager struct {
 	memories       *MemoryManager
-	episodeContext func(now time.Time, activeMaxAge time.Duration) BoundaryEpisodeContext
+	episodeContext func() BoundaryEpisodeContext
 }
 
 func newMemoryManagerSessionManager(
 	memories *MemoryManager,
-	episodeContext func(now time.Time, activeMaxAge time.Duration) BoundaryEpisodeContext,
+	episodeContext func() BoundaryEpisodeContext,
 ) SessionManager {
 	return memoryManagerSessionManager{memories: memories, episodeContext: episodeContext}
 }
@@ -123,7 +123,7 @@ func (m memoryManagerSessionManager) handleSessionBoundary(input string) session
 	now := time.Now().UTC()
 	episodeCtx := BoundaryEpisodeContext{}
 	if m.episodeContext != nil {
-		episodeCtx = m.episodeContext(now, time.Duration(boundaryCfg.LongGapSeconds)*time.Second)
+		episodeCtx = m.episodeContext()
 	}
 	boundary, reason := ClassifyTurnBoundary(events, input, now, boundaryCfg, episodeCtx)
 	telemetry.Decision = boundary
@@ -215,7 +215,7 @@ func loadLastNSessionEvents(manager *MemoryManager, n int) ([]SessionEvent, erro
 	return append([]SessionEvent(nil), events[len(events)-n:]...), nil
 }
 
-func recentEpisodeContext(plane MemoryPlane, now time.Time, activeMaxAge time.Duration) BoundaryEpisodeContext {
+func recentEpisodeContext(plane MemoryPlane) BoundaryEpisodeContext {
 	var ctx BoundaryEpisodeContext
 	fs, ok := plane.(*FilesystemMemoryPlane)
 	if !ok || fs == nil || fs.episodes == nil {
@@ -226,29 +226,10 @@ func recentEpisodeContext(plane MemoryPlane, now time.Time, activeMaxAge time.Du
 		return ctx
 	}
 	for _, entry := range index.Episodes {
-		switch entry.Status {
-		case "running":
+		if entry.Status == "running" {
 			ctx.HasRunning = true
-		case "active":
-			if recentEpisodeEndedAt(entry.EndedAt, now, activeMaxAge) {
-				ctx.HasActive = true
-			}
-		}
-		if ctx.HasRunning && ctx.HasActive {
 			return ctx
 		}
 	}
 	return ctx
-}
-
-func recentEpisodeEndedAt(endedAt string, now time.Time, maxAge time.Duration) bool {
-	if maxAge <= 0 {
-		return false
-	}
-	ended, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(endedAt))
-	if err != nil {
-		return false
-	}
-	age := now.Sub(ended)
-	return age >= 0 && age <= maxAge
 }

--- a/src/agent/internal/agent/session_manager.go
+++ b/src/agent/internal/agent/session_manager.go
@@ -134,7 +134,7 @@ func (m memoryManagerSessionManager) handleSessionBoundary(input string) session
 	}
 
 	if m.memories.logger != nil {
-		m.memories.logger.Info("[memory] session boundary detected: reason=%s", reason)
+		m.memories.logger.Info("[memory] new session started: reason=%s", reason)
 	}
 	archiveDir, err := m.memories.RotateSessionEvents()
 	if err != nil {


### PR DESCRIPTION
## Summary

Neutral voice follow-ups after a >5-minute pause were never starting a new session, even though the gap clearly exceeded the short-gap threshold. Investigation on-device confirmed the boundary classifier *did* run and deliberately returned `continue` (reason=`active_episode`) — not a missed decision.

Root cause: the `HasActive` signal (a `TaskEpisode` that finished within the long-gap window) re-encoded the time gap rather than adding independent evidence. An episode's `EndedAt` equals the most recent session event, so in the 5–30min mid-range it was *always* true, contributing a fixed +2 that single-handedly forced `continue`. This silently collapsed the mid-range scoring into a 30-minute cliff.

## Change

- Remove `HasActive` from `BoundaryEpisodeContext` and the scoring path entirely (plus the now-dead `recentEpisodeEndedAt`, `BoundaryReasonActiveEpisode`, and the `activeMaxAge` plumbing).
- Keep `HasRunning` — an in-flight task is a genuine state signal that is independent of the time gap.
- Mid-range boundary decisions now rest only on lexical cues, running-episode state, and session size.

## Behavior

- Mid-range gap + neutral input + only a *finished* episode → **new session** (was: continue).
- Running episode + neutral input → still **continue**.
- Short gap (<5min) / long gap (>30min) shortcuts unchanged.

## Tests

- Integration RED→GREEN: `TestRuntimeRunRotatesNeutralFollowUpAfterFinishedEpisode` seeds a large session (>16 events, to defeat the small-session bias) + finished episode + 7.9min gap and asserts the session rotates.
- Unit: `TestClassifyTurnBoundary_FinishedEpisodeDoesNotForceContinue` locks the new contract and verifies a running episode still flips it to continue.
- `recentEpisodeContext` tests updated for the running-only signal.
- `go build ./...`, `go vet`, full `internal/agent` package suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)