### PR TITLE
fix(agent): require handoff before sensitive aborts

### DIFF
--- a/src/agent/internal/agent/loop_executor_meta_tools.go
+++ b/src/agent/internal/agent/loop_executor_meta_tools.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	toolFinishStep = "finish_step"
-	toolAbortStep  = "abort_step"
+	toolFinishStep       = "finish_step"
+	toolAbortStep        = "abort_step"
+	toolHumanHandoffStep = "request_human_handoff"
 )
 
 func executorMetaTools() []langtools.Tool {

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -1256,9 +1256,8 @@ func parseDefaultFinalReview(raw, candidateAnswer string) defaultFinalReview {
 	var review defaultFinalReview
 	if decodeRoleJSON(raw, &review) != nil {
 		return defaultFinalReview{
-			CanFinish:   true,
-			FinalAnswer: strings.TrimSpace(candidateAnswer),
-			Reason:      "default final review returned non-JSON; accepting candidate answer",
+			CanFinish: false,
+			Reason:    "default final review returned non-JSON; replanning required",
 		}
 	}
 	review.FinalAnswer = strings.TrimSpace(review.FinalAnswer)

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -1223,6 +1223,10 @@ func buildDefaultFinalReviewPrompt(inputs map[string]string, state roleLoopState
 	builder.WriteString("Default-mode final-answer review.\n")
 	builder.WriteString("Decide whether the candidate final answer may end the run, or whether the runtime must continue.\n")
 	builder.WriteString("Return only JSON: {\"can_finish\":true|false,\"final_answer\":\"optional revised final answer when can_finish is true\",\"needs_human_handoff\":true|false,\"handoff_reason\":\"authentication|login_method_selection|captcha|verification_code|sensitive_operation|redirect_confirmation|permission_confirmation|black_screen|ambiguous_situation|unsupported_action|stuck|other\",\"handoff_details\":\"specific device-side blocker\",\"suggested_action\":\"what the user should do on the device\",\"reason\":\"brief rationale\"}.\n\n")
+	builder.WriteString("Language rule:\n")
+	builder.WriteString("- Use ")
+	builder.WriteString(defaultFinalReviewLanguageHint(inputs))
+	builder.WriteString(" for every free-text JSON value that may be shown to the user or reused in a handoff message, including final_answer, handoff_details, suggested_action, and reason. Keep enum fields such as handoff_reason in English.\n\n")
 	builder.WriteString("Rules:\n")
 	builder.WriteString("- can_finish=true only when the original request is already satisfied by the evidence, or the candidate is a truthful terminal failure/status answer that needs no more user or device action.\n")
 	builder.WriteString("- needs_human_handoff=true when progress is blocked on a human-only action on the target device: private credentials, choosing an account or login path, CAPTCHA, verification, biometric/identity checks, system/app redirect confirmations, permission dialogs, or judgment the tools cannot provide.\n")
@@ -1239,6 +1243,13 @@ func buildDefaultFinalReviewPrompt(inputs map[string]string, state roleLoopState
 		builder.WriteString("(empty)")
 	}
 	return strings.TrimSpace(builder.String())
+}
+
+func defaultFinalReviewLanguageHint(inputs map[string]string) string {
+	if containsHanRunes(strings.TrimSpace(inputs["input"])) {
+		return "Simplified Chinese, matching the latest user request"
+	}
+	return "the same language as the latest user request"
 }
 
 func parseDefaultFinalReview(raw, candidateAnswer string) defaultFinalReview {

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -62,6 +62,16 @@ type verifierDecision struct {
 	ObservedState observedWorldState `json:"observed_state,omitempty"`
 }
 
+type defaultFinalReview struct {
+	CanFinish         bool   `json:"can_finish"`
+	FinalAnswer       string `json:"final_answer,omitempty"`
+	NeedsHumanHandoff bool   `json:"needs_human_handoff,omitempty"`
+	HandoffReason     string `json:"handoff_reason,omitempty"`
+	HandoffDetails    string `json:"handoff_details,omitempty"`
+	SuggestedAction   string `json:"suggested_action,omitempty"`
+	Reason            string `json:"reason,omitempty"`
+}
+
 type roleExecutionResult struct {
 	Action          *schema.AgentAction
 	Step            *schema.AgentStep
@@ -272,6 +282,74 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					if consumed {
 						continue
 					}
+					if state.shouldReviewDefaultFinal(plannerToolSpecs) {
+						review, err := e.callDefaultFinalReview(ctx, inputs, state, turn.Answer, options...)
+						if err != nil {
+							return nil, err
+						}
+						if review.NeedsHumanHandoff {
+							handoffTurn, err := e.executeDefaultFinalHandoff(ctx, &state, plannerToolSpecs, review)
+							if err != nil {
+								return nil, err
+							}
+							if handoffTurn.Step != nil {
+								state.ToolSteps = append(state.ToolSteps, *handoffTurn.Step)
+								state.World.UpdateFromStep(*handoffTurn.Step, len(state.ToolSteps), e.Tools)
+							}
+							if handoffTurn.Kind == plannerTurnTool {
+								consumed, err := e.consumeSteerInterruptIfSignaled(ctx, inputs, &state)
+								if err != nil {
+									return nil, err
+								}
+								if consumed {
+									continue
+								}
+								if _, err := e.consumePendingSteer(ctx, inputs, &state); err != nil {
+									return nil, err
+								}
+								state.noteDefaultToolCallAndMaybeTodoReminder()
+							}
+							if handoffTurn.Kind == plannerTurnSleep {
+								consumed, err := e.consumeSteerInterruptIfSignaled(ctx, inputs, &state)
+								if err != nil {
+									return nil, err
+								}
+								if consumed {
+									continue
+								}
+								consumed, err = e.consumeFinalPendingSteer(ctx, inputs, &state)
+								if err != nil {
+									return nil, err
+								}
+								if consumed {
+									continue
+								}
+								answer := runPausingToolFinalAnswer(handoffTurn.Step)
+								if e.Recorder != nil {
+									e.Recorder.RecordDefaultFinish(answer)
+								}
+								return e.finishRunWithoutStreaming(ctx, answer, answer, &state)
+							}
+							continue
+						}
+						if !review.CanFinish {
+							state.Phase = phasePlan
+							state.PlanCommitRequired = true
+							state.PlannerReason = defaultString(review.Reason, "default final review requested replanning")
+							state.VerifierResults = append(state.VerifierResults, verifierDecision{
+								CanFinish:   false,
+								NeedsReplan: true,
+								Reason:      state.PlannerReason,
+							})
+							if e.Recorder != nil {
+								e.Recorder.RecordLoopPhase(phasePlan, state.PlannerReason)
+							}
+							continue
+						}
+						if answer := strings.TrimSpace(review.FinalAnswer); answer != "" {
+							turn.Answer = answer
+						}
+					}
 					if e.Recorder != nil {
 						e.Recorder.RecordDefaultFinish(turn.Answer)
 					}
@@ -355,7 +433,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					if consumed {
 						continue
 					}
-					answer := waitForWakeupFinalAnswer(turn.Step)
+					answer := runPausingToolFinalAnswer(turn.Step)
 					if e.Recorder != nil {
 						e.Recorder.RecordDefaultFinish(answer)
 					}
@@ -416,7 +494,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					if consumed {
 						continue
 					}
-					answer := waitForWakeupFinalAnswer(turn.Step)
+					answer := runPausingToolFinalAnswer(turn.Step)
 					if e.Recorder != nil {
 						e.Recorder.RecordDefaultFinish(answer)
 					}
@@ -730,7 +808,7 @@ func (e *roleCollaborativeExecutor) executePlannerToolAction(
 		e.Recorder.RecordPlannerExecution(execution)
 	}
 	kind := plannerTurnTool
-	if isWaitForWakeupTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError {
+	if isRunPausingTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError {
 		kind = plannerTurnSleep
 	}
 	return plannerTurnResult{Kind: kind, Step: &toolExecution.Step}, nil
@@ -1031,7 +1109,7 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 	}
 	actionCopy := toolExecution.Step.Action
 	kind := executorTurnTool
-	if isWaitForWakeupTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError {
+	if isRunPausingTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError {
 		kind = executorTurnSleep
 	}
 	return executorTurnResult{
@@ -1064,6 +1142,165 @@ func (e *roleCollaborativeExecutor) callVerifier(ctx context.Context, inputs map
 	}
 	e.emitRoleOutput(ctx, RoleVerifier, roleResponseDebugText(res))
 	return parseVerifierDecision(contentResponseText(res), state.lastCandidateAnswer()), nil
+}
+
+func (s roleLoopState) shouldReviewDefaultFinal(toolSpecs *ToolSpecs) bool {
+	if s.Phase != phaseDefault || len(s.ExecutionResults) == 0 {
+		return false
+	}
+	if last := s.lastExecutionTool(); toolNameEqual(last, toolHumanHandoffStep) || isWaitForWakeupTool(last) {
+		return false
+	}
+	for _, result := range s.ExecutionResults {
+		if result.Action == nil {
+			continue
+		}
+		if shouldReviewDefaultFinalTool(result.Action.Tool, toolSpecs) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s roleLoopState) lastExecutionTool() string {
+	for i := len(s.ExecutionResults) - 1; i >= 0; i-- {
+		if s.ExecutionResults[i].Action != nil {
+			return strings.TrimSpace(s.ExecutionResults[i].Action.Tool)
+		}
+	}
+	return ""
+}
+
+func shouldReviewDefaultFinalTool(toolName string, toolSpecs *ToolSpecs) bool {
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		return false
+	}
+	category := ""
+	if spec, ok := toolSpecs.Lookup(toolName); ok {
+		category = strings.TrimSpace(spec.Category)
+	} else if meta, ok := builtInToolSpecMetadata[toolName]; ok {
+		category = strings.TrimSpace(meta.Category)
+	}
+	switch category {
+	case "phone", "input", "observation", "handoff":
+		return true
+	default:
+		return false
+	}
+}
+
+func (e *roleCollaborativeExecutor) callDefaultFinalReview(
+	ctx context.Context,
+	inputs map[string]string,
+	state roleLoopState,
+	candidateAnswer string,
+	options ...chains.ChainCallOption,
+) (defaultFinalReview, error) {
+	messages := []llms.MessageContent{
+		{
+			Role: llms.ChatMessageTypeSystem,
+			Parts: []llms.ContentPart{llms.TextPart(
+				"You are a strict final-answer gate for an agent that operates external devices. " +
+					"Return only JSON. Do not solve the task yourself and do not ask the user anything directly.",
+			)},
+		},
+		{
+			Role:  llms.ChatMessageTypeHuman,
+			Parts: buildRoleUserMessageParts(buildDefaultFinalReviewPrompt(inputs, state, candidateAnswer), e.InputAttachments, state.World, true),
+		},
+	}
+	res, err := e.generateRoleContent(ctx, RoleVerifier, messages, chains.GetLLMCallOptions(options...)...)
+	if err != nil {
+		return defaultFinalReview{}, err
+	}
+	e.emitRoleOutput(ctx, RoleVerifier, roleResponseDebugText(res))
+	return parseDefaultFinalReview(contentResponseText(res), candidateAnswer), nil
+}
+
+func buildDefaultFinalReviewPrompt(inputs map[string]string, state roleLoopState, candidateAnswer string) string {
+	var builder strings.Builder
+	builder.WriteString("Default-mode final-answer review.\n")
+	builder.WriteString("Decide whether the candidate final answer may end the run, or whether the runtime must continue.\n")
+	builder.WriteString("Return only JSON: {\"can_finish\":true|false,\"final_answer\":\"optional revised final answer when can_finish is true\",\"needs_human_handoff\":true|false,\"handoff_reason\":\"authentication|login_method_selection|captcha|verification_code|sensitive_operation|redirect_confirmation|permission_confirmation|black_screen|ambiguous_situation|unsupported_action|stuck|other\",\"handoff_details\":\"specific device-side blocker\",\"suggested_action\":\"what the user should do on the device\",\"reason\":\"brief rationale\"}.\n\n")
+	builder.WriteString("Rules:\n")
+	builder.WriteString("- can_finish=true only when the original request is already satisfied by the evidence, or the candidate is a truthful terminal failure/status answer that needs no more user or device action.\n")
+	builder.WriteString("- needs_human_handoff=true when progress is blocked on a human-only action on the target device: private credentials, choosing an account or login path, CAPTCHA, verification, biometric/identity checks, system/app redirect confirmations, permission dialogs, or judgment the tools cannot provide.\n")
+	builder.WriteString("- For handoff, set can_finish=false and fill handoff_reason, handoff_details, and suggested_action. The user must complete the action on the device; do not ask for secrets in chat.\n")
+	builder.WriteString("- If more tool work is possible and no human handoff is required, set can_finish=false and needs_human_handoff=false.\n")
+	writeWorldStateWithOptions(&builder, state.World, worldStatePromptOptions{IncludeLatestScreenshot: true})
+	writeRequestContextAndCriteria(&builder, inputs, state)
+	writeSessionContext(&builder, inputs)
+	writeExecutorEvidence(&builder, state)
+	builder.WriteString("\n\nCandidate final answer:\n")
+	if answer := strings.TrimSpace(candidateAnswer); answer != "" {
+		builder.WriteString(answer)
+	} else {
+		builder.WriteString("(empty)")
+	}
+	return strings.TrimSpace(builder.String())
+}
+
+func parseDefaultFinalReview(raw, candidateAnswer string) defaultFinalReview {
+	var review defaultFinalReview
+	if decodeRoleJSON(raw, &review) != nil {
+		return defaultFinalReview{
+			CanFinish:   true,
+			FinalAnswer: strings.TrimSpace(candidateAnswer),
+			Reason:      "default final review returned non-JSON; accepting candidate answer",
+		}
+	}
+	review.FinalAnswer = strings.TrimSpace(review.FinalAnswer)
+	review.Reason = strings.TrimSpace(review.Reason)
+	review.HandoffReason = normalizeHandoffReason(review.HandoffReason)
+	review.HandoffDetails = strings.TrimSpace(review.HandoffDetails)
+	review.SuggestedAction = strings.TrimSpace(review.SuggestedAction)
+	if review.NeedsHumanHandoff {
+		review.CanFinish = false
+		if review.HandoffDetails == "" {
+			review.HandoffDetails = firstNonEmptyString([]string{
+				review.Reason,
+				"Human action is required before the device task can continue.",
+			})
+		}
+		return review
+	}
+	if review.CanFinish {
+		if review.FinalAnswer == "" {
+			review.FinalAnswer = strings.TrimSpace(candidateAnswer)
+		}
+		return review
+	}
+	if review.Reason == "" {
+		review.Reason = "default final review rejected the candidate final answer"
+	}
+	return review
+}
+
+func (e *roleCollaborativeExecutor) executeDefaultFinalHandoff(
+	ctx context.Context,
+	state *roleLoopState,
+	toolSpecs *ToolSpecs,
+	review defaultFinalReview,
+) (plannerTurnResult, error) {
+	if _, ok := toolSpecs.Lookup(toolHumanHandoffStep); !ok {
+		return plannerTurnResult{}, fmt.Errorf("%s is required by default final review but is unavailable", toolHumanHandoffStep)
+	}
+	payload, _ := json.Marshal(HumanHandoffRequest{
+		Reason:          normalizeHandoffReason(review.HandoffReason),
+		Details:         firstNonEmptyString([]string{review.HandoffDetails, review.Reason, "Human action is required before the device task can continue."}),
+		SuggestedAction: strings.TrimSpace(review.SuggestedAction),
+	})
+	action := schema.AgentAction{
+		Tool:      toolHumanHandoffStep,
+		ToolInput: string(payload),
+		Log: formatToolActionLog(toolHumanHandoffStep, string(payload), firstNonEmptyString([]string{
+			review.SuggestedAction,
+			review.HandoffDetails,
+			review.Reason,
+		}), "\n"),
+	}
+	return e.executePlannerToolAction(ctx, state, toolSpecs, action)
 }
 
 func (e *roleCollaborativeExecutor) generateRoleContent(ctx context.Context, role RoleName, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
@@ -1171,6 +1408,8 @@ func isPlannerReadOnlyTool(name string, specs *ToolSpecs) bool {
 func isPlannerReadOnlyToolSpec(spec ToolSpec) bool {
 	switch strings.ToLower(strings.TrimSpace(spec.Category)) {
 	case "observation", "web":
+		return true
+	case "handoff":
 		return true
 	case "memory":
 		switch spec.Name {

--- a/src/agent/internal/agent/role_loop.go
+++ b/src/agent/internal/agent/role_loop.go
@@ -114,6 +114,18 @@ func isWaitForWakeupTool(name string) bool {
 	return toolNameEqual(name, toolWaitForWakeup)
 }
 
+func isHumanHandoffTool(name string) bool {
+	return toolNameEqual(name, toolHumanHandoffStep)
+}
+
+func isRunPausingTool(name string) bool {
+	return isWaitForWakeupTool(name) || isHumanHandoffTool(name)
+}
+
+func runPausingToolFinalAnswer(step *schema.AgentStep) string {
+	return waitForWakeupFinalAnswer(step)
+}
+
 func waitForWakeupFinalAnswer(step *schema.AgentStep) string {
 	if step != nil {
 		if content := toolContentFromAction(step.Action); content != "" {

--- a/src/agent/internal/agent/role_loop.go
+++ b/src/agent/internal/agent/role_loop.go
@@ -123,7 +123,45 @@ func isRunPausingTool(name string) bool {
 }
 
 func runPausingToolFinalAnswer(step *schema.AgentStep) string {
+	if step != nil && isHumanHandoffTool(step.Action.Tool) {
+		return humanHandoffFinalAnswer(step)
+	}
 	return waitForWakeupFinalAnswer(step)
+}
+
+func humanHandoffFinalAnswer(step *schema.AgentStep) string {
+	if step != nil {
+		if content := toolContentFromAction(step.Action); content != "" {
+			return content
+		}
+		if message := humanHandoffMessageFromInput(step.Action.ToolInput); message != "" {
+			return message
+		}
+		if message := humanHandoffMessageFromObservation(step.Observation); message != "" {
+			return message
+		}
+	}
+	return waitForWakeupFinalAnswer(step)
+}
+
+func humanHandoffMessageFromInput(input string) string {
+	var req HumanHandoffRequest
+	if err := json.Unmarshal([]byte(strings.TrimSpace(input)), &req); err != nil {
+		return ""
+	}
+	return firstNonEmptyString([]string{req.SuggestedAction, req.Details})
+}
+
+func humanHandoffMessageFromObservation(observation string) string {
+	var payload struct {
+		Message         string `json:"message"`
+		SuggestedAction string `json:"suggested_action"`
+		Details         string `json:"details"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation)), &payload); err != nil {
+		return ""
+	}
+	return firstNonEmptyString([]string{payload.Message, payload.SuggestedAction, payload.Details})
 }
 
 func waitForWakeupFinalAnswer(step *schema.AgentStep) string {

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -310,9 +310,9 @@ func TestDefaultFinalReviewConvertsHumanQuestionToHandoff(t *testing.T) {
 		"can_finish": false,
 		"needs_human_handoff": true,
 		"handoff_reason": "login_method_selection",
-		"handoff_details": "The current screen requires the user to choose a login method before the login can continue.",
-		"suggested_action": "Please choose the login method on the phone, then tell me to continue.",
-		"reason": "manual login method selection is required"
+		"handoff_details": "当前页面需要用户在手机上选择登录方式后才能继续。",
+		"suggested_action": "请在手机上选择登录方式，完成后告诉我继续。",
+		"reason": "需要用户选择登录方式"
 	}`
 	model := &scriptedModel{responses: []*llms.ContentResponse{
 		toolCallResponse("screen_1", "screenshot", `{"__arg1":"{}"}`),
@@ -345,7 +345,7 @@ func TestDefaultFinalReviewConvertsHumanQuestionToHandoff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Call() error = %v", err)
 	}
-	if output := strings.TrimSpace(fmt.Sprint(result["output"])); output != "Please choose the login method on the phone, then tell me to continue." {
+	if output := strings.TrimSpace(fmt.Sprint(result["output"])); output != "请在手机上选择登录方式，完成后告诉我继续。" {
 		t.Fatalf("output = %q", output)
 	}
 	if !toolCallsContain(handler.calls, toolHumanHandoffStep) {
@@ -353,6 +353,35 @@ func TestDefaultFinalReviewConvertsHumanQuestionToHandoff(t *testing.T) {
 	}
 	if model.callCount != 3 {
 		t.Fatalf("model call count = %d, want 3", model.callCount)
+	}
+}
+
+func TestDefaultFinalReviewPromptRequestsChineseForChineseInput(t *testing.T) {
+	prompt := buildDefaultFinalReviewPrompt(
+		map[string]string{"input": "打开小红书登录我的账号", "history": ""},
+		roleLoopState{},
+		"请问你想用哪种方式登录？",
+	)
+	if !strings.Contains(prompt, "Simplified Chinese, matching the latest user request") {
+		t.Fatalf("prompt should request Simplified Chinese for Chinese input:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "handoff_details, suggested_action") {
+		t.Fatalf("prompt should apply language rule to handoff fields:\n%s", prompt)
+	}
+}
+
+func TestHumanHandoffPauseUsesSuggestedActionWithoutToolContent(t *testing.T) {
+	action := schema.AgentAction{
+		Tool:      toolHumanHandoffStep,
+		ToolInput: `{"reason":"login_method_selection","details":"当前需要选择登录方式。","suggested_action":"请在手机上选择登录方式，完成后告诉我继续。"}`,
+	}
+	step := &schema.AgentStep{
+		Action:      action,
+		Observation: `{"status":"HUMAN_HANDOFF_REQUESTED","reason":"login_method_selection","details":"当前需要选择登录方式。","suggested_action":"请在手机上选择登录方式，完成后告诉我继续。"}`,
+	}
+
+	if got := runPausingToolFinalAnswer(step); got != "请在手机上选择登录方式，完成后告诉我继续。" {
+		t.Fatalf("final answer = %q", got)
 	}
 }
 

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -10,6 +11,15 @@ import (
 	"github.com/tmc/langchaingo/schema"
 	langtools "github.com/tmc/langchaingo/tools"
 )
+
+func toolCallsContain(calls []ToolCall, name string) bool {
+	for _, call := range calls {
+		if toolNameEqual(call.Action.Tool, name) {
+			return true
+		}
+	}
+	return false
+}
 
 func TestDefaultModeFinishesWithoutVerifier(t *testing.T) {
 	model := &scriptedModel{responses: roleDirectResponses("done")}
@@ -227,6 +237,125 @@ func TestDecisionPhaseUseSimpleModeSwitchesToDefaultWithoutToolStep(t *testing.T
 	}
 }
 
+func TestDefaultModeExposesHumanHandoffTool(t *testing.T) {
+	model := &scriptedModel{responses: []*llms.ContentResponse{
+		toolCallResponse("handoff_1", toolHumanHandoffStep, `{"reason":"authentication","details":"manual login confirmation is required"}`),
+	}}
+	executor := newRoleCollaborativeExecutor(
+		model,
+		RoleProfiles{Planner: RoleProfile{Name: RolePlanner, SystemPrompt: "planner"}},
+		[]langtools.Tool{NewHumanHandoffTool()},
+		nil,
+		10,
+		nil,
+		nil,
+		nil,
+		ScreenshotPruningConfig{},
+		nil,
+	)
+	state := &roleLoopState{Phase: phaseDefault}
+	inputs := map[string]string{"input": "登录当前页面", "history": ""}
+
+	turn, err := executor.callPlannerTurn(context.Background(), inputs, state, toolSpecsForRole(RolePlanner, executor.Tools))
+	if err != nil {
+		t.Fatalf("planner turn error: %v", err)
+	}
+	if turn.Kind != plannerTurnSleep || turn.Step == nil {
+		t.Fatalf("turn = %#v, want handoff tool execution that pauses the run", turn)
+	}
+	if turn.Step.Action.Tool != toolHumanHandoffStep {
+		t.Fatalf("tool = %q, want %q", turn.Step.Action.Tool, toolHumanHandoffStep)
+	}
+	if !strings.Contains(turn.Step.Observation, "HUMAN_HANDOFF_REQUESTED") {
+		t.Fatalf("observation = %q", turn.Step.Observation)
+	}
+}
+
+func TestHumanHandoffToolPausesRun(t *testing.T) {
+	handoffContent := "请在手机上选择登录方式，完成后告诉我继续。"
+	model := &scriptedModel{responses: []*llms.ContentResponse{
+		toolCallResponseWithContent("handoff_1", toolHumanHandoffStep, `{"reason":"login_method_selection","details":"manual login method selection is required"}`, handoffContent),
+		contentResponse("should not be used"),
+	}}
+	executor := newRoleCollaborativeExecutor(
+		model,
+		RoleProfiles{Planner: RoleProfile{Name: RolePlanner, SystemPrompt: "planner"}},
+		[]langtools.Tool{NewHumanHandoffTool()},
+		nil,
+		10,
+		nil,
+		nil,
+		nil,
+		ScreenshotPruningConfig{},
+		nil,
+	)
+
+	result, err := executor.Call(context.Background(), map[string]any{
+		"input":   "登录当前页面",
+		"history": "",
+	})
+	if err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+	if output := strings.TrimSpace(fmt.Sprint(result["output"])); output != handoffContent {
+		t.Fatalf("output = %q, want %q", output, handoffContent)
+	}
+	if model.callCount != 1 {
+		t.Fatalf("model call count = %d, want 1", model.callCount)
+	}
+}
+
+func TestDefaultFinalReviewConvertsHumanQuestionToHandoff(t *testing.T) {
+	review := `{
+		"can_finish": false,
+		"needs_human_handoff": true,
+		"handoff_reason": "login_method_selection",
+		"handoff_details": "The current screen requires the user to choose a login method before the login can continue.",
+		"suggested_action": "Please choose the login method on the phone, then tell me to continue.",
+		"reason": "manual login method selection is required"
+	}`
+	model := &scriptedModel{responses: []*llms.ContentResponse{
+		toolCallResponse("screen_1", "screenshot", `{"__arg1":"{}"}`),
+		contentResponse("请问你想用哪种方式登录？"),
+		contentResponse(review),
+	}}
+	handler := &toolExecutionCallbackRecorder{}
+	executor := newRoleCollaborativeExecutor(
+		model,
+		RoleProfiles{
+			Planner: RoleProfile{Name: RolePlanner, SystemPrompt: "planner"},
+		},
+		[]langtools.Tool{
+			&staticTool{name: "screenshot", output: `{"format":"jpeg","width":497,"height":1080,"size":10}`},
+			NewHumanHandoffTool(),
+		},
+		nil,
+		10,
+		nil,
+		handler,
+		nil,
+		ScreenshotPruningConfig{},
+		nil,
+	)
+
+	result, err := executor.Call(context.Background(), map[string]any{
+		"input":   "启动小红书 登录我的账号",
+		"history": "",
+	})
+	if err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+	if output := strings.TrimSpace(fmt.Sprint(result["output"])); output != "Please choose the login method on the phone, then tell me to continue." {
+		t.Fatalf("output = %q", output)
+	}
+	if !toolCallsContain(handler.calls, toolHumanHandoffStep) {
+		t.Fatalf("tool calls = %#v, want synthesized %s", handler.calls, toolHumanHandoffStep)
+	}
+	if model.callCount != 3 {
+		t.Fatalf("model call count = %d, want 3", model.callCount)
+	}
+}
+
 func TestRoutePolicyOverridesSimpleForMultiStageRequests(t *testing.T) {
 	model := &scriptedModel{responses: []*llms.ContentResponse{
 		contentResponse(`{"mode":"simple","reason":"model underestimated task"}`),
@@ -373,6 +502,46 @@ func TestPlanModeAllowsReadOnlyToolBeforeCommit(t *testing.T) {
 	}
 	if len(state.PlannerEvidence) != 1 {
 		t.Fatalf("planner evidence = %#v, want one readonly result", state.PlannerEvidence)
+	}
+}
+
+func TestPlanModeAllowsHumanHandoffBeforeCommit(t *testing.T) {
+	payload := `{"reason":"authentication","details":"Login screen requires the user's password","suggested_action":"Please enter the password on the phone and tell me when finished."}`
+	model := &scriptedModel{responses: []*llms.ContentResponse{
+		toolCallResponse("handoff_1", toolHumanHandoffStep, payload),
+	}}
+	tool := NewHumanHandoffTool()
+	executor := newRoleCollaborativeExecutor(
+		model,
+		RoleProfiles{},
+		[]langtools.Tool{tool},
+		nil,
+		10,
+		nil,
+		nil,
+		nil,
+		ScreenshotPruningConfig{},
+		nil,
+	)
+	state := &roleLoopState{Phase: phasePlan, PlanCommitRequired: true}
+	toolSpecs := NewToolSpecs([]langtools.Tool{tool})
+	inputs := map[string]string{"input": "登录当前页面", "history": ""}
+
+	turn, err := executor.callPlannerTurn(context.Background(), inputs, state, toolSpecs)
+	if err != nil {
+		t.Fatalf("planner turn error: %v", err)
+	}
+	if turn.Kind != plannerTurnSleep || turn.Step == nil {
+		t.Fatalf("turn = %#v, want handoff planner tool that pauses the run", turn)
+	}
+	if turn.Step.Action.Tool != toolHumanHandoffStep {
+		t.Fatalf("tool = %q, want %q", turn.Step.Action.Tool, toolHumanHandoffStep)
+	}
+	if !strings.Contains(turn.Step.Observation, "HUMAN_HANDOFF_REQUESTED") {
+		t.Fatalf("observation = %q", turn.Step.Observation)
+	}
+	if state.Phase != phasePlan || !state.PlanCommitRequired {
+		t.Fatalf("state = %#v, want plan phase with commit still required", state)
 	}
 }
 

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -370,6 +370,19 @@ func TestDefaultFinalReviewPromptRequestsChineseForChineseInput(t *testing.T) {
 	}
 }
 
+func TestDefaultFinalReviewFailsClosedOnNonJSON(t *testing.T) {
+	review := parseDefaultFinalReview("not json", "请问你想用哪种方式登录？")
+	if review.CanFinish {
+		t.Fatalf("CanFinish = true, want false")
+	}
+	if review.FinalAnswer != "" {
+		t.Fatalf("FinalAnswer = %q, want empty", review.FinalAnswer)
+	}
+	if !strings.Contains(review.Reason, "non-JSON") {
+		t.Fatalf("Reason = %q, want non-JSON failure reason", review.Reason)
+	}
+}
+
 func TestHumanHandoffPauseUsesSuggestedActionWithoutToolContent(t *testing.T) {
 	action := schema.AgentAction{
 		Tool:      toolHumanHandoffStep,
@@ -553,7 +566,7 @@ func TestPlanModeAllowsHumanHandoffBeforeCommit(t *testing.T) {
 		nil,
 	)
 	state := &roleLoopState{Phase: phasePlan, PlanCommitRequired: true}
-	toolSpecs := NewToolSpecs([]langtools.Tool{tool})
+	toolSpecs := toolSpecsForRole(RolePlanner, executor.Tools)
 	inputs := map[string]string{"input": "登录当前页面", "history": ""}
 
 	turn, err := executor.callPlannerTurn(context.Background(), inputs, state, toolSpecs)

--- a/src/agent/internal/agent/role_profile.go
+++ b/src/agent/internal/agent/role_profile.go
@@ -63,6 +63,7 @@ func buildRoleProfiles(cfg AgentConfig, skills ResolvedSkills, availableTools []
 				"You may use multiple tool calls within the current step until it is done or blocked.",
 				"When the step is ready for verification, call finish_step with a summary of what was accomplished and key_info for facts, IDs, values, labels, or observations later steps may need.",
 				"When the step is blocked or cannot be completed, call abort_step with the reason.",
+				"When the blocker requires private credentials, CAPTCHA, verification code, biometric/identity confirmation, a lock-screen unlock, system/app redirect confirmation, permission dialog confirmation, or another sensitive human action, call request_human_handoff before abort_step; ask the user to complete it on the device, never to send credentials in chat.",
 				"Plain-text answers alone do not enter verification; you must call finish_step or abort_step.",
 				"Use prior step results as context for the current next_step, but continue to execute only the current next_step.",
 				"Obey tool restrictions and output-format requirements from the original user request.",
@@ -171,7 +172,7 @@ func plannerRoleRules(cfg AgentConfig, openAppAvailable bool) []string {
 			"For semantic platform actions, use quick_action when a matching action may exist; pass observed_state.platform and the concrete action id when possible, and switch to a low-level fallback after failure/no effect.",
 			"Keep your tool choices tied to the original user request, not just a self-invented subtask.",
 			"If the current screenshot clearly identifies the app/page or device platform, use that observed app, page, platform (ios/android/mac), visible text, and dialogs when choosing tools.",
-			"Use request_human_handoff when the task requires credentials, verification, or human judgment your tools cannot fulfill, or when the user refers to a target you cannot unambiguously identify from the screen. Do not guess.",
+			"Call request_human_handoff when the task requires credentials, login-method selection, verification, system/app redirect confirmation, permission dialog confirmation, or human judgment your tools cannot fulfill, or when the user refers to a target you cannot unambiguously identify from the screen. Ask the user to complete it on the device; do not ask them to send credentials or private verification details in chat.",
 		)
 		if openAppAvailable {
 			rules = append(rules, "For launch-only app, URL, or dialer requests, open_app ok=true is enough unless the user asked to inspect or act inside the opened target.")
@@ -184,7 +185,7 @@ func plannerRoleRules(cfg AgentConfig, openAppAvailable bool) []string {
 		"For semantic platform actions, plan quick_action when a matching action may exist; include observed_state.platform, the concrete action id when possible, and a low-level fallback only after quick_action failure/no effect.",
 		"Keep objective and completion_criteria tied to the original user request, not just the current step.",
 		"If the current screenshot clearly identifies the app/page or device platform, include observed_state with app_name, page_name, platform (ios/android/mac), visible_text, dialogs, and confidence when relevant.",
-		"Plan a request_human_handoff step when the task requires credentials, verification, or human judgment your tools cannot fulfill, or when the user refers to a target you cannot unambiguously identify from the screen. Do not guess.",
+		"Call request_human_handoff when the task requires credentials, login-method selection, verification, system/app redirect confirmation, permission dialog confirmation, or human judgment your tools cannot fulfill, or when the user refers to a target you cannot unambiguously identify from the screen. In plan mode, request_human_handoff is allowed before commit_plan when the blocker is already known. Ask the user to complete it on the device; do not ask them to send credentials or private verification details in chat.",
 	)
 	if openAppAvailable {
 		rules = append(rules, "For launch-only app, URL, or dialer requests, use open_app ok=true as the completion criterion.")

--- a/src/agent/internal/agent/role_profile_test.go
+++ b/src/agent/internal/agent/role_profile_test.go
@@ -96,6 +96,10 @@ func TestBuildRoleProfilesInjectsSkillsAndCapabilities(t *testing.T) {
 	if !strings.Contains(profiles.Executor.SystemPrompt, "Execute only the current next_step") {
 		t.Fatalf("executor prompt missing next_step constraint:\n%s", profiles.Executor.SystemPrompt)
 	}
+	if !strings.Contains(profiles.Executor.SystemPrompt, "request_human_handoff before abort_step") ||
+		!strings.Contains(profiles.Executor.SystemPrompt, "never to send credentials in chat") {
+		t.Fatalf("executor prompt should require handoff before credential-sensitive aborts:\n%s", profiles.Executor.SystemPrompt)
+	}
 	if strings.Contains(profiles.Planner.SystemPrompt, "screenshot: Capture screen.") ||
 		strings.Contains(profiles.Planner.SystemPrompt, "enter_plan_mode:") {
 		t.Fatalf("planner prompt should not duplicate callable tool descriptions:\n%s", profiles.Planner.SystemPrompt)
@@ -126,6 +130,10 @@ func TestBuildRoleProfilesInjectsSkillsAndCapabilities(t *testing.T) {
 	}
 	if !strings.Contains(profiles.Planner.SystemPrompt, "Prefer direct tools that cover the requested operation") {
 		t.Fatalf("planner prompt should prefer direct tools:\n%s", profiles.Planner.SystemPrompt)
+	}
+	if !strings.Contains(profiles.Planner.SystemPrompt, "Call request_human_handoff") ||
+		!strings.Contains(profiles.Planner.SystemPrompt, "do not ask them to send credentials") {
+		t.Fatalf("planner prompt should call handoff for sensitive user input:\n%s", profiles.Planner.SystemPrompt)
 	}
 	if strings.Contains(profiles.Planner.SystemPrompt, "open_app") ||
 		strings.Contains(profiles.Verifier.SystemPrompt, "open_app") {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1763,6 +1763,11 @@ func roleToolResponses(toolName, arguments, finalAnswer string) []*llms.ContentR
 	return roleDefaultToolResponses(toolName, arguments, finalAnswer)
 }
 
+func roleReviewedToolResponses(toolName, arguments, finalAnswer string) []*llms.ContentResponse {
+	responses := roleToolResponses(toolName, arguments, finalAnswer)
+	return append(responses, verifierFinishResponse(finalAnswer))
+}
+
 func enterPlanModeToolCall() *llms.ContentResponse {
 	return toolCallResponse("enter_1", toolEnterPlanMode, `{"__arg1":"{}","description":"enter plan mode"}`)
 }
@@ -2088,7 +2093,7 @@ func TestRuntimeRunExecutesOnlyFirstToolCallPerIteration(t *testing.T) {
 
 func TestRuntimeRunFeedsToolErrorsBackToModel(t *testing.T) {
 	model := &scriptedModel{
-		responses: roleToolResponses("screenshot", `{"__arg1":"{}"}`, "屏幕暂时获取失败，frame service 正在恢复。"),
+		responses: roleReviewedToolResponses("screenshot", `{"__arg1":"{}"}`, "屏幕暂时获取失败，frame service 正在恢复。"),
 	}
 	runtime := NewRuntimeWithDeps(
 		Config{
@@ -2669,6 +2674,7 @@ func TestRuntimeSimpleLoopDoesNotGenerateImplicitTodo(t *testing.T) {
 			toolCallResponse("call_1", "screenshot", `{"__arg1":"{}"}`),
 			toolCallResponse("call_2", "web_search", `{"__arg1":"Aiden"}`),
 			contentResponse("done"),
+			verifierFinishResponse("done"),
 		},
 	}
 	screenshot := &stubTool{name: "screenshot", description: "Capture screen.", output: "screen"}
@@ -3257,7 +3263,7 @@ func TestRuntimeRunFallsBackWhenProviderStreamWriterErrorsAfterPartialFinalAnswe
 func TestRuntimeRunScreenshotAddsBinaryImageObservation(t *testing.T) {
 	jpegBytes := []byte("fake-jpeg-binary")
 	model := &scriptedModel{
-		responses: roleToolResponses("screenshot", `{"__arg1":"{}"}`, "The screenshot shows a UI."),
+		responses: roleReviewedToolResponses("screenshot", `{"__arg1":"{}"}`, "The screenshot shows a UI."),
 	}
 	tool := &stubTool{
 		name:        "screenshot",
@@ -3328,7 +3334,7 @@ func TestRuntimeRunScreenshotAddsBinaryImageObservation(t *testing.T) {
 func TestRuntimeRunScreenshotImageSurvivesCallbackToolWrapping(t *testing.T) {
 	jpegBytes := []byte("fake-jpeg-binary")
 	model := &scriptedModel{
-		responses: roleToolResponses("screenshot", `{"__arg1":"{}"}`, "The screenshot shows a UI."),
+		responses: roleReviewedToolResponses("screenshot", `{"__arg1":"{}"}`, "The screenshot shows a UI."),
 	}
 	tool := &stubTool{
 		name:        "screenshot",
@@ -3393,7 +3399,7 @@ func TestRuntimeRunScreenshotImageSurvivesCallbackToolWrapping(t *testing.T) {
 func TestRuntimeRunKeyboardToolAddsPostActionImageObservation(t *testing.T) {
 	jpegBytes := []byte("keyboard-post-action-jpeg")
 	model := &scriptedModel{
-		responses: roleToolResponses("keyboard_tap", `{"keys":["enter"]}`, "The keyboard action updated the UI."),
+		responses: roleReviewedToolResponses("keyboard_tap", `{"keys":["enter"]}`, "The keyboard action updated the UI."),
 	}
 	tool := &stubTool{
 		name:        "keyboard_tap",

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -3286,8 +3286,8 @@ func TestRuntimeRunScreenshotAddsBinaryImageObservation(t *testing.T) {
 	if result.Output != "The screenshot shows a UI." {
 		t.Fatalf("unexpected output: %q", result.Output)
 	}
-	if len(model.messages) != 2 {
-		t.Fatalf("expected 2 default-mode planner calls, got %d", len(model.messages))
+	if len(model.messages) < 3 {
+		t.Fatalf("expected screenshot follow-up plus default final review, got %d model calls", len(model.messages))
 	}
 
 	secondCall := model.messages[1]
@@ -3358,8 +3358,8 @@ func TestRuntimeRunScreenshotImageSurvivesCallbackToolWrapping(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 
-	if len(model.messages) != 2 {
-		t.Fatalf("expected 2 default-mode planner calls, got %d", len(model.messages))
+	if len(model.messages) < 3 {
+		t.Fatalf("expected screenshot follow-up plus default final review, got %d model calls", len(model.messages))
 	}
 
 	var foundToolResponse, foundImageURL bool

--- a/src/agent/internal/agent/tools_human_handoff.go
+++ b/src/agent/internal/agent/tools_human_handoff.go
@@ -18,9 +18,9 @@ import (
 // - Ambiguous situations requiring human judgment
 // - Black screen or inaccessible UI elements
 //
-// Unlike blocking callback approaches, this tool returns immediately with instructions
-// for the agent to communicate to the user. The agent will naturally wait for the user's
-// next message in the conversation flow.
+// Unlike blocking callback approaches, this tool returns immediately with a structured
+// handoff marker. The agent will naturally wait for the user's next message in the
+// conversation flow.
 type HumanHandoffTool struct{}
 
 // HumanHandoffRequest contains details about why human intervention is needed.
@@ -106,7 +106,7 @@ func (t *HumanHandoffTool) Description() string {
 		`"black_screen" (screen not visible), "ambiguous_situation" (unclear what to do), ` +
 		`"unsupported_action" (action not possible with available tools), "stuck" (unable to make progress), "other" (specify in details). ` +
 		`The "details" field should clearly explain the situation. The "suggested_action" field optionally tells the human what to do. ` +
-		`This tool returns immediately with instructions for you to communicate to the user. Wait for the user to complete the task and tell you to continue in their next message. ` +
+		`This tool returns immediately with a structured handoff marker. Wait for the user to complete the task and tell you to continue in their next message. ` +
 		`Use this when: you need credentials you don't have, encounter CAPTCHA, need verification codes, face sensitive operations requiring human approval, ` +
 		`need the user to choose a login method, need a system/app redirect or permission dialog confirmed, see a black/blank screen preventing progress, ` +
 		`are genuinely stuck after multiple attempts, or the task fundamentally requires human judgment. ` +
@@ -164,40 +164,20 @@ func (t *HumanHandoffTool) Call(ctx context.Context, input string) (string, erro
 	details := strings.TrimSpace(args.Details)
 	suggestedAction := strings.TrimSpace(args.SuggestedAction)
 
-	// Build response message for the agent to communicate to the user
-	var response strings.Builder
-	response.WriteString("HUMAN_HANDOFF_REQUESTED. You need to ask the user to perform a manual action. ")
-
-	// Add context about why handoff is needed
-	response.WriteString(fmt.Sprintf("Reason: %s. ", details))
-
-	// Add suggested action if provided
-	if suggestedAction != "" {
-		response.WriteString(fmt.Sprintf("Tell the user: \"%s\" ", suggestedAction))
-	} else {
-		// Provide default instruction based on reason
-		switch reason {
-		case "authentication":
-			response.WriteString("Tell the user to enter their credentials. ")
-		case "login_method_selection":
-			response.WriteString("Tell the user to choose the login method on the device. ")
-		case "captcha", "verification_code":
-			response.WriteString("Tell the user to complete the verification. ")
-		case "sensitive_operation":
-			response.WriteString("Tell the user to review and confirm the sensitive operation. ")
-		case "redirect_confirmation":
-			response.WriteString("Tell the user to confirm the system or app redirect on the device. ")
-		case "permission_confirmation":
-			response.WriteString("Tell the user to review and confirm the permission dialog on the device. ")
-		case "black_screen":
-			response.WriteString("Tell the user to manually complete the action on the screen. ")
-		default:
-			response.WriteString("Tell the user to handle this situation manually. ")
-		}
+	response := struct {
+		Status          string `json:"status"`
+		Reason          string `json:"reason"`
+		Details         string `json:"details"`
+		SuggestedAction string `json:"suggested_action,omitempty"`
+	}{
+		Status:          "HUMAN_HANDOFF_REQUESTED",
+		Reason:          reason,
+		Details:         details,
+		SuggestedAction: suggestedAction,
 	}
-
-	response.WriteString("Then ask the user to tell you when they have completed the task (e.g., say 'done', 'continue', or 'finished'). ")
-	response.WriteString("After the user confirms, take a screenshot to verify the current state before proceeding.")
-
-	return response.String(), nil
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
 }

--- a/src/agent/internal/agent/tools_human_handoff.go
+++ b/src/agent/internal/agent/tools_human_handoff.go
@@ -39,16 +39,54 @@ type HumanHandoffRequest struct {
 type HandoffReason string
 
 const (
-	HandoffReasonAuthentication HandoffReason = "authentication"
-	HandoffReasonCAPTCHA        HandoffReason = "captcha"
-	HandoffReasonVerification   HandoffReason = "verification_code"
-	HandoffReasonSensitive      HandoffReason = "sensitive_operation"
-	HandoffReasonBlackScreen    HandoffReason = "black_screen"
-	HandoffReasonAmbiguous      HandoffReason = "ambiguous_situation"
-	HandoffReasonUnsupported    HandoffReason = "unsupported_action"
-	HandoffReasonStuck          HandoffReason = "stuck"
-	HandoffReasonOther          HandoffReason = "other"
+	HandoffReasonAuthentication         HandoffReason = "authentication"
+	HandoffReasonLoginMethodSelection   HandoffReason = "login_method_selection"
+	HandoffReasonCAPTCHA                HandoffReason = "captcha"
+	HandoffReasonVerification           HandoffReason = "verification_code"
+	HandoffReasonSensitive              HandoffReason = "sensitive_operation"
+	HandoffReasonRedirectConfirmation   HandoffReason = "redirect_confirmation"
+	HandoffReasonPermissionConfirmation HandoffReason = "permission_confirmation"
+	HandoffReasonBlackScreen            HandoffReason = "black_screen"
+	HandoffReasonAmbiguous              HandoffReason = "ambiguous_situation"
+	HandoffReasonUnsupported            HandoffReason = "unsupported_action"
+	HandoffReasonStuck                  HandoffReason = "stuck"
+	HandoffReasonOther                  HandoffReason = "other"
 )
+
+var validHandoffReasonValues = []string{
+	string(HandoffReasonAuthentication),
+	string(HandoffReasonLoginMethodSelection),
+	string(HandoffReasonCAPTCHA),
+	string(HandoffReasonVerification),
+	string(HandoffReasonSensitive),
+	string(HandoffReasonRedirectConfirmation),
+	string(HandoffReasonPermissionConfirmation),
+	string(HandoffReasonBlackScreen),
+	string(HandoffReasonAmbiguous),
+	string(HandoffReasonUnsupported),
+	string(HandoffReasonStuck),
+	string(HandoffReasonOther),
+}
+
+func normalizeHandoffReason(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	for _, valid := range validHandoffReasonValues {
+		if value == valid {
+			return value
+		}
+	}
+	return string(HandoffReasonOther)
+}
+
+func isValidHandoffReason(value string) bool {
+	value = strings.ToLower(strings.TrimSpace(value))
+	for _, valid := range validHandoffReasonValues {
+		if value == valid {
+			return true
+		}
+	}
+	return false
+}
 
 // NewHumanHandoffTool creates a new HumanHandoffTool
 func NewHumanHandoffTool() *HumanHandoffTool {
@@ -62,13 +100,16 @@ func (t *HumanHandoffTool) Name() string {
 func (t *HumanHandoffTool) Description() string {
 	return `Request human intervention when you encounter a situation that requires human judgment, credentials, or actions beyond your capabilities. ` +
 		`Input JSON: {"reason": "authentication", "details": "Login screen requires password", "suggested_action": "Please enter your credentials"}. ` +
-		`Valid reasons: "authentication" (login/credentials required), "captcha" (CAPTCHA challenge), "verification_code" (SMS/email code needed), ` +
-		`"sensitive_operation" (payment/banking/security), "black_screen" (screen not visible), "ambiguous_situation" (unclear what to do), ` +
+		`Valid reasons: "authentication" (login/credentials required), "login_method_selection" (the user must choose a login method), ` +
+		`"captcha" (CAPTCHA challenge), "verification_code" (SMS/email code needed), "sensitive_operation" (payment/banking/security), ` +
+		`"redirect_confirmation" (system/app redirect confirmation dialog), "permission_confirmation" (permission dialog confirmation), ` +
+		`"black_screen" (screen not visible), "ambiguous_situation" (unclear what to do), ` +
 		`"unsupported_action" (action not possible with available tools), "stuck" (unable to make progress), "other" (specify in details). ` +
 		`The "details" field should clearly explain the situation. The "suggested_action" field optionally tells the human what to do. ` +
 		`This tool returns immediately with instructions for you to communicate to the user. Wait for the user to complete the task and tell you to continue in their next message. ` +
 		`Use this when: you need credentials you don't have, encounter CAPTCHA, need verification codes, face sensitive operations requiring human approval, ` +
-		`see a black/blank screen preventing progress, are genuinely stuck after multiple attempts, or the task fundamentally requires human judgment. ` +
+		`need the user to choose a login method, need a system/app redirect or permission dialog confirmed, see a black/blank screen preventing progress, ` +
+		`are genuinely stuck after multiple attempts, or the task fundamentally requires human judgment. ` +
 		`After the user confirms completion in their next message, take a screenshot to verify the result before continuing.`
 }
 
@@ -77,9 +118,12 @@ func (t *HumanHandoffTool) ArgsSchema() map[string]any {
 		"reason": stringEnumArgSchema(
 			"Why human handoff is needed.",
 			string(HandoffReasonAuthentication),
+			string(HandoffReasonLoginMethodSelection),
 			string(HandoffReasonCAPTCHA),
 			string(HandoffReasonVerification),
 			string(HandoffReasonSensitive),
+			string(HandoffReasonRedirectConfirmation),
+			string(HandoffReasonPermissionConfirmation),
 			string(HandoffReasonBlackScreen),
 			string(HandoffReasonAmbiguous),
 			string(HandoffReasonUnsupported),
@@ -113,19 +157,8 @@ func (t *HumanHandoffTool) Call(ctx context.Context, input string) (string, erro
 
 	// Normalize reason
 	reason := strings.ToLower(strings.TrimSpace(args.Reason))
-	validReasons := map[string]bool{
-		"authentication":      true,
-		"captcha":             true,
-		"verification_code":   true,
-		"sensitive_operation": true,
-		"black_screen":        true,
-		"ambiguous_situation": true,
-		"unsupported_action":  true,
-		"stuck":               true,
-		"other":               true,
-	}
-	if !validReasons[reason] {
-		return "", fmt.Errorf("invalid reason: %q, must be one of: authentication, captcha, verification_code, sensitive_operation, black_screen, ambiguous_situation, unsupported_action, stuck, other", args.Reason)
+	if !isValidHandoffReason(reason) {
+		return "", fmt.Errorf("invalid reason: %q, must be one of: %s", args.Reason, strings.Join(validHandoffReasonValues, ", "))
 	}
 
 	details := strings.TrimSpace(args.Details)
@@ -146,10 +179,16 @@ func (t *HumanHandoffTool) Call(ctx context.Context, input string) (string, erro
 		switch reason {
 		case "authentication":
 			response.WriteString("Tell the user to enter their credentials. ")
+		case "login_method_selection":
+			response.WriteString("Tell the user to choose the login method on the device. ")
 		case "captcha", "verification_code":
 			response.WriteString("Tell the user to complete the verification. ")
 		case "sensitive_operation":
 			response.WriteString("Tell the user to review and confirm the sensitive operation. ")
+		case "redirect_confirmation":
+			response.WriteString("Tell the user to confirm the system or app redirect on the device. ")
+		case "permission_confirmation":
+			response.WriteString("Tell the user to review and confirm the permission dialog on the device. ")
 		case "black_screen":
 			response.WriteString("Tell the user to manually complete the action on the screen. ")
 		default:

--- a/src/agent/internal/agent/tools_human_handoff_test.go
+++ b/src/agent/internal/agent/tools_human_handoff_test.go
@@ -62,19 +62,7 @@ func TestHumanHandoffTool_Call_Success(t *testing.T) {
 }
 
 func TestHumanHandoffTool_Call_AllReasons(t *testing.T) {
-	validReasons := []string{
-		"authentication",
-		"captcha",
-		"verification_code",
-		"sensitive_operation",
-		"black_screen",
-		"ambiguous_situation",
-		"unsupported_action",
-		"stuck",
-		"other",
-	}
-
-	for _, reason := range validReasons {
+	for _, reason := range validHandoffReasonValues {
 		t.Run(reason, func(t *testing.T) {
 			tool := NewHumanHandoffTool()
 

--- a/src/agent/internal/agent/tools_human_handoff_test.go
+++ b/src/agent/internal/agent/tools_human_handoff_test.go
@@ -56,8 +56,17 @@ func TestHumanHandoffTool_Call_Success(t *testing.T) {
 		t.Errorf("Result doesn't contain suggested action: %q", result)
 	}
 
-	if !strings.Contains(result, "tell you when they have completed") {
-		t.Errorf("Result doesn't contain continuation instruction: %q", result)
+	var payload struct {
+		Status          string `json:"status"`
+		Reason          string `json:"reason"`
+		Details         string `json:"details"`
+		SuggestedAction string `json:"suggested_action"`
+	}
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		t.Fatalf("Result is not structured JSON: %v\n%s", err, result)
+	}
+	if payload.Status != "HUMAN_HANDOFF_REQUESTED" || payload.Reason != "authentication" {
+		t.Errorf("Unexpected payload: %#v", payload)
 	}
 }
 
@@ -209,22 +218,30 @@ func TestHumanHandoffTool_Call_OptionalFields(t *testing.T) {
 		t.Errorf("Result doesn't contain handoff marker: %q", result)
 	}
 
-	// Should have default instruction when no suggested_action is provided
-	if !strings.Contains(result, "Tell the user") {
-		t.Errorf("Result doesn't contain default instruction: %q", result)
+	var payload struct {
+		Status          string `json:"status"`
+		SuggestedAction string `json:"suggested_action,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		t.Fatalf("Result is not structured JSON: %v\n%s", err, result)
+	}
+	if payload.Status != "HUMAN_HANDOFF_REQUESTED" {
+		t.Errorf("status = %q, want HUMAN_HANDOFF_REQUESTED", payload.Status)
+	}
+	if payload.SuggestedAction != "" {
+		t.Errorf("suggested_action = %q, want empty when omitted", payload.SuggestedAction)
 	}
 }
 
-func TestHumanHandoffTool_Call_DefaultInstructions(t *testing.T) {
+func TestHumanHandoffTool_Call_StructuredOutputForCommonReasons(t *testing.T) {
 	tests := []struct {
-		reason         string
-		expectedPhrase string
+		reason string
 	}{
-		{"authentication", "enter their credentials"},
-		{"captcha", "complete the verification"},
-		{"verification_code", "complete the verification"},
-		{"sensitive_operation", "review and confirm"},
-		{"black_screen", "manually complete the action"},
+		{"authentication"},
+		{"captcha"},
+		{"verification_code"},
+		{"sensitive_operation"},
+		{"black_screen"},
 	}
 
 	for _, tt := range tests {
@@ -244,9 +261,16 @@ func TestHumanHandoffTool_Call_DefaultInstructions(t *testing.T) {
 				t.Fatalf("Call() error = %v, want nil", err)
 			}
 
-			if !strings.Contains(result, tt.expectedPhrase) {
-				t.Errorf("Result for %q doesn't contain expected phrase %q: %q",
-					tt.reason, tt.expectedPhrase, result)
+			var payload struct {
+				Status  string `json:"status"`
+				Reason  string `json:"reason"`
+				Details string `json:"details"`
+			}
+			if err := json.Unmarshal([]byte(result), &payload); err != nil {
+				t.Fatalf("Result is not structured JSON: %v\n%s", err, result)
+			}
+			if payload.Status != "HUMAN_HANDOFF_REQUESTED" || payload.Reason != tt.reason || payload.Details != "Test details" {
+				t.Errorf("Unexpected payload for %q: %#v", tt.reason, payload)
 			}
 		})
 	}
@@ -274,8 +298,7 @@ func TestHumanHandoffTool_Call_ReturnsImmediately(t *testing.T) {
 		t.Error("Call() returned empty result")
 	}
 
-	// Verify it contains instruction to wait for user
-	if !strings.Contains(result, "take a screenshot to verify") {
-		t.Errorf("Result doesn't mention verification after user confirms: %q", result)
+	if !strings.Contains(result, "HUMAN_HANDOFF_REQUESTED") {
+		t.Errorf("Result doesn't contain handoff marker: %q", result)
 	}
 }

--- a/src/agent/internal/agent/tools_human_handoff_test.go
+++ b/src/agent/internal/agent/tools_human_handoff_test.go
@@ -234,22 +234,12 @@ func TestHumanHandoffTool_Call_OptionalFields(t *testing.T) {
 }
 
 func TestHumanHandoffTool_Call_StructuredOutputForCommonReasons(t *testing.T) {
-	tests := []struct {
-		reason string
-	}{
-		{"authentication"},
-		{"captcha"},
-		{"verification_code"},
-		{"sensitive_operation"},
-		{"black_screen"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.reason, func(t *testing.T) {
+	for _, reason := range validHandoffReasonValues {
+		t.Run(reason, func(t *testing.T) {
 			tool := NewHumanHandoffTool()
 
 			input := map[string]string{
-				"reason":  tt.reason,
+				"reason":  reason,
 				"details": "Test details",
 			}
 			inputJSON, _ := json.Marshal(input)
@@ -269,8 +259,8 @@ func TestHumanHandoffTool_Call_StructuredOutputForCommonReasons(t *testing.T) {
 			if err := json.Unmarshal([]byte(result), &payload); err != nil {
 				t.Fatalf("Result is not structured JSON: %v\n%s", err, result)
 			}
-			if payload.Status != "HUMAN_HANDOFF_REQUESTED" || payload.Reason != tt.reason || payload.Details != "Test details" {
-				t.Errorf("Unexpected payload for %q: %#v", tt.reason, payload)
+			if payload.Status != "HUMAN_HANDOFF_REQUESTED" || payload.Reason != reason || payload.Details != "Test details" {
+				t.Errorf("Unexpected payload for %q: %#v", reason, payload)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- expose `request_human_handoff` across default, planner, and plan-mode flows where a human-only action blocks progress
- pause the current run after a successful human handoff instead of continuing into planner churn or a normal final answer
- keep handoff output localized to the user request language and return structured handoff tool results
- fail closed when default final review returns malformed JSON, then replan instead of accepting an unsafe final answer

## Tests
- `go test ./internal/agent`
- `go test ./...`

## Deployment
- Built and deployed the Go agent to the board for hardware validation
- Latest board marker used for validation: `20260624-090124-eb9b0fd`