### PR TITLE
refactor(agent): distinguish runtime and memory session ids

### DIFF
--- a/src/agent/internal/agent/episode_exporter.go
+++ b/src/agent/internal/agent/episode_exporter.go
@@ -181,8 +181,8 @@ func (e *EpisodeExporter) buildLangfuseBatch(ctx context.Context, episode TaskEp
 	if userID := traceUserID(episode); userID != "" {
 		traceBody["userId"] = userID
 	}
-	if sessionID := traceSessionID(episode); sessionID != "" {
-		traceBody["sessionId"] = sessionID
+	if runtimeID := traceRuntimeID(episode); runtimeID != "" {
+		traceBody["sessionId"] = runtimeID
 	}
 	if release := traceReleaseFromEpisode(episode); release != "" {
 		traceBody["release"] = release
@@ -999,9 +999,12 @@ func traceUserID(episode TaskEpisode) string {
 	return ""
 }
 
-func traceSessionID(episode TaskEpisode) string {
-	if sessionID := extraString(episode.Extra, "session_id"); sessionID != "" {
-		return sessionID
+func traceRuntimeID(episode TaskEpisode) string {
+	if runtimeID := extraString(episode.Extra, "runtime_id"); runtimeID != "" {
+		return runtimeID
+	}
+	if legacySessionID := extraString(episode.Extra, "session_id"); legacySessionID != "" {
+		return legacySessionID
 	}
 	return extraString(episode.Extra, "telemetry_session_id")
 }

--- a/src/agent/internal/agent/episode_exporter_test.go
+++ b/src/agent/internal/agent/episode_exporter_test.go
@@ -260,7 +260,7 @@ func TestBuildLangfuseBatchAddsTraceIdentityAndFailureScore(t *testing.T) {
 			FailureReason: "verifier rejected completion",
 		},
 		Extra: map[string]interface{}{
-			"session_id": "session-a",
+			"runtime_id": "runtime-a",
 		},
 	}
 
@@ -287,8 +287,8 @@ func TestBuildLangfuseBatchAddsTraceIdentityAndFailureScore(t *testing.T) {
 	if traceBody["userId"] != "device-a" {
 		t.Fatalf("trace userId = %v, want device-a", traceBody["userId"])
 	}
-	if traceBody["sessionId"] != "session-a" {
-		t.Fatalf("trace sessionId = %v, want session-a", traceBody["sessionId"])
+	if traceBody["sessionId"] != "runtime-a" {
+		t.Fatalf("trace sessionId = %v, want runtime-a", traceBody["sessionId"])
 	}
 	if traceBody["public"] != false {
 		t.Fatalf("trace public = %v, want false", traceBody["public"])

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -466,8 +466,13 @@ func (m *MemoryManager) AppendMessagesWithMetadata(ctx context.Context, agentNam
 	}
 	defer fl.Unlock()
 
-	if err := os.MkdirAll(filepath.Dir(m.sessionEventsPath()), 0o755); err != nil {
+	sessionDir := filepath.Dir(m.sessionEventsPath())
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
 		return fmt.Errorf("create session memory directory: %w", err)
+	}
+	now := time.Now().UTC()
+	if _, err := ensureActiveSessionMetadata(sessionDir, now); err != nil {
+		return fmt.Errorf("ensure active session metadata: %w", err)
 	}
 	if err := m.ensureEventCountLoadedLocked(agentName); err != nil {
 		return err
@@ -478,7 +483,6 @@ func (m *MemoryManager) AppendMessagesWithMetadata(ctx context.Context, agentNam
 	}
 	defer file.Close()
 
-	now := time.Now().UTC()
 	encoder := json.NewEncoder(file)
 	records = sanitizeMessageRecords(records)
 	for i, record := range records {
@@ -515,8 +519,13 @@ func (m *MemoryManager) AppendSessionEvent(ctx context.Context, agentName string
 	}
 	defer fl.Unlock()
 
-	if err := os.MkdirAll(filepath.Dir(m.sessionEventsPath()), 0o755); err != nil {
+	sessionDir := filepath.Dir(m.sessionEventsPath())
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
 		return fmt.Errorf("create session memory directory: %w", err)
+	}
+	now := time.Now().UTC()
+	if _, err := ensureActiveSessionMetadata(sessionDir, now); err != nil {
+		return fmt.Errorf("ensure active session metadata: %w", err)
 	}
 	if err := m.ensureEventCountLoadedLocked(agentName); err != nil {
 		return err
@@ -527,7 +536,6 @@ func (m *MemoryManager) AppendSessionEvent(ctx context.Context, agentName string
 	}
 	defer file.Close()
 
-	now := time.Now().UTC()
 	event = normalizeSessionEventForAppend(event, now, m.eventCount[agentName]+1)
 	event = applySessionEventMetadata(event, meta)
 	if err := json.NewEncoder(file).Encode(event); err != nil {

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -17,7 +17,21 @@ import (
 	"github.com/tmc/langchaingo/schema"
 )
 
-const defaultLockTimeout = 10 * time.Second
+const (
+	defaultLockTimeout      = 10 * time.Second
+	sessionMetadataFileName = "metadata.json"
+)
+
+type sessionMetadata struct {
+	SessionID string `json:"session_id"`
+	CreatedAt string `json:"created_at"`
+}
+
+type SessionRotationResult struct {
+	ArchiveDir      string
+	ClosedSessionID string
+	ActiveSessionID string
+}
 
 // MemoryHandle wraps a langchain memory instance and its chat history.
 type MemoryHandle struct {
@@ -88,13 +102,16 @@ type MessageRecord struct {
 // SessionEvent represents a single event in the session event stream, capturing
 // conversation turns, tool calls, and system events with metadata.
 type SessionEvent struct {
-	EventID            string          `json:"event_id"`
-	Ts                 string          `json:"ts"`
-	Sequence           int             `json:"sequence,omitempty"`
-	Type               string          `json:"type"`
-	Role               string          `json:"role"`
-	Source             string          `json:"source,omitempty"`
-	SessionID          string          `json:"session_id,omitempty"`
+	EventID  string `json:"event_id"`
+	Ts       string `json:"ts"`
+	Sequence int    `json:"sequence,omitempty"`
+	Type     string `json:"type"`
+	Role     string `json:"role"`
+	Source   string `json:"source,omitempty"`
+	// RuntimeID correlates events produced by one daemon Runtime instance.
+	RuntimeID string `json:"runtime_id,omitempty"`
+	// LegacySessionID reads pre-runtime_id event files; new writes leave it empty.
+	LegacySessionID    string          `json:"session_id,omitempty"`
 	EpisodeID          string          `json:"episode_id,omitempty"`
 	RequestID          string          `json:"request_id,omitempty"`
 	RunID              string          `json:"run_id,omitempty"`
@@ -120,7 +137,7 @@ type SessionEvent struct {
 }
 
 type SessionEventMetadata struct {
-	SessionID string
+	RuntimeID string
 	EpisodeID string
 	RequestID string
 	RunID     string
@@ -546,10 +563,15 @@ func (m *MemoryManager) ensureEventCountLoadedLocked(agentName string) error {
 // by active prompt construction, HasCompressedHistory, maintenance, or chunk
 // recall.
 func (m *MemoryManager) RotateSessionEvents() (string, error) {
+	rotation, err := m.RotateSessionEventsDetailed()
+	return rotation.ArchiveDir, err
+}
+
+func (m *MemoryManager) RotateSessionEventsDetailed() (SessionRotationResult, error) {
 	if m.storageDir == "" {
-		return "", nil
+		return SessionRotationResult{}, nil
 	}
-	archiveDir, err := func() (string, error) {
+	rotation, err := func() (SessionRotationResult, error) {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 
@@ -558,40 +580,55 @@ func (m *MemoryManager) RotateSessionEvents() (string, error) {
 
 		fl := NewFileLock(m.storageDir)
 		if err := fl.Lock(m.lockTimeout); err != nil {
-			return "", fmt.Errorf("lock for rotating session events: %w", err)
+			return SessionRotationResult{}, fmt.Errorf("lock for rotating session events: %w", err)
 		}
 		defer fl.Unlock()
 
 		hasData, err := sessionDirHasData(sessionDir)
 		if err != nil {
-			return "", fmt.Errorf("inspect active session for rotation: %w", err)
+			return SessionRotationResult{}, fmt.Errorf("inspect active session for rotation: %w", err)
 		}
 		if !hasData {
 			if err := os.MkdirAll(sessionDir, 0o755); err != nil {
-				return "", fmt.Errorf("create empty session directory after no-op rotation: %w", err)
+				return SessionRotationResult{}, fmt.Errorf("create empty session directory after no-op rotation: %w", err)
 			}
 			if err := os.WriteFile(eventsPath, nil, 0o644); err != nil {
-				return "", fmt.Errorf("create empty session events after no-op rotation: %w", err)
+				return SessionRotationResult{}, fmt.Errorf("create empty session events after no-op rotation: %w", err)
 			}
-			return "", nil
+			activeMeta, err := ensureActiveSessionMetadata(sessionDir, time.Now().UTC())
+			if err != nil {
+				return SessionRotationResult{}, err
+			}
+			return SessionRotationResult{ActiveSessionID: activeMeta.SessionID}, nil
 		}
 
 		archiveParent := filepath.Join(m.storageDir, "session_archive")
 		if err := os.MkdirAll(archiveParent, 0o755); err != nil {
-			return "", fmt.Errorf("create session archive directory: %w", err)
+			return SessionRotationResult{}, fmt.Errorf("create session archive directory: %w", err)
 		}
-		archiveDir, err := nextSessionArchiveDir(archiveParent, time.Now().UTC())
+		now := time.Now().UTC()
+		closedMeta, _ := readSessionMetadata(filepath.Join(sessionDir, sessionMetadataFileName))
+		closedSessionID := strings.TrimSpace(closedMeta.SessionID)
+		if closedSessionID == "" {
+			closedSessionID = newSessionID(now)
+		}
+		archiveDir, err := nextSessionArchiveDir(archiveParent, closedSessionID)
 		if err != nil {
-			return "", err
+			return SessionRotationResult{}, err
 		}
+		closedSessionID = filepath.Base(archiveDir)
 		if err := os.Rename(sessionDir, archiveDir); err != nil {
-			return "", fmt.Errorf("archive active session: %w", err)
+			return SessionRotationResult{}, fmt.Errorf("archive active session: %w", err)
 		}
 		if err := os.MkdirAll(sessionDir, 0o755); err != nil {
-			return "", fmt.Errorf("create active session directory after rotation: %w", err)
+			return SessionRotationResult{}, fmt.Errorf("create active session directory after rotation: %w", err)
 		}
 		if err := os.WriteFile(eventsPath, nil, 0o644); err != nil {
-			return "", fmt.Errorf("create empty session events after rotation: %w", err)
+			return SessionRotationResult{}, fmt.Errorf("create empty session events after rotation: %w", err)
+		}
+		activeMeta, err := writeNewSessionMetadata(sessionDir, now.Add(time.Nanosecond))
+		if err != nil {
+			return SessionRotationResult{}, err
 		}
 
 		for agentName := range m.eventCount {
@@ -604,16 +641,23 @@ func (m *MemoryManager) RotateSessionEvents() (string, error) {
 				_ = handle.Memory.Clear(context.Background())
 			}
 		}
-		return archiveDir, nil
+		return SessionRotationResult{
+			ArchiveDir:      archiveDir,
+			ClosedSessionID: closedSessionID,
+			ActiveSessionID: activeMeta.SessionID,
+		}, nil
 	}()
 	if err != nil {
-		return "", err
+		return SessionRotationResult{}, err
 	}
 
-	if archiveDir != "" && m.logger != nil {
-		m.logger.Info("[memory] session rotated: archive=%s", filepath.Base(archiveDir))
+	if rotation.ArchiveDir != "" && m.logger != nil {
+		m.logger.Info("[memory] session rotated: closed_session_id=%s active_session_id=%s archive=%s",
+			rotation.ClosedSessionID,
+			rotation.ActiveSessionID,
+			filepath.Base(rotation.ArchiveDir))
 	}
-	return archiveDir, nil
+	return rotation, nil
 }
 
 func sessionDirHasData(sessionDir string) (bool, error) {
@@ -625,6 +669,9 @@ func sessionDirHasData(sessionDir string) (bool, error) {
 		return false, err
 	}
 	for _, entry := range entries {
+		if entry.Name() == sessionMetadataFileName && !entry.IsDir() {
+			continue
+		}
 		if entry.Name() != "events.jsonl" || entry.IsDir() {
 			return true, nil
 		}
@@ -639,9 +686,16 @@ func sessionDirHasData(sessionDir string) (bool, error) {
 	return false, nil
 }
 
-func nextSessionArchiveDir(parent string, now time.Time) (string, error) {
+func nextSessionArchiveDir(parent string, baseID string) (string, error) {
+	baseID = strings.TrimSpace(baseID)
+	if baseID == "" {
+		baseID = newSessionID(time.Now().UTC())
+	}
 	for i := int64(0); i < 100; i++ {
-		id := strconv.FormatInt(now.UnixNano()+i, 10)
+		id := baseID
+		if i > 0 {
+			id = fmt.Sprintf("%s-%d", baseID, i)
+		}
 		path := filepath.Join(parent, id)
 		if _, err := os.Stat(path); err != nil {
 			if os.IsNotExist(err) {
@@ -651,6 +705,48 @@ func nextSessionArchiveDir(parent string, now time.Time) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("allocate session archive path: too many collisions")
+}
+
+func ensureActiveSessionMetadata(sessionDir string, now time.Time) (sessionMetadata, error) {
+	path := filepath.Join(sessionDir, sessionMetadataFileName)
+	if meta, err := readSessionMetadata(path); err == nil && strings.TrimSpace(meta.SessionID) != "" {
+		return meta, nil
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return sessionMetadata{}, err
+	}
+	return writeNewSessionMetadata(sessionDir, now)
+}
+
+func writeNewSessionMetadata(sessionDir string, now time.Time) (sessionMetadata, error) {
+	meta := sessionMetadata{
+		SessionID: newSessionID(now),
+		CreatedAt: now.UTC().Format(time.RFC3339Nano),
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return sessionMetadata{}, fmt.Errorf("marshal session metadata: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionDir, sessionMetadataFileName), append(data, '\n'), 0o644); err != nil {
+		return sessionMetadata{}, fmt.Errorf("write session metadata: %w", err)
+	}
+	return meta, nil
+}
+
+func readSessionMetadata(path string) (sessionMetadata, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return sessionMetadata{}, err
+	}
+	var meta sessionMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return sessionMetadata{}, fmt.Errorf("parse session metadata: %w", err)
+	}
+	meta.SessionID = strings.TrimSpace(meta.SessionID)
+	return meta, nil
+}
+
+func newSessionID(now time.Time) string {
+	return "session_" + strconv.FormatInt(now.UTC().UnixNano(), 10)
 }
 
 func (m *MemoryManager) loadPersistedMessages(history *langmemory.ChatMessageHistory, agentName string) error {
@@ -1716,8 +1812,8 @@ func sessionEventFromTurnInput(input TurnInput) SessionEvent {
 }
 
 func applySessionEventMetadata(event SessionEvent, meta SessionEventMetadata) SessionEvent {
-	if event.SessionID == "" {
-		event.SessionID = strings.TrimSpace(meta.SessionID)
+	if event.RuntimeID == "" {
+		event.RuntimeID = strings.TrimSpace(meta.RuntimeID)
 	}
 	if event.EpisodeID == "" {
 		event.EpisodeID = strings.TrimSpace(meta.EpisodeID)

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -1636,12 +1636,19 @@ func (m *MemoryManager) appendSessionEvents(agentName string, records []MessageR
 
 	existingRecords := conversationRecordsFromSessionEvents(events)
 	start := snapshotAppendStart(existingRecords, records)
+	hasSessionEvents := len(events) > 0 || start < len(records)
+	if hasSessionEvents {
+		sessionDir := filepath.Dir(path)
+		if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+			return fmt.Errorf("create session memory directory: %w", err)
+		}
+		if _, err := ensureActiveSessionMetadata(sessionDir, time.Now().UTC()); err != nil {
+			return fmt.Errorf("ensure active session metadata: %w", err)
+		}
+	}
 	if start >= len(records) {
 		m.eventCount[agentName] = len(events)
 		return nil
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create session memory directory: %w", err)
 	}
 
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -625,17 +625,11 @@ func (m *MemoryManager) RotateSessionEventsDetailed() (SessionRotationResult, er
 			return SessionRotationResult{}, err
 		}
 		closedSessionID = filepath.Base(archiveDir)
-		if err := os.Rename(sessionDir, archiveDir); err != nil {
-			return SessionRotationResult{}, fmt.Errorf("archive active session: %w", err)
-		}
-		if err := os.MkdirAll(sessionDir, 0o755); err != nil {
-			return SessionRotationResult{}, fmt.Errorf("create active session directory after rotation: %w", err)
-		}
-		if err := os.WriteFile(eventsPath, nil, 0o644); err != nil {
-			return SessionRotationResult{}, fmt.Errorf("create empty session events after rotation: %w", err)
-		}
-		activeMeta, err := writeNewSessionMetadata(sessionDir, now.Add(time.Nanosecond))
+		activeTempDir, activeMeta, err := prepareStagedActiveSessionDir(m.storageDir, now)
 		if err != nil {
+			return SessionRotationResult{}, err
+		}
+		if err := replaceActiveSessionDir(sessionDir, archiveDir, activeTempDir); err != nil {
 			return SessionRotationResult{}, err
 		}
 
@@ -699,6 +693,9 @@ func nextSessionArchiveDir(parent string, baseID string) (string, error) {
 	if baseID == "" {
 		baseID = newSessionID(time.Now().UTC())
 	}
+	if err := validateSessionArchiveBaseID(baseID); err != nil {
+		return "", err
+	}
 	for i := int64(0); i < 100; i++ {
 		id := baseID
 		if i > 0 {
@@ -713,6 +710,53 @@ func nextSessionArchiveDir(parent string, baseID string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("allocate session archive path: too many collisions")
+}
+
+func validateSessionArchiveBaseID(baseID string) error {
+	if baseID == "" || baseID == "." || baseID != filepath.Base(baseID) || strings.ContainsAny(baseID, `/\`) || strings.Contains(baseID, "..") {
+		return fmt.Errorf("unsafe session archive id %q", baseID)
+	}
+	return nil
+}
+
+func prepareStagedActiveSessionDir(parent string, now time.Time) (string, sessionMetadata, error) {
+	for i := int64(0); i < 100; i++ {
+		activeAt := now.Add(time.Duration(i+1) * time.Nanosecond)
+		tempDir := filepath.Join(parent, ".session-"+strconv.FormatInt(activeAt.UTC().UnixNano(), 10)+".tmp")
+		if err := os.Mkdir(tempDir, 0o755); err != nil {
+			if os.IsExist(err) {
+				continue
+			}
+			return "", sessionMetadata{}, fmt.Errorf("create staged active session directory: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(tempDir, "events.jsonl"), nil, 0o644); err != nil {
+			_ = os.RemoveAll(tempDir)
+			return "", sessionMetadata{}, fmt.Errorf("create staged active session events: %w", err)
+		}
+		activeMeta, err := writeNewSessionMetadata(tempDir, activeAt)
+		if err != nil {
+			_ = os.RemoveAll(tempDir)
+			return "", sessionMetadata{}, err
+		}
+		return tempDir, activeMeta, nil
+	}
+	return "", sessionMetadata{}, fmt.Errorf("allocate staged active session directory: too many collisions")
+}
+
+func replaceActiveSessionDir(sessionDir string, archiveDir string, activeTempDir string) error {
+	if err := os.Rename(sessionDir, archiveDir); err != nil {
+		_ = os.RemoveAll(activeTempDir)
+		return fmt.Errorf("archive active session: %w", err)
+	}
+	if err := os.Rename(activeTempDir, sessionDir); err != nil {
+		rollbackErr := os.Rename(archiveDir, sessionDir)
+		cleanupErr := os.RemoveAll(activeTempDir)
+		if rollbackErr != nil || cleanupErr != nil {
+			return fmt.Errorf("activate staged session: %w; rollback: %v; cleanup: %v", err, rollbackErr, cleanupErr)
+		}
+		return fmt.Errorf("activate staged session: %w", err)
+	}
+	return nil
 }
 
 func ensureActiveSessionMetadata(sessionDir string, now time.Time) (sessionMetadata, error) {

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -48,6 +48,57 @@ func TestMemoryManagerSaveWritesSessionEvents(t *testing.T) {
 	}
 }
 
+func TestMemoryManagerSaveCreatesSessionMetadataOnFirstWrite(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	manager := NewMemoryManager(storageDir)
+	handle, err := manager.Get("default", MemoryConfig{Type: "window", WindowSize: 10})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if err := handle.History.SetMessages(ctx, []llms.ChatMessage{
+		llms.HumanChatMessage{Content: "hello"},
+		llms.AIChatMessage{Content: "hi"},
+	}); err != nil {
+		t.Fatalf("SetMessages() error = %v", err)
+	}
+
+	if err := manager.Save(ctx, "default"); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	metadata := readSessionMetadataForTest(t, filepath.Join(storageDir, "session", sessionMetadataFileName))
+	rotation, err := manager.RotateSessionEventsDetailed()
+	if err != nil {
+		t.Fatalf("RotateSessionEventsDetailed() error = %v", err)
+	}
+	if rotation.ClosedSessionID != metadata.SessionID {
+		t.Fatalf("ClosedSessionID = %q, want active session_id %q", rotation.ClosedSessionID, metadata.SessionID)
+	}
+}
+
+func TestMemoryManagerSaveSnapshotCreatesSessionMetadataOnFirstWrite(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	manager := NewMemoryManager(storageDir)
+
+	if err := manager.SaveSnapshot(ctx, "default", []MessageRecord{
+		{Role: string(llms.ChatMessageTypeHuman), Content: "hello"},
+		{Role: string(llms.ChatMessageTypeAI), Content: "hi"},
+	}); err != nil {
+		t.Fatalf("SaveSnapshot() error = %v", err)
+	}
+
+	metadata := readSessionMetadataForTest(t, filepath.Join(storageDir, "session", sessionMetadataFileName))
+	rotation, err := manager.RotateSessionEventsDetailed()
+	if err != nil {
+		t.Fatalf("RotateSessionEventsDetailed() error = %v", err)
+	}
+	if rotation.ClosedSessionID != metadata.SessionID {
+		t.Fatalf("ClosedSessionID = %q, want active session_id %q", rotation.ClosedSessionID, metadata.SessionID)
+	}
+}
+
 func TestSnapshotAppendStartFindsExistingSuffixOverlap(t *testing.T) {
 	human := func(content string) MessageRecord {
 		return MessageRecord{Role: "human", Content: content}

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -1481,6 +1481,63 @@ func TestSessionRotationDetailedCreatesActiveSessionID(t *testing.T) {
 	}
 }
 
+func TestSessionRotationRejectsUnsafeMetadataSessionID(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	manager := NewMemoryManager(storageDir)
+	sessionDir := filepath.Join(storageDir, "session")
+	session := NewSessionMemoryStore(sessionDir)
+	now := time.Now().UTC()
+	if _, err := session.AppendEvent(ctx, SessionEvent{
+		EventID: "evt_unsafe_session_id",
+		Ts:      now.Format(time.RFC3339Nano),
+		Type:    "user_input",
+		Role:    "user",
+		Content: "old task",
+	}); err != nil {
+		t.Fatalf("AppendEvent() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionDir, sessionMetadataFileName), []byte(`{"session_id":"../escape","created_at":"2026-06-21T00:00:00Z"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write unsafe metadata: %v", err)
+	}
+
+	if _, err := manager.RotateSessionEventsDetailed(); err == nil {
+		t.Fatal("RotateSessionEventsDetailed() succeeded with unsafe metadata session_id")
+	}
+	if _, err := os.Stat(filepath.Join(sessionDir, "events.jsonl")); err != nil {
+		t.Fatalf("active session events should remain after rejected rotation: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(storageDir, "escape")); !os.IsNotExist(err) {
+		t.Fatalf("unsafe archive path should not be created, stat err = %v", err)
+	}
+}
+
+func TestReplaceActiveSessionDirRollsBackWhenStagedActivationFails(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "session")
+	archiveDir := filepath.Join(root, "session_archive", "session_a")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("create active session: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(archiveDir), 0o755); err != nil {
+		t.Fatalf("create archive parent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionDir, "events.jsonl"), []byte("active\n"), 0o644); err != nil {
+		t.Fatalf("write active session marker: %v", err)
+	}
+
+	err := replaceActiveSessionDir(sessionDir, archiveDir, filepath.Join(root, "missing-staged-session"))
+	if err == nil {
+		t.Fatal("replaceActiveSessionDir() succeeded with missing staged session")
+	}
+	if data, readErr := os.ReadFile(filepath.Join(sessionDir, "events.jsonl")); readErr != nil || string(data) != "active\n" {
+		t.Fatalf("active session was not restored, data=%q err=%v", data, readErr)
+	}
+	if _, statErr := os.Stat(archiveDir); !os.IsNotExist(statErr) {
+		t.Fatalf("archive should have been rolled back, stat err=%v", statErr)
+	}
+}
+
 func TestSessionBoundaryLogsProminentNewSessionID(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -375,6 +375,37 @@ func TestMemoryManagerWritesRuntimeIDMetadata(t *testing.T) {
 	}
 }
 
+func TestMemoryManagerCreatesSessionMetadataOnFirstAppend(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	manager := NewMemoryManager(storageDir)
+
+	if err := manager.AppendSessionEvent(ctx, "default", SessionEvent{
+		Type:    "user_input",
+		Role:    "user",
+		Content: "first request",
+	}, SessionEventMetadata{RuntimeID: "runtime-a"}); err != nil {
+		t.Fatalf("AppendSessionEvent() error = %v", err)
+	}
+
+	metadataPath := filepath.Join(storageDir, "session", sessionMetadataFileName)
+	metadata := readSessionMetadataForTest(t, metadataPath)
+	if metadata.SessionID == "" {
+		t.Fatal("active metadata session_id is empty")
+	}
+
+	rotation, err := manager.RotateSessionEventsDetailed()
+	if err != nil {
+		t.Fatalf("RotateSessionEventsDetailed() error = %v", err)
+	}
+	if rotation.ClosedSessionID != metadata.SessionID {
+		t.Fatalf("ClosedSessionID = %q, want original active session_id %q", rotation.ClosedSessionID, metadata.SessionID)
+	}
+	if filepath.Base(rotation.ArchiveDir) != metadata.SessionID {
+		t.Fatalf("archive basename = %q, want original active session_id %q", filepath.Base(rotation.ArchiveDir), metadata.SessionID)
+	}
+}
+
 func TestMemoryManagerAppendSessionEventContinuesExistingEventStream(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -337,6 +338,40 @@ func TestMemoryManagerSaveDoesNotRegressEventCountWithRuntimeEvents(t *testing.T
 		if event.Sequence != want {
 			t.Fatalf("event %d sequence = %d, want %d; events=%#v", i, event.Sequence, want, events)
 		}
+	}
+}
+
+func TestMemoryManagerWritesRuntimeIDMetadata(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	manager := NewMemoryManager(storageDir)
+
+	if err := manager.AppendSessionEvent(ctx, "default", SessionEvent{
+		Type:    "user_input",
+		Role:    "user",
+		Content: "hello",
+	}, SessionEventMetadata{RuntimeID: "runtime-a"}); err != nil {
+		t.Fatalf("AppendSessionEvent() error = %v", err)
+	}
+
+	eventsPath := filepath.Join(storageDir, "session", "events.jsonl")
+	events := readSessionEvents(t, eventsPath)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d: %#v", len(events), events)
+	}
+	if events[0].RuntimeID != "runtime-a" {
+		t.Fatalf("RuntimeID = %q, want runtime-a", events[0].RuntimeID)
+	}
+
+	data, err := os.ReadFile(eventsPath)
+	if err != nil {
+		t.Fatalf("read events file: %v", err)
+	}
+	if bytes.Contains(data, []byte(`"session_id"`)) {
+		t.Fatalf("event should not write legacy session_id field: %s", data)
+	}
+	if !bytes.Contains(data, []byte(`"runtime_id":"runtime-a"`)) {
+		t.Fatalf("event missing runtime_id field: %s", data)
 	}
 }
 
@@ -1328,6 +1363,85 @@ func TestSessionRotationArchivesActiveSessionDirectory(t *testing.T) {
 	}
 }
 
+func TestSessionRotationDetailedCreatesActiveSessionID(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	manager := NewMemoryManager(storageDir)
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	now := time.Now().UTC()
+	if _, err := session.AppendEvent(ctx, SessionEvent{
+		EventID: "evt_before_rotate",
+		Ts:      now.Format(time.RFC3339Nano),
+		Type:    "user_input",
+		Role:    "user",
+		Content: "old task",
+	}); err != nil {
+		t.Fatalf("AppendEvent() before rotate error = %v", err)
+	}
+
+	rotation, err := manager.RotateSessionEventsDetailed()
+	if err != nil {
+		t.Fatalf("RotateSessionEventsDetailed() error = %v", err)
+	}
+	if rotation.ArchiveDir == "" {
+		t.Fatal("ArchiveDir is empty")
+	}
+	if rotation.ClosedSessionID != filepath.Base(rotation.ArchiveDir) {
+		t.Fatalf("ClosedSessionID = %q, want archive basename %q", rotation.ClosedSessionID, filepath.Base(rotation.ArchiveDir))
+	}
+	if rotation.ActiveSessionID == "" {
+		t.Fatal("ActiveSessionID is empty")
+	}
+
+	metadata := readSessionMetadataForTest(t, filepath.Join(storageDir, "session", sessionMetadataFileName))
+	if metadata.SessionID != rotation.ActiveSessionID {
+		t.Fatalf("active metadata session_id = %q, want %q", metadata.SessionID, rotation.ActiveSessionID)
+	}
+}
+
+func TestSessionBoundaryLogsProminentNewSessionID(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	var buf bytes.Buffer
+	logger := &Logger{logger: log.New(&buf, "", 0)}
+	manager := NewMemoryManager(storageDir, WithMemoryLogger(logger))
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	oldTs := time.Now().UTC().Add(-time.Duration(DefaultBoundaryConfig().LongGapSeconds+1) * time.Second)
+	if _, err := session.AppendEvent(ctx, SessionEvent{
+		EventID: "evt_old_task",
+		Ts:      oldTs.Format(time.RFC3339Nano),
+		Type:    "user_input",
+		Role:    "user",
+		Content: "old task",
+	}); err != nil {
+		t.Fatalf("AppendEvent() error = %v", err)
+	}
+
+	sessionManager := newMemoryManagerSessionManager(manager, nil)
+	if _, err := sessionManager.BeginRun(ctx, SessionBeginRequest{
+		AgentName: "default",
+		Input:     "打开微信",
+		Turn:      NewTextTurnInput("打开微信", nil),
+		RuntimeID: "runtime-a",
+	}); err != nil {
+		t.Fatalf("BeginRun() error = %v", err)
+	}
+
+	logText := buf.String()
+	if !strings.Contains(logText, "NEW SESSION STARTED") {
+		t.Fatalf("log missing session banner:\n%s", logText)
+	}
+	if !strings.Contains(logText, "Session ID: ") {
+		t.Fatalf("log missing prominent session id:\n%s", logText)
+	}
+	if !strings.Contains(logText, "Reason: "+BoundaryReasonTimeGapLong) {
+		t.Fatalf("log missing boundary reason:\n%s", logText)
+	}
+	if strings.Contains(logText, "Runtime ID:") {
+		t.Fatalf("session boundary log should not present runtime id as the primary marker:\n%s", logText)
+	}
+}
+
 func TestSessionRotationAppendAfterRotateWritesNewEventsFile(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()
@@ -1624,6 +1738,19 @@ func readSessionEvents(t *testing.T, path string) []SessionEvent {
 		t.Fatalf("scan session events: %v", err)
 	}
 	return events
+}
+
+func readSessionMetadataForTest(t *testing.T, path string) sessionMetadata {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read session metadata: %v", err)
+	}
+	var metadata sessionMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode session metadata: %v", err)
+	}
+	return metadata
 }
 
 func TestFormatSessionSummaryWithWindowKeepsMaxChunks(t *testing.T) {

--- a/src/agent/internal/agent/models.go
+++ b/src/agent/internal/agent/models.go
@@ -41,7 +41,7 @@ type ModelManager struct {
 	metadataHTTPClient        *http.Client
 	providerMetadataCachePath string
 	rawHTTPLogDir             string
-	sessionID                 string
+	runtimeID                 string
 }
 
 type ModelManagerOption func(*ModelManager)
@@ -68,8 +68,8 @@ func NewModelManager(config ModelConfig, proxy ProxyConfig, opts ...ModelManager
 	return m
 }
 
-func (m *ModelManager) SetSessionID(sessionID string) {
-	m.sessionID = sessionID
+func (m *ModelManager) SetRuntimeID(runtimeID string) {
+	m.runtimeID = runtimeID
 }
 
 func (m *ModelManager) Get() (llms.Model, error) {
@@ -156,7 +156,7 @@ func (m *ModelManager) openAICompatibleOptions(cfg ModelConfig) []openAICompatib
 		return nil
 	}
 	return []openAICompatibleModelOption{
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(m.rawHTTPLogDir, m.sessionID)),
+		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(m.rawHTTPLogDir, m.runtimeID)),
 	}
 }
 

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -37,18 +37,18 @@ func withOpenAICompatibleRawHTTPLogger(logger *llmRawHTTPLogger) openAICompatibl
 
 type llmRawHTTPLogger struct {
 	dir       string
-	sessionID string
+	runtimeID string
 	mu        sync.Mutex
 }
 
-func newLLMRawHTTPLogger(logDir, sessionID string) *llmRawHTTPLogger {
+func newLLMRawHTTPLogger(logDir, runtimeID string) *llmRawHTTPLogger {
 	logDir = strings.TrimSpace(logDir)
 	if logDir == "" {
 		return nil
 	}
 	return &llmRawHTTPLogger{
 		dir:       logDir,
-		sessionID: sessionID,
+		runtimeID: runtimeID,
 	}
 }
 
@@ -91,11 +91,11 @@ func (l *llmRawHTTPLogger) Log(model, dir, kind string, statusCode int, raw stri
 		return err
 	}
 
-	// File name includes both date and session ID
+	// File name includes both date and runtime ID.
 	dateStr := now.Format("20060102")
 	fileName := "llm-http-" + dateStr + ".log"
-	if l.sessionID != "" {
-		fileName = "llm-http-" + dateStr + "-" + l.sessionID + ".log"
+	if l.runtimeID != "" {
+		fileName = "llm-http-" + dateStr + "-" + l.runtimeID + ".log"
 	}
 
 	path := filepath.Join(l.dir, fileName)

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -35,24 +35,24 @@ func effectiveMaxIterations(configured int) int {
 const currentEnvironmentHintMaxAge = 10 * time.Minute
 
 type Runtime struct {
-	config             Config
-	models             ModelResolver
-	memories           *MemoryManager
-	tools              *ToolSet
-	skills             *SkillManager
-	skillsLoaded       bool
-	skillsReloadMu     sync.Mutex
-	skillsDirty        bool
-	runGateInit        sync.Once
-	mergeWorker        *MergeWorker
-	logger             *Logger
-	profileDebouncer   *ProfileDebouncer
-	waitForWakeup      *WaitForWakeupController
-	memoryPlane        MemoryPlane
-	sessionManager     SessionManager
-	telemetrySessionID string
-	mobileGym          *mobileGymSessionStore
-	runGate            chan struct{}
+	config           Config
+	models           ModelResolver
+	memories         *MemoryManager
+	tools            *ToolSet
+	skills           *SkillManager
+	skillsLoaded     bool
+	skillsReloadMu   sync.Mutex
+	skillsDirty      bool
+	runGateInit      sync.Once
+	mergeWorker      *MergeWorker
+	logger           *Logger
+	profileDebouncer *ProfileDebouncer
+	waitForWakeup    *WaitForWakeupController
+	memoryPlane      MemoryPlane
+	sessionManager   SessionManager
+	runtimeID        string
+	mobileGym        *mobileGymSessionStore
+	runGate          chan struct{}
 }
 
 type RunRequest struct {
@@ -324,12 +324,9 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 	rt.waitForWakeup = waitForWakeupController
 	rt.mobileGym = mobileGymStore
 
-	// Log session start marker
+	// Log runtime start marker.
 	if logger != nil {
-		logger.Info("========================================")
-		logger.Info("NEW SESSION STARTED")
-		logger.Info("Session ID: %s", rt.telemetrySessionID)
-		logger.Info("========================================")
+		logger.Info("[runtime] started: runtime_id=%s", rt.runtimeID)
 	}
 
 	if len(mergeNeeded) > 0 && cfg.SkillMergeModel != nil {
@@ -362,19 +359,19 @@ func NewRuntimeWithDeps(cfg Config, models ModelResolver, memories *MemoryManage
 		skillManager.SetUsagePath(filepath.Join(cfg.ConfigDir, "skill-state", "usage.json"))
 	}
 	rt := &Runtime{
-		config:             cfg,
-		models:             models,
-		memories:           memories,
-		tools:              tools,
-		skills:             skillManager,
-		skillsLoaded:       skillIndex != nil && len(skillIndex.Names()) > 0,
-		waitForWakeup:      waitForWakeupController,
-		telemetrySessionID: uuid.NewString(),
-		mobileGym:          &mobileGymSessionStore{},
+		config:        cfg,
+		models:        models,
+		memories:      memories,
+		tools:         tools,
+		skills:        skillManager,
+		skillsLoaded:  skillIndex != nil && len(skillIndex.Names()) > 0,
+		waitForWakeup: waitForWakeupController,
+		runtimeID:     uuid.NewString(),
+		mobileGym:     &mobileGymSessionStore{},
 	}
-	// Set session ID for raw HTTP logging
+	// Set runtime ID for raw HTTP logging.
 	if modelManager, ok := models.(*ModelManager); ok {
-		modelManager.SetSessionID(rt.telemetrySessionID)
+		modelManager.SetRuntimeID(rt.runtimeID)
 	}
 	if cfg.ConfigDir != "" {
 		rt.memoryPlane = NewFilesystemMemoryPlane(filepath.Join(cfg.ConfigDir, "memory"), LoadMemoryExtractionConfig(cfg.ConfigDir), nil)
@@ -560,7 +557,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		AgentName:    "default",
 		Input:        normalizedInput,
 		Turn:         turnInput,
-		SessionID:    r.telemetrySessionID,
+		RuntimeID:    r.runtimeID,
 		EpisodeID:    episodeID,
 		RequestID:    req.RequestID,
 		RunID:        runID,
@@ -627,14 +624,14 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			logger:                 r.logger,
 			eventHandler:           req.EventHandler,
 			episodeID:              episodeID,
-			sessionID:              r.telemetrySessionID,
+			runtimeID:              r.runtimeID,
 			requestID:              req.RequestID,
 			runID:                  runID,
 		}
 		if persistRuntimeSessionEvents {
 			streamCallbackHandler.sessionEventAppender = func(ctx context.Context, event SessionEvent) error {
 				return r.appendRuntimeSessionEvent(ctx, "default", event, SessionEventMetadata{
-					SessionID: r.telemetrySessionID,
+					RuntimeID: r.runtimeID,
 					EpisodeID: episodeID,
 					RequestID: req.RequestID,
 					RunID:     runID,
@@ -702,7 +699,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		Input:     normalizedInput,
 		Output:    output,
 		Metrics:   metrics,
-		SessionID: r.telemetrySessionID,
+		RuntimeID: r.runtimeID,
 		EpisodeID: episodeID,
 		RequestID: req.RequestID,
 		RunID:     runID,
@@ -776,9 +773,9 @@ func (r *Runtime) persistRunStatusBestEffort(episodeID, requestID, runID string,
 		EpisodeID: episodeID,
 		RequestID: requestID,
 		RunID:     runID,
-		SessionID: r.telemetrySessionID,
+		RuntimeID: r.runtimeID,
 	}, SessionEventMetadata{
-		SessionID: r.telemetrySessionID,
+		RuntimeID: r.runtimeID,
 		EpisodeID: episodeID,
 		RequestID: requestID,
 		RunID:     runID,
@@ -1069,8 +1066,8 @@ func (r *Runtime) enrichEpisodeRuntimeTelemetry(episode *TaskEpisode) {
 	if episode.Extra == nil {
 		episode.Extra = map[string]interface{}{}
 	}
-	if extraString(episode.Extra, "session_id") == "" && r.telemetrySessionID != "" {
-		episode.Extra["session_id"] = r.telemetrySessionID
+	if extraString(episode.Extra, "runtime_id") == "" && r.runtimeID != "" {
+		episode.Extra["runtime_id"] = r.runtimeID
 	}
 	contextWindow := r.effectiveContextWindow()
 	if contextWindow > 0 {
@@ -1175,7 +1172,7 @@ type runtimeCallbackHandler struct {
 	logger                 *Logger
 	eventHandler           func(RunEvent)
 	episodeID              string
-	sessionID              string
+	runtimeID              string
 	requestID              string
 	runID                  string
 	sessionEventAppender   func(context.Context, SessionEvent) error
@@ -1492,7 +1489,7 @@ func sessionEventFromRunEvent(event RunEvent, h *runtimeCallbackHandler) Session
 		Ts:        ts.UTC().Format(time.RFC3339Nano),
 		Type:      event.Type,
 		Role:      role,
-		SessionID: h.sessionID,
+		RuntimeID: h.runtimeID,
 		EpisodeID: firstNonEmptyString([]string{event.EpisodeID, h.episodeID}),
 		RequestID: h.requestID,
 		RunID:     h.runID,

--- a/src/agent/internal/agent/session_manager.go
+++ b/src/agent/internal/agent/session_manager.go
@@ -22,7 +22,7 @@ type SessionBeginRequest struct {
 	AgentName    string
 	Input        string
 	Turn         TurnInput
-	SessionID    string
+	RuntimeID    string
 	EpisodeID    string
 	RequestID    string
 	RunID        string
@@ -48,7 +48,7 @@ type SessionCommitRequest struct {
 	Output    string
 	Steers    []RunSteerMessage
 	Metrics   *RunMetrics
-	SessionID string
+	RuntimeID string
 	EpisodeID string
 	RequestID string
 	RunID     string
@@ -86,7 +86,7 @@ func (m memoryManagerSessionManager) BeginRun(ctx context.Context, req SessionBe
 			agentName = "default"
 		}
 		meta := SessionEventMetadata{
-			SessionID: req.SessionID,
+			RuntimeID: req.RuntimeID,
 			EpisodeID: req.EpisodeID,
 			RequestID: req.RequestID,
 			RunID:     req.RunID,
@@ -140,20 +140,37 @@ func (m memoryManagerSessionManager) handleSessionBoundary(input string) session
 		return telemetry
 	}
 
-	if m.memories.logger != nil {
-		m.memories.logger.Info("[memory] new session started: reason=%s", reason)
-	}
-	archiveDir, err := m.memories.RotateSessionEvents()
+	rotation, err := m.memories.RotateSessionEventsDetailed()
 	if err != nil {
 		if m.memories.logger != nil {
 			m.memories.logger.Warn("[memory] session rotation failed: %v", err)
 		}
 		return telemetry
 	}
-	if archiveDir != "" {
+	if rotation.ArchiveDir != "" {
 		telemetry.Rotated = true
 	}
+	if m.memories.logger != nil {
+		logProminentSessionStart(m.memories.logger, rotation, reason)
+	}
 	return telemetry
+}
+
+func logProminentSessionStart(logger *Logger, rotation SessionRotationResult, reason string) {
+	if logger == nil || rotation.ActiveSessionID == "" {
+		return
+	}
+	logger.Info("========================================")
+	logger.Info("NEW SESSION STARTED")
+	logger.Info("Session ID: %s", rotation.ActiveSessionID)
+	logger.Info("Reason: %s", reason)
+	if rotation.ClosedSessionID != "" {
+		logger.Info("Closed Session ID: %s", rotation.ClosedSessionID)
+	}
+	if rotation.ArchiveDir != "" {
+		logger.Info("Archive: %s", filepath.Base(rotation.ArchiveDir))
+	}
+	logger.Info("========================================")
 }
 
 func (m memoryManagerSessionManager) CommitRun(ctx context.Context, req SessionCommitRequest) (SessionCommitResult, error) {
@@ -174,7 +191,7 @@ func (m memoryManagerSessionManager) CommitRun(ctx context.Context, req SessionC
 	m.memories.SetLastPromptTokens(lastPromptTokens)
 
 	meta := SessionEventMetadata{
-		SessionID: req.SessionID,
+		RuntimeID: req.RuntimeID,
 		EpisodeID: req.EpisodeID,
 		RequestID: req.RequestID,
 		RunID:     req.RunID,


### PR DESCRIPTION
## Summary
- Rename the runtime-level correlation identifier from session terminology to runtime ID
- Write runtime_id into session events and episode metadata while retaining legacy session_id fallback for old data
- Make memory session boundary logs prominent with a real active session ID and demote runtime startup logging to a compact runtime_id line

## Tests
- go test ./... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated session identification to use runtime-based identifiers
  * Enhanced session rotation with detailed archive and session ID tracking
  * Updated session metadata handling and persistence

* **Tests**
  * Added tests for session metadata and rotation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->