### PR TITLE
fix(agent): omit empty VAD last_error logs

### DIFF
--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -355,6 +355,20 @@ type vadDebugReporter interface {
 	VADDebugState() agent.VADDebugState
 }
 
+func formatVADDebugLog(state agent.VADDebugState) string {
+	msg := fmt.Sprintf("[vad] probability=%.3f threshold=%.3f speaking=%v speech_frames=%d silence_frames=%d",
+		state.Probability,
+		state.Threshold,
+		state.Speaking,
+		state.SpeechFrames,
+		state.SilenceFrames,
+	)
+	if state.LastError != "" {
+		msg += fmt.Sprintf(" last_error=%q", state.LastError)
+	}
+	return msg
+}
+
 type voiceEvent int
 
 const (
@@ -1061,14 +1075,7 @@ func captureUtteranceWithTimeout(dialog audioDialogRunner, sigChan chan os.Signa
 					speechDetected = true
 				}
 				if time.Now().After(nextVADLogAt) {
-					log.Printf("[vad] probability=%.3f threshold=%.3f speaking=%v speech_frames=%d silence_frames=%d last_error=%q\n",
-						state.Probability,
-						state.Threshold,
-						state.Speaking,
-						state.SpeechFrames,
-						state.SilenceFrames,
-						state.LastError,
-					)
+					log.Print(formatVADDebugLog(state))
 					nextVADLogAt = time.Now().Add(time.Second)
 				}
 			}
@@ -1184,14 +1191,7 @@ func processAudioUntilUtteranceWithWakeupInterrupt(
 			}
 			if reporter, ok := dialog.(vadDebugReporter); ok && time.Now().After(nextVADLogAt) {
 				state := reporter.VADDebugState()
-				log.Printf("[vad] probability=%.3f threshold=%.3f speaking=%v speech_frames=%d silence_frames=%d last_error=%q\n",
-					state.Probability,
-					state.Threshold,
-					state.Speaking,
-					state.SpeechFrames,
-					state.SilenceFrames,
-					state.LastError,
-				)
+				log.Print(formatVADDebugLog(state))
 				nextVADLogAt = time.Now().Add(time.Second)
 			}
 			if utterance != nil {

--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -645,6 +645,40 @@ func TestDrainWakeupEventsWhileListeningLogsDrainedCount(t *testing.T) {
 	}
 }
 
+func TestFormatVADDebugLogOmitsEmptyLastError(t *testing.T) {
+	got := formatVADDebugLog(agent.VADDebugState{
+		Probability:   0.1234,
+		Threshold:     0.5,
+		Speaking:      false,
+		SpeechFrames:  0,
+		SilenceFrames: 0,
+	})
+
+	if strings.Contains(got, "last_error=") {
+		t.Fatalf("log = %q, want last_error omitted when empty", got)
+	}
+	want := "[vad] probability=0.123 threshold=0.500 speaking=false speech_frames=0 silence_frames=0"
+	if got != want {
+		t.Fatalf("log = %q, want %q", got, want)
+	}
+}
+
+func TestFormatVADDebugLogIncludesLastErrorWhenPresent(t *testing.T) {
+	got := formatVADDebugLog(agent.VADDebugState{
+		Probability:   0.5,
+		Threshold:     0.5,
+		Speaking:      true,
+		SpeechFrames:  3,
+		SilenceFrames: 1,
+		LastError:     "model failed",
+	})
+
+	want := `[vad] probability=0.500 threshold=0.500 speaking=true speech_frames=3 silence_frames=1 last_error="model failed"`
+	if got != want {
+		t.Fatalf("log = %q, want %q", got, want)
+	}
+}
+
 func TestSignalWakeupEventCoalescesPendingEvents(t *testing.T) {
 	wakeupEvents := make(chan struct{}, 1)
 


### PR DESCRIPTION
## Summary
- omit empty `last_error` from VAD debug logs to avoid false error highlighting in config web
- centralize VAD debug log formatting across both VAD log call sites
- add coverage for empty and non-empty `last_error` formatting

## Testing
- go test ./cmd/daemon