### PR TITLE
fix(build): ship bundled Aiden share assets in OEM

### DIFF
--- a/_build_image.sh
+++ b/_build_image.sh
@@ -670,30 +670,6 @@ if [ -d "$OVERLAY/etc" ]; then
     echo "  ✓ etc directory synced"
 fi
 
-# Bundled phone-bridge app mapping: src/agent/internal/agent/app_mapping.json 是
-# Go embed 的单一源，固件里同步落到 /usr/share/aiden/app_mapping.json，方便运维
-# 不重新 build 二进制就能更新映射（agent 启动时优先读 configDir，再读这里，最后
-# 回退到二进制内嵌副本）。
-APP_MAPPING_SRC="$SCRIPT_DIR/src/agent/internal/agent/app_mapping.json"
-APP_MAPPING_DEST="$DEST_OVERLAY/usr/share/aiden/app_mapping.json"
-if [ -f "$APP_MAPPING_SRC" ]; then
-    mkdir -p "$(dirname "$APP_MAPPING_DEST")"
-    cp "$APP_MAPPING_SRC" "$APP_MAPPING_DEST"
-    echo "  ✓ phone-bridge app mapping synced"
-else
-    echo "  ⚠ Warning: $APP_MAPPING_SRC not found; skipping app mapping" >&2
-fi
-
-QUICK_ACTIONS_SRC="$SCRIPT_DIR/src/agent/internal/agent/quick_actions.json"
-QUICK_ACTIONS_DEST="$DEST_OVERLAY/usr/share/aiden/quick_actions.json"
-if [ -f "$QUICK_ACTIONS_SRC" ]; then
-    mkdir -p "$(dirname "$QUICK_ACTIONS_DEST")"
-    cp "$QUICK_ACTIONS_SRC" "$QUICK_ACTIONS_DEST"
-    echo "  ✓ quick actions mapping synced"
-else
-    echo "  ⚠ Warning: $QUICK_ACTIONS_SRC not found; skipping quick actions" >&2
-fi
-
 # Step 4: Run pico-sdk build stages and base firmware packaging.
 echo "[4/6] Running pico-sdk build stages..."
 cd "$PICO_SDK"
@@ -737,13 +713,38 @@ if [ -d "$OVERLAY/oem" ]; then
         "etc/ota_pubkey.pem" \
         "usr/ko/insmod_wifi.sh" \
         "usr/lib/librknnmrt.so" \
-        "usr/model"
+        "usr/model" \
+        "usr/share/aiden"
     clean_generated_binaries "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin"
     rsync -a "$OVERLAY/oem/" "$RK_PROJECT_PACKAGE_OEM_DIR/"
     # Keep generated binaries anchored to build/bin; overlay/oem/usr/bin is only an intermediate staging copy.
     repair_generated_binaries_from_manifest "sdk-oem-usr-bin" "$SCRIPT_DIR/build/bin" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin" "$GENERATED_BINARY_MANIFEST"
     echo "  ✓ OEM content copied"
     log_generated_binaries_in_dir "sdk-oem-usr-bin" "$RK_PROJECT_PACKAGE_OEM_DIR/usr/bin"
+fi
+
+# Bundled phone-bridge app mapping: src/agent/internal/agent/app_mapping.json is
+# the Go embed source and is also shipped in OEM so operations can update it
+# without rebuilding the agent binary. Runtime order is configDir override,
+# bundled OEM file, then embedded defaults.
+APP_MAPPING_SRC="$SCRIPT_DIR/src/agent/internal/agent/app_mapping.json"
+APP_MAPPING_DEST="$RK_PROJECT_PACKAGE_OEM_DIR/usr/share/aiden/app_mapping.json"
+if [ -f "$APP_MAPPING_SRC" ]; then
+    mkdir -p "$(dirname "$APP_MAPPING_DEST")"
+    cp "$APP_MAPPING_SRC" "$APP_MAPPING_DEST"
+    echo "  ✓ phone-bridge app mapping synced to OEM staging"
+else
+    echo "  ⚠ Warning: $APP_MAPPING_SRC not found; skipping app mapping" >&2
+fi
+
+QUICK_ACTIONS_SRC="$SCRIPT_DIR/src/agent/internal/agent/quick_actions.json"
+QUICK_ACTIONS_DEST="$RK_PROJECT_PACKAGE_OEM_DIR/usr/share/aiden/quick_actions.json"
+if [ -f "$QUICK_ACTIONS_SRC" ]; then
+    mkdir -p "$(dirname "$QUICK_ACTIONS_DEST")"
+    cp "$QUICK_ACTIONS_SRC" "$QUICK_ACTIONS_DEST"
+    echo "  ✓ quick actions mapping synced to OEM staging"
+else
+    echo "  ⚠ Warning: $QUICK_ACTIONS_SRC not found; skipping quick actions" >&2
 fi
 
 # Bundled agent skills use src/agent/config/skills as the single source and

