### PR TITLE
fix(agent): partition LLM HTTP logs by session

### DIFF
--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -742,6 +742,12 @@ func validateSessionIDPathComponent(sessionID string) error {
 	if sessionID == "" || sessionID == "." || sessionID != filepath.Base(sessionID) || strings.ContainsAny(sessionID, `/\`) || strings.Contains(sessionID, "..") {
 		return fmt.Errorf("unsafe session id %q", sessionID)
 	}
+	for i := 0; i < len(sessionID); i++ {
+		ch := sessionID[i]
+		if ch < 0x20 || ch == 0x7f {
+			return fmt.Errorf("unsafe session id %q", sessionID)
+		}
+	}
 	return nil
 }
 

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -214,6 +214,32 @@ func NewMemoryManager(storageDir string, opts ...MemoryManagerOption) *MemoryMan
 	return manager
 }
 
+// ActiveSessionID returns the current filesystem session ID, creating active
+// session metadata when the session directory has not been initialized yet.
+func (m *MemoryManager) ActiveSessionID() (string, error) {
+	if m == nil || strings.TrimSpace(m.storageDir) == "" {
+		return "", nil
+	}
+	fl := NewFileLock(m.storageDir)
+	if err := fl.Lock(m.lockTimeout); err != nil {
+		return "", fmt.Errorf("lock active session metadata: %w", err)
+	}
+	defer fl.Unlock()
+
+	sessionDir := filepath.Join(m.storageDir, "session")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		return "", fmt.Errorf("create active session directory: %w", err)
+	}
+	meta, err := ensureActiveSessionMetadata(sessionDir, time.Now().UTC())
+	if err != nil {
+		return "", err
+	}
+	if err := validateSessionIDPathComponent(meta.SessionID); err != nil {
+		return "", err
+	}
+	return meta.SessionID, nil
+}
+
 // SetLastPromptTokens updates the token count from the most recent prompt.
 func (m *MemoryManager) SetLastPromptTokens(tokens int) {
 	m.mu.Lock()
@@ -693,7 +719,7 @@ func nextSessionArchiveDir(parent string, baseID string) (string, error) {
 	if baseID == "" {
 		baseID = newSessionID(time.Now().UTC())
 	}
-	if err := validateSessionArchiveBaseID(baseID); err != nil {
+	if err := validateSessionIDPathComponent(baseID); err != nil {
 		return "", err
 	}
 	for i := int64(0); i < 100; i++ {
@@ -712,9 +738,9 @@ func nextSessionArchiveDir(parent string, baseID string) (string, error) {
 	return "", fmt.Errorf("allocate session archive path: too many collisions")
 }
 
-func validateSessionArchiveBaseID(baseID string) error {
-	if baseID == "" || baseID == "." || baseID != filepath.Base(baseID) || strings.ContainsAny(baseID, `/\`) || strings.Contains(baseID, "..") {
-		return fmt.Errorf("unsafe session archive id %q", baseID)
+func validateSessionIDPathComponent(sessionID string) error {
+	if sessionID == "" || sessionID == "." || sessionID != filepath.Base(sessionID) || strings.ContainsAny(sessionID, `/\`) || strings.Contains(sessionID, "..") {
+		return fmt.Errorf("unsafe session id %q", sessionID)
 	}
 	return nil
 }

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -96,18 +96,34 @@ func TestMemoryManagerActiveSessionIDCreatesSessionMetadata(t *testing.T) {
 }
 
 func TestMemoryManagerActiveSessionIDRejectsUnsafeMetadata(t *testing.T) {
-	storageDir := t.TempDir()
-	sessionDir := filepath.Join(storageDir, "session")
-	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
-		t.Fatalf("create session dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(sessionDir, sessionMetadataFileName), []byte(`{"session_id":"../escape","created_at":"2026-06-21T00:00:00Z"}`+"\n"), 0o644); err != nil {
-		t.Fatalf("write metadata: %v", err)
-	}
-	manager := NewMemoryManager(storageDir)
+	for _, sessionID := range []string{
+		"../escape",
+		"session\nescape",
+		"session\x7fescape",
+	} {
+		t.Run(fmt.Sprintf("%q", sessionID), func(t *testing.T) {
+			storageDir := t.TempDir()
+			sessionDir := filepath.Join(storageDir, "session")
+			if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+				t.Fatalf("create session dir: %v", err)
+			}
+			metadata := sessionMetadata{
+				SessionID: sessionID,
+				CreatedAt: "2026-06-21T00:00:00Z",
+			}
+			data, err := json.Marshal(metadata)
+			if err != nil {
+				t.Fatalf("marshal metadata: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(sessionDir, sessionMetadataFileName), append(data, '\n'), 0o644); err != nil {
+				t.Fatalf("write metadata: %v", err)
+			}
+			manager := NewMemoryManager(storageDir)
 
-	if _, err := manager.ActiveSessionID(); err == nil {
-		t.Fatal("ActiveSessionID() succeeded with unsafe metadata session_id")
+			if _, err := manager.ActiveSessionID(); err == nil {
+				t.Fatal("ActiveSessionID() succeeded with unsafe metadata session_id")
+			}
+		})
 	}
 }
 

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -77,6 +77,40 @@ func TestMemoryManagerSaveCreatesSessionMetadataOnFirstWrite(t *testing.T) {
 	}
 }
 
+func TestMemoryManagerActiveSessionIDCreatesSessionMetadata(t *testing.T) {
+	storageDir := t.TempDir()
+	manager := NewMemoryManager(storageDir)
+
+	sessionID, err := manager.ActiveSessionID()
+	if err != nil {
+		t.Fatalf("ActiveSessionID() error = %v", err)
+	}
+	if sessionID == "" {
+		t.Fatal("ActiveSessionID() returned empty session ID")
+	}
+
+	metadata := readSessionMetadataForTest(t, filepath.Join(storageDir, "session", sessionMetadataFileName))
+	if metadata.SessionID != sessionID {
+		t.Fatalf("metadata session_id = %q, want %q", metadata.SessionID, sessionID)
+	}
+}
+
+func TestMemoryManagerActiveSessionIDRejectsUnsafeMetadata(t *testing.T) {
+	storageDir := t.TempDir()
+	sessionDir := filepath.Join(storageDir, "session")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("create session dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionDir, sessionMetadataFileName), []byte(`{"session_id":"../escape","created_at":"2026-06-21T00:00:00Z"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	manager := NewMemoryManager(storageDir)
+
+	if _, err := manager.ActiveSessionID(); err == nil {
+		t.Fatal("ActiveSessionID() succeeded with unsafe metadata session_id")
+	}
+}
+
 func TestMemoryManagerSaveSnapshotCreatesSessionMetadataOnFirstWrite(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()

--- a/src/agent/internal/agent/models.go
+++ b/src/agent/internal/agent/models.go
@@ -41,7 +41,7 @@ type ModelManager struct {
 	metadataHTTPClient        *http.Client
 	providerMetadataCachePath string
 	rawHTTPLogDir             string
-	runtimeID                 string
+	rawHTTPLogSessionID       func() string
 }
 
 type ModelManagerOption func(*ModelManager)
@@ -68,8 +68,11 @@ func NewModelManager(config ModelConfig, proxy ProxyConfig, opts ...ModelManager
 	return m
 }
 
-func (m *ModelManager) SetRuntimeID(runtimeID string) {
-	m.runtimeID = runtimeID
+func (m *ModelManager) SetRawHTTPLogSessionIDProvider(provider func() string) {
+	m.rawHTTPLogSessionID = provider
+	if model, ok := m.model.(*openAICompatibleModel); ok && model.rawLogger != nil {
+		model.rawLogger.SetSessionIDProvider(provider)
+	}
 }
 
 func (m *ModelManager) Get() (llms.Model, error) {
@@ -155,8 +158,10 @@ func (m *ModelManager) openAICompatibleOptions(cfg ModelConfig) []openAICompatib
 	if !cfg.LogRawHTTP || strings.TrimSpace(m.rawHTTPLogDir) == "" {
 		return nil
 	}
+	logger := newLLMRawHTTPLogger(m.rawHTTPLogDir, "")
+	logger.SetSessionIDProvider(m.rawHTTPLogSessionID)
 	return []openAICompatibleModelOption{
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(m.rawHTTPLogDir, m.runtimeID)),
+		withOpenAICompatibleRawHTTPLogger(logger),
 	}
 }
 

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -37,6 +37,7 @@ type openAICompatibleModelOption func(*openAICompatibleModel)
 type rawHTTPLogContextKey struct{}
 
 type rawHTTPLogFileTimeContextKey struct{}
+type rawHTTPLogFileSessionIDContextKey struct{}
 
 // contextWithRawHTTPLog marks ctx so model calls made under it are written to
 // the raw HTTP log. Only the main conversation loop should set this.
@@ -58,6 +59,15 @@ func rawHTTPLogFileTime(ctx context.Context) (time.Time, bool) {
 	return fileTime, ok && !fileTime.IsZero()
 }
 
+func contextWithRawHTTPLogFileSessionID(ctx context.Context, sessionID string) context.Context {
+	return context.WithValue(ctx, rawHTTPLogFileSessionIDContextKey{}, strings.TrimSpace(sessionID))
+}
+
+func rawHTTPLogFileSessionID(ctx context.Context) (string, bool) {
+	sessionID, ok := ctx.Value(rawHTTPLogFileSessionIDContextKey{}).(string)
+	return strings.TrimSpace(sessionID), ok
+}
+
 func withOpenAICompatibleRawHTTPLogger(logger *llmRawHTTPLogger) openAICompatibleModelOption {
 	return func(m *openAICompatibleModel) {
 		m.rawLogger = logger
@@ -65,22 +75,32 @@ func withOpenAICompatibleRawHTTPLogger(logger *llmRawHTTPLogger) openAICompatibl
 }
 
 type llmRawHTTPLogger struct {
-	dir       string
-	runtimeID string
-	now       func() time.Time
-	mu        sync.Mutex
+	dir               string
+	sessionID         string
+	sessionIDProvider func() string
+	now               func() time.Time
+	mu                sync.Mutex
 }
 
-func newLLMRawHTTPLogger(logDir, runtimeID string) *llmRawHTTPLogger {
+func newLLMRawHTTPLogger(logDir, sessionID string) *llmRawHTTPLogger {
 	logDir = strings.TrimSpace(logDir)
 	if logDir == "" {
 		return nil
 	}
 	return &llmRawHTTPLogger{
 		dir:       logDir,
-		runtimeID: runtimeID,
+		sessionID: strings.TrimSpace(sessionID),
 		now:       time.Now,
 	}
+}
+
+func (l *llmRawHTTPLogger) SetSessionIDProvider(provider func() string) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.sessionIDProvider = provider
 }
 
 func (l *llmRawHTTPLogger) Log(model, kind string, statusCode int, raw string) error {
@@ -88,6 +108,10 @@ func (l *llmRawHTTPLogger) Log(model, kind string, statusCode int, raw string) e
 }
 
 func (l *llmRawHTTPLogger) LogWithFileTime(model, kind string, statusCode int, raw string, fileTime time.Time) error {
+	return l.LogWithFileScope(model, kind, statusCode, raw, fileTime, l.currentSessionID())
+}
+
+func (l *llmRawHTTPLogger) LogWithFileScope(model, kind string, statusCode int, raw string, fileTime time.Time, sessionID string) error {
 	if l == nil || strings.TrimSpace(l.dir) == "" {
 		return nil
 	}
@@ -129,11 +153,11 @@ func (l *llmRawHTTPLogger) LogWithFileTime(model, kind string, statusCode int, r
 		return err
 	}
 
-	// File name includes date, time (hour+minute), and runtime ID.
+	// File name includes date, time (hour+minute), and session ID.
 	dateTimeStr := fileTime.Format("200601021504")
 	fileName := "llm-http-" + dateTimeStr + ".log"
-	if l.runtimeID != "" {
-		fileName = "llm-http-" + dateTimeStr + "-" + l.runtimeID + ".log"
+	if sessionID = strings.TrimSpace(sessionID); sessionID != "" {
+		fileName = "llm-http-" + dateTimeStr + "-" + sessionID + ".log"
 	}
 
 	path := filepath.Join(l.dir, fileName)
@@ -151,6 +175,22 @@ func (l *llmRawHTTPLogger) currentTime() time.Time {
 		return time.Now()
 	}
 	return l.now()
+}
+
+func (l *llmRawHTTPLogger) currentSessionID() string {
+	if l == nil {
+		return ""
+	}
+	l.mu.Lock()
+	provider := l.sessionIDProvider
+	fallback := l.sessionID
+	l.mu.Unlock()
+	if provider != nil {
+		if sessionID := strings.TrimSpace(provider()); sessionID != "" {
+			return sessionID
+		}
+	}
+	return strings.TrimSpace(fallback)
 }
 
 type compatibleChatRequest struct {
@@ -602,7 +642,8 @@ func (m *openAICompatibleModel) logRawHTTP(ctx context.Context, modelName, kind 
 		return nil
 	}
 	if fileTime, ok := rawHTTPLogFileTime(ctx); ok {
-		return m.rawLogger.LogWithFileTime(modelName, kind, statusCode, raw, fileTime)
+		sessionID, _ := rawHTTPLogFileSessionID(ctx)
+		return m.rawLogger.LogWithFileScope(modelName, kind, statusCode, raw, fileTime, sessionID)
 	}
 	return m.rawLogger.Log(modelName, kind, statusCode, raw)
 }
@@ -612,9 +653,13 @@ func (m *openAICompatibleModel) withRawHTTPLogFileTime(ctx context.Context) cont
 		return ctx
 	}
 	if _, ok := rawHTTPLogFileTime(ctx); ok {
-		return ctx
+		if _, hasSessionID := rawHTTPLogFileSessionID(ctx); hasSessionID {
+			return ctx
+		}
+		return contextWithRawHTTPLogFileSessionID(ctx, m.rawLogger.currentSessionID())
 	}
-	return contextWithRawHTTPLogFileTime(ctx, m.rawLogger.currentTime())
+	ctx = contextWithRawHTTPLogFileTime(ctx, m.rawLogger.currentTime())
+	return contextWithRawHTTPLogFileSessionID(ctx, m.rawLogger.currentSessionID())
 }
 
 func convertMessageContent(message llms.MessageContent) (compatibleMessage, error) {

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -526,6 +526,94 @@ func TestRuntimeConfiguresRawHTTPLogWithActiveMemorySessionID(t *testing.T) {
 	}
 }
 
+func TestRuntimeRawHTTPLogSwitchesSessionFileAfterRotation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	rootDir := t.TempDir()
+	logDir := filepath.Join(rootDir, "log")
+	memoryDir := filepath.Join(rootDir, "memory")
+	manager := NewModelManager(ModelConfig{
+		Provider:   "openai",
+		BaseURL:    server.URL,
+		Model:      "test-model",
+		LogRawHTTP: true,
+	}, ProxyConfig{}, WithLLMRawHTTPLogDir(logDir))
+	memories := NewMemoryManager(memoryDir)
+	NewRuntimeWithDeps(Config{}, manager, memories, nil, nil)
+
+	model, err := manager.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	compatible, ok := model.(*openAICompatibleModel)
+	if !ok {
+		t.Fatalf("model = %T, want *openAICompatibleModel", model)
+	}
+	compatible.rawLogger.now = func() time.Time {
+		return time.Date(2026, 6, 21, 9, 4, 59, 0, time.UTC)
+	}
+
+	runLLM := func(prompt string) {
+		t.Helper()
+		_, err := model.GenerateContent(contextWithRawHTTPLog(context.Background()), []llms.MessageContent{{
+			Role:  llms.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextPart(prompt)},
+		}})
+		if err != nil {
+			t.Fatalf("GenerateContent(%q) error = %v", prompt, err)
+		}
+	}
+
+	runLLM("before rotation")
+	firstMeta := readSessionMetadataForTest(t, filepath.Join(memoryDir, "session", sessionMetadataFileName))
+
+	session := NewSessionMemoryStore(filepath.Join(memoryDir, "session"))
+	if _, err := session.AppendEvent(context.Background(), SessionEvent{
+		EventID: "evt_before_rotation",
+		Ts:      time.Date(2026, 6, 21, 9, 5, 0, 0, time.UTC).Format(time.RFC3339Nano),
+		Type:    "user_input",
+		Role:    "user",
+		Content: "old task",
+	}); err != nil {
+		t.Fatalf("AppendEvent() before rotation error = %v", err)
+	}
+	rotation, err := memories.RotateSessionEventsDetailed()
+	if err != nil {
+		t.Fatalf("RotateSessionEventsDetailed() error = %v", err)
+	}
+	if rotation.ActiveSessionID == "" || rotation.ActiveSessionID == firstMeta.SessionID {
+		t.Fatalf("ActiveSessionID after rotation = %q, first session = %q", rotation.ActiveSessionID, firstMeta.SessionID)
+	}
+
+	runLLM("after rotation")
+
+	matches, err := filepath.Glob(filepath.Join(logDir, "llm-http-*.log"))
+	if err != nil {
+		t.Fatalf("glob raw HTTP logs: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected two raw HTTP log files after rotation, got %d: %#v", len(matches), matches)
+	}
+	wantNames := map[string]bool{
+		"llm-http-202606210904-" + firstMeta.SessionID + ".log":      false,
+		"llm-http-202606210904-" + rotation.ActiveSessionID + ".log": false,
+	}
+	for _, match := range matches {
+		if _, ok := wantNames[filepath.Base(match)]; ok {
+			wantNames[filepath.Base(match)] = true
+		}
+	}
+	for name, found := range wantNames {
+		if !found {
+			t.Fatalf("missing raw HTTP log file %q; got %#v", name, matches)
+		}
+	}
+}
+
 // countRawHTTPKinds returns how many log entries carry each kind, so tests can
 // assert the request/response pairing invariant the log viewer relies on.
 func countRawHTTPKinds(t *testing.T, logText string) map[string]int {

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -411,7 +411,9 @@ func TestOpenAICompatibleModelLogsRawStreamingHTTPOnDecodeError(t *testing.T) {
 }
 
 func TestOpenAICompatibleModelRawHTTPLogKeepsRunInRequestMinuteFile(t *testing.T) {
+	sessionID := "session-a"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sessionID = "session-b"
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"OK\"},\"finish_reason\":\"stop\"}]}\n\n"))
 		w.Write([]byte("data: [DONE]\n\n"))
@@ -419,7 +421,8 @@ func TestOpenAICompatibleModelRawHTTPLogKeepsRunInRequestMinuteFile(t *testing.T
 	defer server.Close()
 
 	logDir := t.TempDir()
-	logger := newLLMRawHTTPLogger(logDir, "test-runtime")
+	logger := newLLMRawHTTPLogger(logDir, "")
+	logger.SetSessionIDProvider(func() string { return sessionID })
 	times := []time.Time{
 		time.Date(2026, 6, 21, 9, 4, 59, 0, time.UTC),
 		time.Date(2026, 6, 21, 9, 4, 59, 0, time.UTC),
@@ -460,13 +463,66 @@ func TestOpenAICompatibleModelRawHTTPLogKeepsRunInRequestMinuteFile(t *testing.T
 	if len(matches) != 1 {
 		t.Fatalf("raw HTTP request/response should stay in one file, got %d: %#v", len(matches), matches)
 	}
-	if !strings.Contains(filepath.Base(matches[0]), "llm-http-202606210904-test-runtime.log") {
+	if !strings.Contains(filepath.Base(matches[0]), "llm-http-202606210904-session-a.log") {
 		t.Fatalf("raw HTTP file should use request minute, got %s", filepath.Base(matches[0]))
 	}
 	logText := readRawHTTPLog(t, logDir)
 	counts := countRawHTTPKinds(t, logText)
 	if counts["request"] != 1 || counts["response"] != 1 {
 		t.Fatalf("raw HTTP log should contain one request and one response:\n%s", logText)
+	}
+}
+
+func TestRuntimeConfiguresRawHTTPLogWithActiveMemorySessionID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	rootDir := t.TempDir()
+	logDir := filepath.Join(rootDir, "log")
+	memoryDir := filepath.Join(rootDir, "memory")
+	manager := NewModelManager(ModelConfig{
+		Provider:   "openai",
+		BaseURL:    server.URL,
+		Model:      "test-model",
+		LogRawHTTP: true,
+	}, ProxyConfig{}, WithLLMRawHTTPLogDir(logDir))
+	memories := NewMemoryManager(memoryDir)
+	NewRuntimeWithDeps(Config{}, manager, memories, nil, nil)
+
+	model, err := manager.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	compatible, ok := model.(*openAICompatibleModel)
+	if !ok {
+		t.Fatalf("model = %T, want *openAICompatibleModel", model)
+	}
+	compatible.rawLogger.now = func() time.Time {
+		return time.Date(2026, 6, 21, 9, 4, 59, 0, time.UTC)
+	}
+
+	_, err = model.GenerateContent(contextWithRawHTTPLog(context.Background()), []llms.MessageContent{{
+		Role:  llms.ChatMessageTypeHuman,
+		Parts: []llms.ContentPart{llms.TextPart("hello")},
+	}})
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	metadata := readSessionMetadataForTest(t, filepath.Join(memoryDir, "session", sessionMetadataFileName))
+	matches, err := filepath.Glob(filepath.Join(logDir, "llm-http-*.log"))
+	if err != nil {
+		t.Fatalf("glob raw HTTP logs: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected one raw HTTP log file, got %d: %#v", len(matches), matches)
+	}
+	wantName := "llm-http-202606210904-" + metadata.SessionID + ".log"
+	if filepath.Base(matches[0]) != wantName {
+		t.Fatalf("raw HTTP file = %q, want %q", filepath.Base(matches[0]), wantName)
 	}
 }
 

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -369,9 +369,18 @@ func NewRuntimeWithDeps(cfg Config, models ModelResolver, memories *MemoryManage
 		runtimeID:     uuid.NewString(),
 		mobileGym:     &mobileGymSessionStore{},
 	}
-	// Set runtime ID for raw HTTP logging.
+	// Use the active memory session ID for raw HTTP log partitioning.
 	if modelManager, ok := models.(*ModelManager); ok {
-		modelManager.SetRuntimeID(rt.runtimeID)
+		modelManager.SetRawHTTPLogSessionIDProvider(func() string {
+			if memories == nil {
+				return ""
+			}
+			sessionID, err := memories.ActiveSessionID()
+			if err != nil {
+				return ""
+			}
+			return sessionID
+		})
 	}
 	if cfg.ConfigDir != "" {
 		rt.memoryPlane = NewFilesystemMemoryPlane(filepath.Join(cfg.ConfigDir, "memory"), LoadMemoryExtractionConfig(cfg.ConfigDir), nil)


### PR DESCRIPTION
## Summary
- Partition raw LLM HTTP log files by the active memory session ID instead of runtime ID
- Freeze the log file timestamp and session ID per HTTP call so request/response entries stay paired
- Add tests for session metadata creation, unsafe session metadata rejection, and runtime logger wiring

## Tests
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added active session ID support to expose the currently active memory session.
  * Updated raw HTTP request/response logging to include a session-based identifier for improved correlation.

* **Improvements**
  * Tightened validation for session-related identifiers to prevent unsafe path usage.
  * Updated session metadata handling to ensure consistent active-session directory initialization.

* **Tests**
  * Added unit tests for active session ID creation and rejection of unsafe metadata.
  * Updated/added tests to verify raw HTTP log filenames now include the active memory session ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->