### PR TITLE
refactor: remove legacy default.json persistence

### DIFF
--- a/benchmark/scripts/quick_memory_test.py
+++ b/benchmark/scripts/quick_memory_test.py
@@ -38,7 +38,7 @@ def ssh(cmd):
 
 
 def clear_state():
-    ssh(f"rm -rf {MEMORY_DIR}/long_term {MEMORY_DIR}/session {MEMORY_DIR}/default.json")
+    ssh(f"rm -rf {MEMORY_DIR}/long_term {MEMORY_DIR}/session")
     http_post("/api/clear")
 
 

--- a/docs/04-agent/context-lifecycle.md
+++ b/docs/04-agent/context-lifecycle.md
@@ -306,7 +306,6 @@ The chat_history store remains available for:
 
 ```text
 /userdata/agent/memory/
-|-- default.json                 # conversation-window snapshot
 |-- chat_history/                # optional persisted UI chat history
 |-- session/
 |   |-- events.jsonl             # hot window

--- a/docs/04-agent/memory-plane.md
+++ b/docs/04-agent/memory-plane.md
@@ -66,7 +66,6 @@ Continue using `/userdata/agent/memory`, add `device` and `episodes`. Existing d
 
 ```text
 /userdata/agent/memory/
-├── default.json                 # existing conversation window snapshot
 ├── session/
 │   ├── events.jsonl             # existing hot session events
 │   ├── summary.md               # existing compressed summary

