### PR TITLE
fix(agent): preserve failed Langfuse traces

### DIFF
--- a/src/agent/internal/agent/episode_exporter.go
+++ b/src/agent/internal/agent/episode_exporter.go
@@ -13,7 +13,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const langfuseBatchSize = 40
+const (
+	langfuseBatchSize               = 40
+	langfuseScreenshotUploadTimeout = 2 * time.Second
+	langfuseTraceIngestReserve      = 5 * time.Second
+)
 
 type langfuseIterationWindow struct {
 	Index int
@@ -505,13 +509,17 @@ func (e *EpisodeExporter) buildLangfuseBatch(ctx context.Context, episode TaskEp
 			}
 			var output interface{} = event.Observation
 			if e.cfg.UploadScreenshotsOrDefault() && strings.TrimSpace(event.ScreenshotRef) != "" {
-				mediaRef, err := e.uploadScreenshot(ctx, traceID, resultSpanID, episodeDir, event.ScreenshotRef)
-				if err != nil && e.logger != nil {
-					e.logger.Warn("[telemetry] screenshot upload failed (%s): %v", event.ScreenshotRef, err)
-				} else if mediaRef != "" {
-					output = map[string]interface{}{
-						"observation": event.Observation,
-						"screenshot":  mediaRef,
+				screenshotCtx, cancel, ok := langfuseScreenshotUploadContext(ctx)
+				if ok {
+					mediaRef, err := e.uploadScreenshot(screenshotCtx, traceID, resultSpanID, episodeDir, event.ScreenshotRef)
+					cancel()
+					if err != nil && e.logger != nil {
+						e.logger.Warn("[telemetry] screenshot upload failed (%s): %v", event.ScreenshotRef, err)
+					} else if mediaRef != "" {
+						output = map[string]interface{}{
+							"observation": event.Observation,
+							"screenshot":  mediaRef,
+						}
 					}
 				}
 			}
@@ -698,6 +706,27 @@ func (e *EpisodeExporter) promptGenerationBody(episode TaskEpisode, traceID stri
 		body["version"] = version
 	}
 	return body
+}
+
+func langfuseScreenshotUploadContext(ctx context.Context) (context.Context, context.CancelFunc, bool) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timeout := langfuseScreenshotUploadTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining <= langfuseTraceIngestReserve {
+			return nil, nil, false
+		}
+		if available := remaining - langfuseTraceIngestReserve; available < timeout {
+			timeout = available
+		}
+	}
+	if timeout <= 0 {
+		return nil, nil, false
+	}
+	screenshotCtx, cancel := context.WithTimeout(ctx, timeout)
+	return screenshotCtx, cancel, true
 }
 
 func (e *EpisodeExporter) traceUsageGenerationBody(episode TaskEpisode, traceID string, startTime, endTime time.Time) map[string]interface{} {

--- a/src/agent/internal/agent/episode_exporter.go
+++ b/src/agent/internal/agent/episode_exporter.go
@@ -14,9 +14,8 @@ import (
 )
 
 const (
-	langfuseBatchSize               = 40
-	langfuseScreenshotUploadTimeout = 2 * time.Second
-	langfuseTraceIngestReserve      = 5 * time.Second
+	langfuseBatchSize          = 40
+	langfuseTraceIngestReserve = 5 * time.Second
 )
 
 type langfuseIterationWindow struct {
@@ -509,7 +508,7 @@ func (e *EpisodeExporter) buildLangfuseBatch(ctx context.Context, episode TaskEp
 			}
 			var output interface{} = event.Observation
 			if e.cfg.UploadScreenshotsOrDefault() && strings.TrimSpace(event.ScreenshotRef) != "" {
-				screenshotCtx, cancel, ok := langfuseScreenshotUploadContext(ctx)
+				screenshotCtx, cancel, ok := langfuseScreenshotUploadContext(ctx, e.cfg.UploadTimeoutOrDefault())
 				if ok {
 					mediaRef, err := e.uploadScreenshot(screenshotCtx, traceID, resultSpanID, episodeDir, event.ScreenshotRef)
 					cancel()
@@ -708,11 +707,13 @@ func (e *EpisodeExporter) promptGenerationBody(episode TaskEpisode, traceID stri
 	return body
 }
 
-func langfuseScreenshotUploadContext(ctx context.Context) (context.Context, context.CancelFunc, bool) {
+func langfuseScreenshotUploadContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc, bool) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	timeout := langfuseScreenshotUploadTimeout
+	if timeout <= 0 {
+		return nil, nil, false
+	}
 	if deadline, ok := ctx.Deadline(); ok {
 		remaining := time.Until(deadline)
 		if remaining <= langfuseTraceIngestReserve {

--- a/src/agent/internal/agent/episode_exporter_test.go
+++ b/src/agent/internal/agent/episode_exporter_test.go
@@ -765,6 +765,44 @@ outcome:
 	}
 }
 
+func TestLangfuseScreenshotUploadContextUsesConfiguredTimeout(t *testing.T) {
+	screenshotCtx, cancel, ok := langfuseScreenshotUploadContext(context.Background(), 120*time.Millisecond)
+	if !ok {
+		t.Fatal("langfuseScreenshotUploadContext() ok = false, want true")
+	}
+	defer cancel()
+	deadline, ok := screenshotCtx.Deadline()
+	if !ok {
+		t.Fatal("screenshot context missing deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 || remaining > 120*time.Millisecond {
+		t.Fatalf("screenshot context timeout = %s, want <= 120ms", remaining)
+	}
+}
+
+func TestLangfuseScreenshotUploadContextReservesTraceIngestionBudget(t *testing.T) {
+	parentCtx, parentCancel := context.WithTimeout(context.Background(), 2*langfuseTraceIngestReserve)
+	defer parentCancel()
+	parentDeadline, ok := parentCtx.Deadline()
+	if !ok {
+		t.Fatal("parent context missing deadline")
+	}
+
+	screenshotCtx, cancel, ok := langfuseScreenshotUploadContext(parentCtx, 30*time.Second)
+	if !ok {
+		t.Fatal("langfuseScreenshotUploadContext() ok = false, want true")
+	}
+	defer cancel()
+	deadline, ok := screenshotCtx.Deadline()
+	if !ok {
+		t.Fatal("screenshot context missing deadline")
+	}
+	if deadline.After(parentDeadline.Add(-langfuseTraceIngestReserve + 100*time.Millisecond)) {
+		t.Fatalf("screenshot deadline = %s, want trace ingestion reserve before parent deadline %s", deadline, parentDeadline)
+	}
+}
+
 func TestRuntimeStartupExportsInterruptedEpisodeToLangfuse(t *testing.T) {
 	ctx := context.Background()
 	configDir := t.TempDir()

--- a/src/agent/internal/agent/episode_exporter_test.go
+++ b/src/agent/internal/agent/episode_exporter_test.go
@@ -672,6 +672,99 @@ outcome:
 	}
 }
 
+func TestExportEpisodeDirIngestsTraceWhenScreenshotUploadWouldExhaustDeadline(t *testing.T) {
+	var ingestionCalls int
+	var mediaCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/public/ingestion":
+			ingestionCalls++
+			w.WriteHeader(http.StatusMultiStatus)
+			_, _ = w.Write([]byte(`{"successes":[{"id":"ok","status":201}],"errors":[]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/public/media":
+			mediaCalls++
+			time.Sleep(200 * time.Millisecond)
+			http.Error(w, "media upload should have been skipped", http.StatusGatewayTimeout)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	episodeDir := t.TempDir()
+	start := time.Date(2026, 6, 23, 9, 30, 0, 0, time.UTC)
+	episode := TaskEpisode{
+		ID:        "ep_export_deadline_test",
+		StartedAt: start.Format(time.RFC3339Nano),
+		EndedAt:   start.Add(5 * time.Second).Format(time.RFC3339Nano),
+		UserGoal:  "失败也要上传 trace",
+		Outcome: TaskEpisodeOutcome{
+			Success:       false,
+			FailureReason: "agent restarted before the task episode completed",
+		},
+	}
+	if err := os.WriteFile(filepath.Join(episodeDir, "episode.yaml"), []byte(`
+id: ep_export_deadline_test
+status: interrupted
+started_at: "`+episode.StartedAt+`"
+ended_at: "`+episode.EndedAt+`"
+user_goal: 失败也要上传 trace
+outcome:
+  success: false
+  failure_reason: agent restarted before the task episode completed
+`), 0o644); err != nil {
+		t.Fatalf("write episode.yaml: %v", err)
+	}
+	if err := writeEpisodeEventsJSONL(filepath.Join(episodeDir, "events.jsonl"), []TaskEpisodeEvent{
+		{
+			EventID:   "evt1",
+			Ts:        start.Format(time.RFC3339Nano),
+			Type:      runEventToolCall,
+			ToolName:  "screenshot",
+			ToolInput: `{}`,
+			Content:   "截图",
+		},
+		{
+			EventID:       "evt2",
+			Ts:            start.Add(time.Second).Format(time.RFC3339Nano),
+			Type:          "tool_result",
+			ToolName:      "screenshot",
+			Observation:   `{"format":"jpeg","size":100}`,
+			ScreenshotRef: "artifacts/step_002.jpeg",
+		},
+	}); err != nil {
+		t.Fatalf("write events.jsonl: %v", err)
+	}
+	artifactsDir := filepath.Join(episodeDir, "artifacts")
+	if err := os.MkdirAll(artifactsDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifacts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactsDir, "step_002.jpeg"), []byte("fakejpeg"), 0o644); err != nil {
+		t.Fatalf("write screenshot: %v", err)
+	}
+
+	exporter := NewEpisodeExporter(TelemetryConfig{
+		Enabled:           boolPtr(true),
+		BaseURL:           server.URL,
+		PublicKey:         "pk-test",
+		SecretKey:         "sk-test",
+		UploadScreenshots: boolPtr(true),
+		MaxRetry:          0,
+	}, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	if err := exporter.ExportEpisodeDir(ctx, episodeDir, episode); err != nil {
+		t.Fatalf("ExportEpisodeDir() error = %v", err)
+	}
+	if ingestionCalls == 0 {
+		t.Fatal("expected ingestion request even when screenshot upload cannot fit within export deadline")
+	}
+	if mediaCalls != 0 {
+		t.Fatalf("mediaCalls = %d, want screenshot upload skipped to preserve trace ingestion budget", mediaCalls)
+	}
+}
+
 func TestRuntimeStartupExportsInterruptedEpisodeToLangfuse(t *testing.T) {
 	ctx := context.Background()
 	configDir := t.TempDir()

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -541,9 +541,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (result RunResult, ru
 			}
 			episodeRecorder = r.memoryPlane.NewEpisodeRecorder(retrieveReq, MemoryContext{})
 			if episodeRecorder != nil {
-				if episodeID == "" {
-					episodeID = episodeRecorder.ID()
-				}
+				episodeID = episodeRecorder.ID()
 				startCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 				if err := episodeRecorder.Start(startCtx); err != nil && r.logger != nil {
 					r.logger.Warn("[memory] start failed episode trace failed: %v", err)
@@ -554,9 +552,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (result RunResult, ru
 		if episodeRecorder == nil {
 			return
 		}
-		if episodeID == "" {
-			episodeID = episodeRecorder.ID()
-		}
+		episodeID = episodeRecorder.ID()
 		r.persistRunStatusBestEffort(episodeID, req.RequestID, runID, runErr)
 		r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, runErr, promptCapture, boundaryTelemetry, req.AsyncEpisodeMaintenance)
 		episodeCommitted = true

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -485,7 +485,7 @@ func (r *Runtime) exportInterruptedEpisodesBestEffort(episodes []TaskEpisode) {
 	}
 }
 
-func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (r *Runtime) Run(ctx context.Context, req RunRequest) (result RunResult, runErr error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -511,13 +511,63 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		return RunResult{}, errors.New("input is required")
 	}
 
+	runID := "run_" + uuid.NewString()
+	episodeID := strings.TrimSpace(req.EpisodeID)
+	if episodeID == "" && r.memoryPlane != nil {
+		episodeID = newTaskEpisodeID(startTime.UTC())
+	}
+	currentHints := r.currentEnvironmentHints()
+	skillNames := uniqueNonEmpty(req.Skills)
+	promptCapture := newTelemetryPromptCapture(r.config.Telemetry.EnabledOrDefault())
+	var episodeRecorder *EpisodeRecorder
+	var availableTools []langtools.Tool
+	var boundaryTelemetry sessionBoundaryTelemetry
+	var output string
+	episodeCommitted := false
+	defer func() {
+		if runErr == nil || episodeCommitted {
+			return
+		}
+		metrics.TotalDuration = float64(time.Since(startTime).Milliseconds())
+		if episodeRecorder == nil && r.memoryPlane != nil {
+			retrieveReq := MemoryRetrieveRequest{
+				Input:        normalizedInput,
+				Attachments:  turnInput.Attachments,
+				Skills:       skillNames,
+				ToolNames:    toolNamesFromTools(availableTools),
+				EpisodeID:    episodeID,
+				DeviceID:     defaultMemoryDeviceID,
+				CurrentHints: currentHints,
+			}
+			episodeRecorder = r.memoryPlane.NewEpisodeRecorder(retrieveReq, MemoryContext{})
+			if episodeRecorder != nil {
+				if episodeID == "" {
+					episodeID = episodeRecorder.ID()
+				}
+				startCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				if err := episodeRecorder.Start(startCtx); err != nil && r.logger != nil {
+					r.logger.Warn("[memory] start failed episode trace failed: %v", err)
+				}
+				cancel()
+			}
+		}
+		if episodeRecorder == nil {
+			return
+		}
+		if episodeID == "" {
+			episodeID = episodeRecorder.ID()
+		}
+		r.persistRunStatusBestEffort(episodeID, req.RequestID, runID, runErr)
+		r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, runErr, promptCapture, boundaryTelemetry, req.AsyncEpisodeMaintenance)
+		episodeCommitted = true
+	}()
+
 	if err := r.reloadSkillsIfDirty(); err != nil {
 		return RunResult{}, err
 	}
 	runSkills := r.skills.Snapshot()
 
 	// Activate skills
-	skillNames := uniqueNonEmpty(req.Skills)
 	for _, skillName := range skillNames {
 		if err := runSkills.Activate(ctx, skillName); err != nil {
 			if r.logger != nil {
@@ -547,10 +597,8 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			r.logger.Info("Resolved model context window: context_window=%d", contextWindow)
 		}
 	}
-	promptCapture := newTelemetryPromptCapture(r.config.Telemetry.EnabledOrDefault())
 	model = &usageTrackingModel{inner: model, metrics: metrics, promptCapture: promptCapture, contextWindowFn: r.effectiveContextWindow}
 
-	currentHints := r.currentEnvironmentHints()
 	memoryCfg := MemoryConfig{Type: "buffer"}
 	var memoryHandle *MemoryHandle
 	if r.memories != nil {
@@ -560,11 +608,6 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	if err != nil {
 		return RunResult{}, err
-	}
-	runID := "run_" + uuid.NewString()
-	episodeID := strings.TrimSpace(req.EpisodeID)
-	if episodeID == "" && r.memoryPlane != nil {
-		episodeID = newTaskEpisodeID(startTime.UTC())
 	}
 	beginResult, err := r.beginSession(ctx, SessionBeginRequest{
 		AgentName:    "default",
@@ -579,12 +622,12 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err != nil {
 		return RunResult{}, err
 	}
-	boundaryTelemetry := beginResult.Boundary
+	boundaryTelemetry = beginResult.Boundary
 	if boundaryTelemetry.PendingRecallCounter == nil {
 		boundaryTelemetry.PendingRecallCounter = &atomic.Int64{}
 	}
 
-	availableTools := r.resolveTools(resolvedSkills)
+	availableTools = r.resolveTools(resolvedSkills)
 	availableTools = wrapSessionRecallTelemetry(availableTools, boundaryTelemetry.PendingRecallCounter)
 	retrieveReq := MemoryRetrieveRequest{
 		Input:        normalizedInput,
@@ -606,7 +649,6 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			memoryContext = retrieved
 		}
 	}
-	var episodeRecorder *EpisodeRecorder
 	if r.memoryPlane != nil {
 		episodeRecorder = r.memoryPlane.NewEpisodeRecorder(retrieveReq, memoryContext)
 		if episodeRecorder != nil {
@@ -719,7 +761,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	executor.SteerWaiter = req.SteerWaiter
 	executor.FinalSteerProvider = req.FinalSteerProvider
 
-	output, err := chains.Run(ctx, executor, normalizedInput, callOptions...)
+	output, err = chains.Run(ctx, executor, normalizedInput, callOptions...)
 	if err != nil {
 		// If the agent couldn't parse the LLM output format, extract the raw
 		// text and return it as the response instead of failing.
@@ -732,8 +774,6 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			}
 		}
 		if err != nil {
-			r.persistRunStatusBestEffort(episodeID, req.RequestID, runID, err)
-			r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture, boundaryTelemetry, req.AsyncEpisodeMaintenance)
 			return RunResult{}, err
 		}
 	}
@@ -756,10 +796,10 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 
 	commitResult, err := r.commitSession(ctx, commitReq)
 	if err != nil {
-		r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, err, promptCapture, boundaryTelemetry, req.AsyncEpisodeMaintenance)
 		return RunResult{}, err
 	}
 	r.commitEpisodeBestEffort(episodeRecorder, normalizedInput, output, metrics, nil, promptCapture, boundaryTelemetry, req.AsyncEpisodeMaintenance)
+	episodeCommitted = true
 
 	waitForWakeupRequested, waitForWakeupReason := false, ""
 	if r.waitForWakeup != nil {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -39,12 +41,16 @@ func TestEffectiveMaxIterationsDefaultsAndUnlimited(t *testing.T) {
 
 type testModelResolver struct {
 	model llms.Model
+	err   error
 	calls int
 	spec  ModelSpec
 }
 
 func (r *testModelResolver) Get() (llms.Model, error) {
 	r.calls++
+	if r.err != nil {
+		return nil, r.err
+	}
 	return r.model, nil
 }
 
@@ -77,6 +83,83 @@ func TestRuntimeRun(t *testing.T) {
 	}
 	if len(result.Memory) != 2 {
 		t.Fatalf("expected 2 memory entries, got %d", len(result.Memory))
+	}
+}
+
+func TestRuntimeRunExportsFailedTraceWhenModelBuildFails(t *testing.T) {
+	ingestCh := make(chan langfuseIngestionRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/public/ingestion" {
+			http.NotFound(w, r)
+			return
+		}
+		var req langfuseIngestionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		select {
+		case ingestCh <- req:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"successes":[]}`))
+	}))
+	defer server.Close()
+
+	configDir := t.TempDir()
+	buildErr := errors.New("model unavailable")
+	runtime := NewRuntimeWithDeps(
+		Config{
+			ConfigDir: configDir,
+			Telemetry: TelemetryConfig{
+				Enabled:          boolPtr(true),
+				BaseURL:          server.URL,
+				PublicKey:        "pk-test",
+				SecretKey:        "sk-test",
+				UploadTimeoutSec: 1,
+			},
+		},
+		&testModelResolver{err: buildErr},
+		NewMemoryManager(filepath.Join(configDir, "memory")),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+
+	_, err := runtime.Run(context.Background(), RunRequest{Input: "turn that should be traced"})
+	if !errors.Is(err, buildErr) {
+		t.Fatalf("Run() error = %v, want %v", err, buildErr)
+	}
+
+	var ingest langfuseIngestionRequest
+	select {
+	case ingest = <-ingestCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected Langfuse ingestion for failed chat")
+	}
+
+	var traceBody map[string]any
+	for _, event := range ingest.Batch {
+		if event.Type != "trace-create" {
+			continue
+		}
+		if err := json.Unmarshal(event.Body, &traceBody); err != nil {
+			t.Fatalf("decode trace body: %v", err)
+		}
+		break
+	}
+	if traceBody == nil {
+		t.Fatalf("ingestion batch missing trace-create: %#v", ingest.Batch)
+	}
+	if got := traceBody["input"]; got != "turn that should be traced" {
+		t.Fatalf("trace input = %#v, want original user input", got)
+	}
+	metadata, ok := traceBody["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("trace metadata missing or invalid: %#v", traceBody["metadata"])
+	}
+	if got := metadata["failure_reason"]; got != buildErr.Error() {
+		t.Fatalf("failure_reason = %#v, want %q", got, buildErr.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Record failed runs into task episodes even when failure happens before the normal recorder path.
- Preserve Langfuse trace ingestion when screenshot media upload is slow or unreachable.
- Add regressions for model-build failures and screenshot-upload deadline exhaustion.

## Test Plan
- go test ./...

## Device Verification
- Deployed fixed agent to 192.168.31.107.
- Verified /oem/usr/bin/agent sha256 014ee7a81086293b065b3b36a85447ead917b743a23efb6af53c617c7e6015a2.
- Verified S53agent watchdog/agent running and /api/tools responds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved screenshot upload handling: uploads are now gracefully skipped when tight deadlines prevent completion, allowing trace ingestion to proceed.
  * Enhanced error tracking: failed episodes are now properly exported and ingested to improve debugging and observability.

* **Tests**
  * Added tests to verify deadline-aware screenshot uploads and trace export on failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->