### PR TITLE
fix(agent): clear spotlight search before typing

### DIFF
--- a/benchmark/suites/unit/tools/quick_action_android_v1.json
+++ b/benchmark/suites/unit/tools/quick_action_android_v1.json
@@ -69,7 +69,7 @@
       },
       "expect": {
         "ok": true,
-        "contains": ["spotlight_search"],
+        "contains": ["spotlight_search", "sequence", "backspace", "delay_ms_after"],
         "json": {
           "width": { "type": "number" },
           "height": { "type": "number" },

--- a/benchmark/suites/unit/tools/quick_action_ios_v1.json
+++ b/benchmark/suites/unit/tools/quick_action_ios_v1.json
@@ -86,7 +86,7 @@
       },
       "expect": {
         "ok": true,
-        "contains": ["spotlight_search"],
+        "contains": ["spotlight_search", "sequence", "backspace", "delay_ms_after"],
         "json": {
           "width": { "type": "number" },
           "height": { "type": "number" },

--- a/benchmark/suites/unit/tools/quick_action_mac_v1.json
+++ b/benchmark/suites/unit/tools/quick_action_mac_v1.json
@@ -35,7 +35,7 @@
       },
       "expect": {
         "ok": true,
-        "contains": ["spotlight_search"],
+        "contains": ["spotlight_search", "sequence", "backspace", "delay_ms_after"],
         "json": {
           "width": { "type": "number" },
           "height": { "type": "number" },
@@ -120,7 +120,7 @@
       },
       "expect": {
         "ok": true,
-        "contains": ["spotlight_search"],
+        "contains": ["spotlight_search", "sequence", "backspace"],
         "json": {
           "width": { "type": "number" },
           "height": { "type": "number" },

--- a/src/agent/internal/agent/quick_actions.json
+++ b/src/agent/internal/agent/quick_actions.json
@@ -211,29 +211,49 @@
       "platforms": {
         "ios": {
           "status": "active",
-          "tool": "keyboard_tap",
-          "input": { "keys": ["meta", "space"] },
-          "note": "external keyboard: Cmd+Space Spotlight Search (HID meta=0x08, space=0x2c)",
+          "steps": [
+            { "tool": "keyboard_tap", "input": { "keys": ["meta", "space"] }, "delay_ms_after": 600 },
+            { "tool": "keyboard_tap", "input": { "keys": ["meta", "a"] }, "delay_ms_after": 60 },
+            { "tool": "keyboard_tap", "input": { "keys": ["backspace"] }, "delay_ms_after": 60 },
+            { "tool": "keyboard_tap", "input": { "keys": ["meta", "a"] }, "delay_ms_after": 60 },
+            { "tool": "keyboard_tap", "input": { "keys": ["backspace"] } }
+          ],
+          "note": "external keyboard: Cmd+Space Spotlight Search, then Cmd+A Backspace twice to clear stale query",
           "alternatives": [
             {
               "status": "active",
-              "tool": "touch_gesture",
-              "input": { "type": "swipe_down", "strength": "medium", "anchor": 500 },
-              "note": "touch fallback: swipe down on home screen"
+              "steps": [
+                { "tool": "touch_gesture", "input": { "type": "swipe_down", "strength": "medium", "anchor": 500 }, "delay_ms_after": 600 },
+                { "tool": "keyboard_tap", "input": { "keys": ["meta", "a"] }, "delay_ms_after": 60 },
+                { "tool": "keyboard_tap", "input": { "keys": ["backspace"] }, "delay_ms_after": 60 },
+                { "tool": "keyboard_tap", "input": { "keys": ["meta", "a"] }, "delay_ms_after": 60 },
+                { "tool": "keyboard_tap", "input": { "keys": ["backspace"] } }
+              ],
+              "note": "touch fallback: swipe down on home screen, then clear stale query"
             }
           ]
         },
         "android": {
           "status": "active",
-          "tool": "keyboard_tap",
-          "input": { "keys": ["meta"] },
-          "note": "verified: Meta alone opens app / global search"
+          "steps": [
+            { "tool": "keyboard_tap", "input": { "keys": ["meta"] }, "delay_ms_after": 600 },
+            { "tool": "keyboard_tap", "input": { "keys": ["ctrl", "a"] }, "delay_ms_after": 60 },
+            { "tool": "keyboard_tap", "input": { "keys": ["backspace"] }, "delay_ms_after": 60 },
+            { "tool": "keyboard_tap", "input": { "keys": ["ctrl", "a"] }, "delay_ms_after": 60 },
+            { "tool": "keyboard_tap", "input": { "keys": ["backspace"] } }
+          ],
+          "note": "verified: Meta alone opens app / global search, then Ctrl+A Backspace twice to clear stale query"
         },
         "mac": {
           "status": "active",
-          "tool": "keyboard_tap",
-          "input": { "keys": ["meta", "space"] },
-          "note": "Spotlight (Cmd+Space)"
+          "steps": [
+            { "tool": "keyboard_tap", "input": { "keys": ["meta", "space"] }, "delay_ms_after": 600 },
+            { "tool": "keyboard_tap", "input": { "keys": ["meta", "a"] }, "delay_ms_after": 60 },
+            { "tool": "keyboard_tap", "input": { "keys": ["backspace"] }, "delay_ms_after": 60 },
+            { "tool": "keyboard_tap", "input": { "keys": ["meta", "a"] }, "delay_ms_after": 60 },
+            { "tool": "keyboard_tap", "input": { "keys": ["backspace"] } }
+          ],
+          "note": "Spotlight (Cmd+Space), then Cmd+A Backspace twice to clear stale query"
         }
       }
     },

--- a/src/agent/internal/agent/tools_quick_actions.go
+++ b/src/agent/internal/agent/tools_quick_actions.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 	"unicode"
 )
 
@@ -35,8 +36,16 @@ type quickActionBinding struct {
 	Status       string               `json:"status"`
 	Tool         string               `json:"tool"`
 	Input        json.RawMessage      `json:"input"`
+	Steps        []quickActionStep    `json:"steps,omitempty"`
 	Note         string               `json:"note,omitempty"`
 	Alternatives []quickActionBinding `json:"alternatives,omitempty"`
+}
+
+type quickActionStep struct {
+	Tool         string          `json:"tool"`
+	Input        json.RawMessage `json:"input"`
+	DelayMsAfter int             `json:"delay_ms_after,omitempty"`
+	Note         string          `json:"note,omitempty"`
 }
 
 type quickActionDefinition struct {
@@ -451,34 +460,83 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 	}
 
 	toolName := strings.TrimSpace(selected.Tool)
-	if toolName == "" {
-		note := strings.TrimSpace(selected.Note)
-		if note == "" {
-			note = "no tool binding configured"
+	var payload []byte
+	var output string
+	var stepResults []map[string]interface{}
+	if len(selected.Steps) > 0 {
+		output = "ok"
+		stepResults = make([]map[string]interface{}, 0, len(selected.Steps))
+		for i, step := range selected.Steps {
+			stepTool := strings.TrimSpace(step.Tool)
+			if stepTool == "" {
+				return t.errorJSON(fmt.Sprintf("action %q step %d has no tool binding configured", actionID, i+1)), nil
+			}
+			stepPayload, err := json.Marshal(step.Input)
+			if err != nil {
+				return t.errorJSON(fmt.Sprintf("invalid action step %d input: %v", i+1, err)), nil
+			}
+			stepOutput, err := t.delegate(ctx, stepTool, string(stepPayload))
+			if err != nil {
+				return fmt.Sprintf("error: %v", err), nil
+			}
+			stepResult := map[string]interface{}{
+				"index":  i + 1,
+				"tool":   stepTool,
+				"input":  json.RawMessage(stepPayload),
+				"output": stepOutput,
+			}
+			if step.DelayMsAfter > 0 {
+				stepResult["delay_ms_after"] = step.DelayMsAfter
+			}
+			stepResults = append(stepResults, stepResult)
+			if strings.HasPrefix(stepOutput, "error:") {
+				return jsonString(map[string]interface{}{
+					"ok":          false,
+					"action":      actionID,
+					"label":       action.Label,
+					"platform":    platform,
+					"binding":     selectedSource,
+					"tool":        "sequence",
+					"failed_step": i + 1,
+					"output":      stepOutput,
+					"steps":       stepResults,
+				}), nil
+			}
+			if err := sleepQuickActionDelay(ctx, step.DelayMsAfter); err != nil {
+				return "", err
+			}
 		}
-		return t.errorJSON(note), nil
-	}
+	} else {
+		if toolName == "" {
+			note := strings.TrimSpace(selected.Note)
+			if note == "" {
+				note = "no tool binding configured"
+			}
+			return t.errorJSON(note), nil
+		}
 
-	payload, err := json.Marshal(selected.Input)
-	if err != nil {
-		return t.errorJSON(fmt.Sprintf("invalid action input: %v", err)), nil
-	}
+		var err error
+		payload, err = json.Marshal(selected.Input)
+		if err != nil {
+			return t.errorJSON(fmt.Sprintf("invalid action input: %v", err)), nil
+		}
 
-	output, err := t.delegate(ctx, toolName, string(payload))
-	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
-	}
-	if strings.HasPrefix(output, "error:") {
-		return jsonString(map[string]interface{}{
-			"ok":       false,
-			"action":   actionID,
-			"label":    action.Label,
-			"platform": platform,
-			"binding":  selectedSource,
-			"tool":     toolName,
-			"input":    json.RawMessage(payload),
-			"output":   output,
-		}), nil
+		output, err = t.delegate(ctx, toolName, string(payload))
+		if err != nil {
+			return fmt.Sprintf("error: %v", err), nil
+		}
+		if strings.HasPrefix(output, "error:") {
+			return jsonString(map[string]interface{}{
+				"ok":       false,
+				"action":   actionID,
+				"label":    action.Label,
+				"platform": platform,
+				"binding":  selectedSource,
+				"tool":     toolName,
+				"input":    json.RawMessage(payload),
+				"output":   output,
+			}), nil
+		}
 	}
 
 	result := map[string]interface{}{
@@ -487,9 +545,14 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 		"label":    action.Label,
 		"platform": platform,
 		"binding":  selectedSource,
-		"tool":     toolName,
-		"input":    json.RawMessage(payload),
 		"output":   output,
+	}
+	if len(selected.Steps) > 0 {
+		result["tool"] = "sequence"
+		result["steps"] = stepResults
+	} else {
+		result["tool"] = toolName
+		result["input"] = json.RawMessage(payload)
 	}
 	if note := strings.TrimSpace(selected.Note); note != "" {
 		result["note"] = note
@@ -523,6 +586,20 @@ func (t *QuickActionTool) delegate(ctx context.Context, toolName, payload string
 		return t.touch.Call(ctx, payload)
 	default:
 		return "", fmt.Errorf("unsupported delegated tool %q", toolName)
+	}
+}
+
+func sleepQuickActionDelay(ctx context.Context, delayMs int) error {
+	if delayMs <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(time.Duration(delayMs) * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }
 

--- a/src/agent/internal/agent/tools_quick_actions_test.go
+++ b/src/agent/internal/agent/tools_quick_actions_test.go
@@ -179,6 +179,69 @@ func TestQuickActionExecutesDelegatedKeyboardTap(t *testing.T) {
 	}
 }
 
+func TestQuickActionSpotlightSearchClearsSearchField(t *testing.T) {
+	dev, path := newTestHIDDevice(t)
+	tool := &QuickActionTool{
+		keyboard: &KeyboardTapTool{dev: dev},
+	}
+	out, err := tool.Call(context.Background(), `{"action":"spotlight_search","platform":"ios"}`)
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if !quickActionResultOK(t, out) {
+		t.Fatalf("unexpected output: %s", out)
+	}
+
+	reports := readKeyboardReports(t, dev, path)
+	if got, want := len(reports), 10; got != want {
+		t.Fatalf("keyboard reports = %d, want %d (Cmd+Space, two Cmd+A/Backspace clear passes): %v", got, want, reports)
+	}
+	assertKeyboardReport(t, reports[0], hidModifierMap["meta"], hidKeyboardMap["space"], "Cmd+Space")
+	assertReleaseReport(t, reports[1], "release after Cmd+Space")
+	assertKeyboardReport(t, reports[2], hidModifierMap["meta"], hidKeyboardMap["a"], "first Cmd+A")
+	assertReleaseReport(t, reports[3], "release after first Cmd+A")
+	assertKeyboardReport(t, reports[4], 0, hidKeyboardMap["backspace"], "first Backspace")
+	assertReleaseReport(t, reports[5], "release after first Backspace")
+	assertKeyboardReport(t, reports[6], hidModifierMap["meta"], hidKeyboardMap["a"], "second Cmd+A")
+	assertReleaseReport(t, reports[7], "release after second Cmd+A")
+	assertKeyboardReport(t, reports[8], 0, hidKeyboardMap["backspace"], "second Backspace")
+	assertReleaseReport(t, reports[9], "release after second Backspace")
+}
+
+func readKeyboardReports(t *testing.T, dev *HIDDevice, path string) [][]byte {
+	t.Helper()
+
+	dev.Close()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(data)%8 != 0 {
+		t.Fatalf("keyboard report data length = %d, want multiple of 8", len(data))
+	}
+	reports := make([][]byte, 0, len(data)/8)
+	for i := 0; i < len(data); i += 8 {
+		reports = append(reports, data[i:i+8])
+	}
+	return reports
+}
+
+func assertKeyboardReport(t *testing.T, report []byte, modifier, key uint8, label string) {
+	t.Helper()
+	if report[0] != modifier || report[2] != key {
+		t.Fatalf("%s report = %v, want modifier 0x%02x key 0x%02x", label, report, modifier, key)
+	}
+}
+
+func assertReleaseReport(t *testing.T, report []byte, label string) {
+	t.Helper()
+	for _, b := range report {
+		if b != 0 {
+			t.Fatalf("%s = %v, want all zeros", label, report)
+		}
+	}
+}
+
 func TestQuickActionDeleteBackwardUsesBackspace(t *testing.T) {
 	dev, path := newTestHIDDevice(t)
 	tool := &QuickActionTool{


### PR DESCRIPTION
## Summary
- Add multi-step quick_action execution with per-step delays
- Update spotlight_search to open search and clear stale query before typing
- Extend quick_action benchmark suites to cover the sequence/backspace behavior

## Test Plan
- go test ./internal/agent -run 'TestQuickAction' -count=1
- uv run pytest tests/test_unit.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-step quick actions with timing control across iOS, Android, and macOS.
  * Enhanced spotlight search to clear stale queries with configurable delays between actions.

* **Tests**
  * Added comprehensive tests for spotlight search verification across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->