### PR TITLE
fix(agent): stabilize omitted tool result prompt

### DIFF
--- a/src/agent/internal/agent/context_budget.go
+++ b/src/agent/internal/agent/context_budget.go
@@ -15,13 +15,12 @@ type contextWindowModel interface {
 }
 
 type toolResponseBudgetCandidate struct {
-	MessageIndex                int
-	PartIndex                   int
-	ToolCallID                  string
-	ToolName                    string
-	Content                     string
-	ContentTokens               int
-	EstimatedPromptTokensSingle int
+	MessageIndex  int
+	PartIndex     int
+	ToolCallID    string
+	ToolName      string
+	Content       string
+	ContentTokens int
 }
 
 type toolResponseBudgetCandidateKey struct {
@@ -75,8 +74,7 @@ func (e *roleCollaborativeExecutor) guardMessagesWithinContextWindow(messages []
 		if singlePromptTokens <= inputBudget {
 			continue
 		}
-		candidate.EstimatedPromptTokensSingle = singlePromptTokens
-		replaceToolResponsePart(sanitized, candidate, omittedToolResultMessage(candidate, contextWindow, inputBudget, callOptions.MaxTokens))
+		replaceToolResponsePart(sanitized, candidate, omittedToolResultMessage(candidate))
 		omitted[candidate.key()] = struct{}{}
 	}
 
@@ -91,8 +89,7 @@ func (e *roleCollaborativeExecutor) guardMessagesWithinContextWindow(messages []
 		if isToolResponseAlreadyOmitted(omitted, candidate) {
 			continue
 		}
-		candidate.EstimatedPromptTokensSingle = estimateSingleToolResponsePromptTokens(messages, candidate) + toolSchemaTokens
-		replaceToolResponsePart(sanitized, candidate, omittedToolResultMessage(candidate, contextWindow, inputBudget, callOptions.MaxTokens))
+		replaceToolResponsePart(sanitized, candidate, omittedToolResultMessage(candidate))
 		omitted[candidate.key()] = struct{}{}
 		if estimateMessagesTokens(sanitized)+toolSchemaTokens <= inputBudget {
 			break
@@ -199,19 +196,14 @@ func isToolResponseAlreadyOmitted(omitted map[toolResponseBudgetCandidateKey]str
 	return ok
 }
 
-func omittedToolResultMessage(candidate toolResponseBudgetCandidate, contextWindow, inputBudget, maxResponseTokens int) string {
+func omittedToolResultMessage(candidate toolResponseBudgetCandidate) string {
 	toolName := strings.TrimSpace(candidate.ToolName)
 	if toolName == "" {
 		toolName = "tool"
 	}
 	return fmt.Sprintf(
-		"error: %s tool result omitted before the next model call because the result is too large for the model context window. context_window=%d available_input_tokens=%d max_response_tokens=%d estimated_prompt_tokens_with_this_result=%d tool_result_estimated_tokens=%d. The original tool call completed, but its raw output was not inserted. Use a narrower query, request a smaller range, or call a tool that returns a concise summary.",
+		"note: %s tool result omitted because including it would exceed the model context window. The tool call already completed, but its raw output was not inserted into the next model call.",
 		toolName,
-		contextWindow,
-		inputBudget,
-		maxResponseTokens,
-		candidate.EstimatedPromptTokensSingle,
-		candidate.ContentTokens,
 	)
 }
 

--- a/src/agent/internal/agent/context_budget_test.go
+++ b/src/agent/internal/agent/context_budget_test.go
@@ -31,6 +31,9 @@ func TestGuardMessagesWithinContextWindowFallbackOmitsCombinedToolResults(t *tes
 	if !strings.Contains(contents[0], "tool result omitted") || !strings.Contains(contents[1], "tool result omitted") {
 		t.Fatalf("combined tool responses should be omitted by fallback pass: %#v", contents)
 	}
+	if !strings.HasPrefix(contents[0], "note:") || !strings.HasPrefix(contents[1], "note:") {
+		t.Fatalf("omission placeholders should use note prefix: %#v", contents)
+	}
 }
 
 func TestGuardMessagesWithinContextWindowDoesNotTreatRawOmissionTextAsAlreadyOmitted(t *testing.T) {
@@ -58,8 +61,41 @@ func TestGuardMessagesWithinContextWindowDoesNotTreatRawOmissionTextAsAlreadyOmi
 	if contents[1] == rawOmissionTextOutput {
 		t.Fatalf("raw tool output containing omission text should not be treated as already omitted")
 	}
-	if !strings.Contains(contents[1], "context_window=") {
+	if !strings.HasPrefix(contents[1], "note:") || !strings.Contains(contents[1], "would exceed the model context window") || !strings.Contains(contents[1], "tool call already completed") {
 		t.Fatalf("second tool response should be replaced with omission metadata, got: %q", contents[1])
+	}
+}
+
+func TestGuardMessagesWithinContextWindowUsesStableOmissionTextAcrossPromptSizes(t *testing.T) {
+	oversizedOutput := strings.Repeat("oversized ", 720)
+	baseMessages := contextBudgetToolMessages(oversizedOutput)
+	extraPromptMessages := []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeSystem, "system prompt"),
+		llms.TextParts(llms.ChatMessageTypeHuman, "summarize tool output"),
+		llms.TextParts(llms.ChatMessageTypeHuman, "extra surrounding context that should not change the omission placeholder"),
+	}
+	extraPromptMessages = append(extraPromptMessages, baseMessages[2:]...)
+
+	baseCandidates := collectToolResponseBudgetCandidates(baseMessages)
+	if len(baseCandidates) != 1 {
+		t.Fatalf("base candidates = %d, want 1", len(baseCandidates))
+	}
+	baseInputBudget := estimateSingleToolResponsePromptTokens(baseMessages, baseCandidates[0]) - 1
+	if baseInputBudget <= 0 {
+		t.Fatalf("base input budget = %d, want > 0", baseInputBudget)
+	}
+
+	executor := &roleCollaborativeExecutor{
+		Model: contextBudgetWindowModel{window: baseInputBudget},
+	}
+
+	baseSanitized := executor.guardMessagesWithinContextWindow(baseMessages, nil)
+	extraSanitized := executor.guardMessagesWithinContextWindow(extraPromptMessages, nil)
+	baseContent := toolResponseContents(t, baseSanitized)[0]
+	extraContent := toolResponseContents(t, extraSanitized)[0]
+
+	if baseContent != extraContent {
+		t.Fatalf("omission placeholder should stay stable across prompt sizes\nbase:  %q\nextra: %q", baseContent, extraContent)
 	}
 }
 

--- a/src/agent/internal/agent/role_loop_test.go
+++ b/src/agent/internal/agent/role_loop_test.go
@@ -720,7 +720,7 @@ func TestCallExecutorTurnOmitOversizedToolResultBeforeModelCall(t *testing.T) {
 	if strings.Contains(content, strings.Repeat("超", 20)) {
 		t.Fatalf("oversized raw observation leaked into model prompt: %q", content)
 	}
-	if !strings.Contains(content, "tool result omitted") || !strings.Contains(content, "context_window=300") {
+	if !strings.HasPrefix(content, "note:") || !strings.Contains(content, "tool result omitted") || !strings.Contains(content, "would exceed the model context window") || !strings.Contains(content, "tool call already completed") {
 		t.Fatalf("tool response should explain the context-window rejection, got: %q", content)
 	}
 }


### PR DESCRIPTION
## Summary
- remove dynamic token-estimate fields from omitted tool-result placeholder text
- keep the placeholder concise while clarifying the omit reason and completed tool-call state
- add tests to lock placeholder stability and note-prefix behavior

## Testing
- go test ./internal/agent -run 'TestGuardMessagesWithinContextWindow|TestCallExecutorTurnOmitOversizedToolResultBeforeModelCall' -count=1