--- a/scripts/clean_rootfs_overlay_staging.sh
+++ b/scripts/clean_rootfs_overlay_staging.sh
@@ -55,6 +55,6 @@ remove_stale_path() {
   fi
 }
 
-# Bundled skills moved from rootfs to OEM staging in 6abb8de. Old dev branches
-# can still leave this directory in the shared self-hosted runner workspace.
-remove_stale_path "usr/share/aiden/skills"
+# Bundled Aiden share assets ship in OEM. Old dev branches can still leave these
+# files in the shared self-hosted runner rootfs overlay workspace.
+remove_stale_path "usr/share/aiden"

--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -192,6 +192,7 @@ fi
 if ! grep -Fq 'clean_managed_staging_paths "$RK_PROJECT_PACKAGE_OEM_DIR"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq '"usr/model"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq '"usr/ko/insmod_wifi.sh"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq '"usr/share/aiden"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq '"etc/ota_pubkey.pem"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq 'clean_managed_staging_paths "$RK_PROJECT_PACKAGE_USERDATA_DIR"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq '"agent/benchmark"' "$ROOT_DIR/_build_image.sh" || \
@@ -223,6 +224,18 @@ if grep -Fq 'SKILLS_DEST="$OVERLAY/oem/usr/share/aiden/skills"' "$ROOT_DIR/_buil
     exit 1
 fi
 
+if grep -Fq 'APP_MAPPING_DEST="$DEST_OVERLAY/usr/share/aiden/app_mapping.json"' "$ROOT_DIR/_build_image.sh" || \
+   grep -Fq 'QUICK_ACTIONS_DEST="$DEST_OVERLAY/usr/share/aiden/quick_actions.json"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must not stage bundled Aiden share JSON into rootfs overlay" >&2
+    exit 1
+fi
+
+if ! grep -Fq 'APP_MAPPING_DEST="$RK_PROJECT_PACKAGE_OEM_DIR/usr/share/aiden/app_mapping.json"' "$ROOT_DIR/_build_image.sh" || \
+   ! grep -Fq 'QUICK_ACTIONS_DEST="$RK_PROJECT_PACKAGE_OEM_DIR/usr/share/aiden/quick_actions.json"' "$ROOT_DIR/_build_image.sh"; then
+    echo "_build_image.sh must sync bundled Aiden share JSON directly into final OEM staging" >&2
+    exit 1
+fi
+
 if ! grep -Fq 'SKILLS_DEST="$RK_PROJECT_PACKAGE_OEM_DIR/usr/share/aiden/skills"' "$ROOT_DIR/_build_image.sh" || \
    ! grep -Fq 'rsync -a --delete "$SKILLS_SRC/" "$SKILLS_DEST/"' "$ROOT_DIR/_build_image.sh"; then
     echo "_build_image.sh must sync bundled skills directly into final OEM staging with delete semantics" >&2
