### PR TITLE
fix(tts): prevent tool-call content from final speech stream

### DIFF
--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -539,24 +539,18 @@ func (e *roleCollaborativeExecutor) callPlannerTurn(
 		Tools:     plannerTools,
 		OutputKey: e.OutputKey,
 	}
-	baseOptions := append(chains.GetLLMCallOptions(options...), llms.WithTools(parser.toolsAsLLM()))
-	finalStreaming := state.Phase == phaseDefault || e.ForceSimpleLoop
-	callOptions := baseOptions
-	if finalStreaming {
-		callOptions = e.finalStreamingCallOptions(baseOptions)
-	}
+	callOptions := append(chains.GetLLMCallOptions(options...), llms.WithTools(parser.toolsAsLLM()))
 	generate := func() (*llms.ContentResponse, error) {
 		return e.generateRoleContent(ctx, RolePlanner, messages, callOptions...)
 	}
-	var (
-		res *llms.ContentResponse
-		err error
-	)
-	if finalStreaming {
-		res, err = e.withFinalStreaming(ctx, generate)
-	} else {
-		res, err = generate()
+	// Planner turns with tool schemas are tool-capable. Do not provider-stream
+	// their content as final speech before ParseOutput proves the response is
+	// not a tool call; finishRun streams confirmed final answers after parsing.
+	if diagnostics, ok := e.CallbacksHandler.(finalStreamingDecisionLogger); ok {
+		diagnostics.LogFinalStreamingDecision(ctx, RolePlanner, false,
+			fmt.Sprintf("tool_capable_planner_turn phase=%s force_simple=%t tools=%d", state.Phase, e.ForceSimpleLoop, len(plannerTools)))
 	}
+	res, err := generate()
 	if err != nil {
 		return plannerTurnResult{}, err
 	}
@@ -2207,6 +2201,10 @@ type finalStreamingController interface {
 
 type providerFinalStreamingController interface {
 	ProviderFinalStreamingEnabled() bool
+}
+
+type finalStreamingDecisionLogger interface {
+	LogFinalStreamingDecision(context.Context, RoleName, bool, string)
 }
 
 func (e *roleCollaborativeExecutor) withFinalStreaming(ctx context.Context, fn func() (*llms.ContentResponse, error)) (*llms.ContentResponse, error) {

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1167,6 +1167,7 @@ type runtimeCallbackHandler struct {
 	startTime              time.Time
 	firstTokenSeen         bool
 	finalTokenSeen         bool
+	finalStreamLogEmitted  bool
 	finalStreamErr         error
 	streamFinal            bool
 	logger                 *Logger
@@ -1563,7 +1564,9 @@ func (h *runtimeCallbackHandler) HandleStreamingFunc(ctx context.Context, chunk 
 		if _, err := h.writer.Write(chunk); err != nil {
 			h.recordFinalStreamError(err)
 		} else if streamWriterEmitted(h.writer) {
-			h.recordFinalToken()
+			if h.recordFinalToken() {
+				h.logFinalStreamEmitted(ctx, chunk)
+			}
 		}
 	}
 
@@ -1582,6 +1585,7 @@ func (h *runtimeCallbackHandler) EnableFinalStreaming(ctx context.Context) {
 	resetStreamBuffer(h.writer)
 	h.mu.Lock()
 	h.finalTokenSeen = false
+	h.finalStreamLogEmitted = false
 	h.finalStreamErr = nil
 	h.streamFinal = true
 	h.mu.Unlock()
@@ -1651,13 +1655,15 @@ func (h *runtimeCallbackHandler) recordFirstToken() {
 	}
 }
 
-func (h *runtimeCallbackHandler) recordFinalToken() {
+func (h *runtimeCallbackHandler) recordFinalToken() bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.finalStreamErr != nil {
-		return
+		return false
 	}
+	first := !h.finalTokenSeen
 	h.finalTokenSeen = true
+	return first
 }
 
 func (h *runtimeCallbackHandler) finalStreamingFailed() bool {
@@ -1680,6 +1686,36 @@ func (h *runtimeCallbackHandler) recordFinalStreamError(err error) {
 	if firstErr && h.logger != nil {
 		h.logger.Warn("Final stream writer failed; falling back to final answer: %v", err)
 	}
+}
+
+func (h *runtimeCallbackHandler) LogFinalStreamingDecision(_ context.Context, role RoleName, providerStreaming bool, reason string) {
+	if h == nil || h.logger == nil || !h.providerFinalStreaming {
+		return
+	}
+	h.logger.Info("Final stream decision: role=%s provider_streaming=%t reason=%s request_id=%s run_id=%s",
+		role, providerStreaming, reason, h.requestID, h.runID)
+}
+
+func (h *runtimeCallbackHandler) logFinalStreamEmitted(ctx context.Context, chunk []byte) {
+	if h == nil || h.logger == nil {
+		return
+	}
+	h.mu.Lock()
+	if h.finalStreamLogEmitted {
+		h.mu.Unlock()
+		return
+	}
+	h.finalStreamLogEmitted = true
+	requestID := h.requestID
+	runID := h.runID
+	h.mu.Unlock()
+
+	role := telemetryRoleFromContext(ctx)
+	if role == "" {
+		role = "post_parse"
+	}
+	h.logger.Info("Final stream emitted: role=%s chunk_len=%d chunk=%s request_id=%s run_id=%s",
+		role, len(chunk), truncateForLog(string(chunk), 120), requestID, runID)
 }
 
 var _ callbacks.Handler = (*runtimeCallbackHandler)(nil)

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -2928,7 +2928,7 @@ func TestRuntimeRunDirectRouteUsesProviderFinalStreaming(t *testing.T) {
 	}
 }
 
-func TestRuntimeRunDefaultModeFinalAnswerUsesProviderFinalStreaming(t *testing.T) {
+func TestRuntimeRunDefaultModeFinalAnswerStreamsAfterParsing(t *testing.T) {
 	model := &scriptedModel{
 		responses: []*llms.ContentResponse{
 			contentResponse(`{"mode":"simple","reason":"ordinary one-pass answer"}`),
@@ -2965,8 +2965,8 @@ func TestRuntimeRunDefaultModeFinalAnswerUsesProviderFinalStreaming(t *testing.T
 		t.Fatalf("Run() error = %v", err)
 	}
 
-	if got, want := model.sawStreaming, []bool{true, true}; !slices.Equal(got, want) {
-		t.Fatalf("expected route and default final calls to use provider streaming, got %#v", got)
+	if got, want := model.sawStreaming, []bool{true, false}; !slices.Equal(got, want) {
+		t.Fatalf("expected route streaming and non-streaming default planner call, got %#v", got)
 	}
 	if stream.String() != "Complete answer." {
 		t.Fatalf("stream = %q, want default final answer", stream.String())
@@ -2977,10 +2977,14 @@ func TestRuntimeRunDefaultModeFinalAnswerUsesProviderFinalStreaming(t *testing.T
 }
 
 func TestRuntimeRunFinalStreamingDoesNotStreamIntermediateToolCalls(t *testing.T) {
+	toolSpeech := "我先读取当前音量。"
 	model := &scriptedModel{
-		responses: roleToolResponses("audio_volume", `{"__arg1":"{}"}`, "The current audio volume is 42."),
+		responses: []*llms.ContentResponse{
+			toolCallResponseWithContent("call_1", "audio_volume", `{"__arg1":"{}"}`, toolSpeech),
+			contentResponse("The current audio volume is 42."),
+		},
 		streamChunks: [][]string{
-			{},
+			{toolSpeech},
 			{"The current audio volume is 42."},
 		},
 	}
@@ -3019,8 +3023,8 @@ func TestRuntimeRunFinalStreamingDoesNotStreamIntermediateToolCalls(t *testing.T
 	if len(tool.inputs) != 1 || tool.inputs[0] != "{}" {
 		t.Fatalf("unexpected tool inputs: %#v", tool.inputs)
 	}
-	if got, want := model.sawStreaming, []bool{true, true}; !slices.Equal(got, want) {
-		t.Fatalf("expected default-mode model calls to use provider streaming, got %#v", got)
+	if got, want := model.sawStreaming, []bool{false, false}; !slices.Equal(got, want) {
+		t.Fatalf("expected default-mode tool-capable model calls to avoid provider streaming, got %#v", got)
 	}
 	if stream.String() != "The current audio volume is 42." {
 		t.Fatalf("unexpected stream output: %q", stream.String())


### PR DESCRIPTION
## Summary
- stop provider-level final streaming on tool-capable planner turns before tool-call parsing
- keep confirmed final answers streaming after parsing through the existing finish path
- add low-volume diagnostics for final-stream decisions and first emitted final stream chunks

## Tests
- go test ./... -count=1