### PR TITLE
fix(agent): freeze planner experience within session

### DIFF
--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -23,8 +23,13 @@ const (
 )
 
 type sessionMetadata struct {
-	SessionID string `json:"session_id"`
-	CreatedAt string `json:"created_at"`
+	SessionID string        `json:"session_id"`
+	CreatedAt string        `json:"created_at"`
+	State     *sessionState `json:"state,omitempty"`
+}
+
+type sessionState struct {
+	RetrievedDeviceExperience *sessionPlannerExperienceSnapshot `json:"retrieved_device_experience,omitempty"`
 }
 
 type SessionRotationResult struct {
@@ -816,14 +821,18 @@ func writeNewSessionMetadata(sessionDir string, now time.Time) (sessionMetadata,
 		SessionID: newSessionID(now),
 		CreatedAt: now.UTC().Format(time.RFC3339Nano),
 	}
-	data, err := json.Marshal(meta)
-	if err != nil {
-		return sessionMetadata{}, fmt.Errorf("marshal session metadata: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(sessionDir, sessionMetadataFileName), append(data, '\n'), 0o644); err != nil {
+	if err := writeSessionMetadata(filepath.Join(sessionDir, sessionMetadataFileName), meta); err != nil {
 		return sessionMetadata{}, fmt.Errorf("write session metadata: %w", err)
 	}
 	return meta, nil
+}
+
+func writeSessionMetadata(path string, meta sessionMetadata) error {
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("marshal session metadata: %w", err)
+	}
+	return writeFileAtomic(path, append(data, '\n'), 0o644)
 }
 
 func readSessionMetadata(path string) (sessionMetadata, error) {

--- a/src/agent/internal/agent/memory_plane.go
+++ b/src/agent/internal/agent/memory_plane.go
@@ -84,6 +84,12 @@ type MemoryHit struct {
 }
 
 const defaultMemoryDeviceID = "default"
+const sessionPlannerExperienceSnapshotVersion = 1
+
+type sessionPlannerExperienceSnapshot struct {
+	Version int               `json:"version"`
+	Planner RoleMemoryContext `json:"planner"`
+}
 
 type memorySearchQuery struct {
 	Terms    []string
@@ -116,6 +122,10 @@ func (p *FilesystemMemoryPlane) Retrieve(ctx context.Context, req MemoryRetrieve
 	// prompts or retrieved through the active memory plane.
 	out.Common.SessionSummary = readTextFileIfExists(filepath.Join(p.memoryDir, "session", "summary.md"))
 	out.Common.Profile = readTextFileIfExists(filepath.Join(p.memoryDir, "long_term", "profile.md"))
+	plannerSnapshot, hasPlannerSnapshot, err := p.loadSessionPlannerExperienceSnapshot()
+	if err != nil && p.logger != nil {
+		p.logger.Warn("[memory] session planner experience snapshot load failed: %v", err)
+	}
 
 	query := p.queryFromRequest(req)
 	deviceHits, err := p.device.Search(ctx, DeviceMemoryQuery{
@@ -185,6 +195,13 @@ func (p *FilesystemMemoryPlane) Retrieve(ctx context.Context, req MemoryRetrieve
 	}
 
 	out.trim(4)
+	if hasPlannerSnapshot {
+		out.Planner = plannerSnapshot
+		return out, nil
+	}
+	if err := p.saveSessionPlannerExperienceSnapshot(out.Planner); err != nil && p.logger != nil {
+		p.logger.Warn("[memory] session planner experience snapshot save failed: %v", err)
+	}
 	return out, nil
 }
 
@@ -284,6 +301,58 @@ func (p *FilesystemMemoryPlane) searchLongTerm(ctx context.Context, query memory
 		hits = append(hits, memoryResultToHit(result))
 	}
 	return hits, nil
+}
+
+func (p *FilesystemMemoryPlane) loadSessionPlannerExperienceSnapshot() (RoleMemoryContext, bool, error) {
+	if p == nil || p.memoryDir == "" {
+		return RoleMemoryContext{}, false, nil
+	}
+	fl := NewFileLock(p.memoryDir)
+	if err := fl.Lock(defaultLockTimeout); err != nil {
+		return RoleMemoryContext{}, false, err
+	}
+	defer fl.Unlock()
+
+	sessionDir := filepath.Join(p.memoryDir, "session")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		return RoleMemoryContext{}, false, err
+	}
+	meta, err := ensureActiveSessionMetadata(sessionDir, time.Now().UTC())
+	if err != nil {
+		return RoleMemoryContext{}, false, err
+	}
+	if meta.State == nil || meta.State.RetrievedDeviceExperience == nil {
+		return RoleMemoryContext{}, false, nil
+	}
+	return meta.State.RetrievedDeviceExperience.Planner, true, nil
+}
+
+func (p *FilesystemMemoryPlane) saveSessionPlannerExperienceSnapshot(planner RoleMemoryContext) error {
+	if p == nil || p.memoryDir == "" {
+		return nil
+	}
+	fl := NewFileLock(p.memoryDir)
+	if err := fl.Lock(defaultLockTimeout); err != nil {
+		return err
+	}
+	defer fl.Unlock()
+
+	sessionDir := filepath.Join(p.memoryDir, "session")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		return err
+	}
+	meta, err := ensureActiveSessionMetadata(sessionDir, time.Now().UTC())
+	if err != nil {
+		return err
+	}
+	if meta.State == nil {
+		meta.State = &sessionState{}
+	}
+	meta.State.RetrievedDeviceExperience = &sessionPlannerExperienceSnapshot{
+		Version: sessionPlannerExperienceSnapshotVersion,
+		Planner: planner,
+	}
+	return writeSessionMetadata(filepath.Join(sessionDir, sessionMetadataFileName), meta)
 }
 
 func (p *FilesystemMemoryPlane) searchLongTermConflicts(ctx context.Context, query memorySearchQuery) ([]MemoryHit, error) {

--- a/src/agent/internal/agent/memory_plane.go
+++ b/src/agent/internal/agent/memory_plane.go
@@ -91,6 +91,17 @@ type sessionPlannerExperienceSnapshot struct {
 	Planner RoleMemoryContext `json:"planner"`
 }
 
+func plannerSnapshotFromSessionState(state *sessionState) (RoleMemoryContext, bool) {
+	if state == nil || state.RetrievedDeviceExperience == nil {
+		return RoleMemoryContext{}, false
+	}
+	snapshot := state.RetrievedDeviceExperience
+	if snapshot.Version != sessionPlannerExperienceSnapshotVersion {
+		return RoleMemoryContext{}, false
+	}
+	return snapshot.Planner, true
+}
+
 type memorySearchQuery struct {
 	Terms    []string
 	Tags     []string
@@ -312,8 +323,7 @@ func (p *FilesystemMemoryPlane) retrieveWithFrozenPlannerSnapshot(retrieve func(
 		_ = fl.Unlock()
 		return MemoryContext{}, err
 	}
-	if meta.State != nil && meta.State.RetrievedDeviceExperience != nil {
-		plannerSnapshot := meta.State.RetrievedDeviceExperience.Planner
+	if plannerSnapshot, ok := plannerSnapshotFromSessionState(meta.State); ok {
 		_ = fl.Unlock()
 
 		out, err := retrieve()

--- a/src/agent/internal/agent/memory_plane.go
+++ b/src/agent/internal/agent/memory_plane.go
@@ -122,87 +122,77 @@ func (p *FilesystemMemoryPlane) Retrieve(ctx context.Context, req MemoryRetrieve
 	// prompts or retrieved through the active memory plane.
 	out.Common.SessionSummary = readTextFileIfExists(filepath.Join(p.memoryDir, "session", "summary.md"))
 	out.Common.Profile = readTextFileIfExists(filepath.Join(p.memoryDir, "long_term", "profile.md"))
-	plannerSnapshot, hasPlannerSnapshot, err := p.loadSessionPlannerExperienceSnapshot()
-	if err != nil && p.logger != nil {
-		p.logger.Warn("[memory] session planner experience snapshot load failed: %v", err)
-	}
-
-	query := p.queryFromRequest(req)
-	deviceHits, err := p.device.Search(ctx, DeviceMemoryQuery{
-		Terms:    query.Terms,
-		Tags:     query.Tags,
-		Entities: query.Entities,
-		DeviceID: req.DeviceID,
-		Limit:    12,
-	})
-	if err != nil && p.logger != nil {
-		p.logger.Warn("[memory] device memory retrieval failed: %v", err)
-	}
-	for _, hit := range deviceHits {
-		if !memoryHitApplicable(hit, req) {
-			continue
+	return p.retrieveWithFrozenPlannerSnapshot(func() (MemoryContext, error) {
+		query := p.queryFromRequest(req)
+		deviceHits, err := p.device.Search(ctx, DeviceMemoryQuery{
+			Terms:    query.Terms,
+			Tags:     query.Tags,
+			Entities: query.Entities,
+			DeviceID: req.DeviceID,
+			Limit:    12,
+		})
+		if err != nil && p.logger != nil {
+			p.logger.Warn("[memory] device memory retrieval failed: %v", err)
 		}
-		p.routeHit(&out, hit)
-	}
-
-	longTermHits, err := p.searchLongTerm(ctx, query)
-	if err != nil && p.logger != nil {
-		p.logger.Warn("[memory] long-term memory retrieval failed: %v", err)
-	}
-	for _, hit := range longTermHits {
-		if !memoryHitApplicable(hit, req) {
-			continue
+		for _, hit := range deviceHits {
+			if !memoryHitApplicable(hit, req) {
+				continue
+			}
+			p.routeHit(&out, hit)
 		}
-		p.routeHit(&out, hit)
-	}
-	conflictHits, err := p.searchLongTermConflicts(ctx, query)
-	if err != nil && p.logger != nil {
-		p.logger.Warn("[memory] conflict memory retrieval failed: %v", err)
-	}
-	for _, hit := range conflictHits {
-		if memoryHitApplicable(hit, req) {
-			out.Verifier.Conflicts = append(out.Verifier.Conflicts, hit)
+
+		longTermHits, err := p.searchLongTerm(ctx, query)
+		if err != nil && p.logger != nil {
+			p.logger.Warn("[memory] long-term memory retrieval failed: %v", err)
 		}
-	}
+		for _, hit := range longTermHits {
+			if !memoryHitApplicable(hit, req) {
+				continue
+			}
+			p.routeHit(&out, hit)
+		}
+		conflictHits, err := p.searchLongTermConflicts(ctx, query)
+		if err != nil && p.logger != nil {
+			p.logger.Warn("[memory] conflict memory retrieval failed: %v", err)
+		}
+		for _, hit := range conflictHits {
+			if memoryHitApplicable(hit, req) {
+				out.Verifier.Conflicts = append(out.Verifier.Conflicts, hit)
+			}
+		}
 
-	success := true
-	successEpisodes, err := p.episodes.Search(ctx, EpisodeQuery{
-		Terms:    query.Terms,
-		Tags:     query.Tags,
-		Entities: query.Entities,
-		Success:  &success,
-		Limit:    3,
-	})
-	if err != nil && p.logger != nil {
-		p.logger.Warn("[memory] episode success retrieval failed: %v", err)
-	}
-	out.Planner.SimilarEpisodes = append(out.Planner.SimilarEpisodes, successEpisodes...)
+		success := true
+		successEpisodes, err := p.episodes.Search(ctx, EpisodeQuery{
+			Terms:    query.Terms,
+			Tags:     query.Tags,
+			Entities: query.Entities,
+			Success:  &success,
+			Limit:    3,
+		})
+		if err != nil && p.logger != nil {
+			p.logger.Warn("[memory] episode success retrieval failed: %v", err)
+		}
+		out.Planner.SimilarEpisodes = append(out.Planner.SimilarEpisodes, successEpisodes...)
 
-	failed := false
-	failureEpisodes, err := p.episodes.Search(ctx, EpisodeQuery{
-		Terms:    query.Terms,
-		Tags:     query.Tags,
-		Entities: query.Entities,
-		Success:  &failed,
-		Limit:    3,
-	})
-	if err != nil && p.logger != nil {
-		p.logger.Warn("[memory] episode failure retrieval failed: %v", err)
-	}
-	for _, hit := range failureEpisodes {
-		hit.Type = "task_episode_failure"
-		out.Verifier.FailureModes = append(out.Verifier.FailureModes, hit)
-	}
+		failed := false
+		failureEpisodes, err := p.episodes.Search(ctx, EpisodeQuery{
+			Terms:    query.Terms,
+			Tags:     query.Tags,
+			Entities: query.Entities,
+			Success:  &failed,
+			Limit:    3,
+		})
+		if err != nil && p.logger != nil {
+			p.logger.Warn("[memory] episode failure retrieval failed: %v", err)
+		}
+		for _, hit := range failureEpisodes {
+			hit.Type = "task_episode_failure"
+			out.Verifier.FailureModes = append(out.Verifier.FailureModes, hit)
+		}
 
-	out.trim(4)
-	if hasPlannerSnapshot {
-		out.Planner = plannerSnapshot
+		out.trim(4)
 		return out, nil
-	}
-	if err := p.saveSessionPlannerExperienceSnapshot(out.Planner); err != nil && p.logger != nil {
-		p.logger.Warn("[memory] session planner experience snapshot save failed: %v", err)
-	}
-	return out, nil
+	})
 }
 
 func (p *FilesystemMemoryPlane) NewEpisodeRecorder(req MemoryRetrieveRequest, retrieved MemoryContext) *EpisodeRecorder {
@@ -303,56 +293,58 @@ func (p *FilesystemMemoryPlane) searchLongTerm(ctx context.Context, query memory
 	return hits, nil
 }
 
-func (p *FilesystemMemoryPlane) loadSessionPlannerExperienceSnapshot() (RoleMemoryContext, bool, error) {
+func (p *FilesystemMemoryPlane) retrieveWithFrozenPlannerSnapshot(retrieve func() (MemoryContext, error)) (MemoryContext, error) {
 	if p == nil || p.memoryDir == "" {
-		return RoleMemoryContext{}, false, nil
+		return retrieve()
 	}
 	fl := NewFileLock(p.memoryDir)
 	if err := fl.Lock(defaultLockTimeout); err != nil {
-		return RoleMemoryContext{}, false, err
+		return MemoryContext{}, err
 	}
-	defer fl.Unlock()
 
 	sessionDir := filepath.Join(p.memoryDir, "session")
 	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
-		return RoleMemoryContext{}, false, err
+		_ = fl.Unlock()
+		return MemoryContext{}, err
 	}
 	meta, err := ensureActiveSessionMetadata(sessionDir, time.Now().UTC())
 	if err != nil {
-		return RoleMemoryContext{}, false, err
+		_ = fl.Unlock()
+		return MemoryContext{}, err
 	}
-	if meta.State == nil || meta.State.RetrievedDeviceExperience == nil {
-		return RoleMemoryContext{}, false, nil
-	}
-	return meta.State.RetrievedDeviceExperience.Planner, true, nil
-}
+	if meta.State != nil && meta.State.RetrievedDeviceExperience != nil {
+		plannerSnapshot := meta.State.RetrievedDeviceExperience.Planner
+		_ = fl.Unlock()
 
-func (p *FilesystemMemoryPlane) saveSessionPlannerExperienceSnapshot(planner RoleMemoryContext) error {
-	if p == nil || p.memoryDir == "" {
-		return nil
+		out, err := retrieve()
+		if err != nil {
+			return out, err
+		}
+		out.Planner = plannerSnapshot
+		return out, nil
 	}
-	fl := NewFileLock(p.memoryDir)
-	if err := fl.Lock(defaultLockTimeout); err != nil {
-		return err
-	}
-	defer fl.Unlock()
 
-	sessionDir := filepath.Join(p.memoryDir, "session")
-	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
-		return err
-	}
-	meta, err := ensureActiveSessionMetadata(sessionDir, time.Now().UTC())
+	// Keep the lock across the first planner retrieval so the session freeze is
+	// owned by the first retriever that entered the active session.
+	out, err := retrieve()
 	if err != nil {
-		return err
+		_ = fl.Unlock()
+		return out, err
 	}
+
 	if meta.State == nil {
 		meta.State = &sessionState{}
 	}
 	meta.State.RetrievedDeviceExperience = &sessionPlannerExperienceSnapshot{
 		Version: sessionPlannerExperienceSnapshotVersion,
-		Planner: planner,
+		Planner: out.Planner,
 	}
-	return writeSessionMetadata(filepath.Join(sessionDir, sessionMetadataFileName), meta)
+	if err := writeSessionMetadata(filepath.Join(sessionDir, sessionMetadataFileName), meta); err != nil {
+		_ = fl.Unlock()
+		return out, err
+	}
+	_ = fl.Unlock()
+	return out, nil
 }
 
 func (p *FilesystemMemoryPlane) searchLongTermConflicts(ctx context.Context, query memorySearchQuery) ([]MemoryHit, error) {

--- a/src/agent/internal/agent/memory_plane_test.go
+++ b/src/agent/internal/agent/memory_plane_test.go
@@ -175,6 +175,139 @@ func TestMemoryPlaneRetrieveRoutesExperienceByRole(t *testing.T) {
 	}
 }
 
+func TestMemoryPlaneRetrieveFreezesPlannerExperienceWithinActiveSession(t *testing.T) {
+	ctx := context.Background()
+	memoryDir := filepath.Join(t.TempDir(), "memory")
+	longTerm := NewLongTermMemoryStore(filepath.Join(memoryDir, "long_term"))
+	for _, item := range []MemoryItem{
+		{
+			ID:               "mem_open_wechat",
+			Type:             "procedure",
+			Priority:         90,
+			Confidence:       0.9,
+			Entities:         []string{"微信App"},
+			Title:            "微信打开路径",
+			Content:          "打开微信App时先使用搜索。",
+			EvidenceExcerpts: []string{"微信路径验证成功。"},
+		},
+		{
+			ID:               "mem_open_alipay",
+			Type:             "procedure",
+			Priority:         90,
+			Confidence:       0.9,
+			Entities:         []string{"支付宝App"},
+			Title:            "支付宝打开路径",
+			Content:          "打开支付宝App时先使用搜索。",
+			EvidenceExcerpts: []string{"支付宝路径验证成功。"},
+		},
+	} {
+		if _, err := longTerm.AddMemory(ctx, item); err != nil {
+			t.Fatalf("AddMemory(%s): %v", item.ID, err)
+		}
+	}
+
+	plane := NewFilesystemMemoryPlane(memoryDir, DefaultMemoryExtractionConfig(), nil)
+	first, err := plane.Retrieve(ctx, MemoryRetrieveRequest{
+		Input:    "打开微信App",
+		DeviceID: "default",
+	})
+	if err != nil {
+		t.Fatalf("first Retrieve() error = %v", err)
+	}
+	if len(first.Planner.Procedures) == 0 || first.Planner.Procedures[0].ID != "mem_open_wechat" {
+		t.Fatalf("first planner procedures = %#v", first.Planner.Procedures)
+	}
+	metadata := readSessionMetadataForTest(t, filepath.Join(memoryDir, "session", sessionMetadataFileName))
+	if metadata.State == nil || metadata.State.RetrievedDeviceExperience == nil {
+		t.Fatalf("session metadata missing retrieved device experience snapshot: %#v", metadata)
+	}
+	if got := metadata.State.RetrievedDeviceExperience.Planner.Procedures[0].ID; got != "mem_open_wechat" {
+		t.Fatalf("metadata planner snapshot = %q, want mem_open_wechat", got)
+	}
+	if _, err := os.Stat(filepath.Join(memoryDir, "session", "retrieved_device_experience.json")); !os.IsNotExist(err) {
+		t.Fatalf("unexpected feature-specific snapshot file, stat err = %v", err)
+	}
+
+	second, err := plane.Retrieve(ctx, MemoryRetrieveRequest{
+		Input:    "打开支付宝App",
+		DeviceID: "default",
+	})
+	if err != nil {
+		t.Fatalf("second Retrieve() error = %v", err)
+	}
+	if len(second.Planner.Procedures) == 0 || second.Planner.Procedures[0].ID != "mem_open_wechat" {
+		t.Fatalf("second planner procedures = %#v, want first-session snapshot", second.Planner.Procedures)
+	}
+	for _, hit := range second.Planner.Procedures {
+		if hit.ID == "mem_open_alipay" {
+			t.Fatalf("planner experience should stay frozen within session: %#v", second.Planner.Procedures)
+		}
+	}
+}
+
+func TestMemoryPlaneRetrieveRefreshesPlannerExperienceAfterSessionRotate(t *testing.T) {
+	ctx := context.Background()
+	memoryDir := filepath.Join(t.TempDir(), "memory")
+	longTerm := NewLongTermMemoryStore(filepath.Join(memoryDir, "long_term"))
+	for _, item := range []MemoryItem{
+		{
+			ID:               "mem_open_wechat",
+			Type:             "procedure",
+			Priority:         90,
+			Confidence:       0.9,
+			Entities:         []string{"微信App"},
+			Title:            "微信打开路径",
+			Content:          "打开微信App时先使用搜索。",
+			EvidenceExcerpts: []string{"微信路径验证成功。"},
+		},
+		{
+			ID:               "mem_open_alipay",
+			Type:             "procedure",
+			Priority:         90,
+			Confidence:       0.9,
+			Entities:         []string{"支付宝App"},
+			Title:            "支付宝打开路径",
+			Content:          "打开支付宝App时先使用搜索。",
+			EvidenceExcerpts: []string{"支付宝路径验证成功。"},
+		},
+	} {
+		if _, err := longTerm.AddMemory(ctx, item); err != nil {
+			t.Fatalf("AddMemory(%s): %v", item.ID, err)
+		}
+	}
+
+	plane := NewFilesystemMemoryPlane(memoryDir, DefaultMemoryExtractionConfig(), nil)
+	if _, err := plane.Retrieve(ctx, MemoryRetrieveRequest{
+		Input:    "打开微信App",
+		DeviceID: "default",
+	}); err != nil {
+		t.Fatalf("first Retrieve() error = %v", err)
+	}
+
+	manager := NewMemoryManager(memoryDir)
+	if err := manager.AppendSessionEvent(ctx, "default", SessionEvent{
+		Type:    "user_input",
+		Role:    "user",
+		Content: "打开微信App",
+	}, SessionEventMetadata{}); err != nil {
+		t.Fatalf("AppendSessionEvent() error = %v", err)
+	}
+	if _, err := manager.RotateSessionEventsDetailed(); err != nil {
+		t.Fatalf("RotateSessionEventsDetailed() error = %v", err)
+	}
+
+	afterRotate, err := plane.Retrieve(ctx, MemoryRetrieveRequest{
+		Input:    "打开支付宝App",
+		DeviceID: "default",
+	})
+	if err != nil {
+		t.Fatalf("second Retrieve() error = %v", err)
+	}
+	if len(afterRotate.Planner.Procedures) == 0 || afterRotate.Planner.Procedures[0].ID != "mem_open_alipay" {
+		t.Fatalf("after rotate planner procedures = %#v", afterRotate.Planner.Procedures)
+	}
+}
+
 func TestRuntimeRunWritesTaskEpisodeTrace(t *testing.T) {
 	ctx := context.Background()
 	configDir := t.TempDir()

--- a/src/agent/internal/agent/memory_plane_test.go
+++ b/src/agent/internal/agent/memory_plane_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	langtools "github.com/tmc/langchaingo/tools"
 )
@@ -305,6 +306,84 @@ func TestMemoryPlaneRetrieveRefreshesPlannerExperienceAfterSessionRotate(t *test
 	}
 	if len(afterRotate.Planner.Procedures) == 0 || afterRotate.Planner.Procedures[0].ID != "mem_open_alipay" {
 		t.Fatalf("after rotate planner procedures = %#v", afterRotate.Planner.Procedures)
+	}
+}
+
+func TestMemoryPlaneFreezePlannerSnapshotUsesFirstConcurrentRetriever(t *testing.T) {
+	memoryDir := filepath.Join(t.TempDir(), "memory")
+	plane := NewFilesystemMemoryPlane(memoryDir, DefaultMemoryExtractionConfig(), nil)
+
+	firstComputeStarted := make(chan struct{})
+	firstMayFinish := make(chan struct{})
+	secondCalled := make(chan struct{})
+	secondComputeStarted := make(chan struct{})
+
+	type retrieveResult struct {
+		out MemoryContext
+		err error
+	}
+	firstDone := make(chan retrieveResult, 1)
+	secondDone := make(chan retrieveResult, 1)
+
+	go func() {
+		out, err := plane.retrieveWithFrozenPlannerSnapshot(func() (MemoryContext, error) {
+			close(firstComputeStarted)
+			<-firstMayFinish
+			return MemoryContext{
+				Planner: RoleMemoryContext{
+					Procedures: []MemoryHit{{ID: "mem_first"}},
+				},
+			}, nil
+		})
+		firstDone <- retrieveResult{out: out, err: err}
+	}()
+
+	<-firstComputeStarted
+
+	go func() {
+		close(secondCalled)
+		out, err := plane.retrieveWithFrozenPlannerSnapshot(func() (MemoryContext, error) {
+			close(secondComputeStarted)
+			return MemoryContext{
+				Planner: RoleMemoryContext{
+					Procedures: []MemoryHit{{ID: "mem_second"}},
+				},
+			}, nil
+		})
+		secondDone <- retrieveResult{out: out, err: err}
+	}()
+
+	<-secondCalled
+	select {
+	case <-secondComputeStarted:
+		t.Fatalf("second concurrent retriever started computing before first freeze completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(firstMayFinish)
+
+	first := <-firstDone
+	if first.err != nil {
+		t.Fatalf("first retrieveWithFrozenPlannerSnapshot() error = %v", first.err)
+	}
+	second := <-secondDone
+	if second.err != nil {
+		t.Fatalf("second retrieveWithFrozenPlannerSnapshot() error = %v", second.err)
+	}
+
+	if got := first.out.Planner.Procedures[0].ID; got != "mem_first" {
+		t.Fatalf("first planner snapshot = %q, want mem_first", got)
+	}
+	if got := second.out.Planner.Procedures[0].ID; got != "mem_first" {
+		t.Fatalf("second planner snapshot = %q, want mem_first", got)
+	}
+
+	metadata := readSessionMetadataForTest(t, filepath.Join(memoryDir, "session", sessionMetadataFileName))
+	if metadata.State == nil || metadata.State.RetrievedDeviceExperience == nil {
+		t.Fatalf("session metadata missing retrieved device experience snapshot: %#v", metadata)
+	}
+	if got := metadata.State.RetrievedDeviceExperience.Planner.Procedures[0].ID; got != "mem_first" {
+		t.Fatalf("metadata planner snapshot = %q, want mem_first", got)
 	}
 }
 

--- a/src/agent/internal/agent/memory_plane_test.go
+++ b/src/agent/internal/agent/memory_plane_test.go
@@ -309,6 +309,71 @@ func TestMemoryPlaneRetrieveRefreshesPlannerExperienceAfterSessionRotate(t *test
 	}
 }
 
+func TestMemoryPlaneRetrieveIgnoresPlannerSnapshotWithUnknownVersion(t *testing.T) {
+	ctx := context.Background()
+	memoryDir := filepath.Join(t.TempDir(), "memory")
+	longTerm := NewLongTermMemoryStore(filepath.Join(memoryDir, "long_term"))
+	if _, err := longTerm.AddMemory(ctx, MemoryItem{
+		ID:               "mem_open_alipay",
+		Type:             "procedure",
+		Priority:         90,
+		Confidence:       0.9,
+		Entities:         []string{"支付宝App"},
+		Title:            "支付宝打开路径",
+		Content:          "打开支付宝App时先使用搜索。",
+		EvidenceExcerpts: []string{"支付宝路径验证成功。"},
+	}); err != nil {
+		t.Fatalf("AddMemory(mem_open_alipay): %v", err)
+	}
+
+	sessionDir := filepath.Join(memoryDir, "session")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(sessionDir): %v", err)
+	}
+	if err := writeSessionMetadata(filepath.Join(sessionDir, sessionMetadataFileName), sessionMetadata{
+		SessionID: "session_stale_snapshot",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		State: &sessionState{
+			RetrievedDeviceExperience: &sessionPlannerExperienceSnapshot{
+				Version: sessionPlannerExperienceSnapshotVersion + 1,
+				Planner: RoleMemoryContext{
+					Procedures: []MemoryHit{{ID: "mem_stale"}},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("writeSessionMetadata(): %v", err)
+	}
+
+	plane := NewFilesystemMemoryPlane(memoryDir, DefaultMemoryExtractionConfig(), nil)
+	got, err := plane.Retrieve(ctx, MemoryRetrieveRequest{
+		Input:    "打开支付宝App",
+		DeviceID: "default",
+	})
+	if err != nil {
+		t.Fatalf("Retrieve() error = %v", err)
+	}
+	if len(got.Planner.Procedures) == 0 || got.Planner.Procedures[0].ID != "mem_open_alipay" {
+		t.Fatalf("planner procedures = %#v, want fresh retrieval", got.Planner.Procedures)
+	}
+	for _, hit := range got.Planner.Procedures {
+		if hit.ID == "mem_stale" {
+			t.Fatalf("stale planner snapshot should be ignored: %#v", got.Planner.Procedures)
+		}
+	}
+
+	metadata := readSessionMetadataForTest(t, filepath.Join(memoryDir, "session", sessionMetadataFileName))
+	if metadata.State == nil || metadata.State.RetrievedDeviceExperience == nil {
+		t.Fatalf("session metadata missing refreshed planner snapshot: %#v", metadata)
+	}
+	if got := metadata.State.RetrievedDeviceExperience.Version; got != sessionPlannerExperienceSnapshotVersion {
+		t.Fatalf("snapshot version = %d, want %d", got, sessionPlannerExperienceSnapshotVersion)
+	}
+	if got := metadata.State.RetrievedDeviceExperience.Planner.Procedures[0].ID; got != "mem_open_alipay" {
+		t.Fatalf("metadata planner snapshot = %q, want mem_open_alipay", got)
+	}
+}
+
 func TestMemoryPlaneFreezePlannerSnapshotUsesFirstConcurrentRetriever(t *testing.T) {
 	memoryDir := filepath.Join(t.TempDir(), "memory")
 	plane := NewFilesystemMemoryPlane(memoryDir, DefaultMemoryExtractionConfig(), nil)


### PR DESCRIPTION
## Summary
- persist the planner experience snapshot in session metadata
- reuse the same planner experience for the active session and refresh it after session rotation
- cover the freeze and refresh behavior with memory plane tests

## Testing
- go test ./internal/agent -run 'TestMemoryPlaneRetrieve(FreezesPlannerExperienceWithinActiveSession|RefreshesPlannerExperienceAfterSessionRotate)$'
- go test ./internal/agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session-based planner context is now retained during an active session, helping keep results consistent across repeated actions.

* **Bug Fixes**
  * Planner context now refreshes correctly after a session rotates, so new input is reflected when starting a new session state.
  * Session data is saved more reliably to reduce the risk of partial writes or lost metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->