### PR TITLE
fix(tts): stop duplicate tool-call speech from residual stream buffer

### DIFF
--- a/src/agent/internal/agent/json_field_stream.go
+++ b/src/agent/internal/agent/json_field_stream.go
@@ -405,6 +405,18 @@ func (w *JSONFieldOrPlainStreamWriter) ResetStreamState() {
 	w.emitted = false
 }
 
+// ResetBuffer forwards a buffer reset to the underlying target writer. The
+// JSON-field extraction layer itself holds no synthesizable buffer, but the
+// downstream TTS session may.
+func (w *JSONFieldOrPlainStreamWriter) ResetBuffer() {
+	if w == nil {
+		return
+	}
+	if resetter, ok := w.target.(ttsBufferResetter); ok {
+		resetter.ResetBuffer()
+	}
+}
+
 func (w *JSONFieldOrPlainStreamWriter) StreamEmitted() bool {
 	if w == nil {
 		return false

--- a/src/agent/internal/agent/progress_speaker.go
+++ b/src/agent/internal/agent/progress_speaker.go
@@ -190,6 +190,16 @@ func (w *cancelOnFirstWriteWriter) ResetStreamState() {
 	w.mu.Unlock()
 }
 
+// ResetBuffer forwards a buffer reset to the inner writer if it supports it.
+func (w *cancelOnFirstWriteWriter) ResetBuffer() {
+	if w == nil {
+		return
+	}
+	if resetter, ok := w.inner.(ttsBufferResetter); ok {
+		resetter.ResetBuffer()
+	}
+}
+
 func (w *cancelOnFirstWriteWriter) StreamEmitted() bool {
 	if w == nil {
 		return false

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1576,6 +1576,13 @@ func (h *runtimeCallbackHandler) HandleStreamingFunc(ctx context.Context, chunk 
 
 func (h *runtimeCallbackHandler) EnableFinalStreaming(ctx context.Context) {
 	resetStreamWriterState(h.writer)
+	// Drop any text the previous turn streamed that the TTS layer buffered but
+	// never synthesized. Without this, residual content from a turn that
+	// returned a tool call (e.g. the assistant's "我查下天气。" preamble) stays
+	// in the sentence buffer and gets prepended to this turn's final answer,
+	// causing it to be spoken twice. Resetting here (before this turn streams
+	// anything) clears the leftover without touching the current turn's text.
+	resetStreamBuffer(h.writer)
 	h.mu.Lock()
 	h.finalTokenSeen = false
 	h.finalStreamErr = nil
@@ -1613,6 +1620,12 @@ func resetStreamWriterState(writer io.Writer) {
 		return
 	}
 	resetter.ResetStreamState()
+}
+
+func resetStreamBuffer(writer io.Writer) {
+	if resetter, ok := writer.(ttsBufferResetter); ok {
+		resetter.ResetBuffer()
+	}
 }
 
 func streamWriterEmitted(writer io.Writer) bool {

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -1569,6 +1569,20 @@ func (w *finalStreamFanoutWriter) ResetStreamState() {
 	w.mu.Unlock()
 }
 
+// ResetBuffer forwards a buffer reset to every fanned-out writer that supports
+// it (e.g. the TTS stream writer), so residual buffered speech does not leak
+// across turns on the streaming chat path.
+func (w *finalStreamFanoutWriter) ResetBuffer() {
+	if w == nil {
+		return
+	}
+	for _, writer := range w.writers {
+		if resetter, ok := writer.(ttsBufferResetter); ok {
+			resetter.ResetBuffer()
+		}
+	}
+}
+
 func (w *finalStreamFanoutWriter) StreamEmitted() bool {
 	if w == nil {
 		return false

--- a/src/agent/internal/agent/stream_buffer_reset_test.go
+++ b/src/agent/internal/agent/stream_buffer_reset_test.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"bytes"
+	"testing"
+)
+
+// bufferResetRecorder is a fake terminal writer that records whether
+// ResetBuffer reached it through the streaming writer chain.
+type bufferResetRecorder struct {
+	resetCalls int
+}
+
+func (r *bufferResetRecorder) Write(p []byte) (int, error) { return len(p), nil }
+func (r *bufferResetRecorder) ResetBuffer()                { r.resetCalls++ }
+
+// TestResetStreamBufferReachesTerminalThroughChain verifies that a buffer
+// reset propagates through the JSON-field-or-plain wrapper and the
+// cancel-on-first-write wrapper down to the underlying TTS sink. This is the
+// chain used for streaming voice replies; without propagation, residual
+// tool-call content would survive into the next turn and be spoken twice.
+func TestResetStreamBufferReachesTerminalThroughChain(t *testing.T) {
+	terminal := &bufferResetRecorder{}
+	jsonWriter := NewJSONFieldOrPlainStreamWriter(terminal, "final_answer")
+	chain := newCancelOnFirstWriteWriter(jsonWriter, func() {})
+
+	resetStreamBuffer(chain)
+
+	if terminal.resetCalls != 1 {
+		t.Fatalf("expected ResetBuffer to reach terminal once, got %d", terminal.resetCalls)
+	}
+}
+
+// TestResetStreamBufferNoopWithoutSupport verifies that resetStreamBuffer is a
+// safe no-op when the writer chain does not support buffer resetting.
+func TestResetStreamBufferNoopWithoutSupport(t *testing.T) {
+	// A plain writer with no ResetBuffer method must not panic.
+	resetStreamBuffer(&bytes.Buffer{})
+	resetStreamBuffer(nil)
+}

--- a/src/agent/internal/agent/stream_buffer_reset_test.go
+++ b/src/agent/internal/agent/stream_buffer_reset_test.go
@@ -38,3 +38,25 @@ func TestResetStreamBufferNoopWithoutSupport(t *testing.T) {
 	resetStreamBuffer(&bytes.Buffer{})
 	resetStreamBuffer(nil)
 }
+
+// TestResetStreamBufferReachesTerminalThroughFanout verifies that a buffer
+// reset propagates through the streaming-chat fanout writer down to the TTS
+// leg. handleChatStream wraps the TTS writer chain in a finalStreamFanoutWriter
+// alongside the SSE writer; without ResetBuffer forwarding here, residual
+// speech would leak across turns on the streaming chat path.
+func TestResetStreamBufferReachesTerminalThroughFanout(t *testing.T) {
+	terminal := &bufferResetRecorder{}
+	ttsLeg := newCancelOnFirstWriteWriter(
+		NewJSONFieldOrPlainStreamWriter(terminal, "final_answer"),
+		func() {},
+	)
+	// The SSE leg has no buffer to reset and must be skipped cleanly.
+	sseLeg := &bytes.Buffer{}
+	fanout := newFinalStreamFanoutWriter(sseLeg, ttsLeg)
+
+	resetStreamBuffer(fanout)
+
+	if terminal.resetCalls != 1 {
+		t.Fatalf("expected ResetBuffer to reach TTS terminal once through fanout, got %d", terminal.resetCalls)
+	}
+}

--- a/src/agent/internal/agent/tts/adapters/minimax/buffer.go
+++ b/src/agent/internal/agent/tts/adapters/minimax/buffer.go
@@ -51,6 +51,14 @@ func (b *sentenceBuffer) Flush() string {
 	return rest
 }
 
+// Reset discards any buffered text without synthesizing it. Used to drop
+// residual content left over from a turn that did not produce a final answer.
+func (b *sentenceBuffer) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf.Reset()
+}
+
 // nextChunk extracts one sentence-bounded chunk if possible.
 // Returns the chunk and true; if no boundary is reached and flush=false,
 // returns "", false. With flush=true, returns whatever remains.

--- a/src/agent/internal/agent/tts/adapters/minimax/buffer_test.go
+++ b/src/agent/internal/agent/tts/adapters/minimax/buffer_test.go
@@ -1,0 +1,38 @@
+package minimax
+
+import "testing"
+
+// TestSentenceBufferResetDropsResidual verifies that Reset discards
+// sub-threshold text the buffer is still holding, so it cannot leak into a
+// later Write/Flush cycle. This guards the tool-call-speech duplication fix:
+// a short tool-call preamble such as "我查下天气。" (< minChunkRunes) must not
+// survive to be prepended to a subsequent final answer.
+func TestSentenceBufferResetDropsResidual(t *testing.T) {
+	var b sentenceBuffer
+
+	// Short text below the chunk threshold stays buffered, nothing emitted.
+	if chunks := b.Write("我查下天气。"); len(chunks) != 0 {
+		t.Fatalf("expected no chunks for sub-threshold text, got %v", chunks)
+	}
+
+	// Reset drops the residual.
+	b.Reset()
+
+	if rest := b.Flush(); rest != "" {
+		t.Fatalf("expected empty buffer after Reset, got %q", rest)
+	}
+}
+
+// TestSentenceBufferResetThenWriteIsClean verifies a Write after Reset is not
+// contaminated by previously buffered residual.
+func TestSentenceBufferResetThenWriteIsClean(t *testing.T) {
+	var b sentenceBuffer
+
+	b.Write("我查下天气。") // residual, sub-threshold
+	b.Reset()
+
+	b.Write("上海今天有小雨。")
+	if rest := b.Flush(); rest != "上海今天有小雨。" {
+		t.Fatalf("expected only post-reset text, got %q", rest)
+	}
+}

--- a/src/agent/internal/agent/tts/adapters/minimax/websocket.go
+++ b/src/agent/internal/agent/tts/adapters/minimax/websocket.go
@@ -82,6 +82,15 @@ func (s *wsSession) Flush() error {
 	return nil
 }
 
+// ResetBuffer discards any text buffered but not yet synthesized. This is used
+// to drop residual content streamed during a turn that ultimately returned a
+// tool call rather than a final answer, so it cannot leak into the next turn.
+func (s *wsSession) ResetBuffer() {
+	if s.buf != nil {
+		s.buf.Reset()
+	}
+}
+
 func (s *wsSession) Close() error {
 	if err := s.Flush(); err != nil {
 		return err

--- a/src/agent/internal/agent/tts_helpers.go
+++ b/src/agent/internal/agent/tts_helpers.go
@@ -296,6 +296,25 @@ func (w *streamSessionWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// ttsBufferResetter is implemented by TTS sessions that buffer text internally
+// (e.g. sentence-boundary buffering in non-incremental providers) and can drop
+// that buffer on demand.
+type ttsBufferResetter interface {
+	ResetBuffer()
+}
+
+// ResetBuffer discards any text buffered by the underlying TTS session but not
+// yet synthesized. Used to prevent residual content from a tool-call turn from
+// leaking into a later final-answer turn.
+func (w *streamSessionWriter) ResetBuffer() {
+	w.mu.Lock()
+	session := w.session
+	w.mu.Unlock()
+	if resetter, ok := session.(ttsBufferResetter); ok {
+		resetter.ResetBuffer()
+	}
+}
+
 func (w *streamSessionWriter) interrupt() {
 	w.mu.Lock()
 	if w.interrupted {


### PR DESCRIPTION
## Summary

Fixes the bug where the assistant speaks its tool-call preamble twice — e.g. you hear "我查下天气" once, then after a pause "我查下天气 + CodeFace, 上海今天有小雨...".

## Root cause

Confirmed by byte-level log correlation across `agent.log`, `audio_service.log`, and the LLM HTTP stream log (turn at 05:07):

- In `phaseDefault`, a planner turn that returns a **tool call** has final streaming enabled, so its content preamble (`我查下天气。`) is streamed into the minimax `sentenceBuffer`.
- The preamble is 6 runes, below `minChunkRunes=18`, so it stays buffered and is never synthesized on its own.
- The same content is also spoken once via `SpeakToolContent` (playback session 46).
- The next **final-answer** turn streams `CodeFace, 上海今天有小雨...`. The leftover preamble is still in the buffer, so it gets prepended and synthesized together (session 47, 74 bytes = 18 + 56) — the user hears "我查下天气" a second time.

`EnableFinalStreaming`'s `resetStreamWriterState` only reset the writer chain, not the TTS adapter's internal sentence buffer.

## Fix

- Add a `ResetBuffer` hook that propagates through the streaming writer chain (`cancelOnFirstWriteWriter` → `JSONFieldOrPlainStreamWriter` → `streamSessionWriter`) down to the minimax session's `sentenceBuffer`.
- Invoke it from `EnableFinalStreaming` so each streaming turn starts with a clean buffer.

**Timing:** reset happens at turn *start*, not end. The final answer's own buffered tail isn't flushed until `closeAndWait` runs after `runtime.Run` returns, so resetting on `DisableFinalStreaming` would have clipped the last sentence of legitimate answers. Resetting on `EnableFinalStreaming` only clears the *previous* turn's residual.

Adapters without `ResetBuffer` (volcengine, alicloud, fishaudio) degrade to the previous behavior.

## Tested

- `go build ./...`, `go vet` — clean
- `go test ./internal/agent/ ./internal/agent/tts/...` — all pass
- New tests:
  - `buffer_test.go` — `sentenceBuffer.Reset` drops sub-threshold residual and a later Write is uncontaminated
  - `stream_buffer_reset_test.go` — `ResetBuffer` propagates through the full writer chain to the terminal sink; safe no-op when unsupported

Note: the separate `INTERNAL_ERROR` from `SpeakToolContent`/streaming TTS contending for the AO device is a distinct concurrency issue and is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)