### PR TITLE
fix(agent): recover empty session metadata

### DIFF
--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -795,7 +795,7 @@ func ensureActiveSessionMetadata(sessionDir string, now time.Time) (sessionMetad
 	path := filepath.Join(sessionDir, sessionMetadataFileName)
 	if meta, err := readSessionMetadata(path); err == nil && strings.TrimSpace(meta.SessionID) != "" {
 		return meta, nil
-	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) && !isTruncatedJSONLineError(err) {
 		return sessionMetadata{}, err
 	}
 	return writeNewSessionMetadata(sessionDir, now)

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -95,6 +95,38 @@ func TestMemoryManagerActiveSessionIDCreatesSessionMetadata(t *testing.T) {
 	}
 }
 
+func TestMemoryManagerActiveSessionIDRecoversEmptySessionMetadata(t *testing.T) {
+	storageDir := t.TempDir()
+	sessionDir := filepath.Join(storageDir, "session")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("create session dir: %v", err)
+	}
+	metadataPath := filepath.Join(sessionDir, sessionMetadataFileName)
+	if err := os.WriteFile(metadataPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty metadata: %v", err)
+	}
+
+	manager := NewMemoryManager(storageDir)
+	sessionID, err := manager.ActiveSessionID()
+	if err != nil {
+		t.Fatalf("ActiveSessionID() error = %v", err)
+	}
+	if sessionID == "" {
+		t.Fatal("ActiveSessionID() returned empty session ID")
+	}
+	metadata := readSessionMetadataForTest(t, metadataPath)
+	if metadata.SessionID != sessionID {
+		t.Fatalf("metadata session_id = %q, want %q", metadata.SessionID, sessionID)
+	}
+	info, err := os.Stat(metadataPath)
+	if err != nil {
+		t.Fatalf("stat metadata: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("metadata file was not rewritten")
+	}
+}
+
 func TestMemoryManagerActiveSessionIDRejectsUnsafeMetadata(t *testing.T) {
 	for _, sessionID := range []string{
 		"../escape",


### PR DESCRIPTION
## Summary
- Recreate active session metadata when metadata.json is empty or truncated.
- Keep unsafe/other malformed session IDs rejected.
- Add a regression test for empty metadata recovery.

## Test Plan
- go test ./internal/agent -count=1
- GOOS=linux GOARCH=arm GOARM=7 go build -buildvcs=false -o ../../build/bin/agent ./cmd/daemon
- git diff --check

## Device Verification
- Recovered /userdata/agent/memory/session/metadata.json on 192.168.31.107.
- Deployed patched /oem/usr/bin/agent and confirmed the post-deploy request reached session boundary without parse session metadata errors.