--- a/docs/04-agent/session-memory.md
+++ b/docs/04-agent/session-memory.md
@@ -199,7 +199,7 @@ Screenshot tool results include base64 image payloads. Before persistence, `stri
 
 The scrubber is idempotent and is used at every session-memory persistence boundary:
 
-- `sanitizeMessageRecords` before writing the legacy `default.json` snapshot.
+- `sanitizeMessageRecords` before synchronizing `MessageRecord` slices into session events.
 - `sessionEventFromRecord` when converting langchain `MessageRecord` values into `SessionEvent` values.
 - `SessionMemoryStore.AppendEvent` for direct writes that bypass the conversion path.
 

--- a/src/agent/internal/agent/chat_history.go
+++ b/src/agent/internal/agent/chat_history.go
@@ -167,8 +167,8 @@ func compactToolResultForChatHistory(content string) string {
 // stripScreenshotData removes the base64 image payload from a screenshot tool
 // result while preserving its metadata (width/height/format/size and any
 // action_output). It is the single source of truth for screenshot-data
-// scrubbing, used by chat_history persistence, the legacy session snapshot, and
-// the session events.jsonl path (sessionEventFromRecord +
+// scrubbing, used by chat_history persistence and the session events.jsonl path
+// (sessionEventFromRecord +
 // SessionMemoryStore.AppendEvent) so a base64 JPEG never lands in persistent
 // memory stores and can never inflate the hot-window token estimate. Returns
 // content unchanged when it is not a screenshot result (or has no Data field),

--- a/src/agent/internal/agent/filelock_test.go
+++ b/src/agent/internal/agent/filelock_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -85,7 +84,7 @@ func TestMemoryManagerConcurrentGoroutines(t *testing.T) {
 					{Role: "human", Content: fmt.Sprintf("goroutine-%d-iter-%d", id, i)},
 					{Role: "ai", Content: fmt.Sprintf("response-%d-%d", id, i)},
 				}
-				if err := mgr.persistSnapshot("shared", records); err != nil {
+				if err := mgr.syncSessionRecords("shared", records); err != nil {
 					errs <- fmt.Errorf("goroutine %d iter %d persist: %w", id, i, err)
 					return
 				}
@@ -100,16 +99,10 @@ func TestMemoryManagerConcurrentGoroutines(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(dir, "shared.json"))
-	if err != nil {
-		t.Fatalf("read final snapshot: %v", err)
-	}
-	var records []MessageRecord
-	if err := json.Unmarshal(data, &records); err != nil {
-		t.Fatalf("final snapshot is not valid JSON: %v\nraw: %s", err, string(data))
-	}
-	if len(records) != 2 {
-		t.Fatalf("expected 2 records in final snapshot, got %d", len(records))
+	events := readSessionEvents(t, filepath.Join(dir, "session", "events.jsonl"))
+	expectedEvents := goroutines * iterations * 2
+	if len(events) != expectedEvents {
+		t.Fatalf("expected %d session events, got %d", expectedEvents, len(events))
 	}
 }
 
@@ -154,16 +147,10 @@ func TestMemoryManagerConcurrentMultiProcess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(dir, "shared.json"))
-	if err != nil {
-		t.Fatalf("read final snapshot: %v", err)
-	}
-	var records []MessageRecord
-	if err := json.Unmarshal(data, &records); err != nil {
-		t.Fatalf("final snapshot corrupted: %v\nraw: %s", err, string(data))
-	}
-	if len(records) != 2 {
-		t.Fatalf("expected 2 records, got %d", len(records))
+	events := readSessionEvents(t, filepath.Join(dir, "session", "events.jsonl"))
+	expectedEvents := procs * writesPerProc * 2
+	if len(events) != expectedEvents {
+		t.Fatalf("expected %d session events, got %d", expectedEvents, len(events))
 	}
 }
 
@@ -179,7 +166,7 @@ func runChildProcess() {
 			{Role: "human", Content: fmt.Sprintf("proc-%s-write-%d", id, i)},
 			{Role: "ai", Content: fmt.Sprintf("reply-%s-%d", id, i)},
 		}
-		if err := mgr.persistSnapshot("shared", records); err != nil {
+		if err := mgr.syncSessionRecords("shared", records); err != nil {
 			fmt.Fprintf(os.Stderr, "persist error: %v\n", err)
 			os.Exit(1)
 		}
@@ -236,7 +223,7 @@ func TestMemoryManagerConcurrentReadWrite(t *testing.T) {
 		{Role: "human", Content: "seed"},
 		{Role: "ai", Content: "seed-reply"},
 	}
-	if err := mgr.persistSnapshot("default", records); err != nil {
+	if err := mgr.syncSessionRecords("default", records); err != nil {
 		t.Fatalf("seed persist: %v", err)
 	}
 
@@ -254,7 +241,7 @@ func TestMemoryManagerConcurrentReadWrite(t *testing.T) {
 						{Role: "human", Content: fmt.Sprintf("w-%d-%d", id, i)},
 						{Role: "ai", Content: fmt.Sprintf("wr-%d-%d", id, i)},
 					}
-					if err := m.persistSnapshot("default", r); err != nil {
+					if err := m.syncSessionRecords("default", r); err != nil {
 						errs <- fmt.Errorf("write g%d i%d: %w", id, i, err)
 						return
 					}
@@ -275,13 +262,16 @@ func TestMemoryManagerConcurrentReadWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(dir, "default.json"))
-	if err != nil {
-		t.Fatalf("read final: %v", err)
+	events := readSessionEvents(t, filepath.Join(dir, "session", "events.jsonl"))
+	writerGoroutines := 0
+	for g := range goroutines {
+		if g%2 == 0 {
+			writerGoroutines++
+		}
 	}
-	var final []MessageRecord
-	if err := json.Unmarshal(data, &final); err != nil {
-		t.Fatalf("final snapshot corrupted: %v", err)
+	expectedEvents := len(records) + writerGoroutines*iterations*2
+	if len(events) != expectedEvents {
+		t.Fatalf("expected %d session events, got %d", expectedEvents, len(events))
 	}
 }
 

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -886,6 +886,31 @@ func (m *MemoryManager) loadSessionMessageRecords(agentName string) ([]MessageRe
 	}
 	defer fl.Unlock()
 
+	if records, hotWindowTokens, eventCount, ok, err := m.loadSessionMessageRecordsLocked(agentName); err != nil {
+		return nil, 0, 0, false, err
+	} else if ok {
+		return records, hotWindowTokens, eventCount, true, nil
+	}
+
+	legacyRecords, ok, err := m.loadLegacyMessageRecordsLocked(agentName)
+	if err != nil {
+		return nil, 0, 0, false, err
+	}
+	if !ok {
+		return nil, 0, 0, false, nil
+	}
+	if len(legacyRecords) == 0 {
+		m.removeLegacySnapshotAfterMigration(agentName)
+		return nil, 0, 0, true, nil
+	}
+	if err := m.appendSessionEvents(agentName, legacyRecords); err != nil {
+		return nil, 0, 0, false, fmt.Errorf("migrate legacy persisted memory for %q: %w", agentName, err)
+	}
+	m.removeLegacySnapshotAfterMigration(agentName)
+	return m.loadSessionMessageRecordsLocked(agentName)
+}
+
+func (m *MemoryManager) loadSessionMessageRecordsLocked(agentName string) ([]MessageRecord, int, int, bool, error) {
 	session := NewSessionMemoryStore(filepath.Join(m.storageDir, "session"), m.extraction.SummaryMaxChunks)
 	result, err := session.readActiveEventsRepairingTruncatedTail()
 	if err != nil {
@@ -909,6 +934,28 @@ func (m *MemoryManager) loadSessionMessageRecords(agentName string) ([]MessageRe
 		}
 	}
 	return records, hotWindowTokens, len(result.events), true, nil
+}
+
+func (m *MemoryManager) loadLegacyMessageRecordsLocked(agentName string) ([]MessageRecord, bool, error) {
+	data, err := os.ReadFile(legacyMemorySnapshotPath(m.storageDir, agentName))
+	if err != nil {
+		if isPathNotExistError(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("read legacy persisted memory for %q: %w", agentName, err)
+	}
+
+	var records []MessageRecord
+	if err := json.Unmarshal(data, &records); err != nil {
+		return nil, false, fmt.Errorf("decode legacy persisted memory for %q: %w", agentName, err)
+	}
+	return records, true, nil
+}
+
+func (m *MemoryManager) removeLegacySnapshotAfterMigration(agentName string) {
+	if err := os.Remove(legacyMemorySnapshotPath(m.storageDir, agentName)); err != nil && !os.IsNotExist(err) && m.logger != nil {
+		m.logger.Warn("[memory] remove migrated legacy snapshot for %q: %v", agentName, err)
+	}
 }
 
 func (m *MemoryManager) LoadActiveSessionEvents(ctx context.Context, limit int) ([]SessionEvent, error) {

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -398,24 +398,16 @@ func (m *MemoryManager) ClearAll(ctx context.Context, agentName string) error {
 	return m.removeAllPersisted(agentName)
 }
 
-// Save persists the current memory snapshot and triggers maintenance.
+// Save persists the current memory state into session events and triggers maintenance.
 func (m *MemoryManager) Save(ctx context.Context, agentName string) error {
 	records, err := m.Snapshot(ctx, agentName)
 	if err != nil {
 		return err
 	}
-	if err := m.persistSnapshot(agentName, records); err != nil {
+	if err := m.syncSessionRecords(agentName, records); err != nil {
 		return err
 	}
 	return m.maintainFilesystemMemory(ctx)
-}
-
-// SaveSnapshot persists a given snapshot of message records.
-func (m *MemoryManager) SaveSnapshot(ctx context.Context, agentName string, records []MessageRecord) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return m.persistSnapshot(agentName, records)
 }
 
 // RequestMaintenance schedules asynchronous memory maintenance.
@@ -884,34 +876,6 @@ func (m *MemoryManager) loadPersistedMessages(history *langmemory.ChatMessageHis
 		}
 		return nil
 	}
-
-	fl := NewFileLock(m.storageDir)
-	if err := fl.Lock(m.lockTimeout); err != nil {
-		return fmt.Errorf("lock for loading memory %q: %w", agentName, err)
-	}
-	defer fl.Unlock()
-
-	data, err := os.ReadFile(m.memoryPath(agentName))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("read persisted memory for %q: %w", agentName, err)
-	}
-
-	var records []MessageRecord
-	if err := json.Unmarshal(data, &records); err != nil {
-		return fmt.Errorf("decode persisted memory for %q: %w", agentName, err)
-	}
-
-	messages := make([]llms.ChatMessage, 0, len(records))
-	for _, record := range records {
-		messages = append(messages, messageFromRecord(record))
-	}
-	if err := history.SetMessages(context.Background(), messages); err != nil {
-		return fmt.Errorf("restore persisted memory for %q: %w", agentName, err)
-	}
-	m.eventCount[agentName] = len(records)
 	return nil
 }
 
@@ -989,7 +953,7 @@ func (m *MemoryManager) logSessionEventsRepair(agentName string, result sessionE
 	m.logger.Warn("[memory] repaired truncated session events for %q", agentName)
 }
 
-func (m *MemoryManager) persistSnapshot(agentName string, records []MessageRecord) error {
+func (m *MemoryManager) syncSessionRecords(agentName string, records []MessageRecord) error {
 	if m.storageDir == "" {
 		return nil
 	}
@@ -1009,20 +973,6 @@ func (m *MemoryManager) persistSnapshot(agentName string, records []MessageRecor
 	records = sanitizeMessageRecords(records)
 	if err := m.appendSessionEvents(agentName, records); err != nil {
 		return err
-	}
-
-	data, err := json.MarshalIndent(records, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal memory snapshot for %q: %w", agentName, err)
-	}
-
-	path := m.memoryPath(agentName)
-	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
-		return fmt.Errorf("write memory snapshot for %q: %w", agentName, err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		return fmt.Errorf("replace memory snapshot for %q: %w", agentName, err)
 	}
 	return nil
 }
@@ -1049,9 +999,6 @@ func (m *MemoryManager) removeSessionPersisted(agentName string) error {
 	}
 	defer fl.Unlock()
 
-	if err := os.Remove(m.memoryPath(agentName)); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove persisted memory for %q: %w", agentName, err)
-	}
 	if err := os.RemoveAll(filepath.Join(m.storageDir, "session")); err != nil {
 		return fmt.Errorf("remove session memory for %q: %w", agentName, err)
 	}
@@ -1075,9 +1022,6 @@ func (m *MemoryManager) removeAllPersisted(agentName string) error {
 	}
 	defer fl.Unlock()
 
-	if err := os.Remove(m.memoryPath(agentName)); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove persisted memory for %q: %w", agentName, err)
-	}
 	for _, path := range []string{
 		filepath.Join(m.storageDir, "session"),
 		filepath.Join(m.storageDir, "long_term"),
@@ -1689,10 +1633,6 @@ func cleanEntityName(entity string) string {
 	return strings.Trim(entity, " ，。,.、；;：:\"'（）()[]【】")
 }
 
-func (m *MemoryManager) memoryPath(agentName string) string {
-	return filepath.Join(m.storageDir, memoryFileName(agentName))
-}
-
 func (m *MemoryManager) sessionEventsPath() string {
 	return filepath.Join(m.storageDir, "session", "events.jsonl")
 }
@@ -1817,31 +1757,6 @@ func messageRecordsEqualSlice(a, b []MessageRecord) bool {
 
 func messageRecordsEqual(a, b MessageRecord) bool {
 	return a.Role == b.Role && a.Content == b.Content
-}
-
-func memoryFileName(agentName string) string {
-	agentName = strings.TrimSpace(agentName)
-	if agentName == "" {
-		agentName = "default"
-	}
-	safe := strings.Map(func(r rune) rune {
-		if r >= 'a' && r <= 'z' {
-			return r
-		}
-		if r >= 'A' && r <= 'Z' {
-			return r
-		}
-		if r >= '0' && r <= '9' {
-			return r
-		}
-		switch r {
-		case '-', '_', '.':
-			return r
-		default:
-			return '_'
-		}
-	}, agentName)
-	return safe + ".json"
 }
 
 func isTruncatedJSONLineError(err error) bool {

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -986,6 +986,31 @@ func sanitizeMessageRecords(records []MessageRecord) []MessageRecord {
 	return out
 }
 
+func legacyMemorySnapshotPath(storageDir, agentName string) string {
+	agentName = strings.TrimSpace(agentName)
+	if agentName == "" {
+		agentName = "default"
+	}
+	safe := strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' {
+			return r
+		}
+		if r >= 'A' && r <= 'Z' {
+			return r
+		}
+		if r >= '0' && r <= '9' {
+			return r
+		}
+		switch r {
+		case '-', '_', '.':
+			return r
+		default:
+			return '_'
+		}
+	}, agentName)
+	return filepath.Join(storageDir, safe+".json")
+}
+
 func (m *MemoryManager) removeSessionPersisted(agentName string) error {
 	if m.storageDir == "" {
 		return nil
@@ -999,6 +1024,9 @@ func (m *MemoryManager) removeSessionPersisted(agentName string) error {
 	}
 	defer fl.Unlock()
 
+	if err := os.Remove(legacyMemorySnapshotPath(m.storageDir, agentName)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove legacy session memory for %q: %w", agentName, err)
+	}
 	if err := os.RemoveAll(filepath.Join(m.storageDir, "session")); err != nil {
 		return fmt.Errorf("remove session memory for %q: %w", agentName, err)
 	}
@@ -1022,6 +1050,9 @@ func (m *MemoryManager) removeAllPersisted(agentName string) error {
 	}
 	defer fl.Unlock()
 
+	if err := os.Remove(legacyMemorySnapshotPath(m.storageDir, agentName)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove legacy memory for %q: %w", agentName, err)
+	}
 	for _, path := range []string{
 		filepath.Join(m.storageDir, "session"),
 		filepath.Join(m.storageDir, "long_term"),

--- a/src/agent/internal/agent/memory_race_test.go
+++ b/src/agent/internal/agent/memory_race_test.go
@@ -10,11 +10,11 @@ import (
 
 // TestMaintenanceDoesNotClobberConcurrentAppends verifies that when maintenance
 // (triggered by RequestMaintenance) runs compression asynchronously, any events
-// appended via AppendExchange or persistSnapshot during the compression window
+// appended via AppendExchange or syncSessionRecords during the compression window
 // are not lost. This is a regression test for the race condition where:
 // 1. maintenance reads events snapshot
 // 2. maintenance runs LLM summary (slow, releases lock)
-// 3. turn N+1 appends new events via persistSnapshot
+// 3. turn N+1 appends new events via syncSessionRecords
 // 4. maintenance replaceEvents with old snapshot → new events clobbered
 func TestMaintenanceDoesNotClobberConcurrentAppends(t *testing.T) {
 	ctx := context.Background()
@@ -68,20 +68,19 @@ func TestMaintenanceDoesNotClobberConcurrentAppends(t *testing.T) {
 		mgr.RequestMaintenance()
 	}()
 
-	// Goroutine 2: Wait for summary to start, then append via persistSnapshot
-	// (the path used by SaveSnapshot in runtime.go:518)
+	// Goroutine 2: Wait for summary to start, then append via syncSessionRecords.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		<-summaryStarted
 
-		// This simulates a turn calling SaveSnapshot while maintenance is running
+		// This simulates a turn synchronizing history while maintenance is running.
 		records := []MessageRecord{
 			{Role: "user", Content: "injected during compression window"},
 			{Role: "assistant", Content: "response during compression window"},
 		}
-		if err := mgr.persistSnapshot("default", records); err != nil {
-			t.Errorf("persistSnapshot during maintenance: %v", err)
+		if err := mgr.syncSessionRecords("default", records); err != nil {
+			t.Errorf("syncSessionRecords during maintenance: %v", err)
 		}
 	}()
 
@@ -115,7 +114,7 @@ func TestMaintenanceDoesNotClobberConcurrentAppends(t *testing.T) {
 	}
 }
 
-// TestAppendAndMaintenanceFileLockSerialization verifies that persistSnapshot
+// TestAppendAndMaintenanceFileLockSerialization verifies that syncSessionRecords
 // and maintainFilesystemMemory properly serialize access to events.jsonl via
 // FileLock, preventing torn reads/writes.
 func TestAppendAndMaintenanceFileLockSerialization(t *testing.T) {
@@ -153,8 +152,8 @@ func TestAppendAndMaintenanceFileLockSerialization(t *testing.T) {
 			records := []MessageRecord{
 				{Role: "user", Content: "concurrent append"},
 			}
-			if err := mgr.persistSnapshot("default", records); err != nil {
-				t.Errorf("goroutine %d persistSnapshot: %v", id, err)
+			if err := mgr.syncSessionRecords("default", records); err != nil {
+				t.Errorf("goroutine %d syncSessionRecords: %v", id, err)
 			}
 		}(i)
 	}

--- a/src/agent/internal/agent/memory_race_test.go
+++ b/src/agent/internal/agent/memory_race_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -33,9 +34,9 @@ func TestMaintenanceDoesNotClobberConcurrentAppends(t *testing.T) {
 	}
 
 	cfg := MemoryExtractionConfig{
-		HotWindowEvents:         5,
+		HotWindowEvents:          5,
 		CountCompressAfterEvents: 10,
-		CompressAtPercent:       50,
+		CompressAtPercent:        50,
 	}
 
 	mgr := NewMemoryManager(
@@ -150,7 +151,7 @@ func TestAppendAndMaintenanceFileLockSerialization(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			records := []MessageRecord{
-				{Role: "user", Content: "concurrent append"},
+				{Role: "user", Content: fmt.Sprintf("concurrent append %d", id)},
 			}
 			if err := mgr.syncSessionRecords("default", records); err != nil {
 				t.Errorf("goroutine %d syncSessionRecords: %v", id, err)

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -1118,6 +1118,10 @@ func TestMemoryManagerClearAllRemovesFilesystemMemoryArtifacts(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(storageDir, "session", "chunks", "index.yaml")); err != nil {
 		t.Fatalf("expected session chunk index before clear: %v", err)
 	}
+	legacyPath := legacyMemorySnapshotPath(storageDir, "default")
+	if err := os.WriteFile(legacyPath, []byte("[]\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile legacy snapshot: %v", err)
+	}
 
 	if err := manager.ClearAll(ctx, "default"); err != nil {
 		t.Fatalf("ClearAll() error = %v", err)
@@ -1130,6 +1134,9 @@ func TestMemoryManagerClearAllRemovesFilesystemMemoryArtifacts(t *testing.T) {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("expected %s to be removed, stat err = %v", path, err)
 		}
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy snapshot to be removed, stat err = %v", err)
 	}
 }
 
@@ -1177,6 +1184,10 @@ func TestMemoryManagerClearSessionPreservesLongTermMemory(t *testing.T) {
 	if _, err := os.Stat(sessionDir); err != nil {
 		t.Fatalf("expected session dir to exist before clear: %v", err)
 	}
+	legacyPath := legacyMemorySnapshotPath(storageDir, "default")
+	if err := os.WriteFile(legacyPath, []byte("[]\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile legacy snapshot: %v", err)
+	}
 
 	// ClearSession should remove session but preserve long_term and lifecycle
 	if err := manager.ClearSession(ctx, "default"); err != nil {
@@ -1185,6 +1196,9 @@ func TestMemoryManagerClearSessionPreservesLongTermMemory(t *testing.T) {
 
 	if _, err := os.Stat(sessionDir); !os.IsNotExist(err) {
 		t.Fatalf("expected session dir to be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy snapshot to be removed, stat err = %v", err)
 	}
 	if _, err := os.Stat(profilePath); err != nil {
 		t.Fatalf("expected long_term/profile.md to be preserved: %v", err)

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -377,6 +377,58 @@ func TestMemoryManagerRestoresFromSessionEvents(t *testing.T) {
 	}
 }
 
+func TestMemoryManagerMigratesLegacySnapshotWhenSessionEventsMissing(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	legacyPath := legacyMemorySnapshotPath(storageDir, "default")
+	legacyRecords := []MessageRecord{
+		{Role: string(llms.ChatMessageTypeHuman), Content: "legacy user"},
+		{Role: string(llms.ChatMessageTypeAI), Content: "legacy answer"},
+	}
+	data, err := json.Marshal(legacyRecords)
+	if err != nil {
+		t.Fatalf("marshal legacy snapshot: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, data, 0o644); err != nil {
+		t.Fatalf("write legacy snapshot: %v", err)
+	}
+
+	manager := NewMemoryManager(storageDir)
+	handle, err := manager.Get("default", MemoryConfig{Type: "window", WindowSize: 10})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	messages, err := handle.History.Messages(ctx)
+	if err != nil {
+		t.Fatalf("Messages() error = %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 migrated messages, got %d", len(messages))
+	}
+	if messages[0].GetContent() != "legacy user" || messages[1].GetContent() != "legacy answer" {
+		t.Fatalf("unexpected migrated messages: %#v", messages)
+	}
+
+	events := readSessionEvents(t, filepath.Join(storageDir, "session", "events.jsonl"))
+	if len(events) != 2 {
+		t.Fatalf("expected 2 migrated session events, got %d: %#v", len(events), events)
+	}
+	if events[0].Type != "user_input" || events[0].Content != "legacy user" {
+		t.Fatalf("unexpected migrated first event: %#v", events[0])
+	}
+	if events[1].Type != "assistant_output" || events[1].Content != "legacy answer" {
+		t.Fatalf("unexpected migrated second event: %#v", events[1])
+	}
+	metadata := readSessionMetadataForTest(t, filepath.Join(storageDir, "session", sessionMetadataFileName))
+	if metadata.SessionID == "" {
+		t.Fatal("expected migrated session metadata to contain a session_id")
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy snapshot to be removed after migration, stat err = %v", err)
+	}
+	assertNoTopLevelJSONFiles(t, storageDir)
+}
+
 func TestMemoryManagerIgnoresRootJSONFilesWithoutSessionData(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -172,19 +172,27 @@ func TestMemoryManagerActiveSessionIDRejectsUnsafeMetadata(t *testing.T) {
 	}
 }
 
-func TestMemoryManagerSaveSnapshotCreatesSessionMetadataOnFirstWrite(t *testing.T) {
+func TestMemoryManagerSaveKeepsMemoryRootSessionOnly(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()
 	manager := NewMemoryManager(storageDir)
+	handle, err := manager.Get("default", MemoryConfig{Type: "window", WindowSize: 10})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
 
-	if err := manager.SaveSnapshot(ctx, "default", []MessageRecord{
-		{Role: string(llms.ChatMessageTypeHuman), Content: "hello"},
-		{Role: string(llms.ChatMessageTypeAI), Content: "hi"},
+	if err := handle.History.SetMessages(ctx, []llms.ChatMessage{
+		llms.HumanChatMessage{Content: "hello"},
+		llms.AIChatMessage{Content: "hi"},
 	}); err != nil {
-		t.Fatalf("SaveSnapshot() error = %v", err)
+		t.Fatalf("SetMessages() error = %v", err)
+	}
+	if err := manager.Save(ctx, "default"); err != nil {
+		t.Fatalf("Save() error = %v", err)
 	}
 
 	metadata := readSessionMetadataForTest(t, filepath.Join(storageDir, "session", sessionMetadataFileName))
+	assertNoTopLevelJSONFiles(t, storageDir)
 	rotation, err := manager.RotateSessionEventsDetailed()
 	if err != nil {
 		t.Fatalf("RotateSessionEventsDetailed() error = %v", err)
@@ -291,27 +299,7 @@ func TestSessionEventsStripScreenshotData(t *testing.T) {
 		t.Fatalf("metadata should be preserved: %s", toolEvent.Content)
 	}
 
-	snapshotData, err := os.ReadFile(filepath.Join(storageDir, "default.json"))
-	if err != nil {
-		t.Fatalf("read legacy memory snapshot: %v", err)
-	}
-	var snapshotRecords []MessageRecord
-	if err := json.Unmarshal(snapshotData, &snapshotRecords); err != nil {
-		t.Fatalf("decode legacy memory snapshot: %v", err)
-	}
-	if len(snapshotRecords) != 3 {
-		t.Fatalf("expected 3 snapshot records, got %d", len(snapshotRecords))
-	}
-	snapshotToolContent := snapshotRecords[1].Content
-	if strings.Contains(snapshotToolContent, "dGVzdC1iYXNlNjQtc2NyZWVuc2hvdC1wYXlsb2FkCg==") {
-		t.Fatalf("legacy snapshot should strip screenshot base64 data: %s", snapshotData)
-	}
-	if strings.Contains(snapshotToolContent, `"data"`) {
-		t.Fatalf("legacy snapshot should omit data field: %s", snapshotData)
-	}
-	if !strings.Contains(snapshotToolContent, `"width":1080`) {
-		t.Fatalf("legacy snapshot should preserve metadata: %s", snapshotData)
-	}
+	assertNoTopLevelJSONFiles(t, storageDir)
 }
 
 func TestSessionMemoryAppendEventStripsScreenshotData(t *testing.T) {
@@ -353,7 +341,7 @@ func TestSessionMemoryAppendEventStripsScreenshotData(t *testing.T) {
 	}
 }
 
-func TestMemoryManagerRestoresFromSessionEventsWhenSnapshotMissing(t *testing.T) {
+func TestMemoryManagerRestoresFromSessionEvents(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()
 	manager := NewMemoryManager(storageDir)
@@ -371,9 +359,6 @@ func TestMemoryManagerRestoresFromSessionEventsWhenSnapshotMissing(t *testing.T)
 	if err := manager.Save(ctx, "default"); err != nil {
 		t.Fatalf("Save() error = %v", err)
 	}
-	if err := os.Remove(filepath.Join(storageDir, "default.json")); err != nil {
-		t.Fatalf("remove default snapshot: %v", err)
-	}
 
 	reloaded := NewMemoryManager(storageDir)
 	reloadedHandle, err := reloaded.Get("default", MemoryConfig{Type: "window", WindowSize: 10})
@@ -389,6 +374,35 @@ func TestMemoryManagerRestoresFromSessionEventsWhenSnapshotMissing(t *testing.T)
 	}
 	if messages[0].GetContent() != "remember this" || messages[1].GetContent() != "stored" {
 		t.Fatalf("unexpected restored messages: %#v", messages)
+	}
+}
+
+func TestMemoryManagerIgnoresRootJSONFilesWithoutSessionData(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	orphanPath := filepath.Join(storageDir, "orphan-history.json")
+	data, err := json.Marshal([]MessageRecord{
+		{Role: "human", Content: "orphan user"},
+		{Role: "ai", Content: "orphan answer"},
+	})
+	if err != nil {
+		t.Fatalf("marshal orphan root file: %v", err)
+	}
+	if err := os.WriteFile(orphanPath, data, 0o644); err != nil {
+		t.Fatalf("write orphan root file: %v", err)
+	}
+
+	manager := NewMemoryManager(storageDir)
+	handle, err := manager.Get("default", MemoryConfig{Type: "window", WindowSize: 10})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	messages, err := handle.History.Messages(ctx)
+	if err != nil {
+		t.Fatalf("Messages() error = %v", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("root-level JSON files should be ignored without session data, got %#v", messages)
 	}
 }
 
@@ -1985,6 +1999,22 @@ func readSessionMetadataForTest(t *testing.T, path string) sessionMetadata {
 		t.Fatalf("decode session metadata: %v", err)
 	}
 	return metadata
+}
+
+func assertNoTopLevelJSONFiles(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s) error = %v", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(entry.Name(), ".json") {
+			t.Fatalf("memory root should not contain top-level JSON files, found %q", entry.Name())
+		}
+	}
 }
 
 func TestFormatSessionSummaryWithWindowKeepsMaxChunks(t *testing.T) {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -4977,6 +4977,10 @@ func TestRuntimeClearMemoryRemovesPersistedSession(t *testing.T) {
 		t.Fatalf("expected persisted session events at %s: %v", eventsPath, err)
 	}
 	assertNoTopLevelJSONFiles(t, memoryDir)
+	legacyPath := legacyMemorySnapshotPath(memoryDir, "default")
+	if err := os.WriteFile(legacyPath, []byte("[]\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile legacy snapshot: %v", err)
+	}
 
 	if err := runtime.ClearMemory(context.Background()); err != nil {
 		t.Fatalf("ClearMemory() error = %v", err)
@@ -4984,5 +4988,8 @@ func TestRuntimeClearMemoryRemovesPersistedSession(t *testing.T) {
 
 	if _, err := os.Stat(eventsPath); !os.IsNotExist(err) {
 		t.Fatalf("expected session events to be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy snapshot to be removed, stat err = %v", err)
 	}
 }

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -3747,10 +3747,12 @@ func TestRuntimePersistsMemoryUnderConfigDir(t *testing.T) {
 		t.Fatalf("expected 2 memory entries after first run, got %d", len(firstResult.Memory))
 	}
 
-	memoryPath := filepath.Join(configDir, "memory", "default.json")
-	if _, err := os.Stat(memoryPath); err != nil {
-		t.Fatalf("expected persisted memory file at %s: %v", memoryPath, err)
+	memoryDir := filepath.Join(configDir, "memory")
+	eventsPath := filepath.Join(memoryDir, "session", "events.jsonl")
+	if _, err := os.Stat(eventsPath); err != nil {
+		t.Fatalf("expected persisted session events at %s: %v", eventsPath, err)
 	}
+	assertNoTopLevelJSONFiles(t, memoryDir)
 
 	secondRuntime, err := NewRuntime(Config{
 		ConfigDir:     configDir,
@@ -4947,7 +4949,7 @@ func TestRuntimeRunIncludesUserAttachments(t *testing.T) {
 	}
 }
 
-func TestRuntimeClearMemoryRemovesPersistedFile(t *testing.T) {
+func TestRuntimeClearMemoryRemovesPersistedSession(t *testing.T) {
 	configDir := t.TempDir()
 	runtime, err := NewRuntime(Config{
 		ConfigDir:     configDir,
@@ -4969,16 +4971,18 @@ func TestRuntimeClearMemoryRemovesPersistedFile(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 
-	memoryPath := filepath.Join(configDir, "memory", "default.json")
-	if _, err := os.Stat(memoryPath); err != nil {
-		t.Fatalf("expected persisted memory file at %s: %v", memoryPath, err)
+	memoryDir := filepath.Join(configDir, "memory")
+	eventsPath := filepath.Join(memoryDir, "session", "events.jsonl")
+	if _, err := os.Stat(eventsPath); err != nil {
+		t.Fatalf("expected persisted session events at %s: %v", eventsPath, err)
 	}
+	assertNoTopLevelJSONFiles(t, memoryDir)
 
 	if err := runtime.ClearMemory(context.Background()); err != nil {
 		t.Fatalf("ClearMemory() error = %v", err)
 	}
 
-	if _, err := os.Stat(memoryPath); !os.IsNotExist(err) {
-		t.Fatalf("expected memory file to be removed, stat err = %v", err)
+	if _, err := os.Stat(eventsPath); !os.IsNotExist(err) {
+		t.Fatalf("expected session events to be removed, stat err = %v", err)
 	}
 }

--- a/src/agent/internal/agent/session_manager.go
+++ b/src/agent/internal/agent/session_manager.go
@@ -207,9 +207,6 @@ func (m memoryManagerSessionManager) CommitRun(ctx context.Context, req SessionC
 	if err != nil {
 		return SessionCommitResult{}, err
 	}
-	if err := m.memories.SaveSnapshot(ctx, agentName, memorySnapshot); err != nil {
-		return SessionCommitResult{}, err
-	}
 	m.memories.RequestMaintenance()
 	return SessionCommitResult{Memory: memorySnapshot}, nil
 }


### PR DESCRIPTION
## Summary
- remove the legacy `default.json` snapshot read/write path from session memory
- keep session persistence rooted in `session/events.jsonl` and update runtime/tests accordingly
- clean up benchmark and docs references to the removed snapshot model

## Testing
- go test ./internal/agent
- python3 -m py_compile benchmark/scripts/quick_memory_test.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory cleanup now fully removes saved session data while avoiding leftover top-level JSON files.
  * Restoring conversation state now relies on active session data, improving consistency when reopening or resuming work.
  * Clearing memory now removes persisted session records and related legacy leftovers more reliably.

* **Documentation**
  * Updated memory and session docs to reflect the current storage layout and restore behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->