### PR TITLE
fix(agent): restore planner runtime context

### DIFF
--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -204,7 +204,15 @@ func TestProcessUtteranceAudioModeSendsWAVAttachmentToRuntime(t *testing.T) {
 		t.Fatalf("expected one default-mode planner model call, got %d", len(model.messages))
 	}
 
-	userMessage := model.messages[0][len(model.messages[0])-1]
+	plannerMessages := model.messages[0]
+	if len(plannerMessages) < 3 {
+		t.Fatalf("expected system, raw audio input, and runtime state messages, got %#v", plannerMessages)
+	}
+	userMessage := plannerMessages[len(plannerMessages)-2]
+	stateMessage := plannerMessages[len(plannerMessages)-1]
+	if stateMessage.Role != llms.ChatMessageTypeHuman || !strings.Contains(messageText(plannerMessages[len(plannerMessages)-1:]), "Planner runtime context (synthetic; not a new user request):") {
+		t.Fatalf("expected final planner message to be runtime state context, got %#v", stateMessage)
+	}
 	var text string
 	var audio []byte
 	for _, part := range userMessage.Parts {

--- a/src/agent/internal/agent/chat_history_memory_test.go
+++ b/src/agent/internal/agent/chat_history_memory_test.go
@@ -448,7 +448,10 @@ func TestRuntimeRunBudgetsActivePlannerHistoryBeforeModelCall(t *testing.T) {
 	}
 
 	plannerMessages := model.messages[0]
-	historyText := messageText(plannerMessages[1 : len(plannerMessages)-1])
+	if len(plannerMessages) < 4 {
+		t.Fatalf("expected planner system, history, raw input, and state prompt messages, got %#v", plannerMessages)
+	}
+	historyText := messageText(plannerMessages[1 : len(plannerMessages)-2])
 	for _, want := range []string{"PINNED_ROOT_REQUEST", "KEEP_RECENT_USER", "KEEP_RECENT_ASSISTANT"} {
 		if !strings.Contains(historyText, want) {
 			t.Fatalf("budgeted planner history missing %q:\n%s", want, historyText)

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -1264,6 +1264,9 @@ func buildRoleStatePromptWithOptions(role RoleName, inputs map[string]string, st
 }
 
 func buildPlannerStatePrompt(inputs map[string]string, state roleLoopState, task string) string {
+	if state.ForceSimpleLoop {
+		return buildSimpleLoopPlannerStatePrompt(inputs, state)
+	}
 	var builder strings.Builder
 	builder.WriteString("Planner runtime context (synthetic; not a new user request):\n")
 	builder.WriteString(task)
@@ -1273,13 +1276,23 @@ func buildPlannerStatePrompt(inputs map[string]string, state roleLoopState, task
 	writeSessionContext(&builder, inputs)
 	writeTodoState(&builder, state)
 	writeTodoReminder(&builder, state)
-	if state.ForceSimpleLoop {
-		return strings.TrimSpace(builder.String())
-	}
 	writeCurrentPlan(&builder, state)
 	writePriorPlanStepResults(&builder, state)
 	writeVerifierFeedback(&builder, state)
 	return strings.TrimSpace(builder.String())
+}
+
+func buildSimpleLoopPlannerStatePrompt(inputs map[string]string, state roleLoopState) string {
+	var builder strings.Builder
+	writeWorldStateIfPresent(&builder, state.World)
+	writeSimpleLoopRootRequest(&builder, inputs)
+	writeTodoState(&builder, state)
+	writeTodoReminder(&builder, state)
+	content := strings.TrimSpace(builder.String())
+	if content == "" {
+		return ""
+	}
+	return "Planner runtime context (synthetic; not a new user request):\n" + content
 }
 
 func buildExecutorStatePrompt(inputs map[string]string, state roleLoopState, task string) string {
@@ -1484,6 +1497,13 @@ func writeWorldState(builder *strings.Builder, world worldState) {
 	writeWorldStateWithOptions(builder, world, worldStatePromptOptions{})
 }
 
+func writeWorldStateIfPresent(builder *strings.Builder, world worldState) {
+	if world.DeviceEnvironment == nil && world.Observation == nil {
+		return
+	}
+	writeWorldState(builder, world)
+}
+
 func writeWorldStateWithOptions(builder *strings.Builder, world worldState, options worldStatePromptOptions) {
 	builder.WriteString("\n\nWorld State (shared across planner, executor, and verifier):\n")
 	if world.DeviceEnvironment != nil {
@@ -1628,6 +1648,19 @@ func writeRequestContextAndCriteria(builder *strings.Builder, inputs map[string]
 			builder.WriteByte('\n')
 		}
 	}
+}
+
+func writeSimpleLoopRootRequest(builder *strings.Builder, inputs map[string]string) {
+	currentInput := strings.TrimSpace(plannerCurrentUserMessage(inputs))
+	rootRequest := strings.TrimSpace(inputs[rootRequestInputKey])
+	if rootRequest == "" {
+		rootRequest = currentInput
+	}
+	if rootRequest == "" || rootRequest == currentInput {
+		return
+	}
+	builder.WriteString("\n\nOriginal user request / root request:\n")
+	builder.WriteString(rootRequest)
 }
 
 func writeSessionContext(builder *strings.Builder, inputs map[string]string) {

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -1273,6 +1273,9 @@ func buildPlannerStatePrompt(inputs map[string]string, state roleLoopState, task
 	writeSessionContext(&builder, inputs)
 	writeTodoState(&builder, state)
 	writeTodoReminder(&builder, state)
+	if state.ForceSimpleLoop {
+		return strings.TrimSpace(builder.String())
+	}
 	writeCurrentPlan(&builder, state)
 	writePriorPlanStepResults(&builder, state)
 	writeVerifierFeedback(&builder, state)

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -1105,6 +1105,13 @@ func (e *roleCollaborativeExecutor) roleMessages(profile RoleProfile, inputs map
 	}
 
 	if profile.Name == RolePlanner {
+		statePrompt := buildRoleStatePrompt(profile.Name, inputs, state, task)
+		if strings.TrimSpace(statePrompt) != "" {
+			messages = append(messages, llms.MessageContent{
+				Role:  llms.ChatMessageTypeHuman,
+				Parts: []llms.ContentPart{llms.TextPart(statePrompt)},
+			})
+		}
 		for _, steer := range state.SteerMessages {
 			messages = append(messages, llms.MessageContent{
 				Role:  llms.ChatMessageTypeHuman,
@@ -1244,7 +1251,7 @@ type roleStatePromptOptions struct {
 func buildRoleStatePromptWithOptions(role RoleName, inputs map[string]string, state roleLoopState, task string, options roleStatePromptOptions) string {
 	switch role {
 	case RolePlanner:
-		return plannerCurrentUserMessage(inputs)
+		return buildPlannerStatePrompt(inputs, state, task)
 	case RoleExecutor:
 		return buildExecutorStatePrompt(inputs, state, task)
 	case RoleVerifier:
@@ -1252,8 +1259,25 @@ func buildRoleStatePromptWithOptions(role RoleName, inputs map[string]string, st
 			IncludeLatestScreenshot: options.IncludeWorldStateLatestScreenshot,
 		})
 	default:
-		return plannerCurrentUserMessage(inputs)
+		return buildPlannerStatePrompt(inputs, state, task)
 	}
+}
+
+func buildPlannerStatePrompt(inputs map[string]string, state roleLoopState, task string) string {
+	var builder strings.Builder
+	builder.WriteString("Planner runtime context (synthetic; not a new user request):\n")
+	builder.WriteString(task)
+	writeLoopMode(&builder, state)
+	writeWorldState(&builder, state.World)
+	writeRequestContextAndCriteria(&builder, inputs, state)
+	writeSessionContext(&builder, inputs)
+	writeTodoState(&builder, state)
+	writeTodoReminder(&builder, state)
+	writeCurrentPlan(&builder, state)
+	writePriorPlanStepResults(&builder, state)
+	writeExecutorResults(&builder, state)
+	writeVerifierFeedback(&builder, state)
+	return strings.TrimSpace(builder.String())
 }
 
 func buildExecutorStatePrompt(inputs map[string]string, state roleLoopState, task string) string {

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -1275,7 +1275,6 @@ func buildPlannerStatePrompt(inputs map[string]string, state roleLoopState, task
 	writeTodoReminder(&builder, state)
 	writeCurrentPlan(&builder, state)
 	writePriorPlanStepResults(&builder, state)
-	writeExecutorResults(&builder, state)
 	writeVerifierFeedback(&builder, state)
 	return strings.TrimSpace(builder.String())
 }

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -1079,15 +1079,20 @@ func TestPlannerCurrentUserMessageIsRawInputOnly(t *testing.T) {
 
 func TestPlannerCurrentUserMessagePrecedesToolScratchpad(t *testing.T) {
 	executor := &roleCollaborativeExecutor{}
+	toolStep := schema.AgentStep{
+		Action: schema.AgentAction{
+			Tool:      "recall_memory",
+			ToolInput: `{"tags":["weather","location"]}`,
+			Log:       "我查下默认地点。",
+		},
+		Observation: `{"results":[]}`,
+	}
 	state := roleLoopState{
-		Phase: phaseDefault,
-		ToolSteps: []schema.AgentStep{{
-			Action: schema.AgentAction{
-				Tool:      "recall_memory",
-				ToolInput: `{"tags":["weather","location"]}`,
-				Log:       "我查下默认地点。",
-			},
-			Observation: `{"results":[]}`,
+		Phase:     phaseDefault,
+		ToolSteps: []schema.AgentStep{toolStep},
+		ExecutionResults: []roleExecutionResult{{
+			Action: &toolStep.Action,
+			Step:   &toolStep,
 		}},
 	}
 	inputs := map[string]string{
@@ -1112,6 +1117,9 @@ func TestPlannerCurrentUserMessagePrecedesToolScratchpad(t *testing.T) {
 	}
 	if messages[4].Role != llms.ChatMessageTypeHuman || !strings.Contains(messageText(messages[4:5]), "Planner runtime context") {
 		t.Fatalf("message[4] should be planner runtime state, got role=%s text=%q", messages[4].Role, messageText(messages[4:5]))
+	}
+	if strings.Contains(messageText(messages[4:5]), "Executor results:") {
+		t.Fatalf("planner runtime state should not summarize planner tool scratchpad as executor results:\n%s", messageText(messages[4:5]))
 	}
 }
 

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -866,12 +866,9 @@ func TestRequestContextPromptDoesNotMarkRootRequestAuthoritative(t *testing.T) {
 		latestUserInputKey:   "打开微信",
 		"follow_up_relation": "continuation",
 	}
-	prompt := buildRoleStatePrompt(RolePlanner, inputs, roleLoopState{}, "Planner task.")
+	prompt := buildRoleStatePrompt(RolePlanner, inputs, roleLoopState{Phase: phasePlan}, "Planner task.")
 
 	for _, unwanted := range []string{
-		"Planner task.",
-		"Loop mode:",
-		"Original user request",
 		"Original user request / root request (authoritative; do not replace it with a subtask)",
 		"authoritative; do not replace it with a subtask",
 		"Current objective:",
@@ -883,16 +880,53 @@ func TestRequestContextPromptDoesNotMarkRootRequestAuthoritative(t *testing.T) {
 			t.Fatalf("planner prompt should not contain %q:\n%s", unwanted, prompt)
 		}
 	}
-	if prompt != "打开微信" {
-		t.Fatalf("planner prompt = %q, want raw current input only", prompt)
+	for _, want := range []string{
+		"Planner runtime context (synthetic; not a new user request):",
+		"Planner task.",
+		"Loop mode:",
+		"Original user request / root request:",
+		"查天气",
+		"Latest user message:",
+		"打开微信",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("planner prompt missing %q:\n%s", want, prompt)
+		}
 	}
 }
 
-func TestPlannerMessagesOmitRuntimeStateContext(t *testing.T) {
+func TestPlannerMessagesAppendRuntimeStateContext(t *testing.T) {
 	executor := &roleCollaborativeExecutor{}
 	state := roleLoopState{
-		Phase: phasePlan,
-		Plan:  []string{"inspect"},
+		Phase:         phasePlan,
+		PlanCommitted: true,
+		Plan:          []string{"inspect", "act"},
+		NextStep:      "inspect",
+		PlanStepResults: []planStepResult{{
+			StepIndex:      1,
+			StepText:       "inspect",
+			Outcome:        "blocked",
+			Summary:        "screen did not change",
+			NeedsReplan:    true,
+			VerifierReason: "not enough progress",
+		}},
+		VerifierResults: []verifierDecision{{
+			NeedsReplan: true,
+			Reason:      "not enough progress",
+		}},
+		Todo: TodoState{
+			Mode:      TodoModePlanned,
+			Objective: "inspect and act",
+			Revision:  1,
+			CurrentID: "todo-r1-step1",
+			Items: []TodoItem{{
+				ID:        "todo-r1-step1",
+				Text:      "inspect",
+				Status:    TodoBlocked,
+				Source:    TodoSourceCommittedPlan,
+				StepIndex: 1,
+			}},
+		},
 		World: worldState{
 			Observation: &worldStateObservation{
 				observedWorldState: observedWorldState{
@@ -913,32 +947,52 @@ func TestPlannerMessagesOmitRuntimeStateContext(t *testing.T) {
 		ThirdPartyApps: []AvailableAppInfo{{Name: "微信", Available: true}},
 	})
 	inputs := map[string]string{
-		"input":             "fallback request",
-		rootRequestInputKey: "原始用户请求",
-		latestUserInputKey:  "最新用户消息",
+		"input":                "fallback request",
+		rootRequestInputKey:    "原始用户请求",
+		latestUserInputKey:     "最新用户消息",
+		sessionContextInputKey: "Session context view:\n- Latest user message: 最新用户消息",
 	}
 
 	messages := executor.roleMessages(RoleProfile{Name: RolePlanner, SystemPrompt: "planner system"}, inputs, state, "Planner task.")
-	prompt := messageText(messages)
-	for _, unwanted := range []string{
+	if len(messages) != 3 {
+		t.Fatalf("planner messages = %d, want system, raw user input, runtime state: %#v", len(messages), messages)
+	}
+	if messages[0].Role != llms.ChatMessageTypeSystem {
+		t.Fatalf("message[0] role = %s, want system", messages[0].Role)
+	}
+	if messageText(messages[:1]) != "planner system\n" {
+		t.Fatalf("planner system should not receive runtime state:\n%s", messageText(messages[:1]))
+	}
+	if messages[1].Role != llms.ChatMessageTypeHuman || messageText(messages[1:2]) != "fallback request\n" {
+		t.Fatalf("message[1] should be raw current user input, got role=%s text=%q", messages[1].Role, messageText(messages[1:2]))
+	}
+	statePrompt := messageText(messages[2:])
+	for _, want := range []string{
+		"Planner runtime context (synthetic; not a new user request):",
 		"Planner task.",
 		"Loop mode:",
 		"Original user request",
 		"Latest user message",
 		"Current plan:",
 		"World State",
-		"Device environment:",
+		"Device environment: available",
 		"Confirmed third-party apps:",
 		"Observed app/page:",
 		"Visible text:",
 		"Dialogs:",
+		"Session context view:",
+		"Current todo state:",
+		"Prior step results",
+		"summary=\"screen did not change\"",
+		"Verifier feedback:",
+		"not enough progress",
 	} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("planner prompt should not contain world state field %q:\n%s", unwanted, prompt)
+		if !strings.Contains(statePrompt, want) {
+			t.Fatalf("planner runtime state prompt missing %q:\n%s", want, statePrompt)
 		}
 	}
-	if !strings.Contains(prompt, "planner system") || !strings.Contains(prompt, "fallback request") {
-		t.Fatalf("planner messages should keep static system prompt and raw input:\n%s", prompt)
+	if strings.Contains(statePrompt, "Latest screenshot:") {
+		t.Fatalf("planner runtime state should not include world latest screenshot text:\n%s", statePrompt)
 	}
 }
 
@@ -974,13 +1028,13 @@ func TestPlannerCurrentUserMessageIsRawInputOnly(t *testing.T) {
 	if len(messages) < 2 {
 		t.Fatalf("planner messages = %#v, want system context and user input", messages)
 	}
-	last := messages[len(messages)-1]
-	if last.Role != llms.ChatMessageTypeHuman {
-		t.Fatalf("last planner message role = %s, want human; messages=%#v", last.Role, messages)
+	raw := messages[1]
+	if raw.Role != llms.ChatMessageTypeHuman {
+		t.Fatalf("raw planner message role = %s, want human; messages=%#v", raw.Role, messages)
 	}
 	var textParts []string
 	var imageParts int
-	for _, part := range last.Parts {
+	for _, part := range raw.Parts {
 		switch typed := part.(type) {
 		case llms.TextContent:
 			textParts = append(textParts, typed.Text)
@@ -989,11 +1043,11 @@ func TestPlannerCurrentUserMessageIsRawInputOnly(t *testing.T) {
 		}
 	}
 	if len(textParts) != 1 || imageParts != 1 {
-		t.Fatalf("last planner message parts = %#v, want one raw text part and one raw image part", last.Parts)
+		t.Fatalf("raw planner message parts = %#v, want one raw text part and one raw image part", raw.Parts)
 	}
 	text := textParts[0]
 	if text != "当前用户原始输入" {
-		t.Fatalf("last planner user message = %q, want raw input only", text)
+		t.Fatalf("raw planner user message = %q, want raw input only", text)
 	}
 	for _, unwanted := range []string{
 		"Planner task.",
@@ -1007,12 +1061,19 @@ func TestPlannerCurrentUserMessageIsRawInputOnly(t *testing.T) {
 		"screen.png",
 	} {
 		if strings.Contains(text, unwanted) {
-			t.Fatalf("last planner user message should not contain %q:\n%s", unwanted, text)
+			t.Fatalf("raw planner user message should not contain %q:\n%s", unwanted, text)
 		}
 	}
 	systemText := messageText(messages[:1])
 	if strings.TrimSpace(systemText) != "planner system" {
 		t.Fatalf("planner system message should not receive runtime state context:\n%s", systemText)
+	}
+	statePrompt := messageText(messages[len(messages)-1:])
+	if !strings.Contains(statePrompt, "Planner runtime context (synthetic; not a new user request):") ||
+		!strings.Contains(statePrompt, "Planner task.") ||
+		strings.Contains(statePrompt, "Attached content:") ||
+		strings.Contains(statePrompt, "screen.png") {
+		t.Fatalf("planner runtime state should be final pure-text context without attachment metadata:\n%s", statePrompt)
 	}
 }
 
@@ -1034,8 +1095,8 @@ func TestPlannerCurrentUserMessagePrecedesToolScratchpad(t *testing.T) {
 	}
 
 	messages := executor.roleMessages(RoleProfile{Name: RolePlanner, SystemPrompt: "planner system"}, inputs, state, "Planner task.")
-	if len(messages) != 4 {
-		t.Fatalf("planner messages = %d, want system, user, assistant tool call, tool result: %#v", len(messages), messages)
+	if len(messages) != 5 {
+		t.Fatalf("planner messages = %d, want system, user, assistant tool call, tool result, runtime state: %#v", len(messages), messages)
 	}
 	if messages[0].Role != llms.ChatMessageTypeSystem {
 		t.Fatalf("message[0] role = %s, want system", messages[0].Role)
@@ -1048,6 +1109,9 @@ func TestPlannerCurrentUserMessagePrecedesToolScratchpad(t *testing.T) {
 	}
 	if messages[3].Role != llms.ChatMessageTypeTool {
 		t.Fatalf("message[3] role = %s, want tool result", messages[3].Role)
+	}
+	if messages[4].Role != llms.ChatMessageTypeHuman || !strings.Contains(messageText(messages[4:5]), "Planner runtime context") {
+		t.Fatalf("message[4] should be planner runtime state, got role=%s text=%q", messages[4].Role, messageText(messages[4:5]))
 	}
 }
 

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -1055,12 +1055,8 @@ func TestForceSimpleLoopPlannerRuntimeContextOmitsDelegatedPlanSections(t *testi
 	prompt := buildRoleStatePrompt(RolePlanner, inputs, state, "Planner task.")
 	for _, want := range []string{
 		"Planner runtime context (synthetic; not a new user request):",
-		"Loop mode:",
-		"force_simple_loop: true",
 		"World State",
 		"Original user request / root request:",
-		"Latest user message:",
-		"Session context view:",
 		"Current todo state:",
 		"Todo reminder:",
 	} {
@@ -1069,6 +1065,11 @@ func TestForceSimpleLoopPlannerRuntimeContextOmitsDelegatedPlanSections(t *testi
 		}
 	}
 	for _, unwanted := range []string{
+		"Planner task.",
+		"Loop mode:",
+		"force_simple_loop: true",
+		"Latest user message:",
+		"Session context view:",
 		"Current plan:",
 		"Prior step results",
 		"Verifier feedback:",

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -996,6 +996,89 @@ func TestPlannerMessagesAppendRuntimeStateContext(t *testing.T) {
 	}
 }
 
+func TestForceSimpleLoopPlannerRuntimeContextOmitsDelegatedPlanSections(t *testing.T) {
+	state := roleLoopState{
+		Phase:           phaseDefault,
+		ForceSimpleLoop: true,
+		Plan:            []string{"inspect", "act"},
+		NextStep:        "inspect",
+		PlanStepResults: []planStepResult{{
+			StepIndex:      1,
+			StepText:       "inspect",
+			Outcome:        "blocked",
+			Summary:        "screen did not change",
+			NeedsReplan:    true,
+			VerifierReason: "not enough progress",
+		}},
+		VerifierResults: []verifierDecision{{
+			NeedsReplan: true,
+			Reason:      "not enough progress",
+		}},
+		Todo: TodoState{
+			Mode:      TodoModeSimple,
+			Objective: "inspect and act",
+			Revision:  2,
+			CurrentID: "todo-simple-2",
+			Items: []TodoItem{{
+				ID:        "todo-simple-1",
+				Text:      "inspect",
+				Status:    TodoDone,
+				Source:    TodoSourceExplicitSimple,
+				StepIndex: 1,
+			}, {
+				ID:        "todo-simple-2",
+				Text:      "act",
+				Status:    TodoInProgress,
+				Source:    TodoSourceExplicitSimple,
+				StepIndex: 2,
+			}},
+		},
+		PendingTodoReminder: "call set_todo if the task now needs an explicit checklist.",
+		World: worldState{
+			Observation: &worldStateObservation{
+				observedWorldState: observedWorldState{
+					AppName:     "微信",
+					PageName:    "聊天列表",
+					Platform:    "android",
+					VisibleText: []string{"微信", "通讯录"},
+				},
+			},
+		},
+	}
+	inputs := map[string]string{
+		"input":                "继续",
+		rootRequestInputKey:    "打开微信后继续处理",
+		latestUserInputKey:     "继续",
+		sessionContextInputKey: "Session context view:\n- Latest user message: 继续",
+	}
+
+	prompt := buildRoleStatePrompt(RolePlanner, inputs, state, "Planner task.")
+	for _, want := range []string{
+		"Planner runtime context (synthetic; not a new user request):",
+		"Loop mode:",
+		"force_simple_loop: true",
+		"World State",
+		"Original user request / root request:",
+		"Latest user message:",
+		"Session context view:",
+		"Current todo state:",
+		"Todo reminder:",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("force_simple_loop planner runtime context missing %q:\n%s", want, prompt)
+		}
+	}
+	for _, unwanted := range []string{
+		"Current plan:",
+		"Prior step results",
+		"Verifier feedback:",
+	} {
+		if strings.Contains(prompt, unwanted) {
+			t.Fatalf("force_simple_loop planner runtime context should not contain %q:\n%s", unwanted, prompt)
+		}
+	}
+}
+
 func TestPlannerCurrentUserMessageIsRawInputOnly(t *testing.T) {
 	executor := &roleCollaborativeExecutor{
 		InputAttachments: []InputAttachment{{

--- a/src/agent/internal/agent/role_profile_test.go
+++ b/src/agent/internal/agent/role_profile_test.go
@@ -455,15 +455,16 @@ func TestForceSimpleLoopPlannerCallOmitsPlanMetaTools(t *testing.T) {
 			t.Fatalf("force_simple_loop prompt should not contain %q:\n%s", unexpected, plannerPrompt)
 		}
 	}
-	for _, want := range []string{
+	for _, unexpected := range []string{
 		"Planner runtime context (synthetic; not a new user request):",
 		"Loop mode:",
 		"force_simple_loop: true",
 		"Original user request / root request:",
-		"set volume to 3",
+		"Latest user message:",
+		"Session context view:",
 	} {
-		if !strings.Contains(plannerPrompt, want) {
-			t.Fatalf("force_simple_loop planner prompt missing runtime context %q:\n%s", want, plannerPrompt)
+		if strings.Contains(plannerPrompt, unexpected) {
+			t.Fatalf("first-turn force_simple_loop planner prompt should not include runtime context %q:\n%s", unexpected, plannerPrompt)
 		}
 	}
 }
@@ -494,18 +495,15 @@ func TestForceSimpleLoopRejectsUnexpectedPlanMetaToolCall(t *testing.T) {
 		t.Fatalf("model calls = %d, want 2", model.callCount)
 	}
 	secondPrompt := messageText(model.messages[1])
-	for _, want := range []string{
+	for _, unexpected := range []string{
 		"Planner runtime context (synthetic; not a new user request):",
 		"current_mode: default",
 		"force_simple_loop: true",
+		"current_mode: plan",
+		"commit_plan is available",
 	} {
-		if !strings.Contains(secondPrompt, want) {
-			t.Fatalf("force_simple_loop planner prompt missing runtime loop state %q:\n%s", want, secondPrompt)
-		}
-	}
-	for _, unexpected := range []string{"current_mode: plan", "commit_plan is available"} {
 		if strings.Contains(secondPrompt, unexpected) {
-			t.Fatalf("force_simple_loop planner prompt should not expose plan-mode state %q:\n%s", unexpected, secondPrompt)
+			t.Fatalf("force_simple_loop planner prompt should not expose runtime context %q:\n%s", unexpected, secondPrompt)
 		}
 	}
 }

--- a/src/agent/internal/agent/role_profile_test.go
+++ b/src/agent/internal/agent/role_profile_test.go
@@ -741,7 +741,6 @@ func TestRoleCollaborativeExecutorReplansAfterRepeatedVerifierFailures(t *testin
 	for _, want := range []string{
 		"Planner runtime context (synthetic; not a new user request):",
 		"Current plan:",
-		"Executor results:",
 		"Prior step results",
 		"Verifier feedback:",
 		"not enough progress",
@@ -751,6 +750,9 @@ func TestRoleCollaborativeExecutorReplansAfterRepeatedVerifierFailures(t *testin
 		if !strings.Contains(secondPlannerPrompt, want) {
 			t.Fatalf("second planner prompt missing %q:\n%s", want, secondPlannerPrompt)
 		}
+	}
+	if strings.Contains(secondPlannerPrompt, "Executor results:") {
+		t.Fatalf("planner runtime context should not duplicate execution history as executor results:\n%s", secondPlannerPrompt)
 	}
 
 	secondExecutorMessages := model.messages[7]

--- a/src/agent/internal/agent/role_profile_test.go
+++ b/src/agent/internal/agent/role_profile_test.go
@@ -455,8 +455,16 @@ func TestForceSimpleLoopPlannerCallOmitsPlanMetaTools(t *testing.T) {
 			t.Fatalf("force_simple_loop prompt should not contain %q:\n%s", unexpected, plannerPrompt)
 		}
 	}
-	if strings.Contains(plannerPrompt, "force_simple_loop: true") || strings.Contains(plannerPrompt, "Loop mode:") {
-		t.Fatalf("force_simple_loop planner prompt should not contain runtime loop state:\n%s", plannerPrompt)
+	for _, want := range []string{
+		"Planner runtime context (synthetic; not a new user request):",
+		"Loop mode:",
+		"force_simple_loop: true",
+		"Original user request / root request:",
+		"set volume to 3",
+	} {
+		if !strings.Contains(plannerPrompt, want) {
+			t.Fatalf("force_simple_loop planner prompt missing runtime context %q:\n%s", want, plannerPrompt)
+		}
 	}
 }
 
@@ -486,9 +494,18 @@ func TestForceSimpleLoopRejectsUnexpectedPlanMetaToolCall(t *testing.T) {
 		t.Fatalf("model calls = %d, want 2", model.callCount)
 	}
 	secondPrompt := messageText(model.messages[1])
-	for _, unexpected := range []string{"current_mode: default", "current_mode: plan", "Loop mode:"} {
+	for _, want := range []string{
+		"Planner runtime context (synthetic; not a new user request):",
+		"current_mode: default",
+		"force_simple_loop: true",
+	} {
+		if !strings.Contains(secondPrompt, want) {
+			t.Fatalf("force_simple_loop planner prompt missing runtime loop state %q:\n%s", want, secondPrompt)
+		}
+	}
+	for _, unexpected := range []string{"current_mode: plan", "commit_plan is available"} {
 		if strings.Contains(secondPrompt, unexpected) {
-			t.Fatalf("force_simple_loop planner prompt should not expose runtime loop state %q:\n%s", unexpected, secondPrompt)
+			t.Fatalf("force_simple_loop planner prompt should not expose plan-mode state %q:\n%s", unexpected, secondPrompt)
 		}
 	}
 }
@@ -721,14 +738,18 @@ func TestRoleCollaborativeExecutorReplansAfterRepeatedVerifierFailures(t *testin
 	}
 
 	secondPlannerPrompt := messageText(model.messages[5])
-	for _, unexpected := range []string{
+	for _, want := range []string{
+		"Planner runtime context (synthetic; not a new user request):",
 		"Current plan:",
 		"Executor results:",
+		"Prior step results",
 		"Verifier feedback:",
 		"not enough progress",
+		"needs_replan=true",
+		"repeat same tool",
 	} {
-		if strings.Contains(secondPlannerPrompt, unexpected) {
-			t.Fatalf("second planner prompt should not expose runtime state %q:\n%s", unexpected, secondPlannerPrompt)
+		if !strings.Contains(secondPlannerPrompt, want) {
+			t.Fatalf("second planner prompt missing %q:\n%s", want, secondPlannerPrompt)
 		}
 	}
 
@@ -1157,14 +1178,20 @@ func TestRoleCollaborativeExecutorUpdatesWorldStateFromObservedState(t *testing.
 
 	secondPlannerMessages := model.messages[5]
 	secondPlannerPrompt := messageText([]llms.MessageContent{secondPlannerMessages[len(secondPlannerMessages)-1]})
-	for _, unexpected := range []string{
+	for _, want := range []string{
+		"Planner runtime context (synthetic; not a new user request):",
 		"World State",
 		"Observed app/page: 微信 / 聊天列表 platform=android confidence=0.82 source_role=verifier",
 		"Visible text: 微信 | 通讯录",
 		"Dialogs: 权限提示",
 	} {
-		if strings.Contains(secondPlannerPrompt, unexpected) {
-			t.Fatalf("second planner prompt should not contain world state field %q:\n%s", unexpected, secondPlannerPrompt)
+		if !strings.Contains(secondPlannerPrompt, want) {
+			t.Fatalf("second planner prompt missing world state field %q:\n%s", want, secondPlannerPrompt)
+		}
+	}
+	for _, part := range secondPlannerMessages[len(secondPlannerMessages)-1].Parts {
+		if _, ok := part.(llms.ImageURLContent); ok {
+			t.Fatalf("planner runtime state should be compact text without world-state image: %#v", secondPlannerMessages[len(secondPlannerMessages)-1])
 		}
 	}
 

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1084,23 +1084,33 @@ func TestRuntimeRunResumeCorrectionUsesRootRequestAndCommittedPlan(t *testing.T)
 		t.Fatalf("expected second run planner prompt, got %#v", model.messages)
 	}
 	resumePrompt := messageText(model.messages[2])
-	role, lastText, ok := runtimeLastMessageText(model.messages[2])
-	if !ok || role != llms.ChatMessageTypeHuman || lastText != correction {
-		t.Fatalf("resume planner current user message = role %s text %q, want raw correction %q", role, lastText, correction)
+	resumeMessages := model.messages[2]
+	if len(resumeMessages) < 2 {
+		t.Fatalf("resume planner prompt missing raw input and runtime context: %#v", resumeMessages)
+	}
+	rawMessage := resumeMessages[len(resumeMessages)-2]
+	if rawMessage.Role != llms.ChatMessageTypeHuman || strings.TrimSpace(messageText(resumeMessages[len(resumeMessages)-2:len(resumeMessages)-1])) != correction {
+		t.Fatalf("resume planner current user message = role %s text %q, want raw correction %q", rawMessage.Role, messageText(resumeMessages[len(resumeMessages)-2:len(resumeMessages)-1]), correction)
+	}
+	if statePrompt := messageText(resumeMessages[len(resumeMessages)-1:]); !strings.Contains(statePrompt, "Planner runtime context (synthetic; not a new user request):") {
+		t.Fatalf("resume planner final message should be runtime state context:\n%s", statePrompt)
 	}
 	for _, unwanted := range []string{
-		"Original user request / root request",
-		"Latest user message",
-		"Latest committed plan",
-		"Current plan:",
-		"Executor results:",
-		"Verifier feedback:",
 		"Follow-up classification:",
 		"follow_up_relation",
 		"Latest correction",
 	} {
 		if strings.Contains(resumePrompt, unwanted) {
-			t.Fatalf("resume planner prompt should not expose follow-up relation judgement %q:\n%s", unwanted, resumePrompt)
+			t.Fatalf("resume planner prompt should not expose legacy follow-up judgement %q:\n%s", unwanted, resumePrompt)
+		}
+	}
+	for _, want := range []string{
+		"Session context view:",
+		"Latest committed plan",
+		"目标群是 Aden AI agent",
+	} {
+		if !strings.Contains(resumePrompt, want) {
+			t.Fatalf("resume planner prompt missing session context %q:\n%s", want, resumePrompt)
 		}
 	}
 	if strings.Contains(resumePrompt, "发介绍") {
@@ -1164,9 +1174,16 @@ func TestRuntimeRunVoiceInterruptionContextUsesTimeBoundary(t *testing.T) {
 		t.Fatalf("expected second model prompt, got %#v", model.messages)
 	}
 	correctionPrompt := messageText(model.messages[1])
-	role, lastText, ok := runtimeLastMessageText(model.messages[1])
-	if !ok || role != llms.ChatMessageTypeHuman || lastText != correction {
-		t.Fatalf("correction planner current user message = role %s text %q, want raw correction %q", role, lastText, correction)
+	correctionMessages := model.messages[1]
+	if len(correctionMessages) < 2 {
+		t.Fatalf("correction planner prompt missing raw input and runtime context: %#v", correctionMessages)
+	}
+	rawMessage := correctionMessages[len(correctionMessages)-2]
+	if rawMessage.Role != llms.ChatMessageTypeHuman || strings.TrimSpace(messageText(correctionMessages[len(correctionMessages)-2:len(correctionMessages)-1])) != correction {
+		t.Fatalf("correction planner current user message = role %s text %q, want raw correction %q", rawMessage.Role, messageText(correctionMessages[len(correctionMessages)-2:len(correctionMessages)-1]), correction)
+	}
+	if statePrompt := messageText(correctionMessages[len(correctionMessages)-1:]); !strings.Contains(statePrompt, "Planner runtime context (synthetic; not a new user request):") {
+		t.Fatalf("correction planner final message should be runtime state context:\n%s", statePrompt)
 	}
 	for _, want := range []string{
 		"## Runtime context",
@@ -1178,17 +1195,23 @@ func TestRuntimeRunVoiceInterruptionContextUsesTimeBoundary(t *testing.T) {
 		}
 	}
 	for _, unwanted := range []string{
-		"Original user request / root request",
-		"Latest user message",
-		"Current plan:",
-		"Executor results:",
-		"Verifier feedback:",
 		"Follow-up classification:",
 		"follow_up_relation",
 		"Latest correction",
 	} {
 		if strings.Contains(correctionPrompt, unwanted) {
-			t.Fatalf("correction prompt should not expose follow-up relation judgement %q:\n%s", unwanted, correctionPrompt)
+			t.Fatalf("correction prompt should not expose legacy follow-up judgement %q:\n%s", unwanted, correctionPrompt)
+		}
+	}
+	for _, want := range []string{
+		"Original user request / root request:",
+		rootRequest,
+		"Latest user message:",
+		correction,
+		"Current plan:",
+	} {
+		if !strings.Contains(correctionPrompt, want) {
+			t.Fatalf("correction prompt missing runtime context %q:\n%s", want, correctionPrompt)
 		}
 	}
 
@@ -2885,8 +2908,8 @@ func TestRuntimeSimpleLoopTodoReminderAfterSeveralToolCalls(t *testing.T) {
 		t.Fatalf("expected fourth model call after reminder, got %d", len(model.messages))
 	}
 	prompt := messageText(model.messages[3])
-	if strings.Contains(prompt, "Todo reminder") || strings.Contains(prompt, "call set_todo") {
-		t.Fatalf("fourth planner prompt should not expose todo reminder runtime state:\n%s", prompt)
+	if !strings.Contains(prompt, "Todo reminder") || !strings.Contains(prompt, "call set_todo") {
+		t.Fatalf("fourth planner prompt missing todo reminder runtime state:\n%s", prompt)
 	}
 }
 
@@ -2914,8 +2937,8 @@ func TestRuntimeSimpleLoopTodoReminderUsesConfiguredToolCallThreshold(t *testing
 		t.Fatalf("expected third model call after configured reminder, got %d", len(model.messages))
 	}
 	prompt := messageText(model.messages[2])
-	if strings.Contains(prompt, "Todo reminder") || strings.Contains(prompt, "call set_todo") {
-		t.Fatalf("third planner prompt should not expose configured todo reminder runtime state:\n%s", prompt)
+	if !strings.Contains(prompt, "Todo reminder") || !strings.Contains(prompt, "call set_todo") {
+		t.Fatalf("third planner prompt missing configured todo reminder runtime state:\n%s", prompt)
 	}
 }
 
@@ -4724,12 +4747,16 @@ func TestRuntimeRunIncludesUserAttachments(t *testing.T) {
 	}
 
 	lastCall := model.messages[0]
-	if len(lastCall) == 0 {
+	if len(lastCall) < 3 {
 		t.Fatalf("expected messages in model call")
 	}
-	userMessage := lastCall[len(lastCall)-1]
+	userMessage := lastCall[len(lastCall)-2]
 	if userMessage.Role != llms.ChatMessageTypeHuman {
-		t.Fatalf("expected final message to be human, got %q", userMessage.Role)
+		t.Fatalf("expected raw user message to be human, got %q", userMessage.Role)
+	}
+	stateMessage := lastCall[len(lastCall)-1]
+	if stateMessage.Role != llms.ChatMessageTypeHuman || !strings.Contains(messageText(lastCall[len(lastCall)-1:]), "Planner runtime context (synthetic; not a new user request):") {
+		t.Fatalf("expected final planner message to be runtime state context, got %#v", stateMessage)
 	}
 
 	var textContent string

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1208,10 +1208,18 @@ func TestRuntimeRunVoiceInterruptionContextUsesTimeBoundary(t *testing.T) {
 		rootRequest,
 		"Latest user message:",
 		correction,
-		"Current plan:",
 	} {
 		if !strings.Contains(correctionPrompt, want) {
 			t.Fatalf("correction prompt missing runtime context %q:\n%s", want, correctionPrompt)
+		}
+	}
+	for _, unwanted := range []string{
+		"Current plan:",
+		"Prior step results",
+		"Verifier feedback:",
+	} {
+		if strings.Contains(correctionPrompt, unwanted) {
+			t.Fatalf("force_simple_loop correction prompt should not contain delegated-plan runtime context %q:\n%s", unwanted, correctionPrompt)
 		}
 	}
 

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1206,14 +1206,16 @@ func TestRuntimeRunVoiceInterruptionContextUsesTimeBoundary(t *testing.T) {
 	for _, want := range []string{
 		"Original user request / root request:",
 		rootRequest,
-		"Latest user message:",
-		correction,
 	} {
 		if !strings.Contains(correctionPrompt, want) {
 			t.Fatalf("correction prompt missing runtime context %q:\n%s", want, correctionPrompt)
 		}
 	}
 	for _, unwanted := range []string{
+		"Planner runtime context (synthetic; not a new user request):\nSingle-agent simple loop mode:",
+		"Loop mode:",
+		"Latest user message:",
+		"Session context view:",
 		"Current plan:",
 		"Prior step results",
 		"Verifier feedback:",
@@ -4708,6 +4710,65 @@ func TestRuntimeRunIncludesRuntimeContextInSystemMessage(t *testing.T) {
 	}
 	if !strings.Contains(systemText.String(), "## Runtime context\n"+runtimeContext) {
 		t.Fatalf("system message missing runtime context:\n%s", systemText.String())
+	}
+}
+
+func TestRuntimeRunDoesNotDuplicateRuntimeContextAcrossTurns(t *testing.T) {
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			contentResponse("first"),
+			contentResponse("second"),
+		},
+	}
+	storageDir := filepath.Join(t.TempDir(), "memory")
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:           ModelConfig{Provider: "fake"},
+			Instruction:     "Answer directly.",
+			ForceSimpleLoop: true,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(storageDir),
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+
+	firstRuntimeContext := "RUNTIME_CTX_FIRST_MARKER"
+	if _, err := runtime.Run(context.Background(), RunRequest{
+		Input:          "hello",
+		RuntimeContext: firstRuntimeContext,
+	}); err != nil {
+		t.Fatalf("first Run() error = %v", err)
+	}
+
+	secondRuntimeContext := "RUNTIME_CTX_SECOND_MARKER"
+	if _, err := runtime.Run(context.Background(), RunRequest{
+		Input:          "continue",
+		RuntimeContext: secondRuntimeContext,
+	}); err != nil {
+		t.Fatalf("second Run() error = %v", err)
+	}
+	if len(model.messages) < 2 || len(model.messages[1]) == 0 {
+		t.Fatalf("expected second planner call with messages, got %#v", model.messages)
+	}
+
+	secondCall := model.messages[1]
+	systemPrompt := messageText(secondCall[:1])
+	if strings.Count(systemPrompt, "## Runtime context") != 1 {
+		t.Fatalf("second system prompt should contain exactly one runtime context section:\n%s", systemPrompt)
+	}
+	if strings.Count(systemPrompt, secondRuntimeContext) != 1 {
+		t.Fatalf("second system prompt should contain current runtime context exactly once:\n%s", systemPrompt)
+	}
+	if strings.Contains(systemPrompt, firstRuntimeContext) {
+		t.Fatalf("second system prompt leaked previous runtime context:\n%s", systemPrompt)
+	}
+
+	nonSystemPrompt := messageText(secondCall[1:])
+	for _, unwanted := range []string{firstRuntimeContext, secondRuntimeContext} {
+		if strings.Contains(nonSystemPrompt, unwanted) {
+			t.Fatalf("runtime context should not re-enter prompt outside the system message %q:\n%s", unwanted, nonSystemPrompt)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- append a synthetic planner runtime context message after raw planner input and tool scratchpad
- restore planner visibility into session context, current plan, prior step results, executor output, verifier feedback, todo state, and world state text
- keep raw user input and attachments separate from runtime state, and keep runtime state out of the system prompt

## Tests
- `cd src/agent && go test ./internal/agent`
- `cd src/agent && go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Planner messages now consistently include a synthetic runtime-context section, with clearer handling across loop modes and better separation of current input vs. runtime state.
  - Added assurance that runtime context is not duplicated or leaked across turns.
- **Tests**
  - Updated and expanded assertions for planner message sequencing, runtime-context content, and role/attachment handling.
  - Added coverage for todo reminder content, user corrections/resume flows, and runtime-context uniqueness across turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->