@@ -231,8 +244,11 @@ fi
 
 oem_dir_line=$(grep -n 'RK_PROJECT_PACKAGE_OEM_DIR="${RK_PROJECT_OUTPUT}/oem"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
 skills_dest_line=$(grep -n 'SKILLS_DEST="$RK_PROJECT_PACKAGE_OEM_DIR/usr/share/aiden/skills"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
-if [ -z "$oem_dir_line" ] || [ -z "$skills_dest_line" ] || [ "$skills_dest_line" -le "$oem_dir_line" ]; then
-    echo "_build_image.sh must resolve final OEM staging before setting bundled skills destination" >&2
+app_mapping_dest_line=$(grep -n 'APP_MAPPING_DEST="$RK_PROJECT_PACKAGE_OEM_DIR/usr/share/aiden/app_mapping.json"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
+quick_actions_dest_line=$(grep -n 'QUICK_ACTIONS_DEST="$RK_PROJECT_PACKAGE_OEM_DIR/usr/share/aiden/quick_actions.json"' "$ROOT_DIR/_build_image.sh" | sed 's/:.*//' | head -n 1)
+if [ -z "$oem_dir_line" ] || [ -z "$skills_dest_line" ] || [ -z "$app_mapping_dest_line" ] || [ -z "$quick_actions_dest_line" ] || \
+   [ "$skills_dest_line" -le "$oem_dir_line" ] || [ "$app_mapping_dest_line" -le "$oem_dir_line" ] || [ "$quick_actions_dest_line" -le "$oem_dir_line" ]; then
+    echo "_build_image.sh must resolve final OEM staging before setting bundled Aiden share destinations" >&2
     exit 1
 fi
 

--- a/scripts/test_clean_rootfs_overlay_staging.sh
+++ b/scripts/test_clean_rootfs_overlay_staging.sh
@@ -20,18 +20,14 @@ mkdir -p "$dest_overlay/usr/share/aiden"
 
 printf 'service\n' > "$dest_overlay/etc/init.d/S53agent"
 printf 'mapping\n' > "$dest_overlay/usr/share/aiden/app_mapping.json"
+printf 'actions\n' > "$dest_overlay/usr/share/aiden/quick_actions.json"
 printf 'planner\n' > "$dest_overlay/usr/share/aiden/skills/planner/SKILL.md"
 printf 'operator\n' > "$dest_overlay/usr/share/aiden/skills/device-operator/SKILL.md"
 
 "$CLEAN_SCRIPT" --dest-overlay "$dest_overlay"
 
-if [ -e "$dest_overlay/usr/share/aiden/skills" ]; then
-    echo "cleanup script must remove legacy rootfs bundled skills staging" >&2
-    exit 1
-fi
-
-if [ "$(cat "$dest_overlay/usr/share/aiden/app_mapping.json")" != "mapping" ]; then
-    echo "cleanup script must preserve rootfs app mapping staging" >&2
+if [ -e "$dest_overlay/usr/share/aiden" ]; then
+    echo "cleanup script must remove legacy rootfs bundled Aiden share staging" >&2
     exit 1
 fi
 

--- a/src/agent/internal/agent/tools_phone_bridge.go
+++ b/src/agent/internal/agent/tools_phone_bridge.go
@@ -22,9 +22,9 @@ var defaultAppMappingJSON []byte
 // configDir, and the bundled file shipped with the firmware.
 const AppMappingFileName = "app_mapping.json"
 
-// BundledAppMappingPath is the on-device install path, populated by
+// BundledAppMappingPath is the on-device OEM install path, populated by
 // _build_image.sh from src/agent/internal/agent/app_mapping.json.
-const BundledAppMappingPath = "/usr/share/aiden/" + AppMappingFileName
+const BundledAppMappingPath = "/oem/usr/share/aiden/" + AppMappingFileName
 
 type appMappingEntry struct {
 	IOSURLs         []string `json:"ios_urls"`

--- a/src/agent/internal/agent/tools_phone_bridge_test.go
+++ b/src/agent/internal/agent/tools_phone_bridge_test.go
@@ -5,6 +5,12 @@ import (
 	"testing"
 )
 
+func TestBundledAppMappingPathUsesOEMPartition(t *testing.T) {
+	if BundledAppMappingPath != "/oem/usr/share/aiden/app_mapping.json" {
+		t.Fatalf("BundledAppMappingPath = %q, want OEM path", BundledAppMappingPath)
+	}
+}
+
 func TestResolveOpenAppTargetsBrowserDoesNotUseFixedWebsite(t *testing.T) {
 	args := openAppArgs{App: "browser"}
 

--- a/src/agent/internal/agent/tools_quick_actions.go
+++ b/src/agent/internal/agent/tools_quick_actions.go
@@ -21,9 +21,9 @@ var defaultQuickActionsJSON []byte
 // configDir, and the bundled file shipped with the firmware.
 const QuickActionsFileName = "quick_actions.json"
 
-// BundledQuickActionsPath is the on-device install path, populated by
+// BundledQuickActionsPath is the on-device OEM install path, populated by
 // _build_image.sh from src/agent/internal/agent/quick_actions.json.
-const BundledQuickActionsPath = "/usr/share/aiden/" + QuickActionsFileName
+const BundledQuickActionsPath = "/oem/usr/share/aiden/" + QuickActionsFileName
 
 const (
 	quickActionStatusActive   = "active"

--- a/src/agent/internal/agent/tools_quick_actions_test.go
+++ b/src/agent/internal/agent/tools_quick_actions_test.go
@@ -8,6 +8,12 @@ import (
 	"testing"
 )
 
+func TestBundledQuickActionsPathUsesOEMPartition(t *testing.T) {
+	if BundledQuickActionsPath != "/oem/usr/share/aiden/quick_actions.json" {
+		t.Fatalf("BundledQuickActionsPath = %q, want OEM path", BundledQuickActionsPath)
+	}
+}
+
 func TestQuickActionsResolveAliasAndPlatform(t *testing.T) {
 	table := newQuickActionsTable()
 	if _, ok := table.resolveActionID("返回"); !ok {


### PR DESCRIPTION
## Summary
- Move bundled app mapping and quick actions JSON staging from rootfs overlay into OEM staging.
- Update agent bundled fallback paths to read from /oem/usr/share/aiden.
- Clean legacy rootfs /usr/share/aiden staging and add regression checks for the new ownership boundary.

## Tests
- go test ./internal/agent
- scripts/test_clean_rootfs_overlay_staging.sh
- bash -n _build_image.sh scripts/clean_rootfs_overlay_staging.sh scripts/test_build_scripts.sh scripts/test_clean_rootfs_overlay_staging.sh
- git diff --check

Note: scripts/test_build_scripts.sh was not run end-to-end in this worktree because pico-sdk/project/build.sh is not present.