### PR TITLE
fix(agent): reject stale frames from screenshot tools

### DIFF
--- a/src/agent/internal/agent/coordinate_debug_capture.go
+++ b/src/agent/internal/agent/coordinate_debug_capture.go
@@ -147,20 +147,25 @@ func (s *Server) captureCoordinateDebugScreenshot(options coordinateDebugScreens
 	client := NewFrameServiceClient(s.runtime.config.HID.FrameSocketOrDefault())
 	if options.CropBlackBars {
 		meta, jpegData, err := client.LatestFrameWithFormat("jpeg", screenshotJPEGQuality)
-		if err == nil && meta != nil && meta.PixelFormat == "jpeg" {
-			if sourceWidth, sourceHeight, sourceActive, ok := frameMetadataSourceActiveArea(meta); ok {
-				screen := s.coordinateDebugScreen()
-				if screen != nil {
-					screen.UpdateActiveArea(sourceWidth, sourceHeight, sourceActive)
+		if err == nil && meta != nil {
+			if meta.Stale {
+				return nil, nil, fmt.Errorf("frame service: STALE_FRAME")
+			}
+			if meta.PixelFormat == "jpeg" {
+				if sourceWidth, sourceHeight, sourceActive, ok := frameMetadataSourceActiveArea(meta); ok {
+					screen := s.coordinateDebugScreen()
+					if screen != nil {
+						screen.UpdateActiveArea(sourceWidth, sourceHeight, sourceActive)
+					}
+					display := coordinateDebugDisplayScreenshot(jpegData, int(meta.Width), int(meta.Height))
+					result := s.newCoordinateDebugScreenshotResult(
+						display,
+						sourceWidth,
+						sourceHeight,
+						coordinateDebugSourceActiveArea(sourceActive, sourceWidth, sourceHeight),
+					)
+					return result, jpegData, nil
 				}
-				display := coordinateDebugDisplayScreenshot(jpegData, int(meta.Width), int(meta.Height))
-				result := s.newCoordinateDebugScreenshotResult(
-					display,
-					sourceWidth,
-					sourceHeight,
-					coordinateDebugSourceActiveArea(sourceActive, sourceWidth, sourceHeight),
-				)
-				return result, jpegData, nil
 			}
 		}
 	}
@@ -168,6 +173,9 @@ func (s *Server) captureCoordinateDebugScreenshot(options coordinateDebugScreens
 	meta, frameData, err := client.LatestFrame()
 	if err != nil {
 		return nil, nil, err
+	}
+	if meta.Stale {
+		return nil, nil, fmt.Errorf("frame service: STALE_FRAME")
 	}
 	rawJPEGData, err := encodeFrameAsJPEG(meta, frameData, screenshotJPEGQuality)
 	if err != nil {

--- a/src/agent/internal/agent/frame_client.go
+++ b/src/agent/internal/agent/frame_client.go
@@ -161,7 +161,7 @@ func (c *FrameServiceClient) LatestFrameWithFormat(format string, quality int) (
 	if uint64(len(payload)) != resp.Frame.Bytes {
 		return nil, nil, fmt.Errorf("payload size mismatch: got %d, expected %d", len(payload), resp.Frame.Bytes)
 	}
-
+	// Return stale frame but let caller check meta.Stale flag
 	return &resp.Frame, payload, nil
 }
 

--- a/src/agent/internal/agent/tools_screenshot.go
+++ b/src/agent/internal/agent/tools_screenshot.go
@@ -90,6 +90,9 @@ func (t *ScreenshotTool) Call(_ context.Context, _ string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if meta.Stale {
+		return "", fmt.Errorf("frame service: STALE_FRAME")
+	}
 
 	if meta.PixelFormat != "jpeg" {
 		return "", fmt.Errorf("expected jpeg format, got %s", meta.PixelFormat)


### PR DESCRIPTION
## Problem

When video signal is interrupted, `frame_service` enters `RECOVERING` state and returns old frames marked with `stale=true`. Previously, screenshot and coordinate debug capture tools would return these stale frames to the model, causing the agent to analyze outdated images and make incorrect decisions, compounding errors over time.

## Root Cause

Investigation found that while `tools_wait_stable.go` correctly checks the `stale` flag and skips old frames, the following tools did not:
- `tools_screenshot.go:89` - screenshot tool
- `coordinate_debug_capture.go:149, 168` - coordinate debug capture (both JPEG and raw paths)

## Solution

Added `meta.Stale` checks in three locations to reject stale frames:
1. **tools_screenshot.go** - Screenshot tool now returns error if frame is stale
2. **coordinate_debug_capture.go** - Both JPEG and raw frame paths check for stale frames

When a stale frame is detected, the tool returns error `"frame service: STALE_FRAME"` instead of the outdated image.

## Impact

**Before**: Model receives stale images → makes decisions based on outdated information → errors compound

**After**: Model receives error notification → can wait for recovery or inform user → avoids incorrect decisions

The agent runtime handles tool errors gracefully (see `runtime_test.go:2105-2145` for existing `SERVICE_RECOVERING` error handling). The error is passed to the model as a tool observation, allowing it to:
- Wait and retry
- Use alternative tools
- Inform the user about the temporary issue

**No process interruption** - the agent continues running and can recover when video signal is restored.

## Testing

- ✅ Go code compiles successfully
- ✅ Existing frame metadata tests pass
- ✅ Consistent with existing error handling pattern (SERVICE_RECOVERING)
- ✅ Does not affect `tools_wait_stable.go` which already handles stale frames correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for stale frame data in screenshot operations. The system now properly detects and rejects outdated frame metadata, returning clear error messages instead of attempting to process invalid data. This ensures screenshot operations only proceed with current, valid frame information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->