### PR TITLE
feat(agent): structured error schema for tool call failures

### DIFF
--- a/src/agent/internal/agent/coordinate_debug.go
+++ b/src/agent/internal/agent/coordinate_debug.go
@@ -167,7 +167,7 @@ func (s *Server) handleCoordinateDebugTap(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if te := ToolErrorFromContext(toolCtx); te != nil {
-		http.Error(w, fmt.Sprintf(`{"ok":false,"error":%q}`, te.Message), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf(`{"ok":false,"error":%q}`, te.Message), httpStatusForToolError(te))
 		return
 	}
 	if screen != nil {
@@ -210,4 +210,18 @@ func (s *Server) handleCoordinateDebugTap(w http.ResponseWriter, r *http.Request
 		ActionType: gestureType,
 		Screenshot: &screenshotPayload,
 	})
+}
+
+func httpStatusForToolError(te *ToolError) int {
+	if te == nil {
+		return http.StatusInternalServerError
+	}
+	switch te.Category {
+	case CategoryInvalidInput, CategoryUnsupported:
+		return http.StatusBadRequest
+	case CategoryPreconditionFailed, CategoryUserActionRequired, CategoryTransient:
+		return http.StatusServiceUnavailable
+	default:
+		return http.StatusInternalServerError
+	}
 }

--- a/src/agent/internal/agent/coordinate_debug.go
+++ b/src/agent/internal/agent/coordinate_debug.go
@@ -160,13 +160,14 @@ func (s *Server) handleCoordinateDebugTap(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	output, err := tool.Call(r.Context(), string(toolInput))
+	toolCtx, _ := WithToolError(r.Context())
+	output, err := tool.Call(toolCtx, string(toolInput))
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"ok":false,"error":%q}`, err.Error()), http.StatusInternalServerError)
 		return
 	}
-	if toolOutputLooksLikeError(output) {
-		http.Error(w, fmt.Sprintf(`{"ok":false,"error":%q}`, output), http.StatusBadRequest)
+	if te := ToolErrorFromContext(toolCtx); te != nil {
+		http.Error(w, fmt.Sprintf(`{"ok":false,"error":%q}`, te.Message), http.StatusBadRequest)
 		return
 	}
 	if screen != nil {

--- a/src/agent/internal/agent/environment_bridge.go
+++ b/src/agent/internal/agent/environment_bridge.go
@@ -45,23 +45,25 @@ func NewEnvironmentBridgeClient(endpoint string, opts ...EnvironmentBridgeClient
 	return c
 }
 
-// CallTool forwards a tool invocation to the environment bridge and returns the result.
-// The response format matches local tool execution (ToolInvokeResponse from server.go).
-func (c *EnvironmentBridgeClient) CallTool(ctx context.Context, toolName, input string) (output string, isError bool, err error) {
+// CallTool forwards a tool invocation to the environment bridge and returns the result
+// as a structured *ToolResult. The Go error return is reserved for context cancellation
+// (Canceled / DeadlineExceeded) so callers can propagate via the executor's existing
+// cancel path. All other failure modes (transport, protocol, remote HTTP non-2xx) are
+// returned as a *ToolResult with Error populated and the second return value nil.
+func (c *EnvironmentBridgeClient) CallTool(ctx context.Context, toolName, input string) (*ToolResult, error) {
 	url := fmt.Sprintf("%s/api/tools/%s", c.endpoint, toolName)
 
-	// Prepare request body matching server.go's decodeToolInvokeInput expectations
 	reqBody := map[string]interface{}{
 		"input": input,
 	}
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", true, fmt.Errorf("marshal request: %w", err)
+		return errorToolResult(CodeEnvironmentBridgeProtocol, fmt.Sprintf("marshal request: %v", err)), nil
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
 	if err != nil {
-		return "", true, fmt.Errorf("create request: %w", err)
+		return errorToolResult(CodeEnvironmentBridgeProtocol, fmt.Sprintf("create request: %v", err)), nil
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.benchmarkTaskID != "" {
@@ -70,31 +72,60 @@ func (c *EnvironmentBridgeClient) CallTool(ctx context.Context, toolName, input 
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", true, fmt.Errorf("http call failed: %w", err)
+		// Surface context cancellation/deadline through the Go error slot so the
+		// executor's existing propagation path runs unchanged.
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return errorToolResult(CodeEnvironmentBridgeTransport, fmt.Sprintf("http call failed: %v", err)), nil
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", true, fmt.Errorf("read response: %w", err)
+		return errorToolResult(CodeEnvironmentBridgeProtocol, fmt.Sprintf("read response: %v", err)), nil
 	}
 
-	// Non-2xx status codes are transport errors
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", true, fmt.Errorf("remote returned HTTP %d: %s", resp.StatusCode, string(respBody))
+		return errorToolResult(CodeEnvironmentBridgeRemote, fmt.Sprintf("remote returned HTTP %d: %s", resp.StatusCode, string(respBody))), nil
 	}
 
-	// Parse ToolInvokeResponse (matches server.go:1793)
+	// Parse the response. The new shape carries a structured *ToolError under
+	// `tool_error`; the legacy shape carries a string `error` plus `is_error`.
+	// Both flow through the same struct: tool_error wins when present.
 	var invokeResp struct {
-		Output     string `json:"output"`
-		IsError    bool   `json:"is_error"`
-		Error      string `json:"error,omitempty"`
-		DurationMs int64  `json:"duration_ms"`
+		Output    string     `json:"output"`
+		Summary   string     `json:"summary,omitempty"`
+		ToolError *ToolError `json:"tool_error,omitempty"`
+		LegacyErr string     `json:"error,omitempty"`
+		IsError   bool       `json:"is_error,omitempty"`
+		Terminate bool       `json:"terminate,omitempty"`
 	}
 	if err := json.Unmarshal(respBody, &invokeResp); err != nil {
-		return "", true, fmt.Errorf("parse response: %w (body: %s)", err, string(respBody))
+		return errorToolResult(CodeEnvironmentBridgeProtocol, fmt.Sprintf("parse response: %v (body: %s)", err, string(respBody))), nil
 	}
 
-	// Return exactly what the environment bridge returned, preserving error semantics.
-	return invokeResp.Output, invokeResp.IsError, nil
+	result := &ToolResult{
+		Output:    invokeResp.Output,
+		Summary:   invokeResp.Summary,
+		Terminate: invokeResp.Terminate,
+		Error:     invokeResp.ToolError,
+	}
+	// Legacy fallback: if remote sends only is_error + error string (no tool_error),
+	// synthesize a *ToolError so the LLM still sees structured failure info.
+	if result.Error == nil && invokeResp.IsError {
+		msg := invokeResp.LegacyErr
+		if msg == "" {
+			msg = invokeResp.Output
+		}
+		result.Error = NewToolError(CodeToolExecutionFailed, msg)
+	}
+	return result, nil
+}
+
+// errorToolResult constructs a *ToolResult carrying a structured ToolError where
+// Output mirrors Error.Message (the spec invariant for failure shapes).
+func errorToolResult(code, message string) *ToolResult {
+	te := NewToolError(code, message)
+	return &ToolResult{Output: te.Message, Error: te}
 }

--- a/src/agent/internal/agent/environment_bridge_test.go
+++ b/src/agent/internal/agent/environment_bridge_test.go
@@ -151,15 +151,51 @@ func TestEnvironmentBridgeSendsBenchmarkTaskIDHeader(t *testing.T) {
 	defer server.Close()
 
 	client := NewEnvironmentBridgeClient(server.URL, WithEnvironmentBridgeBenchmarkTaskID("clock.CountAlarms"))
-	output, isError, err := client.CallTool(context.Background(), "screenshot", "{}")
+	got, err := client.CallTool(context.Background(), "screenshot", "{}")
 	if err != nil {
 		t.Fatalf("CallTool returned error: %v", err)
 	}
-	if isError {
-		t.Fatalf("CallTool is_error = true, output=%q", output)
+	if got == nil || got.IsError() {
+		t.Fatalf("CallTool result = %+v", got)
 	}
-	if got := <-seen; got != "clock.CountAlarms" {
-		t.Fatalf("%s header = %q, want %q", BenchmarkTaskIDHeader, got, "clock.CountAlarms")
+	if hdr := <-seen; hdr != "clock.CountAlarms" {
+		t.Fatalf("%s header = %q, want %q", BenchmarkTaskIDHeader, hdr, "clock.CountAlarms")
+	}
+}
+
+func TestEnvironmentBridgeCallToolReturnsStructuredToolResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Server returns a serialized ToolResult shape (post-Task 4 wire).
+		_, _ = w.Write([]byte(`{"output":"hi","summary":"","error":null,"terminate":false}`))
+	}))
+	defer srv.Close()
+	c := NewEnvironmentBridgeClient(srv.URL)
+	got, err := c.CallTool(context.Background(), "screenshot", "{}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Output != "hi" || got.IsError() {
+		t.Errorf("CallTool result = %+v", got)
+	}
+}
+
+func TestEnvironmentBridgeCallToolHTTPErrorIsStructuredTransientError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream is down"))
+	}))
+	defer srv.Close()
+	c := NewEnvironmentBridgeClient(srv.URL)
+	got, err := c.CallTool(context.Background(), "screenshot", "{}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || !got.IsError() {
+		t.Fatalf("expected structured error result; got %+v", got)
+	}
+	if got.Error.Code != CodeEnvironmentBridgeRemote {
+		t.Errorf("Error.Code = %q want %q", got.Error.Code, CodeEnvironmentBridgeRemote)
 	}
 }
 

--- a/src/agent/internal/agent/environment_bridge_test.go
+++ b/src/agent/internal/agent/environment_bridge_test.go
@@ -127,7 +127,7 @@ func TestEnvironmentBridgeMatchesLocalErrorLikeOutput(t *testing.T) {
 
 func TestEnvironmentBridgeTransportFailureIsError(t *testing.T) {
 	// Point the bridge client at a dead endpoint; the call must surface as a tool error
-	// in the same "error: X failed" shape as a local failure.
+	// in the same structured ToolResult shape as a local failure.
 	bridged := runViaEnvironmentBridge(t, "http://127.0.0.1:1", "echo", "x")
 	if !bridged.IsError() {
 		t.Fatal("expected transport failure to be marked as error")

--- a/src/agent/internal/agent/environment_bridge_test.go
+++ b/src/agent/internal/agent/environment_bridge_test.go
@@ -79,8 +79,8 @@ func TestEnvironmentBridgeMatchesLocalSuccess(t *testing.T) {
 	if bridged.Output != local.Output {
 		t.Fatalf("output mismatch: bridge=%q local=%q", bridged.Output, local.Output)
 	}
-	if bridged.IsError != local.IsError {
-		t.Fatalf("is_error mismatch: bridge=%v local=%v", bridged.IsError, local.IsError)
+	if bridged.IsError() != local.IsError() {
+		t.Fatalf("is_error mismatch: bridge=%v local=%v", bridged.IsError(), local.IsError())
 	}
 }
 
@@ -100,8 +100,8 @@ func TestEnvironmentBridgeMatchesLocalToolError(t *testing.T) {
 	if bridged.Output != local.Output {
 		t.Fatalf("error output mismatch:\n bridge=%q\n local=%q", bridged.Output, local.Output)
 	}
-	if !bridged.IsError || !local.IsError {
-		t.Fatalf("expected both to be errors: bridge=%v local=%v", bridged.IsError, local.IsError)
+	if !bridged.IsError() || !local.IsError() {
+		t.Fatalf("expected both to be errors: bridge=%v local=%v", bridged.IsError(), local.IsError())
 	}
 }
 
@@ -120,8 +120,8 @@ func TestEnvironmentBridgeMatchesLocalErrorLikeOutput(t *testing.T) {
 	if bridged.Output != local.Output {
 		t.Fatalf("output mismatch: bridge=%q local=%q", bridged.Output, local.Output)
 	}
-	if bridged.IsError != local.IsError {
-		t.Fatalf("is_error mismatch for error-like output: bridge=%v local=%v", bridged.IsError, local.IsError)
+	if bridged.IsError() != local.IsError() {
+		t.Fatalf("is_error mismatch for error-like output: bridge=%v local=%v", bridged.IsError(), local.IsError())
 	}
 }
 
@@ -129,7 +129,7 @@ func TestEnvironmentBridgeTransportFailureIsError(t *testing.T) {
 	// Point the bridge client at a dead endpoint; the call must surface as a tool error
 	// in the same "error: X failed" shape as a local failure.
 	bridged := runViaEnvironmentBridge(t, "http://127.0.0.1:1", "echo", "x")
-	if !bridged.IsError {
+	if !bridged.IsError() {
 		t.Fatal("expected transport failure to be marked as error")
 	}
 	if bridged.Output == "" {

--- a/src/agent/internal/agent/environment_bridge_test.go
+++ b/src/agent/internal/agent/environment_bridge_test.go
@@ -135,6 +135,9 @@ func TestEnvironmentBridgeTransportFailureIsError(t *testing.T) {
 	if bridged.Output == "" {
 		t.Fatal("expected non-empty error output on transport failure")
 	}
+	if bridged.Error == nil || bridged.Error.Code != CodeEnvironmentBridgeTransport {
+		t.Fatalf("transport Error = %+v, want environment_bridge_transport_failed", bridged.Error)
+	}
 }
 
 func TestEnvironmentBridgeSendsBenchmarkTaskIDHeader(t *testing.T) {

--- a/src/agent/internal/agent/errors.go
+++ b/src/agent/internal/agent/errors.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
@@ -236,4 +237,19 @@ func cloneToolError(e *ToolError) *ToolError {
 		}
 	}
 	return &clone
+}
+
+func contextError(ctx context.Context, err error) error {
+	if ctx != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+	}
+	if errors.Is(err, context.Canceled) {
+		return context.Canceled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+	return nil
 }

--- a/src/agent/internal/agent/errors.go
+++ b/src/agent/internal/agent/errors.go
@@ -1,0 +1,164 @@
+package agent
+
+// Category enumerates the six fixed error categories used by the LLM and
+// downstream consumers to decide what to do about a failure. The set is
+// deliberately small — adding a 7th requires a spec amendment.
+const (
+	CategoryInvalidInput       = "invalid_input"
+	CategoryPreconditionFailed = "precondition_failed"
+	CategoryUserActionRequired = "user_action_required"
+	CategoryUnsupported        = "unsupported"
+	CategoryTransient          = "transient"
+	CategoryInternal           = "internal"
+)
+
+// Stable error codes. Wire consumers (LLM, aiden-app, telemetry) may switch
+// on these. Adding a new code requires a registry entry below.
+// The code set comes from a real inventory of error sites in the codebase
+// (tool_execution.go, phone_bridge.go, tools_phone_bridge.go,
+// tools_quick_actions.go, environment_bridge.go, aiden-app/src/services/PhoneBridge.ts).
+const (
+	// invalid_input — caller can fix args and retry
+	CodeInvalidArguments   = "invalid_arguments"
+	CodeToolNotFound       = "tool_not_found"
+	CodeUnknownApp         = "unknown_app"
+	CodeQuickActionUnknown = "quick_action_unknown"
+	CodeAppNoLaunchTarget  = "app_no_launch_target"
+
+	// precondition_failed — environment not ready; try alternative or set up
+	CodeBridgeNotConnected = "bridge_not_connected"
+	CodeAppNotInstalled    = "app_not_installed"
+	CodeModuleUnavailable  = "module_unavailable"
+
+	// user_action_required — needs human in the loop
+	CodePermissionDenied = "permission_denied"
+	CodeAppBackgrounded  = "app_backgrounded"
+
+	// unsupported — change path; do not retry the same tool
+	CodeQuickActionReserved            = "quick_action_reserved"
+	CodeQuickActionUnsupportedPlatform = "quick_action_unsupported_platform"
+
+	// transient — retry may help
+	CodeBridgeTimeout              = "bridge_timeout"
+	CodeBridgeWriteFailed          = "bridge_write_failed"
+	CodeBridgeConnectionClosed     = "bridge_connection_closed"
+	CodeAppLaunchFailed            = "app_launch_failed"
+	CodeCanceled                   = "canceled"
+	CodeDeadlineExceeded           = "deadline_exceeded"
+	CodeEnvironmentBridgeTransport = "environment_bridge_transport_failed"
+
+	// internal — bug or protocol violation; record and surface
+	CodeCommandMarshalFailed      = "command_marshal_failed"
+	CodeCommandIDCollision        = "command_id_collision"
+	CodeQuickActionInvalidBinding = "quick_action_invalid_binding"
+	CodeSubtoolFailed             = "subtool_failed" // category overridden to inherit sub-tool category at construction
+	CodeToolExecutionFailed       = "tool_execution_failed"
+	CodeEnvironmentBridgeProtocol = "environment_bridge_protocol_error"
+	CodeEnvironmentBridgeRemote   = "environment_bridge_remote_error"
+	CodeNativeModuleFailed        = "native_module_failed"
+	CodeUnknownErrorCode          = "unknown_error_code"
+)
+
+// ToolErrorSpec is the registry entry for a code.
+type ToolErrorSpec struct {
+	Category string
+	Severity string // "info" | "warning" | "error"; telemetry only, never on the wire
+}
+
+// codeRegistry is the single source of truth for code → category mapping.
+// Adding a new code MUST add a row here in the same PR.
+var codeRegistry = map[string]ToolErrorSpec{
+	// invalid_input
+	CodeInvalidArguments:   {Category: CategoryInvalidInput, Severity: "warning"},
+	CodeToolNotFound:       {Category: CategoryInvalidInput, Severity: "warning"},
+	CodeUnknownApp:         {Category: CategoryInvalidInput, Severity: "warning"},
+	CodeQuickActionUnknown: {Category: CategoryInvalidInput, Severity: "warning"},
+	CodeAppNoLaunchTarget:  {Category: CategoryInvalidInput, Severity: "warning"},
+
+	// precondition_failed
+	CodeBridgeNotConnected: {Category: CategoryPreconditionFailed, Severity: "warning"},
+	CodeAppNotInstalled:    {Category: CategoryPreconditionFailed, Severity: "warning"},
+	CodeModuleUnavailable:  {Category: CategoryPreconditionFailed, Severity: "warning"},
+
+	// user_action_required
+	CodePermissionDenied: {Category: CategoryUserActionRequired, Severity: "warning"},
+	CodeAppBackgrounded:  {Category: CategoryUserActionRequired, Severity: "info"},
+
+	// unsupported
+	CodeQuickActionReserved:            {Category: CategoryUnsupported, Severity: "info"},
+	CodeQuickActionUnsupportedPlatform: {Category: CategoryUnsupported, Severity: "info"},
+
+	// transient
+	CodeBridgeTimeout:              {Category: CategoryTransient, Severity: "warning"},
+	CodeBridgeWriteFailed:          {Category: CategoryTransient, Severity: "warning"},
+	CodeBridgeConnectionClosed:     {Category: CategoryTransient, Severity: "warning"},
+	CodeAppLaunchFailed:            {Category: CategoryTransient, Severity: "warning"},
+	CodeCanceled:                   {Category: CategoryTransient, Severity: "info"},
+	CodeDeadlineExceeded:           {Category: CategoryTransient, Severity: "warning"},
+	CodeEnvironmentBridgeTransport: {Category: CategoryTransient, Severity: "warning"},
+
+	// internal
+	CodeCommandMarshalFailed:      {Category: CategoryInternal, Severity: "error"},
+	CodeCommandIDCollision:        {Category: CategoryInternal, Severity: "error"},
+	CodeQuickActionInvalidBinding: {Category: CategoryInternal, Severity: "error"},
+	CodeSubtoolFailed:             {Category: CategoryInternal, Severity: "warning"}, // category overridden at construction
+	CodeToolExecutionFailed:       {Category: CategoryInternal, Severity: "error"},
+	CodeEnvironmentBridgeProtocol: {Category: CategoryInternal, Severity: "error"},
+	CodeEnvironmentBridgeRemote:   {Category: CategoryInternal, Severity: "error"},
+	CodeNativeModuleFailed:        {Category: CategoryInternal, Severity: "error"},
+	CodeUnknownErrorCode:          {Category: CategoryInternal, Severity: "error"},
+}
+
+// ToolError is the canonical structured-error shape exchanged across the
+// agent, the phone-bridge wire protocol, and quick_action aggregation.
+// Fields are minimal by design: the LLM only ever sees Message (via
+// ToolResult.Output); Category and Code exist for non-LLM consumers
+// (telemetry, app UI, future programmatic policies). User-facing copy is
+// produced app-side via i18n(code); retry/recovery policy is implied by
+// Category, not a separate field.
+type ToolError struct {
+	Category string         `json:"category"`
+	Code     string         `json:"code"`
+	Message  string         `json:"message"`
+	Details  map[string]any `json:"details,omitempty"`
+}
+
+// NewToolError constructs a ToolError, deriving Category from the registry.
+// Unknown codes degrade to category=internal, code=unknown_error_code,
+// preserving the original code in Details for forensics.
+func NewToolError(code, message string) *ToolError {
+	spec, ok := codeRegistry[code]
+	if !ok {
+		return &ToolError{
+			Category: CategoryInternal,
+			Code:     CodeUnknownErrorCode,
+			Message:  message,
+			Details:  map[string]any{"original_code": code},
+		}
+	}
+	return &ToolError{Category: spec.Category, Code: code, Message: message}
+}
+
+// NewToolErrorWithDetails is NewToolError plus a Details map. A nil details
+// arg is treated as empty.
+func NewToolErrorWithDetails(code, message string, details map[string]any) *ToolError {
+	e := NewToolError(code, message)
+	if details != nil {
+		if e.Details == nil {
+			e.Details = map[string]any{}
+		}
+		for k, v := range details {
+			e.Details[k] = v
+		}
+	}
+	return e
+}
+
+// Error makes ToolError implement the error interface so it can be returned
+// alongside Go's error idioms when convenient.
+func (e *ToolError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}

--- a/src/agent/internal/agent/errors.go
+++ b/src/agent/internal/agent/errors.go
@@ -1,5 +1,7 @@
 package agent
 
+import "context"
+
 // Category enumerates the six fixed error categories used by the LLM and
 // downstream consumers to decide what to do about a failure. The set is
 // deliberately small — adding a 7th requires a spec amendment.
@@ -157,6 +159,52 @@ func NewToolErrorWithDetails(code, message string, details map[string]any) *Tool
 // Error makes ToolError implement the error interface so it can be returned
 // alongside Go's error idioms when convenient.
 func (e *ToolError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+// toolErrorSlot is the heap-allocated container used by WithToolError to give
+// tools a way to attach a structured error to their call context. The slot
+// lives in the context but is mutated in place so the caller can read the
+// final value after the tool returns.
+type toolErrorSlot struct{ err *ToolError }
+
+type toolErrorCtxKey struct{}
+
+// WithToolError attaches an empty ToolError slot to ctx and returns the new
+// context plus a setter. Tools that want to surface a structured failure call
+// the setter; the executor reads it back via ToolErrorFromContext after the
+// tool returns. The setter is safe to call zero or one times.
+func WithToolError(ctx context.Context) (context.Context, func(*ToolError)) {
+	slot := &toolErrorSlot{}
+	ctx = context.WithValue(ctx, toolErrorCtxKey{}, slot)
+	return ctx, func(e *ToolError) { slot.err = e }
+}
+
+// ToolErrorFromContext returns the structured error a tool attached to ctx, or
+// nil if none was set (or no slot was installed).
+func ToolErrorFromContext(ctx context.Context) *ToolError {
+	if slot, ok := ctx.Value(toolErrorCtxKey{}).(*toolErrorSlot); ok {
+		return slot.err
+	}
+	return nil
+}
+
+// SetToolError stores e in the context's slot if one was installed by
+// WithToolError. Tools call this just before returning their LLM-facing string
+// so the executor can promote the structured error onto ToolResult.Error.
+func SetToolError(ctx context.Context, e *ToolError) {
+	if slot, ok := ctx.Value(toolErrorCtxKey{}).(*toolErrorSlot); ok {
+		slot.err = e
+	}
+}
+
+// toolErrorString is the LLM-facing string a tool should return alongside
+// SetToolError. By construction it equals e.Message, preserving the
+// Output == Error.Message invariant.
+func toolErrorString(e *ToolError) string {
 	if e == nil {
 		return ""
 	}

--- a/src/agent/internal/agent/errors.go
+++ b/src/agent/internal/agent/errors.go
@@ -1,6 +1,9 @@
 package agent
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // Category enumerates the six fixed error categories used by the LLM and
 // downstream consumers to decide what to do about a failure. The set is
@@ -209,4 +212,28 @@ func toolErrorString(e *ToolError) string {
 		return ""
 	}
 	return e.Message
+}
+
+func toolErrorResultString(ctx context.Context, code, message string) string {
+	te := NewToolError(code, message)
+	SetToolError(ctx, te)
+	return toolErrorString(te)
+}
+
+func toolErrorResultf(ctx context.Context, code, format string, args ...any) string {
+	return toolErrorResultString(ctx, code, fmt.Sprintf(format, args...))
+}
+
+func cloneToolError(e *ToolError) *ToolError {
+	if e == nil {
+		return nil
+	}
+	clone := *e
+	if len(e.Details) > 0 {
+		clone.Details = make(map[string]any, len(e.Details))
+		for k, v := range e.Details {
+			clone.Details[k] = v
+		}
+	}
+	return &clone
 }

--- a/src/agent/internal/agent/errors_test.go
+++ b/src/agent/internal/agent/errors_test.go
@@ -1,0 +1,103 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRegistryHasAllRequiredCodes(t *testing.T) {
+	required := []string{
+		// invalid_input
+		"invalid_arguments", "tool_not_found", "unknown_app",
+		"quick_action_unknown", "app_no_launch_target",
+		// precondition_failed
+		"bridge_not_connected", "app_not_installed", "module_unavailable",
+		// user_action_required
+		"permission_denied", "app_backgrounded",
+		// unsupported
+		"quick_action_reserved", "quick_action_unsupported_platform",
+		// transient
+		"bridge_timeout", "bridge_write_failed", "bridge_connection_closed",
+		"app_launch_failed", "canceled", "deadline_exceeded",
+		"environment_bridge_transport_failed",
+		// internal
+		"command_marshal_failed", "command_id_collision",
+		"quick_action_invalid_binding", "subtool_failed", "tool_execution_failed",
+		"environment_bridge_protocol_error", "environment_bridge_remote_error",
+		"native_module_failed", "unknown_error_code",
+	}
+	for _, code := range required {
+		if _, ok := codeRegistry[code]; !ok {
+			t.Errorf("codeRegistry missing required code %q", code)
+		}
+	}
+}
+
+func TestRegistryCategoriesAreValid(t *testing.T) {
+	valid := map[string]bool{
+		CategoryInvalidInput: true, CategoryPreconditionFailed: true,
+		CategoryUserActionRequired: true, CategoryUnsupported: true,
+		CategoryTransient: true, CategoryInternal: true,
+	}
+	for code, spec := range codeRegistry {
+		if !valid[spec.Category] {
+			t.Errorf("code %q has invalid category %q", code, spec.Category)
+		}
+	}
+}
+
+func TestNewToolErrorSetsCategoryFromRegistry(t *testing.T) {
+	e := NewToolError("app_not_installed", "WeChat is not installed")
+	if e.Category != CategoryPreconditionFailed {
+		t.Errorf("Category = %q, want %q", e.Category, CategoryPreconditionFailed)
+	}
+	if e.Code != "app_not_installed" {
+		t.Errorf("Code = %q", e.Code)
+	}
+	if e.Message != "WeChat is not installed" {
+		t.Errorf("Message = %q", e.Message)
+	}
+}
+
+func TestNewToolErrorUnknownCodeDegradesSafely(t *testing.T) {
+	e := NewToolError("totally_made_up_code", "boom")
+	if e.Category != CategoryInternal {
+		t.Errorf("unknown code Category = %q, want %q", e.Category, CategoryInternal)
+	}
+	if e.Code != "unknown_error_code" {
+		t.Errorf("unknown code Code = %q, want unknown_error_code", e.Code)
+	}
+	if got, _ := e.Details["original_code"].(string); got != "totally_made_up_code" {
+		t.Errorf("Details[original_code] = %v, want totally_made_up_code", e.Details["original_code"])
+	}
+}
+
+func TestToolErrorJSONRoundTrip(t *testing.T) {
+	orig := NewToolError("bridge_timeout", "websocket timed out after 5s")
+	orig.Details = map[string]any{"timeout_ms": 5000.0}
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got ToolError
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Code != orig.Code || got.Category != orig.Category || got.Message != orig.Message {
+		t.Errorf("round-trip mismatch: got %+v", got)
+	}
+	if got.Details["timeout_ms"].(float64) != 5000.0 {
+		t.Errorf("Details not preserved: %+v", got.Details)
+	}
+}
+
+func TestUnknownCodeJSONInUnmarshalsWithoutLossButOriginalKept(t *testing.T) {
+	wire := []byte(`{"category":"internal","code":"unknown_error_code","message":"x","details":{"original_code":"future_code"}}`)
+	var e ToolError
+	if err := json.Unmarshal(wire, &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.Details["original_code"] != "future_code" {
+		t.Errorf("original_code lost: %+v", e.Details)
+	}
+}

--- a/src/agent/internal/agent/live_activity.go
+++ b/src/agent/internal/agent/live_activity.go
@@ -774,7 +774,7 @@ func liveActivityFinalPhase(status string) string {
 }
 
 func liveActivityEventHasError(event RunEvent) bool {
-	if event.IsError || toolOutputLooksLikeError(event.Content) {
+	if event.ToolError != nil || event.IsError {
 		return true
 	}
 	payload, ok := liveActivityJSONObject(event.Content)
@@ -788,17 +788,16 @@ func liveActivityEventHasError(event RunEvent) bool {
 }
 
 func liveActivityEventErrorText(event RunEvent) string {
+	if event.ToolError != nil && strings.TrimSpace(event.ToolError.Message) != "" {
+		return strings.TrimSpace(event.ToolError.Message)
+	}
 	payload, ok := liveActivityJSONObject(event.Content)
 	if ok {
 		if value, ok := payload["error"].(string); ok && strings.TrimSpace(value) != "" {
 			return strings.TrimSpace(value)
 		}
 	}
-	content := strings.TrimSpace(event.Content)
-	if strings.HasPrefix(strings.ToLower(content), "error:") {
-		return strings.TrimSpace(content[len("error:"):])
-	}
-	return content
+	return strings.TrimSpace(event.Content)
 }
 
 func liveActivityResultNeedsApp(event RunEvent, errText string) bool {

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -131,6 +131,7 @@ type SessionEvent struct {
 	ToolCallID         string          `json:"tool_call_id,omitempty"`
 	ToolName           string          `json:"tool_name,omitempty"`
 	ToolInput          string          `json:"tool_input,omitempty"`
+	ToolError          *ToolError      `json:"tool_error,omitempty"`
 	Objective          string          `json:"objective,omitempty"`
 	CompletionCriteria []string        `json:"completion_criteria,omitempty"`
 	Plan               []string        `json:"plan,omitempty"`

--- a/src/agent/internal/agent/phone_bridge.go
+++ b/src/agent/internal/agent/phone_bridge.go
@@ -34,14 +34,10 @@ type BridgeCommand struct {
 }
 
 type BridgeCommandResponse struct {
-	ID     string `json:"id"`
-	OK     bool   `json:"ok"`
-	Method string `json:"method,omitempty"`
-	Error  string `json:"error,omitempty"`
-	// Data carries command-specific JSON returned by the companion app
-	// (clipboard contents, calendar event id, query results, etc.). Empty for
-	// commands that only need an ok/error status.
-	Data json.RawMessage `json:"data,omitempty"`
+	ID     string          `json:"id"`
+	Method string          `json:"method,omitempty"`
+	Error  *ToolError      `json:"error,omitempty"` // nil ⇔ success
+	Data   json.RawMessage `json:"data,omitempty"`
 }
 
 type PhoneEnvironment struct {
@@ -286,9 +282,10 @@ func (pb *PhoneBridge) handleAppEvent(resp BridgeCommandResponse) bool {
 }
 
 func (pb *PhoneBridge) handleEnvironmentEvent(resp BridgeCommandResponse) bool {
-	if !resp.OK {
+	if resp.Error != nil {
 		if pb.logger != nil {
-			pb.logger.Warn("phone-bridge: environment report failed: %s", resp.Error)
+			pb.logger.Warn("phone-bridge: environment report failed: code=%s msg=%s",
+				resp.Error.Code, resp.Error.Message)
 		}
 		return true
 	}
@@ -323,9 +320,10 @@ func (pb *PhoneBridge) handleEnvironmentEvent(resp BridgeCommandResponse) bool {
 }
 
 func (pb *PhoneBridge) handleAppStateEvent(resp BridgeCommandResponse) bool {
-	if !resp.OK {
+	if resp.Error != nil {
 		if pb.logger != nil {
-			pb.logger.Warn("phone-bridge: app state report failed: %s", resp.Error)
+			pb.logger.Warn("phone-bridge: app state report failed: code=%s msg=%s",
+				resp.Error.Code, resp.Error.Message)
 		}
 		return true
 	}
@@ -381,11 +379,19 @@ func (pb *PhoneBridge) SendCommand(ctx context.Context, cmd BridgeCommand) (Brid
 	pb.mu.Lock()
 	if !pb.connected || pb.conn == nil {
 		pb.mu.Unlock()
-		return BridgeCommandResponse{}, fmt.Errorf("phone bridge not connected")
+		return BridgeCommandResponse{
+			ID:    cmd.ID,
+			Error: NewToolError(CodeBridgeNotConnected, "phone bridge not connected"),
+		}, nil
 	}
 	if _, exists := pb.pendingCmds[cmd.ID]; exists {
 		pb.mu.Unlock()
-		return BridgeCommandResponse{}, fmt.Errorf("duplicate command ID %q already in flight", cmd.ID)
+		return BridgeCommandResponse{
+			ID: cmd.ID,
+			Error: NewToolErrorWithDetails(CodeCommandIDCollision,
+				fmt.Sprintf("duplicate command ID %q already in flight", cmd.ID),
+				map[string]any{"command_id": cmd.ID}),
+		}, nil
 	}
 	ch := make(chan BridgeCommandResponse, 1)
 	pb.pendingCmds[cmd.ID] = ch
@@ -397,14 +403,20 @@ func (pb *PhoneBridge) SendCommand(ctx context.Context, cmd BridgeCommand) (Brid
 		pb.mu.Lock()
 		delete(pb.pendingCmds, cmd.ID)
 		pb.mu.Unlock()
-		return BridgeCommandResponse{}, fmt.Errorf("marshal command: %w", err)
+		return BridgeCommandResponse{
+			ID:    cmd.ID,
+			Error: NewToolError(CodeCommandMarshalFailed, fmt.Sprintf("marshal command: %v", err)),
+		}, nil
 	}
 
 	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
 		pb.mu.Lock()
 		delete(pb.pendingCmds, cmd.ID)
 		pb.mu.Unlock()
-		return BridgeCommandResponse{}, fmt.Errorf("write command: %w", err)
+		return BridgeCommandResponse{
+			ID:    cmd.ID,
+			Error: NewToolError(CodeBridgeWriteFailed, fmt.Sprintf("write command: %v", err)),
+		}, nil
 	}
 
 	timeout := 5 * time.Second
@@ -415,14 +427,20 @@ func (pb *PhoneBridge) SendCommand(ctx context.Context, cmd BridgeCommand) (Brid
 	select {
 	case resp, ok := <-ch:
 		if !ok {
-			return BridgeCommandResponse{}, fmt.Errorf("connection closed")
+			return BridgeCommandResponse{
+				ID:    cmd.ID,
+				Error: NewToolError(CodeBridgeConnectionClosed, "connection closed before response"),
+			}, nil
 		}
 		return resp, nil
 	case <-time.After(timeout):
 		pb.mu.Lock()
 		delete(pb.pendingCmds, cmd.ID)
 		pb.mu.Unlock()
-		return BridgeCommandResponse{}, fmt.Errorf("command timeout")
+		return BridgeCommandResponse{
+			ID:    cmd.ID,
+			Error: NewToolError(CodeBridgeTimeout, "command timeout"),
+		}, nil
 	case <-ctx.Done():
 		pb.mu.Lock()
 		delete(pb.pendingCmds, cmd.ID)

--- a/src/agent/internal/agent/phone_bridge_http.go
+++ b/src/agent/internal/agent/phone_bridge_http.go
@@ -181,7 +181,8 @@ func (pb *PhoneBridge) handleSubmitResult(w http.ResponseWriter, r *http.Request
 	}
 
 	if pb.logger != nil {
-		pb.logger.Info("phone-bridge: result received: id=%s ok=%t", req.ID, req.OK)
+		ok := req.Error == nil
+		pb.logger.Info("phone-bridge: result received: id=%s ok=%t", req.ID, ok)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/src/agent/internal/agent/phone_bridge_http_test.go
+++ b/src/agent/internal/agent/phone_bridge_http_test.go
@@ -215,22 +215,18 @@ func TestHTTPSubmitResult(t *testing.T) {
 			name: "valid result",
 			result: BridgeCommandResponse{
 				ID: "test_cmd",
-				OK: true,
 			},
 			expectedStatus: http.StatusOK,
 		},
 		{
-			name: "missing ID",
-			result: BridgeCommandResponse{
-				OK: true,
-			},
+			name:           "missing ID",
+			result:         BridgeCommandResponse{},
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name: "command not found",
 			result: BridgeCommandResponse{
 				ID: "nonexistent",
-				OK: true,
 			},
 			expectedStatus: http.StatusNotFound,
 		},
@@ -272,7 +268,6 @@ func TestHTTPQueryResult(t *testing.T) {
 	bridge.queue.Poll("ios", 1)
 	bridge.queue.SubmitResult(BridgeCommandResponse{
 		ID:     "completed_cmd",
-		OK:     true,
 		Method: "open_app",
 	})
 
@@ -387,7 +382,6 @@ func TestHTTPEndToEnd(t *testing.T) {
 	// Step 3: App submits result
 	result := BridgeCommandResponse{
 		ID:     "e2e_test",
-		OK:     true,
 		Method: "open_app",
 	}
 	resultBody, _ := json.Marshal(result)
@@ -417,8 +411,8 @@ func TestHTTPEndToEnd(t *testing.T) {
 	if queryResp.Result == nil {
 		t.Fatal("expected result, got nil")
 	}
-	if !queryResp.Result.OK {
-		t.Error("expected result.ok=true")
+	if queryResp.Result.Error != nil {
+		t.Errorf("expected result.error=nil, got %v", queryResp.Result.Error)
 	}
 }
 

--- a/src/agent/internal/agent/phone_bridge_queue.go
+++ b/src/agent/internal/agent/phone_bridge_queue.go
@@ -36,13 +36,13 @@ const (
 
 // QueuedCommand wraps a BridgeCommand with queue metadata
 type QueuedCommand struct {
-	Command     BridgeCommand `json:"command"`
-	Status      CommandStatus `json:"status"`
-	QueuedAt    time.Time     `json:"queued_at"`
-	InFlightAt  *time.Time    `json:"in_flight_at,omitempty"`
-	ExpireAt    time.Time     `json:"expire_at"`
-	RetryCount  int           `json:"retry_count"`
-	MaxRetries  int           `json:"max_retries"`
+	Command    BridgeCommand `json:"command"`
+	Status     CommandStatus `json:"status"`
+	QueuedAt   time.Time     `json:"queued_at"`
+	InFlightAt *time.Time    `json:"in_flight_at,omitempty"`
+	ExpireAt   time.Time     `json:"expire_at"`
+	RetryCount int           `json:"retry_count"`
+	MaxRetries int           `json:"max_retries"`
 }
 
 // CommandResult holds the execution result of a command
@@ -214,7 +214,8 @@ func (q *CommandQueue) SubmitResult(resp BridgeCommandResponse) error {
 	}
 
 	if q.logger != nil {
-		q.logger.Info("phone-bridge-queue: result submitted for command %s (ok=%v)", resp.ID, resp.OK)
+		ok := resp.Error == nil
+		q.logger.Info("phone-bridge-queue: result submitted for command %s (ok=%v)", resp.ID, ok)
 	}
 
 	return nil
@@ -324,4 +325,3 @@ func (q *CommandQueue) removeCommandID(id string) {
 		}
 	}
 }
-

--- a/src/agent/internal/agent/phone_bridge_queue_test.go
+++ b/src/agent/internal/agent/phone_bridge_queue_test.go
@@ -141,7 +141,6 @@ func TestSubmitAndQueryResult(t *testing.T) {
 	// Submit result
 	resp := BridgeCommandResponse{
 		ID:     "cmd_1",
-		OK:     true,
 		Method: "clipboard",
 		Data:   json.RawMessage(`{"text":"hello"}`),
 	}
@@ -157,8 +156,8 @@ func TestSubmitAndQueryResult(t *testing.T) {
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
-	if !result.Response.OK {
-		t.Errorf("expected OK=true")
+	if result.Response.Error != nil {
+		t.Errorf("expected Error=nil, got %v", result.Response.Error)
 	}
 	if result.Response.Method != "clipboard" {
 		t.Errorf("expected method=clipboard, got %v", result.Response.Method)
@@ -172,7 +171,10 @@ func TestSubmitAndQueryResult(t *testing.T) {
 	q.mu.RUnlock()
 
 	// Submit result for non-existent command
-	badResp := BridgeCommandResponse{ID: "nonexistent", OK: false}
+	badResp := BridgeCommandResponse{
+		ID:    "nonexistent",
+		Error: NewToolError(CodeBridgeNotConnected, "test error"),
+	}
 	if err := q.SubmitResult(badResp); err == nil {
 		t.Errorf("expected error for nonexistent command")
 	}
@@ -206,7 +208,7 @@ func TestCommandExpiration(t *testing.T) {
 	cmd2 := BridgeCommand{ID: "result_expire", Type: "test"}
 	q.Enqueue(cmd2)
 	q.Poll("", 10)
-	resp := BridgeCommandResponse{ID: "result_expire", OK: true}
+	resp := BridgeCommandResponse{ID: "result_expire"}
 	q.SubmitResult(resp)
 
 	// Manually expire result
@@ -324,7 +326,7 @@ func TestConcurrentAccess(t *testing.T) {
 	for id := range polledIDs {
 		go func(cmdID string) {
 			defer wg.Done()
-			resp := BridgeCommandResponse{ID: cmdID, OK: true}
+			resp := BridgeCommandResponse{ID: cmdID}
 			q.SubmitResult(resp)
 		}(id)
 	}
@@ -336,8 +338,8 @@ func TestConcurrentAccess(t *testing.T) {
 		if status != StatusCompleted {
 			t.Errorf("command %s expected completed, got %v", id, status)
 		}
-		if result == nil || !result.Response.OK {
-			t.Errorf("command %s missing valid result", id)
+		if result == nil || result.Response.Error != nil {
+			t.Errorf("command %s missing valid result or has error", id)
 		}
 	}
 }
@@ -394,9 +396,3 @@ func TestQueryExpiredCommand(t *testing.T) {
 		t.Errorf("expected nil result for expired command")
 	}
 }
-
-
-
-
-
-

--- a/src/agent/internal/agent/phone_bridge_test.go
+++ b/src/agent/internal/agent/phone_bridge_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -18,7 +19,6 @@ func TestPhoneBridgeHandlesEnvironmentEvent(t *testing.T) {
 
 	handled := bridge.handleAppEvent(BridgeCommandResponse{
 		ID:     "phone_environment",
-		OK:     true,
 		Method: "phone_environment",
 		Data: json.RawMessage(`{
 			"captured_at":"2026-06-01T02:03:05Z",
@@ -76,7 +76,6 @@ func TestPhoneBridgeHandlesAppStateEvent(t *testing.T) {
 
 	handled := bridge.handleAppEvent(BridgeCommandResponse{
 		ID:     "phone_app_state",
-		OK:     true,
 		Method: "phone_app_state",
 		Data:   json.RawMessage(`{"app_state":"background","reported_at":"2026-06-01T02:03:06Z","return_entry":"dynamic_island","return_entry_available":true}`),
 	})
@@ -99,5 +98,37 @@ func TestPhoneBridgeHandlesAppStateEvent(t *testing.T) {
 	}
 	if status.ReturnEntryAvailable == nil || !*status.ReturnEntryAvailable {
 		t.Fatalf("return_entry_available = %#v, want true", status.ReturnEntryAvailable)
+	}
+}
+
+func TestBridgeCommandResponseJSONRoundTripStructuredError(t *testing.T) {
+	orig := BridgeCommandResponse{
+		ID:    "cmd-1",
+		Error: NewToolError(CodeBridgeTimeout, "command timeout"),
+	}
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got BridgeCommandResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Error == nil || got.Error.Code != CodeBridgeTimeout {
+		t.Errorf("Error not preserved: %+v", got.Error)
+	}
+	if got.Error.Category != CategoryTransient {
+		t.Errorf("Category not preserved: %+v", got.Error)
+	}
+}
+
+func TestBridgeCommandResponseSuccessOmitsError(t *testing.T) {
+	resp := BridgeCommandResponse{ID: "cmd-2", Data: json.RawMessage(`{}`)}
+	data, _ := json.Marshal(resp)
+	if got := string(data); strings.Contains(got, `"error"`) {
+		t.Errorf("success response must omit error field; got %s", got)
+	}
+	if resp.Error != nil {
+		t.Errorf("success response must have nil Error")
 	}
 }

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -813,7 +813,7 @@ func (e *roleCollaborativeExecutor) executePlannerToolAction(
 		e.Recorder.RecordPlannerExecution(execution)
 	}
 	kind := plannerTurnTool
-	if isRunPausingTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError {
+	if isRunPausingTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError() {
 		kind = plannerTurnSleep
 	}
 	return plannerTurnResult{Kind: kind, Step: &toolExecution.Step}, nil
@@ -1116,7 +1116,7 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 	}
 	actionCopy := toolExecution.Step.Action
 	kind := executorTurnTool
-	if isRunPausingTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError {
+	if isRunPausingTool(toolExecution.Step.Action.Tool) && !toolExecution.Result.IsError() {
 		kind = executorTurnSleep
 	}
 	return executorTurnResult{

--- a/src/agent/internal/agent/role_executor.go
+++ b/src/agent/internal/agent/role_executor.go
@@ -78,6 +78,7 @@ type defaultFinalReview struct {
 type roleExecutionResult struct {
 	Action          *schema.AgentAction
 	Step            *schema.AgentStep
+	ToolError       *ToolError
 	CandidateAnswer string
 }
 
@@ -465,7 +466,7 @@ func (e *roleCollaborativeExecutor) Call(ctx context.Context, inputValues map[st
 					state.World.UpdateFromStep(*turn.Step, len(state.ToolSteps), e.Tools)
 				}
 				if turn.Kind == executorTurnTool {
-					execution := roleExecutionResult{Action: turn.Action, Step: turn.Step}
+					execution := roleExecutionResult{Action: turn.Action, Step: turn.Step, ToolError: turn.ToolError}
 					state.StepExecutionResults = append(state.StepExecutionResults, execution)
 					state.ExecutionResults = append(state.ExecutionResults, execution)
 					if e.Recorder != nil {
@@ -804,8 +805,9 @@ func (e *roleCollaborativeExecutor) executePlannerToolAction(
 		return plannerTurnResult{}, toolExecution.Error
 	}
 	execution := roleExecutionResult{
-		Action: &toolExecution.Step.Action,
-		Step:   &toolExecution.Step,
+		Action:    &toolExecution.Step.Action,
+		Step:      &toolExecution.Step,
+		ToolError: toolExecution.Result.Error,
 	}
 	state.ExecutionResults = append(state.ExecutionResults, execution)
 	state.PlannerEvidence = append(state.PlannerEvidence, execution)
@@ -1120,9 +1122,10 @@ func (e *roleCollaborativeExecutor) callExecutorTurn(
 		kind = executorTurnSleep
 	}
 	return executorTurnResult{
-		Kind:   kind,
-		Action: &actionCopy,
-		Step:   &toolExecution.Step,
+		Kind:      kind,
+		Action:    &actionCopy,
+		Step:      &toolExecution.Step,
+		ToolError: toolExecution.Result.Error,
 	}, nil
 }
 

--- a/src/agent/internal/agent/role_loop.go
+++ b/src/agent/internal/agent/role_loop.go
@@ -78,6 +78,7 @@ type executorTurnResult struct {
 	Action          *schema.AgentAction
 	Step            *schema.AgentStep
 	InvalidMetaStep *schema.AgentStep
+	ToolError       *ToolError
 }
 
 func plannerCommitRequiredTurn(action schema.AgentAction) plannerTurnResult {

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -174,6 +174,7 @@ type RunEvent struct {
 	SpeechEligible bool       `json:"speech_eligible,omitempty"`
 	Timestamp      time.Time  `json:"timestamp"`
 	IsError        bool       `json:"is_error,omitempty"`
+	ToolError      *ToolError `json:"tool_error,omitempty"`
 }
 
 type usageTrackingModel struct {
@@ -1404,15 +1405,23 @@ func (h *runtimeCallbackHandler) HandleToolError(ctx context.Context, err error)
 	}
 	action, ok := h.popPendingAction()
 	if ok {
+		var toolErr *ToolError
+		if te, ok := err.(*ToolError); ok {
+			toolErr = te
+		} else {
+			toolErr = NewToolError(CodeToolExecutionFailed, err.Error())
+		}
+		content := toolErr.Message
 		h.emitRunEvent(ctx, RunEvent{
 			Type:       "tool_result",
 			EpisodeID:  h.episodeID,
 			ToolCallID: action.ToolID,
 			ToolName:   action.Tool,
 			ToolInput:  normalizeToolInput(action.ToolInput),
-			Content:    "error: " + err.Error(),
+			Content:    content,
 			Timestamp:  time.Now(),
 			IsError:    true,
+			ToolError:  cloneToolError(toolErr),
 		})
 	}
 }
@@ -1432,7 +1441,6 @@ func (h *runtimeCallbackHandler) HandleNamedToolEnd(ctx context.Context, name, i
 		ToolInput: input,
 		Content:   output,
 		Timestamp: time.Now(),
-		IsError:   toolOutputLooksLikeError(output),
 	})
 }
 
@@ -1441,15 +1449,23 @@ func (h *runtimeCallbackHandler) HandleNamedToolError(ctx context.Context, name,
 	if h.logger != nil {
 		h.logger.Error("Tool error: name=%s err=%v", name, err)
 	}
+	var toolErr *ToolError
+	if te, ok := err.(*ToolError); ok {
+		toolErr = te
+	} else {
+		toolErr = NewToolError(CodeToolExecutionFailed, err.Error())
+	}
+	content := toolErr.Message
 	h.removePendingAction(name, input)
 	h.emitRunEvent(ctx, RunEvent{
 		Type:      "tool_result",
 		EpisodeID: h.episodeID,
 		ToolName:  name,
 		ToolInput: input,
-		Content:   "error: " + err.Error(),
+		Content:   content,
 		Timestamp: time.Now(),
 		IsError:   true,
+		ToolError: cloneToolError(toolErr),
 	})
 }
 
@@ -1501,6 +1517,7 @@ func (h *runtimeCallbackHandler) HandleToolCallResult(ctx context.Context, call 
 		Content:    output,
 		Timestamp:  time.Now(),
 		IsError:    result.IsError(),
+		ToolError:  cloneToolError(result.Error),
 	})
 }
 
@@ -1621,6 +1638,7 @@ func sessionEventFromRunEvent(event RunEvent, h *runtimeCallbackHandler) Session
 		ToolName:   event.ToolName,
 		ToolInput:  event.ToolInput,
 		IsError:    event.IsError,
+		ToolError:  cloneToolError(event.ToolError),
 	}
 	return sessionEvent
 }

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1486,7 +1486,7 @@ func (h *runtimeCallbackHandler) AfterToolCall(ctx context.Context, call ToolCal
 func (h *runtimeCallbackHandler) HandleToolCallResult(ctx context.Context, call ToolCall, result ToolResult) {
 	output := result.EventOutput()
 	if h.logger != nil {
-		if result.IsError {
+		if result.IsError() {
 			h.logger.Error("Tool result: name=%s output=%s", call.Spec.Name, truncateForLog(output, 240))
 		} else {
 			h.logger.Info("Tool result: name=%s output=%s", call.Spec.Name, truncateForLog(output, 240))
@@ -1500,7 +1500,7 @@ func (h *runtimeCallbackHandler) HandleToolCallResult(ctx context.Context, call 
 		ToolInput:  call.Input,
 		Content:    output,
 		Timestamp:  time.Now(),
-		IsError:    result.IsError,
+		IsError:    result.IsError(),
 	})
 }
 

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1406,9 +1406,7 @@ func (h *runtimeCallbackHandler) HandleToolError(ctx context.Context, err error)
 	action, ok := h.popPendingAction()
 	if ok {
 		var toolErr *ToolError
-		if te, ok := err.(*ToolError); ok {
-			toolErr = te
-		} else {
+		if !errors.As(err, &toolErr) {
 			toolErr = NewToolError(CodeToolExecutionFailed, err.Error())
 		}
 		content := toolErr.Message
@@ -1450,9 +1448,7 @@ func (h *runtimeCallbackHandler) HandleNamedToolError(ctx context.Context, name,
 		h.logger.Error("Tool error: name=%s err=%v", name, err)
 	}
 	var toolErr *ToolError
-	if te, ok := err.(*ToolError); ok {
-		toolErr = te
-	} else {
+	if !errors.As(err, &toolErr) {
 		toolErr = NewToolError(CodeToolExecutionFailed, err.Error())
 	}
 	content := toolErr.Message

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1942,6 +1942,50 @@ func firstRunEventOfType(events []RunEvent, eventType string) (RunEvent, bool) {
 	return RunEvent{}, false
 }
 
+func TestRuntimeCallbackPropagatesToolErrorToEventsAndMessages(t *testing.T) {
+	toolErr := NewToolErrorWithDetails(CodePermissionDenied, "contacts permission denied", map[string]any{"scope": "contacts"})
+	var gotRunEvent RunEvent
+	var gotSessionEvent SessionEvent
+	handler := &runtimeCallbackHandler{
+		episodeID: "ep-1",
+		runtimeID: "runtime-1",
+		requestID: "req-1",
+		runID:     "run-1",
+		eventHandler: func(event RunEvent) {
+			gotRunEvent = event
+		},
+		sessionEventAppender: func(ctx context.Context, event SessionEvent) error {
+			gotSessionEvent = event
+			return nil
+		},
+	}
+	call := ToolCall{
+		Spec: ToolSpec{Name: "contacts"},
+		Action: schema.AgentAction{
+			Tool:      "contacts",
+			ToolID:    "call-1",
+			ToolInput: `{"action":"query"}`,
+		},
+		Input: `{"action":"query"}`,
+	}
+
+	handler.HandleToolCallResult(context.Background(), call, ToolResult{Output: toolErr.Message, Error: toolErr})
+
+	if gotRunEvent.ToolError == nil || gotRunEvent.ToolError.Code != CodePermissionDenied {
+		t.Fatalf("RunEvent.ToolError = %+v, want permission_denied", gotRunEvent.ToolError)
+	}
+	if gotSessionEvent.ToolError == nil || gotSessionEvent.ToolError.Code != CodePermissionDenied {
+		t.Fatalf("SessionEvent.ToolError = %+v, want permission_denied", gotSessionEvent.ToolError)
+	}
+	message := messageFromRunEvent(gotRunEvent, "", "req-1")
+	if message.ToolError == nil || message.ToolError.Code != CodePermissionDenied {
+		t.Fatalf("Message.ToolError = %+v, want permission_denied", message.ToolError)
+	}
+	if gotRunEvent.Content != toolErr.Message || message.Content != toolErr.Message {
+		t.Fatalf("error message content mismatch: run=%q message=%q want=%q", gotRunEvent.Content, message.Content, toolErr.Message)
+	}
+}
+
 func runEventsOfType(events []RunEvent, eventType string) []RunEvent {
 	var matching []RunEvent
 	for _, event := range events {
@@ -2320,12 +2364,15 @@ func TestRuntimeRunFeedsToolErrorsBackToModel(t *testing.T) {
 			}
 		}
 	}
-	if !strings.Contains(toolObservation, "error: screenshot failed: frame service: SERVICE_RECOVERING") {
+	if !strings.Contains(toolObservation, "frame service: SERVICE_RECOVERING") || strings.Contains(toolObservation, "error:") {
 		t.Fatalf("unexpected tool observation: %q", toolObservation)
 	}
 	toolResult, ok := firstRunEventOfType(events, "tool_result")
 	if !ok || !toolResult.IsError {
 		t.Fatalf("expected error tool_result event, got %#v", events)
+	}
+	if toolResult.ToolError == nil || toolResult.ToolError.Code != CodeToolExecutionFailed || toolResult.ToolError.Message != toolObservation {
+		t.Fatalf("tool_result ToolError = %+v, want execution failure matching observation %q", toolResult.ToolError, toolObservation)
 	}
 }
 

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1974,12 +1974,21 @@ func TestRuntimeCallbackPropagatesToolErrorToEventsAndMessages(t *testing.T) {
 	if gotRunEvent.ToolError == nil || gotRunEvent.ToolError.Code != CodePermissionDenied {
 		t.Fatalf("RunEvent.ToolError = %+v, want permission_denied", gotRunEvent.ToolError)
 	}
+	if gotRunEvent.ToolError.Details["scope"] != "contacts" {
+		t.Fatalf("RunEvent.ToolError.Details = %+v, want scope=contacts", gotRunEvent.ToolError.Details)
+	}
 	if gotSessionEvent.ToolError == nil || gotSessionEvent.ToolError.Code != CodePermissionDenied {
 		t.Fatalf("SessionEvent.ToolError = %+v, want permission_denied", gotSessionEvent.ToolError)
+	}
+	if gotSessionEvent.ToolError.Details["scope"] != "contacts" {
+		t.Fatalf("SessionEvent.ToolError.Details = %+v, want scope=contacts", gotSessionEvent.ToolError.Details)
 	}
 	message := messageFromRunEvent(gotRunEvent, "", "req-1")
 	if message.ToolError == nil || message.ToolError.Code != CodePermissionDenied {
 		t.Fatalf("Message.ToolError = %+v, want permission_denied", message.ToolError)
+	}
+	if message.ToolError.Details["scope"] != "contacts" {
+		t.Fatalf("Message.ToolError.Details = %+v, want scope=contacts", message.ToolError.Details)
 	}
 	if gotRunEvent.Content != toolErr.Message || message.Content != toolErr.Message {
 		t.Fatalf("error message content mismatch: run=%q message=%q want=%q", gotRunEvent.Content, message.Content, toolErr.Message)

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -1852,7 +1852,7 @@ func (s *Server) handleScreen(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, execution.Error.Error(), http.StatusInternalServerError)
 		return
 	}
-	if execution.Result.IsError {
+	if execution.Result.IsError() {
 		http.Error(w, execution.Result.Output, http.StatusInternalServerError)
 		return
 	}
@@ -2294,23 +2294,27 @@ func (s *Server) handleToolInvoke(w http.ResponseWriter, r *http.Request) {
 		Action: schema.AgentAction{Tool: spec.Name, ToolInput: rawInput},
 	})
 	duration := time.Since(startedAt).Milliseconds()
-	callErr := execution.Result.Error
+	isError := execution.Result.IsError() || execution.Error != nil
+	var errStr string
+	if execution.Result.Error != nil {
+		errStr = execution.Result.Error.Message
+	}
 	if execution.Error != nil {
-		callErr = execution.Error
+		errStr = execution.Error.Error()
 	}
 
 	response := ToolInvokeResponse{
 		Tool:       spec.Descriptor(),
 		RawInput:   execution.Call.Input,
 		Output:     execution.Result.Output,
-		IsError:    execution.Result.IsError || execution.Error != nil,
+		IsError:    isError,
 		DurationMs: duration,
 		CalledAt:   startedAt,
 	}
-	if callErr != nil {
-		response.Error = callErr.Error()
+	if errStr != "" {
+		response.Error = errStr
 		if response.Output == "" {
-			response.Output = callErr.Error()
+			response.Output = errStr
 		}
 	}
 

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -308,6 +308,7 @@ type ToolInvokeResponse struct {
 	Output     string         `json:"output"`
 	IsError    bool           `json:"is_error"`
 	Error      string         `json:"error,omitempty"`
+	ToolError  *ToolError     `json:"tool_error,omitempty"`
 	DurationMs int64          `json:"duration_ms"`
 	CalledAt   time.Time      `json:"called_at"`
 }
@@ -2308,6 +2309,7 @@ func (s *Server) handleToolInvoke(w http.ResponseWriter, r *http.Request) {
 		RawInput:   execution.Call.Input,
 		Output:     execution.Result.Output,
 		IsError:    isError,
+		ToolError:  execution.Result.Error,
 		DurationMs: duration,
 		CalledAt:   startedAt,
 	}

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -104,6 +104,7 @@ type Message struct {
 	SpeechEligible  bool                `json:"speech_eligible,omitempty"`
 	ToolName        string              `json:"tool_name,omitempty"`
 	ToolInput       string              `json:"tool_input,omitempty"`
+	ToolError       *ToolError          `json:"tool_error,omitempty"`
 	Attachments     []MessageAttachment `json:"attachments,omitempty"`
 	Artifacts       []InputArtifact     `json:"artifacts,omitempty"`
 	Source          string              `json:"source,omitempty"`
@@ -136,6 +137,7 @@ func messageFromRunEvent(event RunEvent, fallbackEpisodeID string, requestID str
 		SpeechEligible: event.SpeechEligible,
 		ToolName:       event.ToolName,
 		ToolInput:      event.ToolInput,
+		ToolError:      cloneToolError(event.ToolError),
 		Timestamp:      event.Timestamp,
 		IsError:        event.IsError,
 	}
@@ -2411,7 +2413,9 @@ func decodeToolInvokeInput(body io.Reader) (string, error) {
 	return trimmed, nil
 }
 
-func toolOutputLooksLikeError(output string) bool {
+func legacyToolOutputLooksLikeError(output string) bool {
+	// Boundary compatibility for older subtools/stubs that still return only a
+	// legacy string. Do not use this as the internal source of error truth.
 	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(output)), "error:")
 }
 

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -609,6 +609,45 @@ func TestHandleCoordinateDebugTap(t *testing.T) {
 	}
 }
 
+func TestHandleCoordinateDebugTapMapsStructuredToolErrorStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		toolErr    *ToolError
+		wantStatus int
+	}{
+		{name: "invalid input", toolErr: NewToolError(CodeInvalidArguments, "bad tap"), wantStatus: http.StatusBadRequest},
+		{name: "module unavailable", toolErr: NewToolError(CodeModuleUnavailable, "hid unavailable"), wantStatus: http.StatusServiceUnavailable},
+		{name: "execution failed", toolErr: NewToolError(CodeToolExecutionFailed, "hid write failed"), wantStatus: http.StatusInternalServerError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			toolSet := &ToolSet{tools: map[string]langtools.Tool{
+				"touch_gesture": &contextToolErrorStub{name: "touch_gesture", toolErr: tc.toolErr},
+			}}
+			runtime := NewRuntimeWithDeps(
+				Config{Model: ModelConfig{Provider: "fake"}},
+				&testModelResolver{},
+				NewMemoryManager(""),
+				toolSet,
+				NewSkillIndex(),
+			)
+			server := NewServer(runtime, ":0")
+
+			req := httptest.NewRequest(http.MethodPost, "/api/coordinate-debug/tap", bytes.NewBufferString(`{"x":123,"y":456}`))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			server.handleCoordinateDebugTap(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d body=%s, want %d", rec.Code, rec.Body.String(), tc.wantStatus)
+			}
+			if !strings.Contains(rec.Body.String(), tc.toolErr.Message) {
+				t.Fatalf("body = %s, want message %q", rec.Body.String(), tc.toolErr.Message)
+			}
+		})
+	}
+}
+
 func TestServerHandleChatStreamTagsHistoryWithRequestID(t *testing.T) {
 	model := &scriptedModel{
 		responses: roleDirectResponses("你好！"),

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -804,7 +804,6 @@ func TestHandleScreenshotJPEGUpdatesSharedScreenStateFromPhoneAspectRatio(t *tes
 	if !server.bridge.handleAppEvent(BridgeCommandResponse{
 		ID:     "phone_environment",
 		Method: "phone_environment",
-		OK:     true,
 		Data:   envData,
 	}) {
 		t.Fatal("expected phone_environment event to be handled")

--- a/src/agent/internal/agent/task_episode.go
+++ b/src/agent/internal/agent/task_episode.go
@@ -69,6 +69,7 @@ type TaskEpisodeEvent struct {
 	NextStep           string              `json:"next_step,omitempty" yaml:"next_step,omitempty"`
 	ToolName           string              `json:"tool_name,omitempty" yaml:"tool_name,omitempty"`
 	ToolInput          string              `json:"tool_input,omitempty" yaml:"tool_input,omitempty"`
+	ToolError          *ToolError          `json:"tool_error,omitempty" yaml:"tool_error,omitempty"`
 	Content            string              `json:"content,omitempty" yaml:"content,omitempty"`
 	Todo               *TodoState          `json:"todo,omitempty" yaml:"todo,omitempty"`
 	SpeechEligible     bool                `json:"speech_eligible,omitempty" yaml:"speech_eligible,omitempty"`
@@ -309,7 +310,8 @@ func (r *EpisodeRecorder) recordExecutionForRole(result roleExecutionResult, rol
 			Type:        "tool_result",
 			Role:        "tool",
 			Observation: compactToolObservation(result.Step.Observation),
-			IsError:     toolOutputLooksLikeError(result.Step.Observation),
+			IsError:     result.ToolError != nil,
+			ToolError:   cloneToolError(result.ToolError),
 		}
 		if result.Step.Action.Tool != "" {
 			event.ToolName = result.Step.Action.Tool

--- a/src/agent/internal/agent/task_episode_error_test.go
+++ b/src/agent/internal/agent/task_episode_error_test.go
@@ -26,6 +26,12 @@ func TestEpisodeRecorderRecordsStructuredToolError(t *testing.T) {
 		if event.ToolError == nil || event.ToolError.Code != CodePermissionDenied {
 			t.Fatalf("TaskEpisodeEvent.ToolError = %+v, want permission_denied", event.ToolError)
 		}
+		if !event.IsError {
+			t.Fatalf("TaskEpisodeEvent.IsError = false, want true")
+		}
+		if event.ToolError.Message != "contacts permission denied" {
+			t.Fatalf("TaskEpisodeEvent.ToolError.Message = %q", event.ToolError.Message)
+		}
 		return
 	}
 	t.Fatal("missing tool_result event")

--- a/src/agent/internal/agent/task_episode_error_test.go
+++ b/src/agent/internal/agent/task_episode_error_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/tmc/langchaingo/schema"
+)
+
+func TestEpisodeRecorderRecordsStructuredToolError(t *testing.T) {
+	recorder := NewEpisodeRecorder(MemoryRetrieveRequest{}, MemoryContext{})
+	action := schema.AgentAction{Tool: "contacts", ToolInput: `{"action":"query"}`}
+	step := schema.AgentStep{Action: action, Observation: "contacts permission denied"}
+	toolErr := NewToolError(CodePermissionDenied, "contacts permission denied")
+
+	recorder.RecordExecution(roleExecutionResult{
+		Action:    &action,
+		Step:      &step,
+		ToolError: toolErr,
+	})
+	episode := recorder.Finish("", nil, nil, nil, nil)
+
+	for _, event := range episode.Events {
+		if event.Type != "tool_result" {
+			continue
+		}
+		if event.ToolError == nil || event.ToolError.Code != CodePermissionDenied {
+			t.Fatalf("TaskEpisodeEvent.ToolError = %+v, want permission_denied", event.ToolError)
+		}
+		return
+	}
+	t.Fatal("missing tool_result event")
+}

--- a/src/agent/internal/agent/text_input_common.go
+++ b/src/agent/internal/agent/text_input_common.go
@@ -15,14 +15,14 @@ const (
 	textInputModeComposition textInputMode = "composition"
 	textInputModeUnknown     textInputMode = "unknown"
 
-	textInputKeystrokeGap         = 60 * time.Millisecond
-	textInputFocusRestoreDelay    = 250 * time.Millisecond
-	textInputIMESwitchSettleDelay = time.Second
+	textInputKeystrokeGap           = 60 * time.Millisecond
+	textInputFocusRestoreDelay      = 250 * time.Millisecond
+	textInputIMESwitchSettleDelay   = time.Second
 	textInputClearBackspaceRepeats  = 32
 	textInputClearBackspaceFallback = 16
 	textInputMaxAttempts            = 3
-	textInputCandidatePageMax      = 5
-	textInputCandidatePageDelay    = 300 * time.Millisecond
+	textInputCandidatePageMax       = 5
+	textInputCandidatePageDelay     = 300 * time.Millisecond
 )
 
 func requiredTextInputMode(text string) textInputMode {
@@ -222,9 +222,6 @@ func interpretTextInputToolOutput(out string) error {
 	out = strings.TrimSpace(out)
 	if out == "" {
 		return fmt.Errorf("empty tool output")
-	}
-	if strings.HasPrefix(out, "error:") {
-		return fmt.Errorf("%s", out)
 	}
 	if strings.HasPrefix(out, "{") {
 		var payload struct {

--- a/src/agent/internal/agent/text_input_engine.go
+++ b/src/agent/internal/agent/text_input_engine.go
@@ -307,14 +307,11 @@ func (e *textInputEngine) applyFocus(ctx context.Context, focus focusPointArgs) 
 	if coordSpace == "" {
 		coordSpace = "normalized"
 	}
-	out, err := e.hw.mouseClick.Call(ctx, jsonString(map[string]any{
+	_, err := callTextInputTool(ctx, e.hw.mouseClick, jsonString(map[string]any{
 		"x": focus.X, "y": focus.Y, "coord_space": coordSpace,
 	}))
 	if err != nil {
 		return err
-	}
-	if strings.HasPrefix(out, "error:") {
-		return fmt.Errorf("%s", out)
 	}
 	time.Sleep(textInputFocusRestoreDelay)
 	return nil
@@ -324,11 +321,23 @@ func (e *textInputEngine) tapKeys(ctx context.Context, keys []string) error {
 	if e == nil || e.hw.keyboardTap == nil {
 		return fmt.Errorf("keyboard_tap is not configured")
 	}
-	out, err := e.hw.keyboardTap.Call(ctx, jsonString(map[string]any{"keys": keys}))
+	out, err := callTextInputTool(ctx, e.hw.keyboardTap, jsonString(map[string]any{"keys": keys}))
 	if err != nil {
 		return err
 	}
 	return interpretTextInputToolOutput(out)
+}
+
+func callTextInputTool(ctx context.Context, tool langtools.Tool, input string) (string, error) {
+	toolCtx, _ := WithToolError(ctx)
+	out, err := tool.Call(toolCtx, input)
+	if err != nil {
+		return out, err
+	}
+	if te := ToolErrorFromContext(toolCtx); te != nil {
+		return out, te
+	}
+	return out, nil
 }
 
 func (e *textInputEngine) cycleIME(ctx context.Context, platform string) (string, error) {
@@ -365,7 +374,7 @@ func (e *textInputEngine) typeASCII(ctx context.Context, text string) error {
 }
 
 func (e *textInputEngine) typeASCIIChunk(ctx context.Context, text string) error {
-	out, err := e.hw.keyboardText.Call(ctx, jsonString(map[string]string{"text": text}))
+	out, err := callTextInputTool(ctx, e.hw.keyboardText, jsonString(map[string]string{"text": text}))
 	if err != nil {
 		return err
 	}
@@ -375,12 +384,9 @@ func (e *textInputEngine) typeASCIIChunk(ctx context.Context, text string) error
 func (e *textInputEngine) typeCompositionWithCandidateSelection(ctx context.Context, platform string, args enterTextInFieldArgs, segments []string) (committed bool, fieldText string, wrongIME bool, vlmCalls int, steps []string, err error) {
 	for i, segment := range segments {
 		steps = append(steps, fmt.Sprintf("type segment %d: %q", i+1, segment))
-		out, err := e.hw.keyboardText.Call(ctx, jsonString(map[string]string{"text": segment}))
+		_, err := callTextInputTool(ctx, e.hw.keyboardText, jsonString(map[string]string{"text": segment}))
 		if err != nil {
 			return false, fieldText, false, vlmCalls, steps, err
-		}
-		if strings.HasPrefix(out, "error:") {
-			return false, fieldText, false, vlmCalls, steps, fmt.Errorf("%s", out)
 		}
 		time.Sleep(textInputKeystrokeGap)
 	}

--- a/src/agent/internal/agent/tool_execution.go
+++ b/src/agent/internal/agent/tool_execution.go
@@ -24,11 +24,12 @@ type ToolCall struct {
 type ToolResult struct {
 	Output    string
 	Summary   string
-	IsError   bool
-	Error     error
+	Error     *ToolError
 	Terminate bool
 	Duration  time.Duration
 }
+
+func (r ToolResult) IsError() bool { return r.Error != nil }
 
 type ToolCallExecution struct {
 	Specs                  *ToolSpecs
@@ -124,12 +125,12 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 	}
 
 	if err := spec.ValidateInput(input); err != nil {
+		msg := fmt.Sprintf("error: %s failed: %v", spec.Name, err)
 		result := ToolResult{
-			Output:  fmt.Sprintf("error: %s failed: %v", spec.Name, err),
-			IsError: true,
-			Error:   err,
+			Output:   msg,
+			Error:    NewToolError(CodeToolExecutionFailed, msg),
+			Duration: time.Since(call.StartedAt),
 		}
-		result.Duration = time.Since(call.StartedAt)
 		result = runAfterToolCallHook(ctx, execution, call, result)
 		emitToolResult(ctx, execution.Callback, call, result)
 		return resultForToolCall(call, result, nil)
@@ -147,9 +148,18 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 	if execution.EnvironmentBridge != nil && shouldForwardToEnvironmentBridge(spec.Name, execution.EnvironmentBridgeTools) {
 		output, remoteIsError, err := execution.EnvironmentBridge.CallTool(ctx, spec.Name, input)
 		if err != nil {
+			var toolErr *ToolError
+			if errors.Is(err, context.Canceled) {
+				toolErr = NewToolError(CodeCanceled, err.Error())
+			} else if errors.Is(err, context.DeadlineExceeded) {
+				toolErr = NewToolError(CodeDeadlineExceeded, err.Error())
+			} else {
+				msg := fmt.Sprintf("error: %s failed: %v", spec.Name, err)
+				toolErr = NewToolError(CodeEnvironmentBridgeTransport, msg)
+			}
 			result := ToolResult{
-				Error:    err,
-				IsError:  true,
+				Output:   toolErr.Message,
+				Error:    toolErr,
 				Duration: time.Since(call.StartedAt),
 			}
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -157,14 +167,17 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 				emitToolResult(ctx, execution.Callback, call, result)
 				return ToolCallExecutionResult{Call: call, Result: result, Error: err}
 			}
-			result.Output = fmt.Sprintf("error: %s failed: %v", spec.Name, err)
 			result = runAfterToolCallHook(ctx, execution, call, result)
 			emitToolResult(ctx, execution.Callback, call, result)
 			return resultForToolCall(call, result, nil)
 		}
+		var remoteErr *ToolError
+		if remoteIsError {
+			remoteErr = NewToolError(CodeToolExecutionFailed, output)
+		}
 		result := ToolResult{
 			Output:   output,
-			IsError:  remoteIsError,
+			Error:    remoteErr,
 			Duration: time.Since(call.StartedAt),
 		}
 		result = runAfterToolCallHook(ctx, execution, call, result)
@@ -173,10 +186,23 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 	}
 
 	output, err := spec.Tool.Call(ctx, input)
+	var toolErr *ToolError
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			toolErr = NewToolError(CodeCanceled, err.Error())
+		} else if errors.Is(err, context.DeadlineExceeded) {
+			toolErr = NewToolError(CodeDeadlineExceeded, err.Error())
+		} else {
+			msg := fmt.Sprintf("error: %s failed: %v", spec.Name, err)
+			toolErr = NewToolError(CodeToolExecutionFailed, msg)
+		}
+	} else if toolOutputLooksLikeError(output) {
+		// Preserve existing string-sniffing behavior (Task 5 will remove this).
+		toolErr = NewToolError(CodeToolExecutionFailed, output)
+	}
 	result := ToolResult{
 		Output:   output,
-		IsError:  err != nil || toolOutputLooksLikeError(output),
-		Error:    err,
+		Error:    toolErr,
 		Duration: time.Since(call.StartedAt),
 	}
 	if err != nil {
@@ -185,7 +211,7 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 			emitToolResult(ctx, execution.Callback, call, result)
 			return ToolCallExecutionResult{Call: call, Result: result, Error: err}
 		}
-		result.Output = fmt.Sprintf("error: %s failed: %v", spec.Name, err)
+		result.Output = toolErr.Message
 	}
 
 	result = runAfterToolCallHook(ctx, execution, call, result)
@@ -210,11 +236,17 @@ func invalidToolResult(call ToolCall) ToolResult {
 	if toolName == "" {
 		toolName = strings.TrimSpace(call.Spec.Name)
 	}
-	output := fmt.Sprintf("%s is not a valid tool, try another one", toolName)
+	var msg string
 	if toolName == "" {
-		output = "requested tool is not a valid tool, try another one"
+		msg = "requested tool is not a valid tool, try another one"
+	} else {
+		msg = fmt.Sprintf("%s is not a valid tool, try another one", toolName)
 	}
-	return ToolResult{Output: output, IsError: true, Duration: time.Since(call.StartedAt)}
+	return ToolResult{
+		Output:   msg,
+		Error:    NewToolError(CodeToolNotFound, msg),
+		Duration: time.Since(call.StartedAt),
+	}
 }
 
 func runBeforeToolCallHook(ctx context.Context, execution ToolCallExecution, call ToolCall) (bool, ToolResult) {
@@ -249,21 +281,24 @@ func normalizeRejectedToolResult(toolName string, result ToolResult) ToolResult 
 	result = normalizeToolResult(result)
 	if strings.TrimSpace(result.Output) == "" {
 		if result.Error != nil {
-			result.Output = "error: " + result.Error.Error()
+			result.Output = "error: " + result.Error.Message
 		} else {
 			result.Output = fmt.Sprintf("error: %s call rejected", toolName)
 		}
 	}
-	result.IsError = true
+	if result.Error == nil {
+		result.Error = NewToolError(CodeToolExecutionFailed, result.Output)
+	}
 	return result
 }
 
 func normalizeToolResult(result ToolResult) ToolResult {
 	if result.Output == "" && result.Error != nil {
-		result.Output = "error: " + result.Error.Error()
+		result.Output = "error: " + result.Error.Message
 	}
-	if toolOutputLooksLikeError(result.Output) {
-		result.IsError = true
+	if result.Error == nil && toolOutputLooksLikeError(result.Output) {
+		// Preserve existing string-sniffing behavior (Task 5 will remove this).
+		result.Error = NewToolError(CodeToolExecutionFailed, result.Output)
 	}
 	return result
 }
@@ -306,14 +341,14 @@ func emitToolResult(ctx context.Context, handler callbacks.Handler, call ToolCal
 	}
 	output := result.EventOutput()
 	if named, ok := handler.(namedToolCallbackHandler); ok {
-		if result.IsError && result.Error != nil {
+		if result.IsError() && result.Error != nil {
 			named.HandleNamedToolError(ctx, call.Spec.Name, call.Input, result.Error)
 			return
 		}
 		named.HandleNamedToolEnd(ctx, call.Spec.Name, call.Input, output)
 		return
 	}
-	if result.IsError && result.Error != nil {
+	if result.IsError() && result.Error != nil {
 		handler.HandleToolError(ctx, result.Error)
 		return
 	}

--- a/src/agent/internal/agent/tool_execution.go
+++ b/src/agent/internal/agent/tool_execution.go
@@ -146,40 +146,25 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 	// Only forward tools whose name matches one of the configured EnvironmentBridgeTools
 	// patterns (see shouldForwardToEnvironmentBridge). Everything else runs locally.
 	if execution.EnvironmentBridge != nil && shouldForwardToEnvironmentBridge(spec.Name, execution.EnvironmentBridgeTools) {
-		output, remoteIsError, err := execution.EnvironmentBridge.CallTool(ctx, spec.Name, input)
+		remote, err := execution.EnvironmentBridge.CallTool(ctx, spec.Name, input)
 		if err != nil {
-			var toolErr *ToolError
-			if errors.Is(err, context.Canceled) {
-				toolErr = NewToolError(CodeCanceled, err.Error())
-			} else if errors.Is(err, context.DeadlineExceeded) {
-				toolErr = NewToolError(CodeDeadlineExceeded, err.Error())
-			} else {
-				msg := fmt.Sprintf("error: %s failed: %v", spec.Name, err)
-				toolErr = NewToolError(CodeEnvironmentBridgeTransport, msg)
+			// Reserved for context.Canceled / DeadlineExceeded only.
+			code := CodeCanceled
+			if errors.Is(err, context.DeadlineExceeded) {
+				code = CodeDeadlineExceeded
 			}
+			toolErr := NewToolError(code, err.Error())
 			result := ToolResult{
 				Output:   toolErr.Message,
 				Error:    toolErr,
 				Duration: time.Since(call.StartedAt),
 			}
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				result = runAfterToolCallHook(ctx, execution, call, result)
-				emitToolResult(ctx, execution.Callback, call, result)
-				return ToolCallExecutionResult{Call: call, Result: result, Error: err}
-			}
 			result = runAfterToolCallHook(ctx, execution, call, result)
 			emitToolResult(ctx, execution.Callback, call, result)
-			return resultForToolCall(call, result, nil)
+			return ToolCallExecutionResult{Call: call, Result: result, Error: err}
 		}
-		var remoteErr *ToolError
-		if remoteIsError {
-			remoteErr = NewToolError(CodeToolExecutionFailed, output)
-		}
-		result := ToolResult{
-			Output:   output,
-			Error:    remoteErr,
-			Duration: time.Since(call.StartedAt),
-		}
+		result := *remote
+		result.Duration = time.Since(call.StartedAt)
 		result = runAfterToolCallHook(ctx, execution, call, result)
 		emitToolResult(ctx, execution.Callback, call, result)
 		return resultForToolCall(call, result, nil)

--- a/src/agent/internal/agent/tool_execution.go
+++ b/src/agent/internal/agent/tool_execution.go
@@ -170,7 +170,8 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 		return resultForToolCall(call, result, nil)
 	}
 
-	output, err := spec.Tool.Call(ctx, input)
+	ctx2, _ := WithToolError(ctx)
+	output, err := spec.Tool.Call(ctx2, input)
 	var toolErr *ToolError
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -181,9 +182,11 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 			msg := fmt.Sprintf("error: %s failed: %v", spec.Name, err)
 			toolErr = NewToolError(CodeToolExecutionFailed, msg)
 		}
-	} else if toolOutputLooksLikeError(output) {
-		// Preserve existing string-sniffing behavior (Task 5 will remove this).
-		toolErr = NewToolError(CodeToolExecutionFailed, output)
+	} else if attached := ToolErrorFromContext(ctx2); attached != nil {
+		// Tool surfaced a structured error via SetToolError. Adopt it directly
+		// so the LLM-facing Output (already equal to attached.Message) and the
+		// downstream Error stay aligned.
+		toolErr = attached
 	}
 	result := ToolResult{
 		Output:   output,
@@ -284,10 +287,6 @@ func normalizeRejectedToolResult(toolName string, result ToolResult) ToolResult 
 func normalizeToolResult(result ToolResult) ToolResult {
 	if result.Output == "" && result.Error != nil {
 		result.Output = result.Error.Message
-	}
-	if result.Error == nil && toolOutputLooksLikeError(result.Output) {
-		// Preserve existing string-sniffing behavior (Task 5 will remove this).
-		result.Error = NewToolError(CodeToolExecutionFailed, result.Output)
 	}
 	return result
 }

--- a/src/agent/internal/agent/tool_execution.go
+++ b/src/agent/internal/agent/tool_execution.go
@@ -125,10 +125,10 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 	}
 
 	if err := spec.ValidateInput(input); err != nil {
-		msg := fmt.Sprintf("error: %s failed: %v", spec.Name, err)
+		msg := err.Error()
 		result := ToolResult{
 			Output:   msg,
-			Error:    NewToolError(CodeToolExecutionFailed, msg),
+			Error:    NewToolError(CodeInvalidArguments, msg),
 			Duration: time.Since(call.StartedAt),
 		}
 		result = runAfterToolCallHook(ctx, execution, call, result)
@@ -137,11 +137,10 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 	}
 
 	// If environment bridge is enabled, forward the call to the bridge. When the
-	// HTTP call succeeds the remote output/is_error are passed through verbatim,
-	// because the remote ran the same executeToolCall path and already produced
-	// the exact response (including any "error: X failed" formatting) the LLM
-	// would see locally. Only transport failures are formatted here, mirroring
-	// how a local tool error is surfaced.
+	// HTTP call succeeds the remote ToolResult is passed through verbatim because
+	// the remote ran the same executeToolCall path and already produced the same
+	// structured response the LLM would see locally. Only transport failures are
+	// formatted here, mirroring how a local tool error is surfaced.
 	//
 	// Only forward tools whose name matches one of the configured EnvironmentBridgeTools
 	// patterns (see shouldForwardToEnvironmentBridge). Everything else runs locally.
@@ -179,8 +178,7 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 		} else if errors.Is(err, context.DeadlineExceeded) {
 			toolErr = NewToolError(CodeDeadlineExceeded, err.Error())
 		} else {
-			msg := fmt.Sprintf("error: %s failed: %v", spec.Name, err)
-			toolErr = NewToolError(CodeToolExecutionFailed, msg)
+			toolErr = NewToolError(CodeToolExecutionFailed, err.Error())
 		}
 	} else if attached := ToolErrorFromContext(ctx2); attached != nil {
 		// Tool surfaced a structured error via SetToolError. Adopt it directly
@@ -192,6 +190,9 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 		Output:   output,
 		Error:    toolErr,
 		Duration: time.Since(call.StartedAt),
+	}
+	if err == nil && toolErr != nil {
+		result.Output = toolErr.Message
 	}
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -285,8 +286,12 @@ func normalizeRejectedToolResult(toolName string, result ToolResult) ToolResult 
 }
 
 func normalizeToolResult(result ToolResult) ToolResult {
-	if result.Output == "" && result.Error != nil {
-		result.Output = result.Error.Message
+	if result.Error != nil {
+		if result.Output == "" {
+			result.Output = result.Error.Message
+		} else if result.Output != result.Error.Message {
+			result.Error.Message = result.Output
+		}
 	}
 	return result
 }

--- a/src/agent/internal/agent/tool_execution.go
+++ b/src/agent/internal/agent/tool_execution.go
@@ -281,20 +281,24 @@ func normalizeRejectedToolResult(toolName string, result ToolResult) ToolResult 
 	result = normalizeToolResult(result)
 	if strings.TrimSpace(result.Output) == "" {
 		if result.Error != nil {
-			result.Output = "error: " + result.Error.Message
+			result.Output = result.Error.Message
 		} else {
-			result.Output = fmt.Sprintf("error: %s call rejected", toolName)
+			result.Output = fmt.Sprintf("%s call rejected", toolName)
 		}
 	}
 	if result.Error == nil {
 		result.Error = NewToolError(CodeToolExecutionFailed, result.Output)
+	}
+	// Ensure Output == Error.Message invariant.
+	if result.Error != nil && result.Output != result.Error.Message {
+		result.Error.Message = result.Output
 	}
 	return result
 }
 
 func normalizeToolResult(result ToolResult) ToolResult {
 	if result.Output == "" && result.Error != nil {
-		result.Output = "error: " + result.Error.Message
+		result.Output = result.Error.Message
 	}
 	if result.Error == nil && toolOutputLooksLikeError(result.Output) {
 		// Preserve existing string-sniffing behavior (Task 5 will remove this).
@@ -341,14 +345,14 @@ func emitToolResult(ctx context.Context, handler callbacks.Handler, call ToolCal
 	}
 	output := result.EventOutput()
 	if named, ok := handler.(namedToolCallbackHandler); ok {
-		if result.IsError() && result.Error != nil {
+		if result.Error != nil {
 			named.HandleNamedToolError(ctx, call.Spec.Name, call.Input, result.Error)
 			return
 		}
 		named.HandleNamedToolEnd(ctx, call.Spec.Name, call.Input, output)
 		return
 	}
-	if result.IsError() && result.Error != nil {
+	if result.Error != nil {
 		handler.HandleToolError(ctx, result.Error)
 		return
 	}

--- a/src/agent/internal/agent/tool_execution.go
+++ b/src/agent/internal/agent/tool_execution.go
@@ -147,9 +147,10 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 	if execution.EnvironmentBridge != nil && shouldForwardToEnvironmentBridge(spec.Name, execution.EnvironmentBridgeTools) {
 		remote, err := execution.EnvironmentBridge.CallTool(ctx, spec.Name, input)
 		if err != nil {
-			// Reserved for context.Canceled / DeadlineExceeded only.
-			code := CodeCanceled
-			if errors.Is(err, context.DeadlineExceeded) {
+			code := CodeToolExecutionFailed
+			if errors.Is(err, context.Canceled) {
+				code = CodeCanceled
+			} else if errors.Is(err, context.DeadlineExceeded) {
 				code = CodeDeadlineExceeded
 			}
 			toolErr := NewToolError(code, err.Error())
@@ -195,12 +196,12 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 		result.Output = toolErr.Message
 	}
 	if err != nil {
+		result.Output = toolErr.Message
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			result = runAfterToolCallHook(ctx, execution, call, result)
 			emitToolResult(ctx, execution.Callback, call, result)
 			return ToolCallExecutionResult{Call: call, Result: result, Error: err}
 		}
-		result.Output = toolErr.Message
 	}
 
 	result = runAfterToolCallHook(ctx, execution, call, result)

--- a/src/agent/internal/agent/tool_execution_test.go
+++ b/src/agent/internal/agent/tool_execution_test.go
@@ -242,8 +242,75 @@ func TestExecuteToolCallWrapsToolErrorsAndContinues(t *testing.T) {
 	if !result.Result.IsError() {
 		t.Fatalf("result should be marked as error: %#v", result.Result)
 	}
-	if result.Step.Observation != "error: echo failed: boom" {
+	if result.Result.Error == nil || result.Result.Error.Code != CodeToolExecutionFailed || result.Result.Error.Message != "boom" {
+		t.Fatalf("ToolError = %+v, want tool_execution_failed boom", result.Result.Error)
+	}
+	if result.Step.Observation != "boom" {
 		t.Fatalf("observation = %q", result.Step.Observation)
+	}
+}
+
+func TestExecuteToolCallBuiltInStringErrorToolsReturnStructuredErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		tool     langtools.Tool
+		input    string
+		wantCode string
+	}{
+		{
+			name:     "shell missing command",
+			tool:     &ShellTool{},
+			input:    `{}`,
+			wantCode: CodeInvalidArguments,
+		},
+		{
+			name:     "image diff missing after",
+			tool:     &ImageDiffTool{},
+			input:    `{"before":"x"}`,
+			wantCode: CodeInvalidArguments,
+		},
+		{
+			name:     "web search unconfigured",
+			tool:     &WebSearchTool{provider: "brave"},
+			input:    `{"query":"aiden"}`,
+			wantCode: CodeModuleUnavailable,
+		},
+		{
+			name:     "current time invalid timezone",
+			tool:     &CurrentTimeTool{},
+			input:    `{"timezone":"Not/AZone"}`,
+			wantCode: CodeInvalidArguments,
+		},
+		{
+			name:     "keyboard tap empty keys",
+			tool:     &KeyboardTapTool{},
+			input:    `{"keys":[]}`,
+			wantCode: CodeInvalidArguments,
+		},
+		{
+			name:     "touch gesture missing type",
+			tool:     &TouchGestureTool{},
+			input:    `{}`,
+			wantCode: CodeInvalidArguments,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := executeToolCall(context.Background(), ToolCallExecution{
+				Specs:  NewToolSpecs([]langtools.Tool{tc.tool}),
+				Action: schema.AgentAction{Tool: tc.tool.Name(), ToolInput: tc.input},
+			})
+			if result.Result.Error == nil {
+				t.Fatalf("expected structured ToolError, got result %#v", result.Result)
+			}
+			if result.Result.Error.Code != tc.wantCode {
+				t.Fatalf("Error.Code = %q, want %q (error=%+v)", result.Result.Error.Code, tc.wantCode, result.Result.Error)
+			}
+			if result.Result.Output != result.Result.Error.Message {
+				t.Fatalf("Output must equal Error.Message, got %q vs %q", result.Result.Output, result.Result.Error.Message)
+			}
+		})
 	}
 }
 
@@ -354,6 +421,19 @@ func TestExecuteToolCallBeforeHookRejectWithEmptyOutputSatisfiesInvariant(t *tes
 	if result.Result.Output != result.Result.Error.Message {
 		t.Fatalf("Output == Error.Message invariant violated: Output=%q Error.Message=%q",
 			result.Result.Output, result.Result.Error.Message)
+	}
+}
+
+func TestNormalizeToolResultAlignsNonEmptyErrorMessageToOutput(t *testing.T) {
+	result := normalizeToolResult(ToolResult{
+		Output: "policy override message",
+		Error:  NewToolError(CodeToolExecutionFailed, "original message"),
+	})
+	if result.Error == nil {
+		t.Fatal("expected structured error")
+	}
+	if result.Output != result.Error.Message {
+		t.Fatalf("Output == Error.Message invariant violated: Output=%q Error.Message=%q", result.Output, result.Error.Message)
 	}
 }
 

--- a/src/agent/internal/agent/tool_execution_test.go
+++ b/src/agent/internal/agent/tool_execution_test.go
@@ -322,6 +322,41 @@ func TestDefaultAfterToolCallSummarizesScreenshotAndMarksTerminate(t *testing.T)
 	}
 }
 
+func TestExecuteToolCallBeforeHookRejectWithEmptyOutputSatisfiesInvariant(t *testing.T) {
+	// Regression: normalizeRejectedToolResult called normalizeToolResult which back-filled
+	// Output with "error: " + Error.Message, breaking Output == Error.Message invariant.
+	tool := &stubTool{name: "echo", description: "Echo text.", output: "should-not-run"}
+	specs := NewToolSpecs([]langtools.Tool{tool})
+
+	result := executeToolCall(context.Background(), ToolCallExecution{
+		Specs: specs,
+		Action: schema.AgentAction{
+			Tool:      "echo",
+			ToolInput: "hello",
+		},
+		Before: func(ctx context.Context, call ToolCall) (ToolResult, bool) {
+			// Hook returns Error but leaves Output empty — the bug case.
+			return ToolResult{
+				Error: NewToolError(CodeToolExecutionFailed, "denied"),
+			}, false
+		},
+	})
+
+	if len(tool.inputs) != 0 {
+		t.Fatalf("tool should not have been called, inputs=%#v", tool.inputs)
+	}
+	if strings.TrimSpace(result.Result.Output) == "" {
+		t.Fatalf("Output must be non-empty so LLM sees a message; got empty string")
+	}
+	if result.Result.Error == nil {
+		t.Fatalf("Error must be set on a rejected result")
+	}
+	if result.Result.Output != result.Result.Error.Message {
+		t.Fatalf("Output == Error.Message invariant violated: Output=%q Error.Message=%q",
+			result.Result.Output, result.Result.Error.Message)
+	}
+}
+
 func TestToolResultErrorIsStructured(t *testing.T) {
 	ok := ToolResult{Output: "done", Summary: "ok"}
 	if ok.IsError() {

--- a/src/agent/internal/agent/tool_execution_test.go
+++ b/src/agent/internal/agent/tool_execution_test.go
@@ -146,7 +146,7 @@ func TestExecuteToolCallInvalidToolEmitsToolCallAndResult(t *testing.T) {
 		Callback: recorder,
 	})
 
-	if !result.Result.IsError {
+	if !result.Result.IsError() {
 		t.Fatalf("invalid tool should be an error result: %#v", result.Result)
 	}
 	if result.Call.Spec.Name != "missing" || result.Call.Input != "hello" {
@@ -155,7 +155,7 @@ func TestExecuteToolCallInvalidToolEmitsToolCallAndResult(t *testing.T) {
 	if len(recorder.events) != 2 || recorder.events[0] != "start" || recorder.events[1] != "result" {
 		t.Fatalf("callback lifecycle events = %#v, want start then result", recorder.events)
 	}
-	if len(recorder.results) != 1 || !recorder.results[0].IsError {
+	if len(recorder.results) != 1 || !recorder.results[0].IsError() {
 		t.Fatalf("expected one error result callback, got %#v", recorder.results)
 	}
 }
@@ -173,13 +173,13 @@ func TestExecuteToolCallValidationFailureEmitsToolCallAndResult(t *testing.T) {
 		Callback: recorder,
 	})
 
-	if !result.Result.IsError {
+	if !result.Result.IsError() {
 		t.Fatalf("invalid JSON should be an error result: %#v", result.Result)
 	}
 	if len(recorder.calls) != 1 || recorder.calls[0].Input != "not-json" {
 		t.Fatalf("expected one tool_call before validation failure, got %#v", recorder.calls)
 	}
-	if len(recorder.results) != 1 || !recorder.results[0].IsError {
+	if len(recorder.results) != 1 || !recorder.results[0].IsError() {
 		t.Fatalf("expected one error result callback, got %#v", recorder.results)
 	}
 	if len(recorder.events) != 2 || recorder.events[0] != "start" || recorder.events[1] != "result" {
@@ -203,9 +203,8 @@ func TestExecuteToolCallBeforeMayRejectWithToolResult(t *testing.T) {
 		},
 		Before: func(ctx context.Context, call ToolCall) (ToolResult, bool) {
 			return ToolResult{
-				Output:  "blocked by policy",
-				IsError: true,
-				Error:   errors.New("blocked by policy"),
+				Output: "blocked by policy",
+				Error:  NewToolError(CodeToolExecutionFailed, "blocked by policy"),
 			}, false
 		},
 		Callback: recorder,
@@ -214,7 +213,7 @@ func TestExecuteToolCallBeforeMayRejectWithToolResult(t *testing.T) {
 	if len(tool.inputs) != 0 {
 		t.Fatalf("tool should not have been called, inputs=%#v", tool.inputs)
 	}
-	if !result.Result.IsError || result.Result.Output != "blocked by policy" {
+	if !result.Result.IsError() || result.Result.Output != "blocked by policy" {
 		t.Fatalf("unexpected rejection result: %#v", result.Result)
 	}
 	if result.Step.Observation != "blocked by policy" {
@@ -240,7 +239,7 @@ func TestExecuteToolCallWrapsToolErrorsAndContinues(t *testing.T) {
 	if result.Error != nil {
 		t.Fatalf("tool failure should be returned as tool result, got execution error: %v", result.Error)
 	}
-	if !result.Result.IsError {
+	if !result.Result.IsError() {
 		t.Fatalf("result should be marked as error: %#v", result.Result)
 	}
 	if result.Step.Observation != "error: echo failed: boom" {
@@ -267,14 +266,21 @@ func TestExecuteToolCallPropagatesContextErrors(t *testing.T) {
 			if !errors.Is(result.Error, err) {
 				t.Fatalf("execution error = %v, want %v", result.Error, err)
 			}
-			if !errors.Is(result.Result.Error, err) {
-				t.Fatalf("result error = %v, want %v", result.Result.Error, err)
+			if result.Result.Error == nil {
+				t.Fatalf("result.Error is nil, want structured error for %v", err)
+			}
+			wantCode := CodeCanceled
+			if errors.Is(err, context.DeadlineExceeded) {
+				wantCode = CodeDeadlineExceeded
+			}
+			if result.Result.Error.Code != wantCode {
+				t.Fatalf("result error code = %q, want %q", result.Result.Error.Code, wantCode)
 			}
 			if len(recorder.events) != 2 || recorder.events[0] != "start" || recorder.events[1] != "result" {
 				t.Fatalf("callback lifecycle events = %#v, want start then result", recorder.events)
 			}
-			if len(recorder.results) != 1 || !errors.Is(recorder.results[0].Error, err) {
-				t.Fatalf("terminal result callback = %#v, want error %v", recorder.results, err)
+			if len(recorder.results) != 1 || recorder.results[0].Error == nil || recorder.results[0].Error.Code != wantCode {
+				t.Fatalf("terminal result callback = %#v, want error code %v", recorder.results, wantCode)
 			}
 		})
 	}
@@ -313,5 +319,29 @@ func TestDefaultAfterToolCallSummarizesScreenshotAndMarksTerminate(t *testing.T)
 	}
 	if result.Step.Observation != result.Result.Output {
 		t.Fatalf("step observation should preserve raw output")
+	}
+}
+
+func TestToolResultErrorIsStructured(t *testing.T) {
+	ok := ToolResult{Output: "done", Summary: "ok"}
+	if ok.IsError() {
+		t.Errorf("success result reported IsError")
+	}
+	if ok.Error != nil {
+		t.Errorf("success result has non-nil Error: %+v", ok.Error)
+	}
+
+	err := ToolResult{
+		Output: "WeChat is not installed",
+		Error:  NewToolError(CodeAppNotInstalled, "WeChat is not installed"),
+	}
+	if !err.IsError() {
+		t.Errorf("failure result did not report IsError")
+	}
+	if err.Error.Code != CodeAppNotInstalled {
+		t.Errorf("Error.Code = %q", err.Error.Code)
+	}
+	if err.Output != err.Error.Message {
+		t.Errorf("Output must equal Error.Message on failure; got %q vs %q", err.Output, err.Error.Message)
 	}
 }

--- a/src/agent/internal/agent/tool_execution_test.go
+++ b/src/agent/internal/agent/tool_execution_test.go
@@ -343,11 +343,17 @@ func TestExecuteToolCallPropagatesContextErrors(t *testing.T) {
 			if result.Result.Error.Code != wantCode {
 				t.Fatalf("result error code = %q, want %q", result.Result.Error.Code, wantCode)
 			}
+			if result.Result.Output != result.Result.Error.Message {
+				t.Fatalf("Output must equal Error.Message, got %q vs %q", result.Result.Output, result.Result.Error.Message)
+			}
 			if len(recorder.events) != 2 || recorder.events[0] != "start" || recorder.events[1] != "result" {
 				t.Fatalf("callback lifecycle events = %#v, want start then result", recorder.events)
 			}
 			if len(recorder.results) != 1 || recorder.results[0].Error == nil || recorder.results[0].Error.Code != wantCode {
 				t.Fatalf("terminal result callback = %#v, want error code %v", recorder.results, wantCode)
+			}
+			if recorder.results[0].Output != recorder.results[0].Error.Message {
+				t.Fatalf("callback Output must equal Error.Message, got %q vs %q", recorder.results[0].Output, recorder.results[0].Error.Message)
 			}
 		})
 	}

--- a/src/agent/internal/agent/tools_audio.go
+++ b/src/agent/internal/agent/tools_audio.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 
@@ -36,7 +35,7 @@ func (t *AudioVolumeTool) ArgsSchema() map[string]any {
 	})
 }
 
-func (t *AudioVolumeTool) Call(_ context.Context, input string) (string, error) {
+func (t *AudioVolumeTool) Call(ctx context.Context, input string) (string, error) {
 	var args struct {
 		Volume *int `json:"volume"`
 	}
@@ -44,22 +43,22 @@ func (t *AudioVolumeTool) Call(_ context.Context, input string) (string, error) 
 	trimmed := strings.TrimSpace(input)
 	if trimmed != "" {
 		if err := json.Unmarshal([]byte(trimmed), &args); err != nil {
-			return fmt.Sprintf("error: invalid input: %v. Expected JSON format: {\"volume\": 70} or {} to read current volume. Volume must be a number between 0 and 100", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "invalid input: %v. Expected JSON format: {\"volume\": 70} or {} to read current volume. Volume must be a number between 0 and 100", err), nil
 		}
 	}
 
 	if args.Volume != nil {
 		if *args.Volume < 0 || *args.Volume > 100 {
-			return "error: volume must be between 0 and 100", nil
+			return toolErrorResultString(ctx, CodeInvalidArguments, "volume must be between 0 and 100"), nil
 		}
 		if err := t.client.SetPlaybackVolume(*args.Volume); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 	}
 
 	volume, err := t.client.GetPlaybackVolume()
 	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 
 	result := struct {

--- a/src/agent/internal/agent/tools_audio_test.go
+++ b/src/agent/internal/agent/tools_audio_test.go
@@ -69,13 +69,17 @@ func TestAudioVolumeToolSet(t *testing.T) {
 func TestAudioVolumeToolRejectsOutOfRange(t *testing.T) {
 	client := &fakePlaybackVolumeClient{volume: 55}
 	tool := &AudioVolumeTool{client: client}
+	ctx, _ := WithToolError(context.Background())
 
-	out, err := tool.Call(context.Background(), `{"volume":101}`)
+	out, err := tool.Call(ctx, `{"volume":101}`)
 	if err != nil {
 		t.Fatalf("Call() error = %v", err)
 	}
-	if out != "error: volume must be between 0 and 100" {
+	if out != "volume must be between 0 and 100" {
 		t.Fatalf("Call() = %q", out)
+	}
+	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeInvalidArguments || got.Message != out {
+		t.Fatalf("ToolError = %+v, want invalid_arguments with output message", got)
 	}
 	if len(client.sets) != 0 {
 		t.Fatalf("set calls = %v, want none", client.sets)

--- a/src/agent/internal/agent/tools_enter_text_in_field.go
+++ b/src/agent/internal/agent/tools_enter_text_in_field.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 
@@ -45,11 +44,11 @@ func (t *EnterTextInFieldTool) ArgsSchema() map[string]any {
 
 func (t *EnterTextInFieldTool) Call(ctx context.Context, input string) (string, error) {
 	if t == nil || t.engine == nil {
-		return "error: enter_text_in_field is not fully configured", nil
+		return toolErrorResultString(ctx, CodeModuleUnavailable, "enter_text_in_field is not fully configured"), nil
 	}
 	var args enterTextInFieldArgs
 	if err := json.Unmarshal([]byte(strings.TrimSpace(input)), &args); err != nil {
-		return fmt.Sprintf("error: invalid input: %v", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "invalid input: %v", err), nil
 	}
 	if t.platformFn != nil {
 		if override := strings.TrimSpace(t.platformFn()); override != "" {
@@ -58,7 +57,7 @@ func (t *EnterTextInFieldTool) Call(ctx context.Context, input string) (string, 
 	}
 	result, err := t.engine.Run(ctx, args)
 	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 	if !result.Committed {
 		result.OK = false

--- a/src/agent/internal/agent/tools_enter_text_in_field.go
+++ b/src/agent/internal/agent/tools_enter_text_in_field.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 )
 
@@ -57,6 +58,11 @@ func (t *EnterTextInFieldTool) Call(ctx context.Context, input string) (string, 
 	}
 	result, err := t.engine.Run(ctx, args)
 	if err != nil {
+		var toolErr *ToolError
+		if errors.As(err, &toolErr) {
+			SetToolError(ctx, toolErr)
+			return toolErrorString(toolErr), nil
+		}
 		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 	if !result.Committed {

--- a/src/agent/internal/agent/tools_enter_text_in_field_test.go
+++ b/src/agent/internal/agent/tools_enter_text_in_field_test.go
@@ -123,6 +123,36 @@ func TestEnterTextInFieldCompositionRequiresSegments(t *testing.T) {
 	}
 }
 
+func TestEnterTextInFieldStructuredKeyboardErrorDoesNotPoisonRetriableResult(t *testing.T) {
+	keyboardErr := NewToolError(CodeInvalidArguments, "keyboard_text failed")
+	engine := newTextInputEngine(textInputHardwareDeps{
+		mouseClick:  textInputStubTool{name: "mouse_click", out: "ok"},
+		keyboardTap: textInputStubTool{name: "keyboard_tap", out: "ok"},
+		keyboardText: &stubTextInputCallTool{
+			tool: textInputStubTool{name: "keyboard_text"},
+			fn: func(ctx context.Context, _ string) (string, error) {
+				SetToolError(ctx, keyboardErr)
+				return keyboardErr.Message, nil
+			},
+		},
+		quickAction: textInputStubTool{name: "quick_action", out: "ok"},
+		screenshot:  textInputStubTool{name: "screenshot", out: `{"format":"jpeg","width":100,"height":100,"data":"abc"}`},
+	}, &stubTextInputVision{})
+	tool := &EnterTextInFieldTool{engine: engine}
+	ctx, _ := WithToolError(context.Background())
+
+	out, err := tool.Call(ctx, `{"text":"hello","focus":{"x":500,"y":100},"max_attempts":1}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ToolErrorFromContext(ctx); got != nil {
+		t.Fatalf("ToolError = %+v, want nil for retriable keyboard_text failure", got)
+	}
+	if !strings.Contains(out, `"committed": false`) || !strings.Contains(out, "exhausted retries") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
 func TestEnterTextInFieldCompositionSuccess(t *testing.T) {
 	vision := &stubTextInputVision{analyses: []textInputScreenAnalysis{
 		// after all segments typed + space: pending with candidate
@@ -323,8 +353,11 @@ func TestCycleIMEUsesKeyboardTapNotQuickAction(t *testing.T) {
 	qa := textInputStubTool{name: "quick_action"}
 	qaOut := "ok"
 	engine := newTextInputEngine(textInputHardwareDeps{
-		keyboardTap:  &stubTextInputCallTool{tool: kb, fn: kbCall},
-		quickAction:  &stubTextInputCallTool{tool: qa, fn: func(context.Context, string) (string, error) { qaOut = `{"ok":false,"status":"reserved"}`; return qaOut, nil }},
+		keyboardTap: &stubTextInputCallTool{tool: kb, fn: kbCall},
+		quickAction: &stubTextInputCallTool{tool: qa, fn: func(context.Context, string) (string, error) {
+			qaOut = `{"ok":false,"status":"reserved"}`
+			return qaOut, nil
+		}},
 	}, &stubTextInputVision{})
 	label, err := engine.cycleIME(context.Background(), "android")
 	if err != nil {

--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -1078,10 +1078,8 @@ func (t *MouseScrollTool) Call(ctx context.Context, input string) (string, error
 	if args.Delta == 0 {
 		return "ok", nil
 	}
-	if args.Delta < -127 {
-		args.Delta = -127
-	} else if args.Delta > 127 {
-		args.Delta = 127
+	if args.Delta < -127 || args.Delta > 127 {
+		return toolErrorResultString(ctx, CodeInvalidArguments, "delta must be between -127 and 127"), nil
 	}
 
 	if err := scrollPointer(t.pc, args.Delta); err != nil {

--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -516,16 +516,16 @@ func (t *KeyboardTapTool) ArgsSchema() map[string]any {
 	}
 }
 
-func (t *KeyboardTapTool) Call(_ context.Context, input string) (string, error) {
+func (t *KeyboardTapTool) Call(ctx context.Context, input string) (string, error) {
 	var args struct {
 		Keys   []string `json:"keys"`
 		HoldMs int      `json:"hold_ms"`
 	}
 	if err := json.Unmarshal([]byte(input), &args); err != nil {
-		return fmt.Sprintf("error: invalid input: %v. Expected JSON format: {\"keys\": [\"ctrl\", \"c\"]}. Common mistakes: missing quotes around key names, incorrect comma placement in array", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "invalid input: %v. Expected JSON format: {\"keys\": [\"ctrl\", \"c\"]}. Common mistakes: missing quotes around key names, incorrect comma placement in array", err), nil
 	}
 	if len(args.Keys) == 0 {
-		return "error: keys array is required", nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "keys array is required"), nil
 	}
 
 	var modifier uint8
@@ -537,11 +537,11 @@ func (t *KeyboardTapTool) Call(_ context.Context, input string) (string, error) 
 		} else if code, ok := hidKeyboardMap[k]; ok {
 			keys = append(keys, code)
 		} else {
-			return fmt.Sprintf("error: unknown key: %q", k), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "unknown key: %q", k), nil
 		}
 	}
 	if modifier == 0 && len(keys) == 0 {
-		return "error: at least one key or modifier is required", nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "at least one key or modifier is required"), nil
 	}
 
 	holdMs := args.HoldMs
@@ -553,7 +553,7 @@ func (t *KeyboardTapTool) Call(_ context.Context, input string) (string, error) 
 	}
 
 	if err := t.tapKeyboardChord(modifier, keys, holdMs); err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 	return "ok", nil
 }
@@ -606,20 +606,22 @@ func (t *KeyboardTextTool) ArgsSchema() map[string]any {
 	}
 }
 
-func (t *KeyboardTextTool) Call(_ context.Context, input string) (string, error) {
+func (t *KeyboardTextTool) Call(ctx context.Context, input string) (string, error) {
 	text, errText := parseKeyboardTextInput(input)
 	if errText != "" {
-		return errText, nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, errText), nil
 	}
 
 	if unsupported := unsupportedKeyboardTextRunes(text); len(unsupported) > 0 {
-		return fmt.Sprintf(
-			"error: keyboard_text supports only US-keyboard ASCII characters; unsupported characters: %q. Use enter_text_in_field for this target.",
+		return toolErrorResultf(
+			ctx,
+			CodeInvalidArguments,
+			"keyboard_text supports only US-keyboard ASCII characters; unsupported characters: %q. Use enter_text_in_field for this target.",
 			string(unsupported),
 		), nil
 	}
 	if looksLikeSpacedRomanizationBlob(text) {
-		return "error: keyboard_text received spaced romanization; use enter_text_in_field instead.", nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "keyboard_text received spaced romanization; use enter_text_in_field instead."), nil
 	}
 
 	releaseReport := make([]byte, 8)
@@ -633,10 +635,10 @@ func (t *KeyboardTextTool) Call(_ context.Context, input string) (string, error)
 		report[2] = code
 		// Press then release immediately, same as keyboard_tap.
 		if err := t.dev.Write(report); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 		if err := t.dev.Write(releaseReport); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 	}
 
@@ -681,7 +683,7 @@ func (t *MouseClickTool) ArgsSchema() map[string]any {
 	}
 }
 
-func (t *MouseClickTool) Call(_ context.Context, input string) (string, error) {
+func (t *MouseClickTool) Call(ctx context.Context, input string) (string, error) {
 	var args struct {
 		X          pointerCoordinate `json:"x"`
 		Y          pointerCoordinate `json:"y"`
@@ -689,17 +691,17 @@ func (t *MouseClickTool) Call(_ context.Context, input string) (string, error) {
 		CoordSpace string            `json:"coord_space"`
 	}
 	if err := json.Unmarshal([]byte(input), &args); err != nil {
-		return fmt.Sprintf("error: invalid input: %v. Expected JSON format: {\"x\": 500, \"y\": 300, \"button\": \"left\", \"coord_space\": \"normalized\"}. Common mistakes: x and y must be numbers, missing quotes around field names", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "invalid input: %v. Expected JSON format: {\"x\": 500, \"y\": 300, \"button\": \"left\", \"coord_space\": \"normalized\"}. Common mistakes: x and y must be numbers, missing quotes around field names", err), nil
 	}
 
 	absX, absY, err := resolvePointerPositionForSurface(t.screen, t.pc.touchscreen, args.X.Float64(), args.Y.Float64(), args.CoordSpace, coordinateSpaceAuto)
 	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 	}
 	btn := mouseButtonByte(args.Button)
 
 	if err := tapPointer(t.pc, absX, absY, btn); err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 
 	return "ok", nil
@@ -734,23 +736,23 @@ func (t *MouseMoveTool) ArgsSchema() map[string]any {
 	}
 }
 
-func (t *MouseMoveTool) Call(_ context.Context, input string) (string, error) {
+func (t *MouseMoveTool) Call(ctx context.Context, input string) (string, error) {
 	var args struct {
 		X          pointerCoordinate `json:"x"`
 		Y          pointerCoordinate `json:"y"`
 		CoordSpace string            `json:"coord_space"`
 	}
 	if err := json.Unmarshal([]byte(input), &args); err != nil {
-		return fmt.Sprintf("error: invalid input: %v. Expected JSON format: {\"x\": 500, \"y\": 300, \"coord_space\": \"normalized\"}. Common mistakes: x and y must be numbers, missing quotes around field names", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "invalid input: %v. Expected JSON format: {\"x\": 500, \"y\": 300, \"coord_space\": \"normalized\"}. Common mistakes: x and y must be numbers, missing quotes around field names", err), nil
 	}
 
 	absX, absY, err := resolvePointerPositionForSurface(t.screen, t.pc.touchscreen, args.X.Float64(), args.Y.Float64(), args.CoordSpace, coordinateSpaceAuto)
 	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 	}
 
 	if err := positionPointer(t.pc, absX, absY, 0); err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 
 	return "ok", nil
@@ -858,7 +860,7 @@ func nonNegativeIntegerSchema(description string) map[string]any {
 	}
 }
 
-func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error) {
+func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, error) {
 	var args struct {
 		Type         string        `json:"type"`
 		Point        *pointerPoint `json:"point"`
@@ -877,12 +879,12 @@ func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error)
 		Strength     string        `json:"strength"`
 	}
 	if err := json.Unmarshal([]byte(input), &args); err != nil {
-		return fmt.Sprintf("error: invalid input: %v. Common mistakes: missing quotes around string values, incorrect comma placement, point/start/end must be objects with named keys like {\"x\":500,\"y\":300} not bare values. Example: {\"type\":\"tap\",\"point\":{\"x\":500,\"y\":500}}", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "invalid input: %v. Common mistakes: missing quotes around string values, incorrect comma placement, point/start/end must be objects with named keys like {\"x\":500,\"y\":300} not bare values. Example: {\"type\":\"tap\",\"point\":{\"x\":500,\"y\":500}}", err), nil
 	}
 
 	gestureType := strings.ToLower(strings.TrimSpace(args.Type))
 	if gestureType == "" {
-		return "error: type is required", nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "type is required"), nil
 	}
 
 	coordSpace := strings.TrimSpace(args.CoordSpace)
@@ -895,34 +897,34 @@ func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error)
 	case "tap":
 		point, err := resolveRequiredPoint(t.screen, t.pc.touchscreen, args.Point, coordSpace)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		if err := tapPointerWithHold(t.pc, point.x, point.y, button, intOrDefault(args.HoldMs, defaultTapHoldMs)); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 	case "double_tap":
 		point, err := resolveRequiredPoint(t.screen, t.pc.touchscreen, args.Point, coordSpace)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		holdMs := intOrDefault(args.HoldMs, defaultTapHoldMs)
 		if err := tapPointerWithHold(t.pc, point.x, point.y, button, holdMs); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 		sleepMs(intOrDefault(args.PauseMs, 100))
 		if err := tapPointerWithHold(t.pc, point.x, point.y, button, holdMs); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 	case "long_press":
 		point, err := resolveRequiredPoint(t.screen, t.pc.touchscreen, args.Point, coordSpace)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		if err := settlePointer(t.pc, point.x, point.y); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 		if err := pressPointer(t.pc, point.x, point.y, button); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 		released := false
 		defer func() {
@@ -932,17 +934,17 @@ func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error)
 		}()
 		sleepMs(intOrDefault(args.DurationMs, 500))
 		if err := releasePointerRepeated(t.pc, point.x, point.y, touchReleaseReportCount, touchReleaseReportDelayMs); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 		released = true
 	case "swipe_left", "swipe_right", "swipe_up", "swipe_down":
 		preset, err := directionalSwipePreset(args.Strength)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		start, end, err := directionalSwipeEndpoints(t.screen, t.pc.touchscreen, gestureType, args.Distance, args.Anchor, preset)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		if err := runSwipeLikeGesture(
 			t.pc,
@@ -954,16 +956,16 @@ func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error)
 			intOrDefault(args.HoldAfterMs, preset.holdAfterMs),
 			positiveIntOrDefault(args.Steps, preset.steps),
 		); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 	case "drag":
 		start, err := resolveRequiredPoint(t.screen, t.pc.touchscreen, args.Start, coordSpace)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		end, err := resolveRequiredPoint(t.screen, t.pc.touchscreen, args.End, coordSpace)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		if err := runPositionedDragGesture(
 			t.pc,
@@ -975,16 +977,16 @@ func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error)
 			intOrDefault(args.HoldAfterMs, 0),
 			positiveIntOrDefault(args.Steps, 12),
 		); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 	case "swipe":
 		start, err := resolveRequiredPoint(t.screen, t.pc.touchscreen, args.Start, coordSpace)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		end, err := resolveRequiredPoint(t.screen, t.pc.touchscreen, args.End, coordSpace)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		if err := runSwipeLikeGesture(
 			t.pc,
@@ -996,16 +998,16 @@ func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error)
 			intOrDefault(args.HoldAfterMs, defaultSwipeHoldAfterMs),
 			positiveIntOrDefault(args.Steps, defaultSwipeSteps),
 		); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 	case "back", "edge_back", "left_edge_back":
 		start, err := resolvePointOrDefaultNormalized(t.screen, t.pc.touchscreen, args.Start, coordSpace, phoneBackStartX, phoneBackY)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		end, err := resolvePointOrDefaultNormalized(t.screen, t.pc.touchscreen, args.End, coordSpace, phoneBackEndX, phoneBackY)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		if err := runPositionedDragGesture(
 			t.pc,
@@ -1017,16 +1019,16 @@ func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error)
 			intOrDefault(args.HoldAfterMs, defaultSwipeHoldAfterMs),
 			positiveIntOrDefault(args.Steps, defaultSwipeSteps),
 		); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 	case "home", "home_swipe", "bottom_edge_home":
 		start, err := resolvePointOrDefaultNormalized(t.screen, t.pc.touchscreen, args.Start, coordSpace, phoneHomeX, phoneHomeStartY)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		end, err := resolvePointOrDefaultNormalized(t.screen, t.pc.touchscreen, args.End, coordSpace, phoneHomeX, phoneHomeEndY)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 		if err := runPositionedDragGesture(
 			t.pc,
@@ -1038,10 +1040,10 @@ func (t *TouchGestureTool) Call(_ context.Context, input string) (string, error)
 			intOrDefault(args.HoldAfterMs, defaultSwipeHoldAfterMs),
 			positiveIntOrDefault(args.Steps, defaultSwipeSteps),
 		); err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 	default:
-		return fmt.Sprintf("error: unsupported gesture type: %q", args.Type), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "unsupported gesture type: %q", args.Type), nil
 	}
 
 	return "ok", nil
@@ -1066,12 +1068,12 @@ func (t *MouseScrollTool) ArgsSchema() map[string]any {
 	}, "delta")
 }
 
-func (t *MouseScrollTool) Call(_ context.Context, input string) (string, error) {
+func (t *MouseScrollTool) Call(ctx context.Context, input string) (string, error) {
 	var args struct {
 		Delta int `json:"delta"`
 	}
 	if err := json.Unmarshal([]byte(input), &args); err != nil {
-		return fmt.Sprintf("error: invalid input: %v. Expected JSON format: {\"delta\": -3}. Delta must be a number between -127 and 127", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "invalid input: %v. Expected JSON format: {\"delta\": -3}. Delta must be a number between -127 and 127", err), nil
 	}
 	if args.Delta == 0 {
 		return "ok", nil
@@ -1083,7 +1085,7 @@ func (t *MouseScrollTool) Call(_ context.Context, input string) (string, error) 
 	}
 
 	if err := scrollPointer(t.pc, args.Delta); err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 
 	return "ok", nil
@@ -1722,7 +1724,7 @@ func charToHIDKey(ch byte) (modifier uint8, code uint8, ok bool) {
 func parseKeyboardTextInput(input string) (string, string) {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {
-		return "", "error: text is required"
+		return "", "text is required"
 	}
 
 	if strings.HasPrefix(trimmed, "{") {
@@ -1730,10 +1732,10 @@ func parseKeyboardTextInput(input string) (string, string) {
 			Text string `json:"text"`
 		}
 		if err := json.Unmarshal([]byte(trimmed), &args); err != nil {
-			return "", fmt.Sprintf("error: invalid input: %v", err)
+			return "", fmt.Sprintf("invalid input: %v", err)
 		}
 		if args.Text == "" {
-			return "", "error: text is required"
+			return "", "text is required"
 		}
 		return args.Text, ""
 	}
@@ -1741,10 +1743,10 @@ func parseKeyboardTextInput(input string) (string, string) {
 	if strings.HasPrefix(trimmed, `"`) {
 		var text string
 		if err := json.Unmarshal([]byte(trimmed), &text); err != nil {
-			return "", fmt.Sprintf("error: invalid input: %v", err)
+			return "", fmt.Sprintf("invalid input: %v", err)
 		}
 		if text == "" {
-			return "", "error: text is required"
+			return "", "text is required"
 		}
 		return text, ""
 	}

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -778,17 +778,60 @@ func TestPostActionScreenshotToolSkipsScreenshotOnActionErrorOutput(t *testing.T
 		output: `{"width":320,"height":240,"format":"jpeg","size":4,"data":"ZmFrZQ=="}`,
 	}
 	tool := newPostActionScreenshotTool(action, screenshot, 0)
+	ctx, _ := WithToolError(context.Background())
 
-	out, err := tool.Call(context.Background(), `{}`)
+	out, err := tool.Call(ctx, `{}`)
 	if err != nil {
 		t.Fatalf("Call returned error: %v", err)
 	}
-	if out != "error: invalid input" {
-		t.Fatalf("Call output = %q, want original error output", out)
+	if out != "invalid input" {
+		t.Fatalf("Call output = %q, want structured error message", out)
+	}
+	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeToolExecutionFailed || got.Message != out {
+		t.Fatalf("ToolError = %+v, want tool_execution_failed with output message", got)
 	}
 	if len(screenshot.inputs) != 0 {
 		t.Fatalf("screenshot should not be called on action error, got inputs %#v", screenshot.inputs)
 	}
+}
+
+func TestPostActionScreenshotToolSkipsScreenshotOnStructuredActionError(t *testing.T) {
+	toolErr := NewToolError(CodeInvalidArguments, "invalid touch gesture")
+	action := &contextToolErrorStub{name: "touch_gesture", toolErr: toolErr}
+	screenshot := &stubTool{
+		name:   "screenshot",
+		output: `{"width":320,"height":240,"format":"jpeg","size":4,"data":"ZmFrZQ=="}`,
+	}
+	tool := newPostActionScreenshotTool(action, screenshot, 0)
+	ctx, _ := WithToolError(context.Background())
+
+	out, err := tool.Call(ctx, `{}`)
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if out != toolErr.Message {
+		t.Fatalf("Call output = %q, want structured error message %q", out, toolErr.Message)
+	}
+	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeInvalidArguments {
+		t.Fatalf("context ToolError = %+v, want invalid_arguments", got)
+	}
+	if len(screenshot.inputs) != 0 {
+		t.Fatalf("screenshot should not be called on structured action error, got inputs %#v", screenshot.inputs)
+	}
+}
+
+type contextToolErrorStub struct {
+	name    string
+	toolErr *ToolError
+}
+
+func (t *contextToolErrorStub) Name() string { return t.name }
+
+func (t *contextToolErrorStub) Description() string { return "structured error stub" }
+
+func (t *contextToolErrorStub) Call(ctx context.Context, input string) (string, error) {
+	SetToolError(ctx, t.toolErr)
+	return toolErrorString(t.toolErr), nil
 }
 
 func TestHIDDeviceWriteRetriesAfterEndpointShutdown(t *testing.T) {

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -881,6 +881,22 @@ func TestHIDDeviceWriteReturnsNonRetryableError(t *testing.T) {
 	}
 }
 
+func TestMouseScrollToolRejectsOutOfRangeDelta(t *testing.T) {
+	tool := &MouseScrollTool{}
+	ctx, _ := WithToolError(context.Background())
+
+	out, err := tool.Call(ctx, `{"delta":128}`)
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if out != "delta must be between -127 and 127" {
+		t.Fatalf("output = %q", out)
+	}
+	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeInvalidArguments || got.Message != out {
+		t.Fatalf("ToolError = %+v, want invalid_arguments with output message", got)
+	}
+}
+
 func TestHIDDeviceWriteTimesOutWhenFDWouldBlock(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("requires Linux nonblocking pipe semantics")

--- a/src/agent/internal/agent/tools_image_diff.go
+++ b/src/agent/internal/agent/tools_image_diff.go
@@ -45,43 +45,43 @@ func (t *ImageDiffTool) ArgsSchema() map[string]any {
 	}, "before", "after")
 }
 
-func (t *ImageDiffTool) Call(_ context.Context, input string) (string, error) {
+func (t *ImageDiffTool) Call(ctx context.Context, input string) (string, error) {
 	var args struct {
 		Before string           `json:"before"`
 		After  string           `json:"after"`
 		Region *imageDiffRegion `json:"region"`
 	}
 	if err := json.Unmarshal([]byte(input), &args); err != nil {
-		return fmt.Sprintf("error: invalid input: %v. Expected JSON format: {\"before\": \"<base64>\", \"after\": \"<base64>\", \"region\": {\"x\": 300, \"y\": 200, \"w\": 400, \"h\": 600}}. Common mistakes: before/after must be base64-encoded JPEG strings, region is optional but if provided must be an object with x, y, w, h fields", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "invalid input: %v. Expected JSON format: {\"before\": \"<base64>\", \"after\": \"<base64>\", \"region\": {\"x\": 300, \"y\": 200, \"w\": 400, \"h\": 600}}. Common mistakes: before/after must be base64-encoded JPEG strings, region is optional but if provided must be an object with x, y, w, h fields", err), nil
 	}
 	if args.Before == "" {
-		return "error: before is required", nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "before is required"), nil
 	}
 	if args.After == "" {
-		return "error: after is required", nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "after is required"), nil
 	}
 
 	beforeData, err := base64.StdEncoding.DecodeString(args.Before)
 	if err != nil {
-		return fmt.Sprintf("error: decode before: %v", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "decode before: %v", err), nil
 	}
 	afterData, err := base64.StdEncoding.DecodeString(args.After)
 	if err != nil {
-		return fmt.Sprintf("error: decode after: %v", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "decode after: %v", err), nil
 	}
 
 	beforeImg, err := jpeg.Decode(bytes.NewReader(beforeData))
 	if err != nil {
-		return fmt.Sprintf("error: decode before JPEG: %v", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "decode before JPEG: %v", err), nil
 	}
 	afterImg, err := jpeg.Decode(bytes.NewReader(afterData))
 	if err != nil {
-		return fmt.Sprintf("error: decode after JPEG: %v", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "decode after JPEG: %v", err), nil
 	}
 
 	fullBounds := beforeImg.Bounds()
 	if afterImg.Bounds() != fullBounds {
-		return "error: before and after images have different dimensions", nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "before and after images have different dimensions"), nil
 	}
 
 	bounds := fullBounds
@@ -89,13 +89,13 @@ func (t *ImageDiffTool) Call(_ context.Context, input string) (string, error) {
 		var err error
 		bounds, err = args.Region.toPixelRect(fullBounds)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
 	}
 
 	result, err := computeImageDiff(beforeImg, afterImg, bounds)
 	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 
 	out, _ := json.Marshal(result)

--- a/src/agent/internal/agent/tools_phone_bridge.go
+++ b/src/agent/internal/agent/tools_phone_bridge.go
@@ -162,10 +162,10 @@ func isHTTPURL(value string) bool {
 	return strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://")
 }
 
-func applyOpenAppURL(args *openAppArgs, rawURL string) error {
+func applyOpenAppURL(args *openAppArgs, rawURL string) *ToolError {
 	targetURL := strings.TrimSpace(rawURL)
 	if !isHTTPURL(targetURL) {
-		return fmt.Errorf("url must start with http:// or https://")
+		return NewToolError(CodeInvalidArguments, "url must start with http:// or https://")
 	}
 	args.IOSURLs = []string{targetURL}
 	args.AndroidPackages = []string{"android.intent.action.VIEW:" + targetURL}
@@ -185,9 +185,9 @@ func isPhoneAppAlias(value string) bool {
 	}
 }
 
-func resolveOpenAppTargets(args *openAppArgs) error {
+func resolveOpenAppTargets(args *openAppArgs) *ToolError {
 	if args == nil {
-		return fmt.Errorf("missing open_app args")
+		return NewToolError(CodeInvalidArguments, "missing open_app args")
 	}
 	if strings.TrimSpace(args.App) == "" && strings.TrimSpace(args.Name) != "" {
 		args.App = args.Name
@@ -198,10 +198,10 @@ func resolveOpenAppTargets(args *openAppArgs) error {
 
 	if strings.TrimSpace(args.PhoneNumber) != "" {
 		if hasURL || hasExplicitTargets {
-			return fmt.Errorf("phone_number cannot be combined with url, ios_urls, or android_packages")
+			return NewToolError(CodeInvalidArguments, "phone_number cannot be combined with url, ios_urls, or android_packages")
 		}
 		if hasApp && !isPhoneAppAlias(args.App) {
-			return fmt.Errorf("phone_number can only be combined with app/name when the app is phone")
+			return NewToolError(CodeInvalidArguments, "phone_number can only be combined with app/name when the app is phone")
 		}
 		telURL := "tel:" + strings.TrimSpace(args.PhoneNumber)
 		args.IOSURLs = []string{telURL}
@@ -211,13 +211,13 @@ func resolveOpenAppTargets(args *openAppArgs) error {
 
 	if hasURL {
 		if hasApp || hasExplicitTargets {
-			return fmt.Errorf("url cannot be combined with app, name, ios_urls, or android_packages")
+			return NewToolError(CodeInvalidArguments, "url cannot be combined with app, name, ios_urls, or android_packages")
 		}
 		return applyOpenAppURL(args, args.URL)
 	}
 
 	if hasApp && hasExplicitTargets {
-		return fmt.Errorf("app/name cannot be combined with ios_urls or android_packages")
+		return NewToolError(CodeInvalidArguments, "app/name cannot be combined with ios_urls or android_packages")
 	}
 
 	if hasApp {
@@ -228,12 +228,14 @@ func resolveOpenAppTargets(args *openAppArgs) error {
 		} else if isHTTPURL(key) {
 			return applyOpenAppURL(args, args.App)
 		} else {
-			return fmt.Errorf("unknown app %q, please provide url, ios_urls, or android_packages explicitly", args.App)
+			return NewToolErrorWithDetails(CodeUnknownApp,
+				fmt.Sprintf("unknown app %q, please provide url, ios_urls, or android_packages explicitly", args.App),
+				map[string]any{"app": args.App})
 		}
 	}
 
 	if len(args.IOSURLs) == 0 && len(args.AndroidPackages) == 0 {
-		return fmt.Errorf("must provide app name, url, ios_urls, or android_packages")
+		return NewToolError(CodeInvalidArguments, "must provide app name, url, ios_urls, or android_packages")
 	}
 	return nil
 }
@@ -384,26 +386,28 @@ func (t *OpenAppTool) Call(ctx context.Context, input string) (string, error) {
 	trimmed := strings.TrimSpace(input)
 	if strings.HasPrefix(trimmed, "{") {
 		if err := json.Unmarshal([]byte(trimmed), &args); err != nil {
-			return fmt.Sprintf("error: invalid input: %v. Expected JSON format: {\"app\": \"WeChat\"} or {\"ios_urls\": [\"url\"], \"android_packages\": [\"pkg\"]}. Common mistakes: missing quotes around field names and string values", err), nil
+			te := NewToolErrorWithDetails(CodeInvalidArguments,
+				fmt.Sprintf("invalid input: %v. Expected JSON like {\"app\": \"WeChat\"} or {\"ios_urls\": [...], \"android_packages\": [...]}", err),
+				map[string]any{"raw_input": trimmed})
+			SetToolError(ctx, te)
+			return toolErrorString(te), nil
 		}
 	} else {
 		args.App = trimmed
 	}
 
-	if err := resolveOpenAppTargets(&args); err != nil {
-		return jsonString(map[string]interface{}{
-			"ok":    false,
-			"error": err.Error(),
-		}), nil
+	if te := resolveOpenAppTargets(&args); te != nil {
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	restored, err := ensurePhoneBridgeReadyForCommand(ctx, t.bridge, t.restorer)
 	if err != nil {
-		return jsonString(map[string]interface{}{
-			"ok":       false,
-			"error":    err.Error(),
-			"fallback": "If a Dynamic Island entry is visible, tap it to reopen Aiden, wait for Phone Bridge to reconnect, then retry; otherwise use HID actions.",
-		}), nil
+		te := NewToolErrorWithDetails(CodeBridgeNotConnected,
+			fmt.Sprintf("%v. If a Dynamic Island entry is visible, tap it to reopen Aiden, wait for Phone Bridge to reconnect, then retry; otherwise use HID actions.", err),
+			map[string]any{"fallback": "tap Dynamic Island or use HID"})
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	cmdID := fmt.Sprintf("open_%d_%d", time.Now().UnixMilli(), openAppCmdSeq.Add(1))
@@ -421,15 +425,30 @@ func (t *OpenAppTool) Call(ctx context.Context, input string) (string, error) {
 		if t.bridge != nil {
 			status = t.bridge.Status()
 		}
-		return jsonString(map[string]interface{}{
-			"ok":       false,
-			"error":    err.Error(),
-			"fallback": phoneBridgeRecoveryGuidance(status),
-		}), nil
+		te := NewToolErrorWithDetails(CodeToolExecutionFailed,
+			fmt.Sprintf("send command: %v", err),
+			map[string]any{"fallback": phoneBridgeRecoveryGuidance(status)})
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
+	}
+
+	if resp.Error != nil {
+		status := PhoneBridgeStatus{}
+		if t.bridge != nil {
+			status = t.bridge.Status()
+		}
+		// Preserve upstream Code/Category; attach app-side fallback hint.
+		te := resp.Error
+		if te.Details == nil {
+			te.Details = map[string]any{}
+		}
+		te.Details["fallback"] = phoneBridgeRecoveryGuidance(status)
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	result := map[string]interface{}{
-		"ok":     resp.Error == nil,
+		"ok":     true,
 		"method": openAppResultMethod(args),
 	}
 	if restored {
@@ -440,14 +459,6 @@ func (t *OpenAppTool) Call(ctx context.Context, input string) (string, error) {
 	}
 	if mechanism := openAppResultMechanism(args, resp.Method); mechanism != "" {
 		result["mechanism"] = mechanism
-	}
-	if resp.Error != nil {
-		result["error"] = resp.Error.Message
-		status := PhoneBridgeStatus{}
-		if t.bridge != nil {
-			status = t.bridge.Status()
-		}
-		result["fallback"] = phoneBridgeRecoveryGuidance(status)
 	}
 	return jsonString(result), nil
 }

--- a/src/agent/internal/agent/tools_phone_bridge.go
+++ b/src/agent/internal/agent/tools_phone_bridge.go
@@ -429,7 +429,7 @@ func (t *OpenAppTool) Call(ctx context.Context, input string) (string, error) {
 	}
 
 	result := map[string]interface{}{
-		"ok":     resp.OK,
+		"ok":     resp.Error == nil,
 		"method": openAppResultMethod(args),
 	}
 	if restored {
@@ -441,8 +441,8 @@ func (t *OpenAppTool) Call(ctx context.Context, input string) (string, error) {
 	if mechanism := openAppResultMechanism(args, resp.Method); mechanism != "" {
 		result["mechanism"] = mechanism
 	}
-	if !resp.OK {
-		result["error"] = resp.Error
+	if resp.Error != nil {
+		result["error"] = resp.Error.Message
 		status := PhoneBridgeStatus{}
 		if t.bridge != nil {
 			status = t.bridge.Status()

--- a/src/agent/internal/agent/tools_phone_bridge_data.go
+++ b/src/agent/internal/agent/tools_phone_bridge_data.go
@@ -109,12 +109,12 @@ func (t *ClipboardTool) read(ctx context.Context) (string, error) {
 	if err != nil {
 		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
 	}
-	result := map[string]interface{}{"ok": resp.OK}
+	result := map[string]interface{}{"ok": resp.Error == nil}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
-	if !resp.OK {
-		result["error"] = resp.Error
+	if resp.Error != nil {
+		result["error"] = resp.Error.Message
 		return jsonString(result), nil
 	}
 	var data struct {
@@ -142,12 +142,12 @@ func (t *ClipboardTool) write(ctx context.Context, text string) (string, error) 
 	if err != nil {
 		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
 	}
-	result := map[string]interface{}{"ok": resp.OK}
+	result := map[string]interface{}{"ok": resp.Error == nil}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
-	if !resp.OK {
-		result["error"] = resp.Error
+	if resp.Error != nil {
+		result["error"] = resp.Error.Message
 	}
 	return jsonString(result), nil
 }
@@ -247,12 +247,12 @@ func (t *CalendarTool) create(ctx context.Context, args calendarArgs) (string, e
 	if err != nil {
 		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
 	}
-	result := map[string]interface{}{"ok": resp.OK}
+	result := map[string]interface{}{"ok": resp.Error == nil}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
-	if !resp.OK {
-		result["error"] = resp.Error
+	if resp.Error != nil {
+		result["error"] = resp.Error.Message
 		return jsonString(result), nil
 	}
 	var data struct {
@@ -283,12 +283,12 @@ func (t *CalendarTool) query(ctx context.Context, args calendarArgs) (string, er
 	if err != nil {
 		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
 	}
-	result := map[string]interface{}{"ok": resp.OK}
+	result := map[string]interface{}{"ok": resp.Error == nil}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
-	if !resp.OK {
-		result["error"] = resp.Error
+	if resp.Error != nil {
+		result["error"] = resp.Error.Message
 		return jsonString(result), nil
 	}
 	var data struct {
@@ -322,12 +322,12 @@ func (t *CalendarTool) delete(ctx context.Context, args calendarArgs) (string, e
 	if err != nil {
 		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
 	}
-	result := map[string]interface{}{"ok": resp.OK}
+	result := map[string]interface{}{"ok": resp.Error == nil}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
-	if !resp.OK {
-		result["error"] = resp.Error
+	if resp.Error != nil {
+		result["error"] = resp.Error.Message
 	}
 	return jsonString(result), nil
 }
@@ -414,12 +414,12 @@ func (t *ContactsTool) query(ctx context.Context, args contactsArgs) (string, er
 	if err != nil {
 		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
 	}
-	result := map[string]interface{}{"ok": resp.OK}
+	result := map[string]interface{}{"ok": resp.Error == nil}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
-	if !resp.OK {
-		result["error"] = resp.Error
+	if resp.Error != nil {
+		result["error"] = resp.Error.Message
 		return jsonString(result), nil
 	}
 	var data struct {
@@ -459,12 +459,12 @@ func (t *ContactsTool) create(ctx context.Context, args contactsArgs) (string, e
 	if err != nil {
 		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
 	}
-	result := map[string]interface{}{"ok": resp.OK}
+	result := map[string]interface{}{"ok": resp.Error == nil}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
-	if !resp.OK {
-		result["error"] = resp.Error
+	if resp.Error != nil {
+		result["error"] = resp.Error.Message
 		return jsonString(result), nil
 	}
 	var data struct {
@@ -502,12 +502,12 @@ func (t *ContactsTool) update(ctx context.Context, args contactsArgs) (string, e
 	if err != nil {
 		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
 	}
-	result := map[string]interface{}{"ok": resp.OK}
+	result := map[string]interface{}{"ok": resp.Error == nil}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
-	if !resp.OK {
-		result["error"] = resp.Error
+	if resp.Error != nil {
+		result["error"] = resp.Error.Message
 	}
 	return jsonString(result), nil
 }
@@ -577,12 +577,12 @@ func (t *NotificationTool) Call(ctx context.Context, input string) (string, erro
 	if err != nil {
 		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
 	}
-	result := map[string]interface{}{"ok": resp.OK}
+	result := map[string]interface{}{"ok": resp.Error == nil}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
-	if !resp.OK {
-		result["error"] = resp.Error
+	if resp.Error != nil {
+		result["error"] = resp.Error.Message
 		return jsonString(result), nil
 	}
 	var data struct {

--- a/src/agent/internal/agent/tools_phone_bridge_data.go
+++ b/src/agent/internal/agent/tools_phone_bridge_data.go
@@ -40,17 +40,6 @@ func bridgeStatusForError(bridge *PhoneBridge) []PhoneBridgeStatus {
 	return []PhoneBridgeStatus{bridge.Status()}
 }
 
-// toolErrorHelper returns a JSON envelope for a tool-level error string. Keeps
-// every branch of these tools on the same {"ok":false,"error":"..."} contract
-// so callers do not have to special-case plain strings vs JSON.
-func toolErrorHelper(format string, a ...interface{}) string {
-	msg := format
-	if len(a) > 0 {
-		msg = fmt.Sprintf(format, a...)
-	}
-	return jsonString(map[string]interface{}{"ok": false, "error": msg})
-}
-
 // ClipboardTool reads and writes the connected phone's system clipboard.
 type ClipboardTool struct {
 	bridge   *PhoneBridge
@@ -129,7 +118,7 @@ func (t *ClipboardTool) read(ctx context.Context) (string, error) {
 			return toolErrorString(te), nil
 		}
 	}
-	result := map[string]interface{}{"text": data.Text}
+	result := map[string]interface{}{"ok": true, "text": data.Text}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
@@ -153,7 +142,7 @@ func (t *ClipboardTool) write(ctx context.Context, text string) (string, error) 
 		SetToolError(ctx, resp.Error)
 		return toolErrorString(resp.Error), nil
 	}
-	result := map[string]interface{}{}
+	result := map[string]interface{}{"ok": true}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
@@ -279,7 +268,7 @@ func (t *CalendarTool) create(ctx context.Context, args calendarArgs) (string, e
 			return toolErrorString(te), nil
 		}
 	}
-	result := map[string]interface{}{"event_id": data.EventID}
+	result := map[string]interface{}{"ok": true, "event_id": data.EventID}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
@@ -321,7 +310,7 @@ func (t *CalendarTool) query(ctx context.Context, args calendarArgs) (string, er
 	if data.Events == nil {
 		data.Events = []map[string]interface{}{}
 	}
-	result := map[string]interface{}{"events": data.Events}
+	result := map[string]interface{}{"ok": true, "events": data.Events}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
@@ -350,7 +339,7 @@ func (t *CalendarTool) delete(ctx context.Context, args calendarArgs) (string, e
 		SetToolError(ctx, resp.Error)
 		return toolErrorString(resp.Error), nil
 	}
-	result := map[string]interface{}{}
+	result := map[string]interface{}{"ok": true}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
@@ -406,7 +395,9 @@ type contactsArgs struct {
 func (t *ContactsTool) Call(ctx context.Context, input string) (string, error) {
 	var args contactsArgs
 	if err := json.Unmarshal([]byte(strings.TrimSpace(input)), &args); err != nil {
-		return toolErrorHelper("invalid input: %v. Expected JSON format: {\"action\":\"query\",\"query\":\"name\",\"limit\":20} or {\"action\":\"create\",\"name\":\"...\",\"phone_numbers\":[\"...\"],\"emails\":[\"...\"]} or {\"action\":\"update\",\"contact_id\":\"...\",\"name\":\"...\"}. Arrays must use square brackets", err), nil
+		te := NewToolError(CodeInvalidArguments, fmt.Sprintf("invalid input: %v. Expected JSON format: {\"action\":\"query\",\"query\":\"name\",\"limit\":20} or {\"action\":\"create\",\"name\":\"...\",\"phone_numbers\":[\"...\"],\"emails\":[\"...\"]} or {\"action\":\"update\",\"contact_id\":\"...\",\"name\":\"...\"}. Arrays must use square brackets", err))
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	switch strings.ToLower(strings.TrimSpace(args.Action)) {
@@ -417,7 +408,9 @@ func (t *ContactsTool) Call(ctx context.Context, input string) (string, error) {
 	case "update":
 		return t.update(ctx, args)
 	default:
-		return toolErrorHelper("unknown action %q, expected \"query\", \"create\", or \"update\"", args.Action), nil
+		te := NewToolError(CodeInvalidArguments, fmt.Sprintf("unknown action %q, expected \"query\", \"create\", or \"update\"", args.Action))
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 }
 
@@ -441,7 +434,7 @@ func (t *ContactsTool) query(ctx context.Context, args contactsArgs) (string, er
 		SetToolError(ctx, te)
 		return toolErrorString(te), nil
 	}
-	result := map[string]interface{}{}
+	result := map[string]interface{}{"ok": true}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
@@ -490,7 +483,7 @@ func (t *ContactsTool) create(ctx context.Context, args contactsArgs) (string, e
 		SetToolError(ctx, te)
 		return toolErrorString(te), nil
 	}
-	result := map[string]interface{}{}
+	result := map[string]interface{}{"ok": true}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
@@ -537,12 +530,13 @@ func (t *ContactsTool) update(ctx context.Context, args contactsArgs) (string, e
 		SetToolError(ctx, te)
 		return toolErrorString(te), nil
 	}
-	result := map[string]interface{}{}
+	result := map[string]interface{}{"ok": true}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
 	if resp.Error != nil {
-		result["error"] = resp.Error.Message
+		SetToolError(ctx, resp.Error)
+		return toolErrorString(resp.Error), nil
 	}
 	return jsonString(result), nil
 }
@@ -589,7 +583,9 @@ type notificationArgs struct {
 func (t *NotificationTool) Call(ctx context.Context, input string) (string, error) {
 	var args notificationArgs
 	if err := json.Unmarshal([]byte(strings.TrimSpace(input)), &args); err != nil {
-		return toolErrorHelper("invalid input: %v. Expected JSON format: {\"title\":\"Reminder\",\"body\":\"Take medicine\",\"schedule_at\":\"2026-06-04T18:00:00+08:00\",\"sound\":true,\"badge\":1}. schedule_at is optional, sound and badge are boolean/number", err), nil
+		te := NewToolError(CodeInvalidArguments, fmt.Sprintf("invalid input: %v. Expected JSON format: {\"title\":\"Reminder\",\"body\":\"Take medicine\",\"schedule_at\":\"2026-06-04T18:00:00+08:00\",\"sound\":true,\"badge\":1}. schedule_at is optional, sound and badge are boolean/number", err))
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	if strings.TrimSpace(args.Title) == "" {
@@ -616,7 +612,7 @@ func (t *NotificationTool) Call(ctx context.Context, input string) (string, erro
 		SetToolError(ctx, te)
 		return toolErrorString(te), nil
 	}
-	result := map[string]interface{}{}
+	result := map[string]interface{}{"ok": true}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}

--- a/src/agent/internal/agent/tools_phone_bridge_data.go
+++ b/src/agent/internal/agent/tools_phone_bridge_data.go
@@ -25,7 +25,7 @@ func bridgeNotConnected(status ...PhoneBridgeStatus) string {
 	return jsonString(result)
 }
 
-func bridgeRespError(err error, status ...PhoneBridgeStatus) string {
+func toolErrorBridgeResp(err error, status ...PhoneBridgeStatus) string {
 	result := map[string]interface{}{"ok": false, "error": err.Error()}
 	if len(status) > 0 {
 		result["fallback"] = phoneBridgeRecoveryGuidance(status[0])
@@ -40,10 +40,10 @@ func bridgeStatusForError(bridge *PhoneBridge) []PhoneBridgeStatus {
 	return []PhoneBridgeStatus{bridge.Status()}
 }
 
-// bridgeMsgError returns a JSON envelope for a tool-level error string. Keeps
+// toolErrorHelper returns a JSON envelope for a tool-level error string. Keeps
 // every branch of these tools on the same {"ok":false,"error":"..."} contract
 // so callers do not have to special-case plain strings vs JSON.
-func bridgeMsgError(format string, a ...interface{}) string {
+func toolErrorHelper(format string, a ...interface{}) string {
 	msg := format
 	if len(a) > 0 {
 		msg = fmt.Sprintf(format, a...)
@@ -86,7 +86,9 @@ type clipboardArgs struct {
 func (t *ClipboardTool) Call(ctx context.Context, input string) (string, error) {
 	var args clipboardArgs
 	if err := json.Unmarshal([]byte(strings.TrimSpace(input)), &args); err != nil {
-		return bridgeMsgError("invalid input: %v. Expected JSON format: {\"action\":\"read\"} or {\"action\":\"write\",\"text\":\"content\"}. Common mistakes: action must be \"read\" or \"write\", missing quotes around field names", err), nil
+		te := NewToolError(CodeInvalidArguments, fmt.Sprintf("invalid input: %v. Expected JSON like {\"action\":\"read\"} or {\"action\":\"write\",\"text\":\"...\"}", err))
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	action := strings.ToLower(strings.TrimSpace(args.Action))
@@ -96,7 +98,9 @@ func (t *ClipboardTool) Call(ctx context.Context, input string) (string, error) 
 	case "write":
 		return t.write(ctx, args.Text)
 	default:
-		return bridgeMsgError("unknown action %q, expected \"read\" or \"write\"", args.Action), nil
+		te := NewToolError(CodeInvalidArguments, fmt.Sprintf("unknown action %q, expected \"read\" or \"write\"", args.Action))
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 }
 
@@ -107,27 +111,28 @@ func (t *ClipboardTool) read(ctx context.Context) (string, error) {
 		TimeoutMs: 5000,
 	})
 	if err != nil {
-		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
-	}
-	result := map[string]interface{}{"ok": resp.Error == nil}
-	if restored {
-		result["restored_from_return_entry"] = true
+		te := NewToolError(CodeBridgeNotConnected, err.Error())
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	if resp.Error != nil {
-		result["error"] = resp.Error.Message
-		return jsonString(result), nil
+		SetToolError(ctx, resp.Error)
+		return toolErrorString(resp.Error), nil
 	}
 	var data struct {
 		Text string `json:"text"`
 	}
 	if len(resp.Data) > 0 {
 		if err := json.Unmarshal(resp.Data, &data); err != nil {
-			result["ok"] = false
-			result["error"] = fmt.Sprintf("decode clipboard data: %v", err)
-			return jsonString(result), nil
+			te := NewToolError(CodeToolExecutionFailed, fmt.Sprintf("decode clipboard data: %v", err))
+			SetToolError(ctx, te)
+			return toolErrorString(te), nil
 		}
 	}
-	result["text"] = data.Text
+	result := map[string]interface{}{"text": data.Text}
+	if restored {
+		result["restored_from_return_entry"] = true
+	}
 	return jsonString(result), nil
 }
 
@@ -140,14 +145,17 @@ func (t *ClipboardTool) write(ctx context.Context, text string) (string, error) 
 		TimeoutMs: 5000,
 	})
 	if err != nil {
-		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
-	}
-	result := map[string]interface{}{"ok": resp.Error == nil}
-	if restored {
-		result["restored_from_return_entry"] = true
+		te := NewToolError(CodeBridgeNotConnected, err.Error())
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	if resp.Error != nil {
-		result["error"] = resp.Error.Message
+		SetToolError(ctx, resp.Error)
+		return toolErrorString(resp.Error), nil
+	}
+	result := map[string]interface{}{}
+	if restored {
+		result["restored_from_return_entry"] = true
 	}
 	return jsonString(result), nil
 }
@@ -207,7 +215,9 @@ type calendarArgs struct {
 func (t *CalendarTool) Call(ctx context.Context, input string) (string, error) {
 	var args calendarArgs
 	if err := json.Unmarshal([]byte(strings.TrimSpace(input)), &args); err != nil {
-		return bridgeMsgError("invalid input: %v. Expected JSON format: {\"action\":\"create\",\"title\":\"...\",\"start_at\":\"2026-06-02T15:00:00+08:00\",...} or {\"action\":\"query\",\"from\":\"...\",\"to\":\"...\"} or {\"action\":\"delete\",\"event_id\":\"...\"}. Times must be RFC3339 format with timezone", err), nil
+		te := NewToolError(CodeInvalidArguments, fmt.Sprintf("invalid input: %v. Expected JSON like {\"action\":\"create\",\"title\":\"...\",\"start_at\":\"2026-06-02T15:00:00+08:00\"} or {\"action\":\"query\",\"from\":\"...\",\"to\":\"...\"}", err))
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	switch strings.ToLower(strings.TrimSpace(args.Action)) {
@@ -218,16 +228,22 @@ func (t *CalendarTool) Call(ctx context.Context, input string) (string, error) {
 	case "delete":
 		return t.delete(ctx, args)
 	default:
-		return bridgeMsgError("unknown action %q, expected \"create\", \"query\", or \"delete\"", args.Action), nil
+		te := NewToolError(CodeInvalidArguments, fmt.Sprintf("unknown action %q, expected \"create\", \"query\", or \"delete\"", args.Action))
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 }
 
 func (t *CalendarTool) create(ctx context.Context, args calendarArgs) (string, error) {
 	if strings.TrimSpace(args.Title) == "" {
-		return bridgeMsgError("create requires a title"), nil
+		te := NewToolError(CodeInvalidArguments, "create requires a title")
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	if strings.TrimSpace(args.StartAt) == "" {
-		return bridgeMsgError("create requires a start_at time (RFC3339)"), nil
+		te := NewToolError(CodeInvalidArguments, "create requires a start_at time (RFC3339)")
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	payload, _ := json.Marshal(map[string]interface{}{
 		"title":                args.Title,
@@ -245,33 +261,36 @@ func (t *CalendarTool) create(ctx context.Context, args calendarArgs) (string, e
 		TimeoutMs: 8000,
 	})
 	if err != nil {
-		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
-	}
-	result := map[string]interface{}{"ok": resp.Error == nil}
-	if restored {
-		result["restored_from_return_entry"] = true
+		te := NewToolError(CodeBridgeNotConnected, err.Error())
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	if resp.Error != nil {
-		result["error"] = resp.Error.Message
-		return jsonString(result), nil
+		SetToolError(ctx, resp.Error)
+		return toolErrorString(resp.Error), nil
 	}
 	var data struct {
 		EventID string `json:"event_id"`
 	}
 	if len(resp.Data) > 0 {
 		if err := json.Unmarshal(resp.Data, &data); err != nil {
-			result["ok"] = false
-			result["error"] = fmt.Sprintf("decode calendar data: %v", err)
-			return jsonString(result), nil
+			te := NewToolError(CodeToolExecutionFailed, fmt.Sprintf("decode calendar data: %v", err))
+			SetToolError(ctx, te)
+			return toolErrorString(te), nil
 		}
 	}
-	result["event_id"] = data.EventID
+	result := map[string]interface{}{"event_id": data.EventID}
+	if restored {
+		result["restored_from_return_entry"] = true
+	}
 	return jsonString(result), nil
 }
 
 func (t *CalendarTool) query(ctx context.Context, args calendarArgs) (string, error) {
 	if strings.TrimSpace(args.From) == "" || strings.TrimSpace(args.To) == "" {
-		return bridgeMsgError("query requires both from and to times (RFC3339)"), nil
+		te := NewToolError(CodeInvalidArguments, "query requires both from and to times (RFC3339)")
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	payload, _ := json.Marshal(map[string]string{"from": args.From, "to": args.To})
 	resp, restored, err := sendForegroundBridgeCommand(ctx, t.bridge, t.restorer, BridgeCommand{
@@ -281,36 +300,39 @@ func (t *CalendarTool) query(ctx context.Context, args calendarArgs) (string, er
 		TimeoutMs: 8000,
 	})
 	if err != nil {
-		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
-	}
-	result := map[string]interface{}{"ok": resp.Error == nil}
-	if restored {
-		result["restored_from_return_entry"] = true
+		te := NewToolError(CodeBridgeNotConnected, err.Error())
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	if resp.Error != nil {
-		result["error"] = resp.Error.Message
-		return jsonString(result), nil
+		SetToolError(ctx, resp.Error)
+		return toolErrorString(resp.Error), nil
 	}
 	var data struct {
 		Events []map[string]interface{} `json:"events"`
 	}
 	if len(resp.Data) > 0 {
 		if err := json.Unmarshal(resp.Data, &data); err != nil {
-			result["ok"] = false
-			result["error"] = fmt.Sprintf("decode calendar data: %v", err)
-			return jsonString(result), nil
+			te := NewToolError(CodeToolExecutionFailed, fmt.Sprintf("decode calendar data: %v", err))
+			SetToolError(ctx, te)
+			return toolErrorString(te), nil
 		}
 	}
 	if data.Events == nil {
 		data.Events = []map[string]interface{}{}
 	}
-	result["events"] = data.Events
+	result := map[string]interface{}{"events": data.Events}
+	if restored {
+		result["restored_from_return_entry"] = true
+	}
 	return jsonString(result), nil
 }
 
 func (t *CalendarTool) delete(ctx context.Context, args calendarArgs) (string, error) {
 	if strings.TrimSpace(args.EventID) == "" {
-		return bridgeMsgError("delete requires an event_id"), nil
+		te := NewToolError(CodeInvalidArguments, "delete requires an event_id")
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	payload, _ := json.Marshal(map[string]string{"event_id": args.EventID})
 	resp, restored, err := sendForegroundBridgeCommand(ctx, t.bridge, t.restorer, BridgeCommand{
@@ -320,14 +342,17 @@ func (t *CalendarTool) delete(ctx context.Context, args calendarArgs) (string, e
 		TimeoutMs: 8000,
 	})
 	if err != nil {
-		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
-	}
-	result := map[string]interface{}{"ok": resp.Error == nil}
-	if restored {
-		result["restored_from_return_entry"] = true
+		te := NewToolError(CodeBridgeNotConnected, err.Error())
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	if resp.Error != nil {
-		result["error"] = resp.Error.Message
+		SetToolError(ctx, resp.Error)
+		return toolErrorString(resp.Error), nil
+	}
+	result := map[string]interface{}{}
+	if restored {
+		result["restored_from_return_entry"] = true
 	}
 	return jsonString(result), nil
 }
@@ -381,7 +406,7 @@ type contactsArgs struct {
 func (t *ContactsTool) Call(ctx context.Context, input string) (string, error) {
 	var args contactsArgs
 	if err := json.Unmarshal([]byte(strings.TrimSpace(input)), &args); err != nil {
-		return bridgeMsgError("invalid input: %v. Expected JSON format: {\"action\":\"query\",\"query\":\"name\",\"limit\":20} or {\"action\":\"create\",\"name\":\"...\",\"phone_numbers\":[\"...\"],\"emails\":[\"...\"]} or {\"action\":\"update\",\"contact_id\":\"...\",\"name\":\"...\"}. Arrays must use square brackets", err), nil
+		return toolErrorHelper("invalid input: %v. Expected JSON format: {\"action\":\"query\",\"query\":\"name\",\"limit\":20} or {\"action\":\"create\",\"name\":\"...\",\"phone_numbers\":[\"...\"],\"emails\":[\"...\"]} or {\"action\":\"update\",\"contact_id\":\"...\",\"name\":\"...\"}. Arrays must use square brackets", err), nil
 	}
 
 	switch strings.ToLower(strings.TrimSpace(args.Action)) {
@@ -392,7 +417,7 @@ func (t *ContactsTool) Call(ctx context.Context, input string) (string, error) {
 	case "update":
 		return t.update(ctx, args)
 	default:
-		return bridgeMsgError("unknown action %q, expected \"query\", \"create\", or \"update\"", args.Action), nil
+		return toolErrorHelper("unknown action %q, expected \"query\", \"create\", or \"update\"", args.Action), nil
 	}
 }
 
@@ -412,24 +437,26 @@ func (t *ContactsTool) query(ctx context.Context, args contactsArgs) (string, er
 		TimeoutMs: 8000,
 	})
 	if err != nil {
-		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
+		te := NewToolError(CodeBridgeNotConnected, err.Error())
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
-	result := map[string]interface{}{"ok": resp.Error == nil}
+	result := map[string]interface{}{}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
 	if resp.Error != nil {
-		result["error"] = resp.Error.Message
-		return jsonString(result), nil
+		SetToolError(ctx, resp.Error)
+		return toolErrorString(resp.Error), nil
 	}
 	var data struct {
 		Contacts []map[string]interface{} `json:"contacts"`
 	}
 	if len(resp.Data) > 0 {
 		if err := json.Unmarshal(resp.Data, &data); err != nil {
-			result["ok"] = false
-			result["error"] = fmt.Sprintf("decode contacts data: %v", err)
-			return jsonString(result), nil
+			te := NewToolError(CodeToolExecutionFailed, fmt.Sprintf("decode contacts data: %v", err))
+			SetToolError(ctx, te)
+			return toolErrorString(te), nil
 		}
 	}
 	if data.Contacts == nil {
@@ -441,7 +468,9 @@ func (t *ContactsTool) query(ctx context.Context, args contactsArgs) (string, er
 
 func (t *ContactsTool) create(ctx context.Context, args contactsArgs) (string, error) {
 	if strings.TrimSpace(args.Name) == "" {
-		return bridgeMsgError("create requires a name"), nil
+		te := NewToolError(CodeInvalidArguments, fmt.Sprintf("create requires a name"))
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	payload, _ := json.Marshal(map[string]interface{}{
 		"name":          args.Name,
@@ -457,24 +486,26 @@ func (t *ContactsTool) create(ctx context.Context, args contactsArgs) (string, e
 		TimeoutMs: 8000,
 	})
 	if err != nil {
-		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
+		te := NewToolError(CodeBridgeNotConnected, err.Error())
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
-	result := map[string]interface{}{"ok": resp.Error == nil}
+	result := map[string]interface{}{}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
 	if resp.Error != nil {
-		result["error"] = resp.Error.Message
-		return jsonString(result), nil
+		SetToolError(ctx, resp.Error)
+		return toolErrorString(resp.Error), nil
 	}
 	var data struct {
 		ContactID string `json:"contact_id"`
 	}
 	if len(resp.Data) > 0 {
 		if err := json.Unmarshal(resp.Data, &data); err != nil {
-			result["ok"] = false
-			result["error"] = fmt.Sprintf("decode contacts data: %v", err)
-			return jsonString(result), nil
+			te := NewToolError(CodeToolExecutionFailed, fmt.Sprintf("decode contacts data: %v", err))
+			SetToolError(ctx, te)
+			return toolErrorString(te), nil
 		}
 	}
 	result["contact_id"] = data.ContactID
@@ -483,7 +514,9 @@ func (t *ContactsTool) create(ctx context.Context, args contactsArgs) (string, e
 
 func (t *ContactsTool) update(ctx context.Context, args contactsArgs) (string, error) {
 	if strings.TrimSpace(args.ContactID) == "" {
-		return bridgeMsgError("update requires a contact_id"), nil
+		te := NewToolError(CodeInvalidArguments, fmt.Sprintf("update requires a contact_id"))
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	payload, _ := json.Marshal(map[string]interface{}{
 		"contact_id":    args.ContactID,
@@ -500,9 +533,11 @@ func (t *ContactsTool) update(ctx context.Context, args contactsArgs) (string, e
 		TimeoutMs: 8000,
 	})
 	if err != nil {
-		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
+		te := NewToolError(CodeBridgeNotConnected, err.Error())
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
-	result := map[string]interface{}{"ok": resp.Error == nil}
+	result := map[string]interface{}{}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
@@ -554,11 +589,13 @@ type notificationArgs struct {
 func (t *NotificationTool) Call(ctx context.Context, input string) (string, error) {
 	var args notificationArgs
 	if err := json.Unmarshal([]byte(strings.TrimSpace(input)), &args); err != nil {
-		return bridgeMsgError("invalid input: %v. Expected JSON format: {\"title\":\"Reminder\",\"body\":\"Take medicine\",\"schedule_at\":\"2026-06-04T18:00:00+08:00\",\"sound\":true,\"badge\":1}. schedule_at is optional, sound and badge are boolean/number", err), nil
+		return toolErrorHelper("invalid input: %v. Expected JSON format: {\"title\":\"Reminder\",\"body\":\"Take medicine\",\"schedule_at\":\"2026-06-04T18:00:00+08:00\",\"sound\":true,\"badge\":1}. schedule_at is optional, sound and badge are boolean/number", err), nil
 	}
 
 	if strings.TrimSpace(args.Title) == "" {
-		return bridgeMsgError("notification requires a title"), nil
+		te := NewToolError(CodeInvalidArguments, fmt.Sprintf("notification requires a title"))
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	payload, _ := json.Marshal(map[string]interface{}{
@@ -575,24 +612,26 @@ func (t *NotificationTool) Call(ctx context.Context, input string) (string, erro
 		TimeoutMs: 5000,
 	})
 	if err != nil {
-		return bridgeRespError(err, bridgeStatusForError(t.bridge)...), nil
+		te := NewToolError(CodeBridgeNotConnected, err.Error())
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
-	result := map[string]interface{}{"ok": resp.Error == nil}
+	result := map[string]interface{}{}
 	if restored {
 		result["restored_from_return_entry"] = true
 	}
 	if resp.Error != nil {
-		result["error"] = resp.Error.Message
-		return jsonString(result), nil
+		SetToolError(ctx, resp.Error)
+		return toolErrorString(resp.Error), nil
 	}
 	var data struct {
 		NotificationID string `json:"notification_id"`
 	}
 	if len(resp.Data) > 0 {
 		if err := json.Unmarshal(resp.Data, &data); err != nil {
-			result["ok"] = false
-			result["error"] = fmt.Sprintf("decode notification data: %v", err)
-			return jsonString(result), nil
+			te := NewToolError(CodeToolExecutionFailed, fmt.Sprintf("decode notification data: %v", err))
+			SetToolError(ctx, te)
+			return toolErrorString(te), nil
 		}
 	}
 	result["notification_id"] = data.NotificationID

--- a/src/agent/internal/agent/tools_phone_bridge_test.go
+++ b/src/agent/internal/agent/tools_phone_bridge_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -269,5 +270,40 @@ func TestOpenAppResultMetadataForAndroidIntent(t *testing.T) {
 	}
 	if got := openAppResultMechanism(args, ""); got != "android_intent" {
 		t.Fatalf("fallback mechanism = %q, want android_intent", got)
+	}
+}
+
+func TestOpenAppMissingArgsReturnsInvalidArguments(t *testing.T) {
+	tool := &OpenAppTool{}
+	ctx, _ := WithToolError(context.Background())
+	out, err := tool.Call(ctx, `{}`)
+	if err != nil {
+		t.Fatalf("Call returned err: %v", err)
+	}
+	te := ToolErrorFromContext(ctx)
+	if te == nil {
+		t.Fatalf("expected structured ToolError on context; got nil")
+	}
+	if te.Code != CodeInvalidArguments {
+		t.Errorf("Code = %q want %q", te.Code, CodeInvalidArguments)
+	}
+	if out != te.Message {
+		t.Errorf("Call output (%q) must equal Error.Message (%q)", out, te.Message)
+	}
+}
+
+func TestOpenAppUnknownAppReturnsUnknownApp(t *testing.T) {
+	tool := &OpenAppTool{}
+	ctx, _ := WithToolError(context.Background())
+	out, err := tool.Call(ctx, `{"app":"NoSuchApp12345"}`)
+	if err != nil {
+		t.Fatalf("Call returned err: %v", err)
+	}
+	te := ToolErrorFromContext(ctx)
+	if te == nil || te.Code != CodeUnknownApp {
+		t.Fatalf("expected unknown_app; got %+v", te)
+	}
+	if out != te.Message {
+		t.Errorf("Call output (%q) must equal Error.Message (%q)", out, te.Message)
 	}
 }

--- a/src/agent/internal/agent/tools_phone_bridge_test.go
+++ b/src/agent/internal/agent/tools_phone_bridge_test.go
@@ -2,8 +2,14 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
 )
 
 func TestBundledAppMappingPathUsesOEMPartition(t *testing.T) {
@@ -306,4 +312,136 @@ func TestOpenAppUnknownAppReturnsUnknownApp(t *testing.T) {
 	if out != te.Message {
 		t.Errorf("Call output (%q) must equal Error.Message (%q)", out, te.Message)
 	}
+}
+
+func TestContactsInvalidInputReturnsStructuredError(t *testing.T) {
+	tool := NewContactsTool(nil, nil)
+	ctx, _ := WithToolError(context.Background())
+	out, err := tool.Call(ctx, `{bad json`)
+	if err != nil {
+		t.Fatalf("Call returned err: %v", err)
+	}
+	te := ToolErrorFromContext(ctx)
+	if te == nil || te.Code != CodeInvalidArguments {
+		t.Fatalf("expected invalid_arguments; got %+v", te)
+	}
+	if out != te.Message {
+		t.Fatalf("Call output (%q) must equal Error.Message (%q)", out, te.Message)
+	}
+}
+
+func TestNotificationInvalidInputReturnsStructuredError(t *testing.T) {
+	tool := NewNotificationTool(nil, nil)
+	ctx, _ := WithToolError(context.Background())
+	out, err := tool.Call(ctx, `{bad json`)
+	if err != nil {
+		t.Fatalf("Call returned err: %v", err)
+	}
+	te := ToolErrorFromContext(ctx)
+	if te == nil || te.Code != CodeInvalidArguments {
+		t.Fatalf("expected invalid_arguments; got %+v", te)
+	}
+	if out != te.Message {
+		t.Fatalf("Call output (%q) must equal Error.Message (%q)", out, te.Message)
+	}
+}
+
+func TestContactsUpdatePropagatesAppToolError(t *testing.T) {
+	bridge := newTestPhoneBridgeWithApp(t, func(cmd BridgeCommand) BridgeCommandResponse {
+		return BridgeCommandResponse{
+			ID:    cmd.ID,
+			Error: NewToolError(CodePermissionDenied, "contacts permission denied"),
+		}
+	})
+	tool := NewContactsTool(bridge, nil)
+	ctx, _ := WithToolError(context.Background())
+
+	out, err := tool.Call(ctx, `{"action":"update","contact_id":"abc","name":"Alice"}`)
+	if err != nil {
+		t.Fatalf("Call returned err: %v", err)
+	}
+	te := ToolErrorFromContext(ctx)
+	if te == nil || te.Code != CodePermissionDenied {
+		t.Fatalf("expected permission_denied; got %+v output=%q", te, out)
+	}
+	if out != te.Message {
+		t.Fatalf("Call output (%q) must equal Error.Message (%q)", out, te.Message)
+	}
+}
+
+func TestClipboardReadSuccessPreservesOKField(t *testing.T) {
+	bridge := newTestPhoneBridgeWithApp(t, func(cmd BridgeCommand) BridgeCommandResponse {
+		return BridgeCommandResponse{
+			ID:   cmd.ID,
+			Data: json.RawMessage(`{"text":"hello"}`),
+		}
+	})
+	tool := NewClipboardTool(bridge, nil)
+
+	out, err := tool.Call(context.Background(), `{"action":"read"}`)
+	if err != nil {
+		t.Fatalf("Call returned err: %v", err)
+	}
+	var payload struct {
+		OK   bool   `json:"ok"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("output is not JSON: %v", err)
+	}
+	if !payload.OK || payload.Text != "hello" {
+		t.Fatalf("clipboard success payload = %+v, raw=%s; want ok=true text=hello", payload, out)
+	}
+}
+
+func newTestPhoneBridgeWithApp(t *testing.T, handle func(BridgeCommand) BridgeCommandResponse) *PhoneBridge {
+	t.Helper()
+	bridge := NewPhoneBridge(nil)
+	t.Cleanup(func() { bridge.queue.Stop() })
+
+	server := httptest.NewServer(http.HandlerFunc(bridge.HandleWebSocket))
+	t.Cleanup(server.Close)
+
+	dialURL := "ws" + strings.TrimPrefix(server.URL, "http") + "?platform=android"
+	dialCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(dialCtx, dialURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial failed: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
+
+	go func() {
+		for {
+			_, data, err := conn.Read(context.Background())
+			if err != nil {
+				return
+			}
+			var cmd BridgeCommand
+			if err := json.Unmarshal(data, &cmd); err != nil {
+				return
+			}
+			resp := handle(cmd)
+			if resp.ID == "" {
+				resp.ID = cmd.ID
+			}
+			payload, err := json.Marshal(resp)
+			if err != nil {
+				return
+			}
+			if err := conn.Write(context.Background(), websocket.MessageText, payload); err != nil {
+				return
+			}
+		}
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if bridge.Status().Connected {
+			return bridge
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("phone bridge did not connect")
+	return nil
 }

--- a/src/agent/internal/agent/tools_post_action_screenshot.go
+++ b/src/agent/internal/agent/tools_post_action_screenshot.go
@@ -100,6 +100,9 @@ func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (stri
 			if err != nil {
 				return "", err
 			}
+			if te := ToolErrorFromContext(ctx); te != nil {
+				return wrapPostActionSubtoolError(ctx, te, "%s completed with output %q, but stable-screen wait failed: %s", t.inner.Name(), actionOutput, te.Message), nil
+			}
 			if legacyToolOutputLooksLikeError(waitOutput) {
 				return toolErrorResultf(ctx, CodeToolExecutionFailed, "%s completed with output %q, but stable-screen wait failed: %s", t.inner.Name(), actionOutput, waitOutput), nil
 			}
@@ -121,6 +124,9 @@ func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (stri
 	if err != nil {
 		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%s completed with output %q, but post-action screenshot failed: %v", t.inner.Name(), actionOutput, err), nil
 	}
+	if te := ToolErrorFromContext(ctx); te != nil {
+		return wrapPostActionSubtoolError(ctx, te, "%s completed with output %q, but post-action screenshot failed: %s", t.inner.Name(), actionOutput, te.Message), nil
+	}
 
 	var result screenshotResult
 	if err := json.Unmarshal([]byte(screenshotOutput), &result); err != nil {
@@ -141,6 +147,12 @@ func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (stri
 
 	out, _ := json.Marshal(payload)
 	return string(out), nil
+}
+
+func wrapPostActionSubtoolError(ctx context.Context, te *ToolError, format string, args ...any) string {
+	wrapped := NewToolErrorWithDetails(te.Code, fmt.Sprintf(format, args...), te.Details)
+	SetToolError(ctx, wrapped)
+	return toolErrorString(wrapped)
 }
 
 func waitForPostActionScreenshot(ctx context.Context, delay time.Duration) error {

--- a/src/agent/internal/agent/tools_post_action_screenshot.go
+++ b/src/agent/internal/agent/tools_post_action_screenshot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	langtools "github.com/tmc/langchaingo/tools"
@@ -77,8 +78,14 @@ func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (stri
 	if err != nil {
 		return "", err
 	}
-	if toolOutputLooksLikeError(actionOutput) {
-		return actionOutput, nil
+	if te := ToolErrorFromContext(ctx); te != nil {
+		return toolErrorString(te), nil
+	}
+	if legacyToolOutputLooksLikeError(actionOutput) {
+		trimmed := strings.TrimSpace(actionOutput)
+		te := NewToolError(CodeToolExecutionFailed, strings.TrimSpace(trimmed[len("error:"):]))
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	var waitResult waitStableScreenResult
@@ -86,25 +93,25 @@ func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (stri
 		if waiter, ok := t.waitStable.(stableScreenWaiter); ok {
 			waitResult, err = waiter.wait(ctx, t.waitInput)
 			if err != nil {
-				return fmt.Sprintf("error: %s completed with output %q, but stable-screen wait failed: %v", t.inner.Name(), actionOutput, err), nil
+				return toolErrorResultf(ctx, CodeToolExecutionFailed, "%s completed with output %q, but stable-screen wait failed: %v", t.inner.Name(), actionOutput, err), nil
 			}
 		} else {
 			waitOutput, err := t.waitStable.Call(ctx, t.waitInput)
 			if err != nil {
 				return "", err
 			}
-			if toolOutputLooksLikeError(waitOutput) {
-				return fmt.Sprintf("error: %s completed with output %q, but stable-screen wait failed: %s", t.inner.Name(), actionOutput, waitOutput), nil
+			if legacyToolOutputLooksLikeError(waitOutput) {
+				return toolErrorResultf(ctx, CodeToolExecutionFailed, "%s completed with output %q, but stable-screen wait failed: %s", t.inner.Name(), actionOutput, waitOutput), nil
 			}
 			if err := json.Unmarshal([]byte(waitOutput), &waitResult); err != nil {
-				return fmt.Sprintf("error: %s completed with output %q, but stable-screen wait returned invalid JSON: %v", t.inner.Name(), actionOutput, err), nil
+				return toolErrorResultf(ctx, CodeToolExecutionFailed, "%s completed with output %q, but stable-screen wait returned invalid JSON: %v", t.inner.Name(), actionOutput, err), nil
 			}
 			if !waitResult.OK {
-				return fmt.Sprintf("error: %s completed with output %q, but stable-screen wait failed: %s", t.inner.Name(), actionOutput, waitOutput), nil
+				return toolErrorResultf(ctx, CodeToolExecutionFailed, "%s completed with output %q, but stable-screen wait failed: %s", t.inner.Name(), actionOutput, waitOutput), nil
 			}
 		}
 		if !waitResult.OK {
-			return fmt.Sprintf("error: %s completed with output %q, but stable-screen wait failed", t.inner.Name(), actionOutput), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%s completed with output %q, but stable-screen wait failed", t.inner.Name(), actionOutput), nil
 		}
 	} else if err := waitForPostActionScreenshot(ctx, t.delay); err != nil {
 		return "", err
@@ -112,12 +119,12 @@ func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (stri
 
 	screenshotOutput, err := t.screenshot.Call(ctx, "{}")
 	if err != nil {
-		return fmt.Sprintf("error: %s completed with output %q, but post-action screenshot failed: %v", t.inner.Name(), actionOutput, err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%s completed with output %q, but post-action screenshot failed: %v", t.inner.Name(), actionOutput, err), nil
 	}
 
 	var result screenshotResult
 	if err := json.Unmarshal([]byte(screenshotOutput), &result); err != nil {
-		return fmt.Sprintf("error: %s completed with output %q, but post-action screenshot was invalid: %v", t.inner.Name(), actionOutput, err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%s completed with output %q, but post-action screenshot was invalid: %v", t.inner.Name(), actionOutput, err), nil
 	}
 
 	payload := postActionScreenshotResult{

--- a/src/agent/internal/agent/tools_quick_actions.go
+++ b/src/agent/internal/agent/tools_quick_actions.go
@@ -386,11 +386,15 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 	var args quickActionArgs
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {
-		return t.errorJSON("action or list is required"), nil
+		te := NewToolError(CodeInvalidArguments, "action or list is required")
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	if strings.HasPrefix(trimmed, "{") {
 		if err := json.Unmarshal([]byte(trimmed), &args); err != nil {
-			return fmt.Sprintf("error: invalid input: %v", err), nil
+			te := NewToolError(CodeInvalidArguments, fmt.Sprintf("invalid input: %v", err))
+			SetToolError(ctx, te)
+			return toolErrorString(te), nil
 		}
 	} else {
 		args.Action = trimmed
@@ -398,7 +402,9 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 
 	platform, err := normalizeQuickActionPlatform(args.Platform)
 	if err != nil {
-		return t.errorJSON(err.Error()), nil
+		te := NewToolError(CodeInvalidArguments, err.Error())
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	if strings.EqualFold(strings.TrimSpace(args.Action), "list") {
@@ -415,12 +421,19 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 		if len(suggestions) > 0 {
 			message = fmt.Sprintf("%s; suggested actions: %s", message, strings.Join(suggestions, ", "))
 		}
-		return t.errorJSON(message), nil
+		te := NewToolErrorWithDetails(CodeQuickActionUnknown, message,
+			map[string]any{"action": args.Action, "platform": platform, "suggestions": suggestions})
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	action, binding, ok := globalQuickActions.lookup(actionID, platform)
 	if !ok {
-		return t.errorJSON(fmt.Sprintf("action %q is not defined for platform %q", actionID, platform)), nil
+		te := NewToolErrorWithDetails(CodeQuickActionUnsupportedPlatform,
+			fmt.Sprintf("action %q is not defined for platform %q", actionID, platform),
+			map[string]any{"action": actionID, "platform": platform})
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	selected := binding
@@ -431,7 +444,10 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 			idx = 1
 		}
 		if len(binding.Alternatives) < idx {
-			return t.errorJSON(fmt.Sprintf("action %q has no alternative #%d on platform %q", actionID, idx, platform)), nil
+			te := NewToolError(CodeInvalidArguments,
+				fmt.Sprintf("action %q has no alternative #%d on platform %q", actionID, idx, platform))
+			SetToolError(ctx, te)
+			return toolErrorString(te), nil
 		}
 		selected = binding.Alternatives[idx-1]
 		selectedSource = fmt.Sprintf("alternative_%d", idx)
@@ -446,17 +462,21 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 		if note == "" {
 			note = "reserved on this platform"
 		}
-		return jsonString(map[string]interface{}{
-			"ok":       false,
-			"status":   quickActionStatusReserved,
-			"action":   actionID,
-			"label":    action.Label,
-			"platform": platform,
-			"message":  note,
-		}), nil
+		te := NewToolErrorWithDetails(CodeQuickActionReserved, note,
+			map[string]any{
+				"action":   actionID,
+				"label":    action.Label,
+				"platform": platform,
+				"status":   quickActionStatusReserved,
+			})
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 	if status != quickActionStatusActive {
-		return t.errorJSON(fmt.Sprintf("action %q has unsupported status %q on platform %q", actionID, status, platform)), nil
+		te := NewToolError(CodeQuickActionInvalidBinding,
+			fmt.Sprintf("action %q has unsupported status %q on platform %q", actionID, status, platform))
+		SetToolError(ctx, te)
+		return toolErrorString(te), nil
 	}
 
 	toolName := strings.TrimSpace(selected.Tool)
@@ -469,15 +489,21 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 		for i, step := range selected.Steps {
 			stepTool := strings.TrimSpace(step.Tool)
 			if stepTool == "" {
-				return t.errorJSON(fmt.Sprintf("action %q step %d has no tool binding configured", actionID, i+1)), nil
+				te := NewToolError(CodeQuickActionInvalidBinding,
+					fmt.Sprintf("action %q step %d has no tool binding configured", actionID, i+1))
+				SetToolError(ctx, te)
+				return toolErrorString(te), nil
 			}
 			stepPayload, err := json.Marshal(step.Input)
 			if err != nil {
-				return t.errorJSON(fmt.Sprintf("invalid action step %d input: %v", i+1, err)), nil
+				te := NewToolError(CodeQuickActionInvalidBinding,
+					fmt.Sprintf("invalid action step %d input: %v", i+1, err))
+				SetToolError(ctx, te)
+				return toolErrorString(te), nil
 			}
-			stepOutput, err := t.delegate(ctx, stepTool, string(stepPayload))
+			stepOutput, subErr, err := t.delegate(ctx, stepTool, string(stepPayload))
 			if err != nil {
-				return fmt.Sprintf("error: %v", err), nil
+				return "", err
 			}
 			stepResult := map[string]interface{}{
 				"index":  i + 1,
@@ -489,18 +515,23 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 				stepResult["delay_ms_after"] = step.DelayMsAfter
 			}
 			stepResults = append(stepResults, stepResult)
-			if strings.HasPrefix(stepOutput, "error:") {
-				return jsonString(map[string]interface{}{
-					"ok":          false,
-					"action":      actionID,
-					"label":       action.Label,
-					"platform":    platform,
-					"binding":     selectedSource,
-					"tool":        "sequence",
-					"failed_step": i + 1,
-					"output":      stepOutput,
-					"steps":       stepResults,
-				}), nil
+			if subErr != nil {
+				te := NewToolErrorWithDetails(CodeSubtoolFailed,
+					fmt.Sprintf("step %d (%s) failed: %s", i+1, stepTool, subErr.Message),
+					map[string]any{
+						"source":        "tool:quick_action",
+						"action":        actionID,
+						"label":         action.Label,
+						"platform":      platform,
+						"binding":       selectedSource,
+						"failed_step":   i + 1,
+						"subtool":       stepTool,
+						"subtool_error": subErr,
+						"steps":         stepResults,
+					})
+				te.Category = subErr.Category
+				SetToolError(ctx, te)
+				return toolErrorString(te), nil
 			}
 			if err := sleepQuickActionDelay(ctx, step.DelayMsAfter); err != nil {
 				return "", err
@@ -512,30 +543,40 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 			if note == "" {
 				note = "no tool binding configured"
 			}
-			return t.errorJSON(note), nil
+			te := NewToolError(CodeQuickActionInvalidBinding, note)
+			SetToolError(ctx, te)
+			return toolErrorString(te), nil
 		}
 
 		var err error
 		payload, err = json.Marshal(selected.Input)
 		if err != nil {
-			return t.errorJSON(fmt.Sprintf("invalid action input: %v", err)), nil
+			te := NewToolError(CodeQuickActionInvalidBinding, fmt.Sprintf("invalid action input: %v", err))
+			SetToolError(ctx, te)
+			return toolErrorString(te), nil
 		}
 
-		output, err = t.delegate(ctx, toolName, string(payload))
+		var subErr *ToolError
+		output, subErr, err = t.delegate(ctx, toolName, string(payload))
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return "", err
 		}
-		if strings.HasPrefix(output, "error:") {
-			return jsonString(map[string]interface{}{
-				"ok":       false,
-				"action":   actionID,
-				"label":    action.Label,
-				"platform": platform,
-				"binding":  selectedSource,
-				"tool":     toolName,
-				"input":    json.RawMessage(payload),
-				"output":   output,
-			}), nil
+		if subErr != nil {
+			te := NewToolErrorWithDetails(CodeSubtoolFailed,
+				fmt.Sprintf("step 1 (%s) failed: %s", toolName, subErr.Message),
+				map[string]any{
+					"source":        "tool:quick_action",
+					"action":        actionID,
+					"label":         action.Label,
+					"platform":      platform,
+					"binding":       selectedSource,
+					"failed_step":   1,
+					"subtool":       toolName,
+					"subtool_error": subErr,
+				})
+			te.Category = subErr.Category
+			SetToolError(ctx, te)
+			return toolErrorString(te), nil
 		}
 	}
 
@@ -572,21 +613,28 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 	return jsonString(result), nil
 }
 
-func (t *QuickActionTool) delegate(ctx context.Context, toolName, payload string) (string, error) {
+func (t *QuickActionTool) delegate(ctx context.Context, toolName, payload string) (string, *ToolError, error) {
+	subCtx, _ := WithToolError(ctx)
+	var output string
+	var err error
 	switch toolName {
 	case "keyboard_tap":
 		if t.keyboard == nil {
-			return "", fmt.Errorf("keyboard_tap is not available")
+			return "", nil, fmt.Errorf("keyboard_tap is not available")
 		}
-		return t.keyboard.Call(ctx, payload)
+		output, err = t.keyboard.Call(subCtx, payload)
 	case "touch_gesture":
 		if t.touch == nil {
-			return "", fmt.Errorf("touch_gesture is not available")
+			return "", nil, fmt.Errorf("touch_gesture is not available")
 		}
-		return t.touch.Call(ctx, payload)
+		output, err = t.touch.Call(subCtx, payload)
 	default:
-		return "", fmt.Errorf("unsupported delegated tool %q", toolName)
+		return "", nil, fmt.Errorf("unsupported delegated tool %q", toolName)
 	}
+	if err != nil {
+		return output, nil, err
+	}
+	return output, ToolErrorFromContext(subCtx), nil
 }
 
 func sleepQuickActionDelay(ctx context.Context, delayMs int) error {
@@ -679,13 +727,6 @@ func platformNote(actionID, platform string, binding quickActionBinding) string 
 		return ""
 	}
 	return fmt.Sprintf("%s on %s has no primary tool binding", actionID, platform)
-}
-
-func (t *QuickActionTool) errorJSON(message string) string {
-	return jsonString(map[string]interface{}{
-		"ok":    false,
-		"error": message,
-	})
 }
 
 func quickActionBehaviorSummary() string {

--- a/src/agent/internal/agent/tools_quick_actions.go
+++ b/src/agent/internal/agent/tools_quick_actions.go
@@ -634,7 +634,15 @@ func (t *QuickActionTool) delegate(ctx context.Context, toolName, payload string
 	if err != nil {
 		return output, nil, err
 	}
-	return output, ToolErrorFromContext(subCtx), nil
+	if te := ToolErrorFromContext(subCtx); te != nil {
+		return output, te, nil
+	}
+	if legacyToolOutputLooksLikeError(output) {
+		trimmed := strings.TrimSpace(output)
+		message := strings.TrimSpace(trimmed[len("error:"):])
+		return output, NewToolError(CodeToolExecutionFailed, message), nil
+	}
+	return output, nil, nil
 }
 
 func sleepQuickActionDelay(ctx context.Context, delayMs int) error {

--- a/src/agent/internal/agent/tools_quick_actions.go
+++ b/src/agent/internal/agent/tools_quick_actions.go
@@ -742,7 +742,7 @@ func quickActionBehaviorSummary() string {
 		"Common actions: back, home, hide_app, quit_app, app_switch, spotlight_search, copy, paste, cut, undo, redo, select_all, delete_backward, delete_forward, find, send, browser_new_tab, browser_close_tab, browser_refresh, browser_address_bar, screenshot_full, screenshot_region.",
 		"- Infer platform from screenshot/context and pass platform=ios/android/mac.",
 		"- Prefer quick_action before ad-hoc keyboard_tap or touch_gesture when an active catalog entry exists.",
-		"- If status=reserved or ok=false: skip quick_action and use direct input tools instead.",
+		"- If status=reserved in a list result or quick_action returns an error message: skip quick_action and use direct input tools instead.",
 		"- If ok=true but the screenshot shows no expected change: treat as ineffective, try alternative=true once or switch tools.",
 		"- Never loop on the same quick_action binding; change tool or strategy after one failed attempt.",
 	}, "\n")

--- a/src/agent/internal/agent/tools_quick_actions_test.go
+++ b/src/agent/internal/agent/tools_quick_actions_test.go
@@ -131,16 +131,20 @@ func TestQuickActionDescriptionWarnsAgainstActionList(t *testing.T) {
 
 func TestQuickActionReservedBinding(t *testing.T) {
 	tool := &QuickActionTool{}
-	out, err := tool.Call(context.Background(), `{"action":"app_drawer","platform":"ios"}`)
+	ctx, _ := WithToolError(context.Background())
+	out, err := tool.Call(ctx, `{"action":"app_drawer","platform":"ios"}`)
 	if err != nil {
 		t.Fatalf("Call failed: %v", err)
 	}
-	var payload map[string]interface{}
-	if err := json.Unmarshal([]byte(out), &payload); err != nil {
-		t.Fatalf("invalid json: %v", err)
+	te := ToolErrorFromContext(ctx)
+	if te == nil || te.Code != CodeQuickActionReserved {
+		t.Fatalf("expected quick_action_reserved; got %+v", te)
 	}
-	if payload["ok"] != false || payload["status"] != quickActionStatusReserved {
-		t.Fatalf("expected reserved response, got %v", payload)
+	if te.Category != CategoryUnsupported {
+		t.Errorf("Category = %q, want %q", te.Category, CategoryUnsupported)
+	}
+	if out != te.Message {
+		t.Errorf("Output (%q) must equal Error.Message (%q)", out, te.Message)
 	}
 }
 
@@ -296,23 +300,23 @@ func TestQuickActionAlternativeBinding(t *testing.T) {
 
 func TestQuickActionUnknownAction(t *testing.T) {
 	tool := &QuickActionTool{}
-	out, err := tool.Call(context.Background(), `{"action":"browser backward","platform":"ios"}`)
+	ctx, _ := WithToolError(context.Background())
+	out, err := tool.Call(ctx, `{"action":"browser backward","platform":"ios"}`)
 	if err != nil {
 		t.Fatalf("Call failed: %v", err)
 	}
-	var payload map[string]interface{}
-	if err := json.Unmarshal([]byte(out), &payload); err != nil {
-		t.Fatalf("invalid json: %v", err)
+	te := ToolErrorFromContext(ctx)
+	if te == nil || te.Code != CodeQuickActionUnknown {
+		t.Fatalf("expected quick_action_unknown; got %+v", te)
 	}
-	if payload["ok"] != false {
-		t.Fatalf("expected ok=false, got %s", out)
+	if !strings.Contains(te.Message, "unknown action") {
+		t.Fatalf("unexpected message: %s", te.Message)
 	}
-	errText, _ := payload["error"].(string)
-	if !strings.Contains(errText, "unknown action") {
-		t.Fatalf("unexpected output: %s", out)
+	if !strings.Contains(te.Message, "suggested actions") {
+		t.Fatalf("expected suggested actions in message, got %s", te.Message)
 	}
-	if !strings.Contains(errText, "suggested actions") {
-		t.Fatalf("expected suggested actions, got %s", out)
+	if out != te.Message {
+		t.Errorf("Output (%q) must equal Error.Message (%q)", out, te.Message)
 	}
 }
 

--- a/src/agent/internal/agent/tools_shell.go
+++ b/src/agent/internal/agent/tools_shell.go
@@ -71,7 +71,8 @@ func (t *ShellTool) Call(ctx context.Context, input string) (string, error) {
 		}
 	}
 
-	if shellBoolArg(arguments, "background") || shellHasAction(arguments) {
+	_, hasAction := arguments["action"]
+	if shellBoolArg(arguments, "background") || hasAction {
 		out, err := shellExecuteBackground(ctx, arguments, t.proxy)
 		if err != nil {
 			return out, err
@@ -99,6 +100,9 @@ func (t *ShellTool) Call(ctx context.Context, input string) (string, error) {
 	defer cancel()
 
 	result, runErr := shellRunForeground(execCtx, command, workdir, usePTY, t.proxy)
+	if contextErr := contextError(execCtx, runErr); errors.Is(contextErr, context.Canceled) {
+		return "", contextErr
+	}
 	if errors.Is(execCtx.Err(), context.DeadlineExceeded) {
 		return toolErrorResultf(ctx, CodeDeadlineExceeded, "Error: command timed out after %.0f seconds", timeoutSecs), nil
 	}

--- a/src/agent/internal/agent/tools_shell.go
+++ b/src/agent/internal/agent/tools_shell.go
@@ -67,17 +67,21 @@ func (t *ShellTool) Call(ctx context.Context, input string) (string, error) {
 	trimmed := strings.TrimSpace(input)
 	if trimmed != "" {
 		if err := json.Unmarshal([]byte(trimmed), &arguments); err != nil {
-			return shellErrorString(fmt.Sprintf("invalid input: %v", err)), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "invalid input: %v", err), nil
 		}
 	}
 
 	if shellBoolArg(arguments, "background") || shellHasAction(arguments) {
-		return shellExecuteBackground(ctx, arguments, t.proxy)
+		out, err := shellExecuteBackground(ctx, arguments, t.proxy)
+		if err != nil {
+			return out, err
+		}
+		return out, nil
 	}
 
 	command, ok := arguments["command"].(string)
 	if !ok || strings.TrimSpace(command) == "" {
-		return shellErrorString("Missing required parameter: command"), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "Missing required parameter: command"), nil
 	}
 
 	timeoutSecs := shellDefaultTimeoutSeconds
@@ -96,10 +100,10 @@ func (t *ShellTool) Call(ctx context.Context, input string) (string, error) {
 
 	result, runErr := shellRunForeground(execCtx, command, workdir, usePTY, t.proxy)
 	if errors.Is(execCtx.Err(), context.DeadlineExceeded) {
-		return shellErrorString(fmt.Sprintf("Error: command timed out after %.0f seconds", timeoutSecs)), nil
+		return toolErrorResultf(ctx, CodeDeadlineExceeded, "Error: command timed out after %.0f seconds", timeoutSecs), nil
 	}
 	if runErr != nil {
-		return shellErrorString(result), nil
+		return toolErrorResultString(ctx, CodeToolExecutionFailed, result), nil
 	}
 	return result, nil
 }
@@ -110,26 +114,26 @@ func shellExecuteBackground(ctx context.Context, arguments map[string]interface{
 	case "start":
 		return shellStartBackground(ctx, arguments, proxy)
 	case "poll":
-		return shellPollBackground(arguments)
+		return shellPollBackground(ctx, arguments)
 	case "write":
-		return shellWriteBackground(arguments)
+		return shellWriteBackground(ctx, arguments)
 	case "submit":
-		return shellSubmitBackground(arguments)
+		return shellSubmitBackground(ctx, arguments)
 	case "send_keys":
-		return shellSendKeysBackground(arguments)
+		return shellSendKeysBackground(ctx, arguments)
 	case "resize":
-		return shellResizeBackground(arguments)
+		return shellResizeBackground(ctx, arguments)
 	case "stop":
-		return shellStopBackground(arguments)
+		return shellStopBackground(ctx, arguments)
 	default:
-		return shellErrorString(fmt.Sprintf("invalid action: %s", action)), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "invalid action: %s", action), nil
 	}
 }
 
 func shellStartBackground(ctx context.Context, arguments map[string]interface{}, proxy ProxyConfig) (string, error) {
 	command := shellStringArg(arguments, "command", "")
 	if command == "" {
-		return shellErrorString("Missing required parameter: command"), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "Missing required parameter: command"), nil
 	}
 
 	workdir := shellStringArg(arguments, "workdir", "")
@@ -150,7 +154,7 @@ func shellStartBackground(ctx context.Context, arguments map[string]interface{},
 	cmd, err := shellBuildCommand(sessionCtx, command, proxy)
 	if err != nil {
 		cancel()
-		return shellErrorString(err.Error()), nil
+		return toolErrorResultString(ctx, CodeToolExecutionFailed, err.Error()), nil
 	}
 
 	session := &shellSession{
@@ -168,7 +172,7 @@ func shellStartBackground(ctx context.Context, arguments map[string]interface{},
 	if usePTY {
 		if err = shellStartPTYBackground(sessionCtx, session, arguments, proxy); err != nil {
 			cancel()
-			return shellErrorString(err.Error()), nil
+			return toolErrorResultString(ctx, CodeToolExecutionFailed, err.Error()), nil
 		}
 	} else {
 		if workdir != "" {
@@ -177,20 +181,20 @@ func shellStartBackground(ctx context.Context, arguments map[string]interface{},
 		stdin, pipeErr := cmd.StdinPipe()
 		if pipeErr != nil {
 			cancel()
-			return shellErrorString(pipeErr.Error()), nil
+			return toolErrorResultString(ctx, CodeToolExecutionFailed, pipeErr.Error()), nil
 		}
 		stdoutPipe, pipeErr := cmd.StdoutPipe()
 		if pipeErr != nil {
 			cancel()
 			_ = stdin.Close()
-			return shellErrorString(pipeErr.Error()), nil
+			return toolErrorResultString(ctx, CodeToolExecutionFailed, pipeErr.Error()), nil
 		}
 		stderrPipe, pipeErr := cmd.StderrPipe()
 		if pipeErr != nil {
 			cancel()
 			_ = stdin.Close()
 			_ = stdoutPipe.Close()
-			return shellErrorString(pipeErr.Error()), nil
+			return toolErrorResultString(ctx, CodeToolExecutionFailed, pipeErr.Error()), nil
 		}
 
 		if pipeErr = cmd.Start(); pipeErr != nil {
@@ -198,7 +202,7 @@ func shellStartBackground(ctx context.Context, arguments map[string]interface{},
 			_ = stdin.Close()
 			_ = stdoutPipe.Close()
 			_ = stderrPipe.Close()
-			return shellErrorString(pipeErr.Error()), nil
+			return toolErrorResultString(ctx, CodeToolExecutionFailed, pipeErr.Error()), nil
 		}
 
 		session.stdin = stdin
@@ -221,14 +225,14 @@ func shellStartBackground(ctx context.Context, arguments map[string]interface{},
 	}), nil
 }
 
-func shellPollBackground(arguments map[string]interface{}) (string, error) {
+func shellPollBackground(ctx context.Context, arguments map[string]interface{}) (string, error) {
 	sessionID := shellStringArg(arguments, "session_id", "")
 	if sessionID == "" {
-		return shellErrorString("Missing required parameter: session_id"), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "Missing required parameter: session_id"), nil
 	}
 	session := globalShellSessionManager.get(sessionID)
 	if session == nil {
-		return shellErrorString(fmt.Sprintf("shell session not found: %s", sessionID)), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "shell session not found: %s", sessionID), nil
 	}
 
 	maxBytes := shellIntArg(arguments, "bytes", shellDefaultPollBytes)
@@ -261,27 +265,27 @@ func shellPollBackground(arguments map[string]interface{}) (string, error) {
 	return shellJSONString(payload), nil
 }
 
-func shellWriteBackground(arguments map[string]interface{}) (string, error) {
+func shellWriteBackground(ctx context.Context, arguments map[string]interface{}) (string, error) {
 	sessionID := shellStringArg(arguments, "session_id", "")
 	if sessionID == "" {
-		return shellErrorString("Missing required parameter: session_id"), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "Missing required parameter: session_id"), nil
 	}
 	session := globalShellSessionManager.get(sessionID)
 	if session == nil {
-		return shellErrorString(fmt.Sprintf("shell session not found: %s", sessionID)), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "shell session not found: %s", sessionID), nil
 	}
 	if !session.isRunning() {
-		return shellErrorString("shell session is no longer running"), nil
+		return toolErrorResultString(ctx, CodeToolExecutionFailed, "shell session is no longer running"), nil
 	}
 
 	input := shellStringArg(arguments, "input", "")
 	if input == "" {
-		return shellErrorString("Missing required parameter: input"), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "Missing required parameter: input"), nil
 	}
 
 	n, err := session.writeString(input)
 	if err != nil {
-		return shellErrorString(err.Error()), nil
+		return toolErrorResultString(ctx, CodeToolExecutionFailed, err.Error()), nil
 	}
 	return shellJSONString(map[string]interface{}{
 		"session_id":    session.id,
@@ -290,50 +294,50 @@ func shellWriteBackground(arguments map[string]interface{}) (string, error) {
 	}), nil
 }
 
-func shellSubmitBackground(arguments map[string]interface{}) (string, error) {
+func shellSubmitBackground(ctx context.Context, arguments map[string]interface{}) (string, error) {
 	input := shellStringArg(arguments, "input", "")
 	if input == "" {
-		return shellWriteBackground(map[string]interface{}{
+		return shellWriteBackground(ctx, map[string]interface{}{
 			"session_id": arguments["session_id"],
 			"input":      "\n",
 		})
 	}
-	return shellWriteBackground(map[string]interface{}{
+	return shellWriteBackground(ctx, map[string]interface{}{
 		"session_id": arguments["session_id"],
 		"input":      input + "\n",
 	})
 }
 
-func shellSendKeysBackground(arguments map[string]interface{}) (string, error) {
+func shellSendKeysBackground(ctx context.Context, arguments map[string]interface{}) (string, error) {
 	sessionID := shellStringArg(arguments, "session_id", "")
 	if sessionID == "" {
-		return shellErrorString("Missing required parameter: session_id"), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "Missing required parameter: session_id"), nil
 	}
 	session := globalShellSessionManager.get(sessionID)
 	if session == nil {
-		return shellErrorString(fmt.Sprintf("shell session not found: %s", sessionID)), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "shell session not found: %s", sessionID), nil
 	}
 	if !session.isRunning() {
-		return shellErrorString("shell session is no longer running"), nil
+		return toolErrorResultString(ctx, CodeToolExecutionFailed, "shell session is no longer running"), nil
 	}
 
 	keys := shellStringSliceArg(arguments, "keys")
 	if len(keys) == 0 {
-		return shellErrorString("Missing required parameter: keys"), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "Missing required parameter: keys"), nil
 	}
 
 	var seq strings.Builder
 	for _, key := range keys {
 		part, err := shellKeySequence(key)
 		if err != nil {
-			return shellErrorString(err.Error()), nil
+			return toolErrorResultString(ctx, CodeInvalidArguments, err.Error()), nil
 		}
 		seq.WriteString(part)
 	}
 
 	n, err := session.writeString(seq.String())
 	if err != nil {
-		return shellErrorString(err.Error()), nil
+		return toolErrorResultString(ctx, CodeToolExecutionFailed, err.Error()), nil
 	}
 	return shellJSONString(map[string]interface{}{
 		"session_id":    session.id,
@@ -342,23 +346,23 @@ func shellSendKeysBackground(arguments map[string]interface{}) (string, error) {
 	}), nil
 }
 
-func shellResizeBackground(arguments map[string]interface{}) (string, error) {
+func shellResizeBackground(ctx context.Context, arguments map[string]interface{}) (string, error) {
 	sessionID := shellStringArg(arguments, "session_id", "")
 	if sessionID == "" {
-		return shellErrorString("Missing required parameter: session_id"), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "Missing required parameter: session_id"), nil
 	}
 	session := globalShellSessionManager.get(sessionID)
 	if session == nil {
-		return shellErrorString(fmt.Sprintf("shell session not found: %s", sessionID)), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "shell session not found: %s", sessionID), nil
 	}
 	if !session.usePTY || session.pty == nil {
-		return shellErrorString("shell session is not running in pty mode"), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "shell session is not running in pty mode"), nil
 	}
 
 	cols := shellPTYCols(arguments)
 	rows := shellPTYRows(arguments)
 	if err := shellResizePTY(session, cols, rows); err != nil {
-		return shellErrorString(err.Error()), nil
+		return toolErrorResultString(ctx, CodeToolExecutionFailed, err.Error()), nil
 	}
 	return shellJSONString(map[string]interface{}{
 		"session_id": session.id,
@@ -369,14 +373,14 @@ func shellResizeBackground(arguments map[string]interface{}) (string, error) {
 	}), nil
 }
 
-func shellStopBackground(arguments map[string]interface{}) (string, error) {
+func shellStopBackground(ctx context.Context, arguments map[string]interface{}) (string, error) {
 	sessionID := shellStringArg(arguments, "session_id", "")
 	if sessionID == "" {
-		return shellErrorString("Missing required parameter: session_id"), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "Missing required parameter: session_id"), nil
 	}
 	session := globalShellSessionManager.get(sessionID)
 	if session == nil {
-		return shellErrorString(fmt.Sprintf("shell session not found: %s", sessionID)), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "shell session not found: %s", sessionID), nil
 	}
 
 	session.stop()
@@ -655,14 +659,10 @@ func shellPTYCols(arguments map[string]interface{}) uint16 {
 	return uint16(cols)
 }
 
-func shellErrorString(text string) string {
-	return "error: " + text
-}
-
 func shellJSONString(v interface{}) string {
 	bs, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		return shellErrorString(err.Error())
+		return fmt.Sprintf("json marshal failed: %v", err)
 	}
 	return string(bs)
 }

--- a/src/agent/internal/agent/tools_shell_test.go
+++ b/src/agent/internal/agent/tools_shell_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"runtime"
 	"strings"
 	"testing"
@@ -197,6 +198,18 @@ func TestShellToolForegroundTimeout(t *testing.T) {
 	}
 }
 
+func TestShellToolForegroundCancellationReturnsContextError(t *testing.T) {
+	skipOnWindows(t)
+	tool := &ShellTool{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := tool.Call(ctx, `{"command":"sleep 1"}`)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Call error = %v, want context.Canceled", err)
+	}
+}
+
 func TestShellToolMissingCommand(t *testing.T) {
 	tool := &ShellTool{}
 
@@ -370,15 +383,17 @@ func TestShellToolBackgroundSubmitInput(t *testing.T) {
 
 func TestShellToolUnknownAction(t *testing.T) {
 	tool := &ShellTool{}
+	ctx, _ := WithToolError(context.Background())
 
-	out, err := tool.Call(context.Background(), `{"action":"bogus"}`)
+	out, err := tool.Call(ctx, `{"action":"bogus"}`)
 	if err != nil {
 		t.Fatalf("Call returned error: %v", err)
 	}
-	// Unknown actions don't pass shellHasAction, so they fall through to the
-	// foreground path which then complains about a missing command.
-	if !strings.Contains(out, "Missing required parameter: command") {
-		t.Fatalf("expected missing-command error, got %q", out)
+	if !strings.Contains(out, "invalid action: bogus") {
+		t.Fatalf("expected invalid-action error, got %q", out)
+	}
+	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeInvalidArguments || got.Message != out {
+		t.Fatalf("ToolError = %+v, want invalid_arguments with output message", got)
 	}
 }
 

--- a/src/agent/internal/agent/tools_shell_test.go
+++ b/src/agent/internal/agent/tools_shell_test.go
@@ -167,16 +167,20 @@ func TestShellToolForegroundWorkdir(t *testing.T) {
 func TestShellToolForegroundFailureSurfacesStderr(t *testing.T) {
 	skipOnWindows(t)
 	tool := &ShellTool{}
+	ctx, _ := WithToolError(context.Background())
 
-	out, err := tool.Call(context.Background(), `{"command":"sh -c 'echo boom 1>&2; exit 7'"}`)
+	out, err := tool.Call(ctx, `{"command":"sh -c 'echo boom 1>&2; exit 7'"}`)
 	if err != nil {
 		t.Fatalf("Call returned error: %v", err)
 	}
-	if !strings.HasPrefix(out, "error: Error: ") {
-		t.Fatalf("expected error prefix, got %q", out)
+	if !strings.HasPrefix(out, "Error: ") {
+		t.Fatalf("expected error message, got %q", out)
 	}
 	if !strings.Contains(out, "Stderr:\nboom") {
 		t.Fatalf("expected stderr in output, got %q", out)
+	}
+	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeToolExecutionFailed || got.Message != out {
+		t.Fatalf("ToolError = %+v, want tool_execution_failed with output message", got)
 	}
 }
 

--- a/src/agent/internal/agent/tools_system.go
+++ b/src/agent/internal/agent/tools_system.go
@@ -186,6 +186,9 @@ func (t *WeatherTool) Call(ctx context.Context, input string) (string, error) {
 	} else {
 		geo, err := t.geocode(callCtx, args.Location)
 		if err != nil {
+			if contextErr := contextError(callCtx, err); contextErr != nil {
+				return "", contextErr
+			}
 			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 		locationName = geo.DisplayName()
@@ -195,6 +198,9 @@ func (t *WeatherTool) Call(ctx context.Context, input string) (string, error) {
 
 	forecast, err := t.fetchForecast(callCtx, lat, lon)
 	if err != nil {
+		if contextErr := contextError(callCtx, err); contextErr != nil {
+			return "", contextErr
+		}
 		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 

--- a/src/agent/internal/agent/tools_system.go
+++ b/src/agent/internal/agent/tools_system.go
@@ -54,14 +54,14 @@ func (t *CurrentTimeTool) Call(ctx context.Context, input string) (string, error
 			Timezone string `json:"timezone"`
 		}
 		if err := json.Unmarshal([]byte(timezone), &args); err != nil {
-			return fmt.Sprintf("error: invalid input: %v. Expected JSON format: {\"timezone\": \"Asia/Shanghai\"} or a bare timezone string like \"UTC\" or \"+08:00\"", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "invalid input: %v. Expected JSON format: {\"timezone\": \"Asia/Shanghai\"} or a bare timezone string like \"UTC\" or \"+08:00\"", err), nil
 		}
 		timezone = strings.TrimSpace(args.Timezone)
 	}
 
 	loc, normalized, err := parseTimezone(timezone)
 	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 	}
 
 	nowFn := t.now
@@ -170,7 +170,7 @@ func (t *WeatherTool) ArgsSchema() map[string]any {
 func (t *WeatherTool) Call(ctx context.Context, input string) (string, error) {
 	args, err := parseWeatherArgs(input)
 	if err != nil {
-		return "error: " + err.Error(), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, err.Error()), nil
 	}
 
 	callCtx, cancel := contextWithDefaultTimeout(ctx)
@@ -186,7 +186,7 @@ func (t *WeatherTool) Call(ctx context.Context, input string) (string, error) {
 	} else {
 		geo, err := t.geocode(callCtx, args.Location)
 		if err != nil {
-			return fmt.Sprintf("error: %v", err), nil
+			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
 		locationName = geo.DisplayName()
 		lat = geo.Latitude
@@ -195,7 +195,7 @@ func (t *WeatherTool) Call(ctx context.Context, input string) (string, error) {
 
 	forecast, err := t.fetchForecast(callCtx, lat, lon)
 	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 
 	result := map[string]interface{}{
@@ -579,7 +579,7 @@ func (t *WaitForWakeupTool) Call(ctx context.Context, input string) (string, err
 			Reason string `json:"reason"`
 		}
 		if err := json.Unmarshal([]byte(reason), &args); err != nil {
-			return fmt.Sprintf("error: invalid input: %v. Expected JSON format: {\"reason\": \"task completed\"} or a bare string describing why Aiden should wait for wakeup", err), nil
+			return toolErrorResultf(ctx, CodeInvalidArguments, "invalid input: %v. Expected JSON format: {\"reason\": \"task completed\"} or a bare string describing why Aiden should wait for wakeup", err), nil
 		}
 		reason = strings.TrimSpace(args.Reason)
 	}
@@ -597,7 +597,7 @@ func (t *WaitForWakeupTool) Call(ctx context.Context, input string) (string, err
 func jsonString(value interface{}) string {
 	payload, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
-		return fmt.Sprintf("error: encode response: %v", err)
+		return fmt.Sprintf("encode response: %v", err)
 	}
 	return string(payload)
 }

--- a/src/agent/internal/agent/tools_system_test.go
+++ b/src/agent/internal/agent/tools_system_test.go
@@ -60,12 +60,16 @@ func TestBuiltinToolSetRegistersSystemTools(t *testing.T) {
 }
 
 func TestCurrentTimeToolRejectsUnknownTimezone(t *testing.T) {
-	out, err := NewCurrentTimeTool().Call(context.Background(), `{"timezone":"Mars/Base"}`)
+	ctx, _ := WithToolError(context.Background())
+	out, err := NewCurrentTimeTool().Call(ctx, `{"timezone":"Mars/Base"}`)
 	if err != nil {
 		t.Fatalf("Call returned error: %v", err)
 	}
-	if !strings.HasPrefix(out, "error:") {
-		t.Fatalf("output = %q, want error response", out)
+	if !strings.Contains(out, `unknown timezone "Mars/Base"`) {
+		t.Fatalf("output = %q, want timezone error message", out)
+	}
+	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeInvalidArguments || got.Message != out {
+		t.Fatalf("ToolError = %+v, want invalid_arguments with output message", got)
 	}
 }
 

--- a/src/agent/internal/agent/tools_system_test.go
+++ b/src/agent/internal/agent/tools_system_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -178,6 +179,20 @@ func TestWeatherToolAcceptsCoordinatesWithoutGeocoding(t *testing.T) {
 	}
 	if !strings.Contains(out, `"timezone": "UTC"`) {
 		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestWeatherToolPropagatesContextCancellation(t *testing.T) {
+	tool := &WeatherTool{
+		client:      http.DefaultClient,
+		forecastURL: "https://example.invalid/v1/forecast",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := tool.Call(ctx, `{"latitude":1,"longitude":2,"location":"point"}`)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Call error = %v, want context.Canceled", err)
 	}
 }
 

--- a/src/agent/internal/agent/tools_wait_stable.go
+++ b/src/agent/internal/agent/tools_wait_stable.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -126,6 +127,9 @@ func (t *WaitStableScreenTool) ArgsSchema() map[string]any {
 func (t *WaitStableScreenTool) Call(ctx context.Context, input string) (string, error) {
 	result, err := t.wait(ctx, input)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return "", err
+		}
 		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 	screenshot, err := t.captureScreenshot()

--- a/src/agent/internal/agent/tools_wait_stable.go
+++ b/src/agent/internal/agent/tools_wait_stable.go
@@ -126,11 +126,11 @@ func (t *WaitStableScreenTool) ArgsSchema() map[string]any {
 func (t *WaitStableScreenTool) Call(ctx context.Context, input string) (string, error) {
 	result, err := t.wait(ctx, input)
 	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 	screenshot, err := t.captureScreenshot()
 	if err != nil {
-		return fmt.Sprintf("error: stable-screen wait completed with stable=%v elapsed_ms=%d, but screenshot failed: %v", result.Stable, result.ElapsedMs, err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "stable-screen wait completed with stable=%v elapsed_ms=%d, but screenshot failed: %v", result.Stable, result.ElapsedMs, err), nil
 	}
 	stable := result.Stable
 	elapsed := result.ElapsedMs

--- a/src/agent/internal/agent/tools_wait_stable_test.go
+++ b/src/agent/internal/agent/tools_wait_stable_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -113,6 +114,26 @@ func TestWaitStableScreenToolReturnsScreenshotObservationJSON(t *testing.T) {
 	visual, ok := any(tool).(visualObservationTool)
 	if !ok || !visual.ReturnsVisualObservation() {
 		t.Fatalf("wait_for_stable_screen must be a visual observation tool")
+	}
+}
+
+func TestWaitStableScreenToolPropagatesContextCancellation(t *testing.T) {
+	rawFrame := []byte{128, 128, 128, 128, 128, 128}
+	client := &fakeWaitStableFrameClient{
+		rawFrames: []fakeWaitStableFrame{
+			{meta: frameMetadata{Seq: 1, Width: 2, Height: 2, PixelFormat: "nv12"}, data: rawFrame},
+		},
+	}
+	tool := &WaitStableScreenTool{
+		client:   client,
+		defaults: ScreenStableDefaults{TimeoutMs: 1000, StableMs: 500, DiffThreshold: 2},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := tool.Call(ctx, `{}`)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Call error = %v, want context.Canceled", err)
 	}
 }
 

--- a/src/agent/internal/agent/tools_web.go
+++ b/src/agent/internal/agent/tools_web.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -25,6 +26,8 @@ const defaultUserAgent = "aiden-agent/1.0 (+https://github.com/AidenAI-IO)"
 const defaultWebToolTimeout = 15 * time.Second
 const maxWebToolOutputBytes = 12_000
 const braveSearchEndpoint = "https://api.search.brave.com/res/v1/web/search"
+
+var lookupScrapeHostIPs = net.LookupIP
 
 // searchBackend abstracts the actual search call.
 type searchBackend interface {
@@ -116,6 +119,9 @@ func (t *WebSearchTool) Call(ctx context.Context, input string) (string, error) 
 
 	result, err := t.backend.Search(callCtx, query)
 	if err != nil {
+		if contextErr := contextError(callCtx, err); contextErr != nil {
+			return "", contextErr
+		}
 		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 	return truncateToolOutput(result), nil
@@ -324,6 +330,9 @@ func (t *WikipediaTool) Call(ctx context.Context, input string) (string, error) 
 
 	result, err := t.inner.Call(callCtx, query)
 	if err != nil {
+		if contextErr := contextError(callCtx, err); contextErr != nil {
+			return "", contextErr
+		}
 		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 	return truncateToolOutput(result), nil
@@ -424,6 +433,9 @@ func (t *WebScraperTool) Call(ctx context.Context, input string) (string, error)
 
 	result, err := t.scrape(callCtx, rawURL)
 	if err != nil {
+		if contextErr := contextError(callCtx, err); contextErr != nil {
+			return "", contextErr
+		}
 		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 	return truncateToolOutput(result), nil
@@ -449,12 +461,18 @@ func (t *WebScraperTool) scrape(ctx context.Context, targetURL string) (string, 
 	scrapedLinksMutex := sync.RWMutex{}
 	pageCount := 0
 	pageCountMutex := sync.Mutex{}
+	var requestErr error
 	const maxPages = 1
 
 	blacklist := []string{"login", "signup", "signin", "register", "logout", "download", "redirect"}
 
 	c.OnRequest(func(r *colly.Request) {
 		if ctx.Err() != nil {
+			r.Abort()
+			return
+		}
+		if err := validateScrapeURL(r.URL.String()); err != nil {
+			requestErr = err
 			r.Abort()
 			return
 		}
@@ -531,6 +549,9 @@ func (t *WebScraperTool) scrape(ctx context.Context, targetURL string) (string, 
 	})
 
 	if err := c.Visit(targetURL); err != nil {
+		if requestErr != nil {
+			return "", requestErr
+		}
 		return "", err
 	}
 
@@ -544,6 +565,9 @@ func (t *WebScraperTool) scrape(ctx context.Context, targetURL string) (string, 
 	case <-ctx.Done():
 		return "", ctx.Err()
 	case <-done:
+	}
+	if requestErr != nil {
+		return "", requestErr
 	}
 
 	return siteData.String(), nil
@@ -565,11 +589,31 @@ func validateScrapeURL(rawURL string) error {
 		return fmt.Errorf("url host is not allowed")
 	}
 	if ip := net.ParseIP(host); ip != nil {
-		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		if scrapeIPIsDisallowed(ip) {
 			return fmt.Errorf("url host is not allowed")
+		}
+		return nil
+	}
+	addrs, err := lookupScrapeHostIPs(host)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		return fmt.Errorf("resolve url host: %w", err)
+	}
+	if len(addrs) == 0 {
+		return fmt.Errorf("resolve url host: no addresses")
+	}
+	for _, ip := range addrs {
+		if scrapeIPIsDisallowed(ip) {
+			return fmt.Errorf("url host resolves to a private or link-local address")
 		}
 	}
 	return nil
+}
+
+func scrapeIPIsDisallowed(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
 }
 
 func contextWithDefaultTimeout(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/src/agent/internal/agent/tools_web.go
+++ b/src/agent/internal/agent/tools_web.go
@@ -94,12 +94,12 @@ func (t *WebSearchTool) ArgsSchema() map[string]any {
 
 func (t *WebSearchTool) Call(ctx context.Context, input string) (string, error) {
 	if t.backend == nil {
-		return "error: web_search tool is not configured (provider=" + t.provider + ")", nil
+		return toolErrorResultString(ctx, CodeModuleUnavailable, "web_search tool is not configured (provider="+t.provider+")"), nil
 	}
 
 	query := strings.TrimSpace(input)
 	if query == "" {
-		return "error: query is required", nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "query is required"), nil
 	}
 
 	if strings.HasPrefix(query, "{") {
@@ -116,7 +116,7 @@ func (t *WebSearchTool) Call(ctx context.Context, input string) (string, error) 
 
 	result, err := t.backend.Search(callCtx, query)
 	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 	return truncateToolOutput(result), nil
 }
@@ -307,7 +307,7 @@ func (t *WikipediaTool) ArgsSchema() map[string]any {
 func (t *WikipediaTool) Call(ctx context.Context, input string) (string, error) {
 	query := strings.TrimSpace(input)
 	if query == "" {
-		return "error: query is required", nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "query is required"), nil
 	}
 
 	if strings.HasPrefix(query, "{") {
@@ -324,7 +324,7 @@ func (t *WikipediaTool) Call(ctx context.Context, input string) (string, error) 
 
 	result, err := t.inner.Call(callCtx, query)
 	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 	return truncateToolOutput(result), nil
 }
@@ -356,7 +356,7 @@ func (t *CalculatorTool) ArgsSchema() map[string]any {
 func (t *CalculatorTool) Call(ctx context.Context, input string) (string, error) {
 	expr := strings.TrimSpace(input)
 	if expr == "" {
-		return "error: expression is required", nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "expression is required"), nil
 	}
 
 	if strings.HasPrefix(expr, "{") {
@@ -370,7 +370,7 @@ func (t *CalculatorTool) Call(ctx context.Context, input string) (string, error)
 
 	result, err := t.inner.Call(ctx, expr)
 	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 	}
 	return result, nil
 }
@@ -403,7 +403,7 @@ func (t *WebScraperTool) ArgsSchema() map[string]any {
 func (t *WebScraperTool) Call(ctx context.Context, input string) (string, error) {
 	rawURL := strings.TrimSpace(input)
 	if rawURL == "" {
-		return "error: url is required", nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "url is required"), nil
 	}
 
 	if strings.HasPrefix(rawURL, "{") {
@@ -416,7 +416,7 @@ func (t *WebScraperTool) Call(ctx context.Context, input string) (string, error)
 	}
 
 	if err := validateScrapeURL(rawURL); err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 	}
 
 	callCtx, cancel := contextWithDefaultTimeout(ctx)
@@ -424,7 +424,7 @@ func (t *WebScraperTool) Call(ctx context.Context, input string) (string, error)
 
 	result, err := t.scrape(callCtx, rawURL)
 	if err != nil {
-		return fmt.Sprintf("error: %v", err), nil
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 	return truncateToolOutput(result), nil
 }

--- a/src/agent/internal/agent/tools_web.go
+++ b/src/agent/internal/agent/tools_web.go
@@ -446,7 +446,7 @@ func (t *WebScraperTool) scrape(ctx context.Context, targetURL string) (string, 
 		colly.MaxDepth(1),
 		colly.Async(false),
 	)
-	c.WithTransport(newProxyTransport(t.proxy))
+	c.WithTransport(newScrapeTransport(t.proxy))
 
 	if err := c.Limit(&colly.LimitRule{
 		DomainGlob:  "*",
@@ -581,35 +581,81 @@ func validateScrapeURL(rawURL string) error {
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return fmt.Errorf("invalid url scheme: only http/https allowed")
 	}
-	host := strings.ToLower(u.Hostname())
+	_, err = lookupAllowedScrapeHostIPs(u.Hostname())
+	return err
+}
+
+func newScrapeTransport(proxy ProxyConfig) http.RoundTripper {
+	transport := newProxyTransport(proxy)
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		return transport
+	}
+
+	baseDialContext := httpTransport.DialContext
+	if baseDialContext == nil {
+		baseDialContext = (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext
+	}
+	httpTransport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		return dialAllowedScrapeAddress(ctx, baseDialContext, network, address)
+	}
+	return httpTransport
+}
+
+func dialAllowedScrapeAddress(ctx context.Context, dialContext func(context.Context, string, string) (net.Conn, error), network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := lookupAllowedScrapeHostIPs(host)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	for _, ip := range addrs {
+		conn, err := dialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+func lookupAllowedScrapeHostIPs(host string) ([]net.IP, error) {
+	host = strings.ToLower(strings.TrimSpace(strings.Trim(host, "[]")))
 	if host == "" {
-		return fmt.Errorf("invalid url: empty host")
+		return nil, fmt.Errorf("invalid url: empty host")
 	}
 	if host == "localhost" {
-		return fmt.Errorf("url host is not allowed")
+		return nil, fmt.Errorf("url host is not allowed")
 	}
 	if ip := net.ParseIP(host); ip != nil {
 		if scrapeIPIsDisallowed(ip) {
-			return fmt.Errorf("url host is not allowed")
+			return nil, fmt.Errorf("url host is not allowed")
 		}
-		return nil
+		return []net.IP{ip}, nil
 	}
 	addrs, err := lookupScrapeHostIPs(host)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return err
+			return nil, err
 		}
-		return fmt.Errorf("resolve url host: %w", err)
+		return nil, fmt.Errorf("resolve url host: %w", err)
 	}
 	if len(addrs) == 0 {
-		return fmt.Errorf("resolve url host: no addresses")
+		return nil, fmt.Errorf("resolve url host: no addresses")
 	}
 	for _, ip := range addrs {
 		if scrapeIPIsDisallowed(ip) {
-			return fmt.Errorf("url host resolves to a private or link-local address")
+			return nil, fmt.Errorf("url host resolves to a private or link-local address")
 		}
 	}
-	return nil
+	return addrs, nil
 }
 
 func scrapeIPIsDisallowed(ip net.IP) bool {

--- a/src/agent/internal/agent/tools_web_test.go
+++ b/src/agent/internal/agent/tools_web_test.go
@@ -193,3 +193,38 @@ func TestWebScraperRejectsHostnamesResolvingToPrivateIPs(t *testing.T) {
 		t.Fatalf("ToolError = %+v, want invalid_arguments with output message", got)
 	}
 }
+
+func TestWebScraperRejectsHostnamesRebindingToPrivateIPsAtDialTime(t *testing.T) {
+	for _, env := range []string{"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "all_proxy", "no_proxy"} {
+		t.Setenv(env, "")
+	}
+
+	original := lookupScrapeHostIPs
+	lookupCalls := 0
+	lookupScrapeHostIPs = func(host string) ([]net.IP, error) {
+		if host != "rebind.invalid" {
+			t.Fatalf("lookup host = %q, want rebind.invalid", host)
+		}
+		lookupCalls++
+		if lookupCalls < 3 {
+			return []net.IP{net.ParseIP("93.184.216.34")}, nil
+		}
+		return []net.IP{net.ParseIP("169.254.169.254")}, nil
+	}
+	defer func() { lookupScrapeHostIPs = original }()
+
+	ctx, _ := WithToolError(context.Background())
+	out, err := NewWebScraperTool(ProxyConfig{}).Call(ctx, `{"url":"http://rebind.invalid/"}`)
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if lookupCalls < 3 {
+		t.Fatalf("lookup calls = %d, want dial-time validation", lookupCalls)
+	}
+	if !strings.Contains(out, "url host resolves to a private or link-local address") {
+		t.Fatalf("output = %q, want private IP rejection", out)
+	}
+	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeToolExecutionFailed || got.Message != out {
+		t.Fatalf("ToolError = %+v, want tool_execution_failed with output message", got)
+	}
+}

--- a/src/agent/internal/agent/tools_web_test.go
+++ b/src/agent/internal/agent/tools_web_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +14,18 @@ type fakeSearchBackend struct {
 	query string
 	out   string
 	err   error
+}
+
+func TestWebSearchPropagatesContextErrors(t *testing.T) {
+	for _, wantErr := range []error{context.Canceled, context.DeadlineExceeded} {
+		t.Run(wantErr.Error(), func(t *testing.T) {
+			tool := &WebSearchTool{backend: &fakeSearchBackend{err: wantErr}, provider: "fake"}
+			_, err := tool.Call(context.Background(), `{"query":"golang"}`)
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("Call error = %v, want %v", err, wantErr)
+			}
+		})
+	}
 }
 
 func (b *fakeSearchBackend) Search(ctx context.Context, query string) (string, error) {
@@ -152,6 +165,29 @@ func TestWebScraperRejectsInvalidURL(t *testing.T) {
 	}
 	if out != "invalid url scheme: only http/https allowed" {
 		t.Fatalf("output = %q, want invalid URL error message", out)
+	}
+	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeInvalidArguments || got.Message != out {
+		t.Fatalf("ToolError = %+v, want invalid_arguments with output message", got)
+	}
+}
+
+func TestWebScraperRejectsHostnamesResolvingToPrivateIPs(t *testing.T) {
+	original := lookupScrapeHostIPs
+	lookupScrapeHostIPs = func(host string) ([]net.IP, error) {
+		if host != "public.example" {
+			t.Fatalf("lookup host = %q, want public.example", host)
+		}
+		return []net.IP{net.ParseIP("169.254.169.254")}, nil
+	}
+	defer func() { lookupScrapeHostIPs = original }()
+
+	ctx, _ := WithToolError(context.Background())
+	out, err := NewWebScraperTool(ProxyConfig{}).Call(ctx, `{"url":"https://public.example/page"}`)
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if out != "url host resolves to a private or link-local address" {
+		t.Fatalf("output = %q", out)
 	}
 	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeInvalidArguments || got.Message != out {
 		t.Fatalf("ToolError = %+v, want invalid_arguments with output message", got)

--- a/src/agent/internal/agent/tools_web_test.go
+++ b/src/agent/internal/agent/tools_web_test.go
@@ -145,11 +145,15 @@ func TestCalculatorAcceptsJSONExpression(t *testing.T) {
 }
 
 func TestWebScraperRejectsInvalidURL(t *testing.T) {
-	out, err := NewWebScraperTool(ProxyConfig{}).Call(context.Background(), `{"url":"not a url"}`)
+	ctx, _ := WithToolError(context.Background())
+	out, err := NewWebScraperTool(ProxyConfig{}).Call(ctx, `{"url":"not a url"}`)
 	if err != nil {
 		t.Fatalf("Call returned error: %v", err)
 	}
-	if !strings.HasPrefix(out, "error:") {
-		t.Fatalf("output = %q, want error response", out)
+	if out != "invalid url scheme: only http/https allowed" {
+		t.Fatalf("output = %q, want invalid URL error message", out)
+	}
+	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeInvalidArguments || got.Message != out {
+		t.Fatalf("ToolError = %+v, want invalid_arguments with output message", got)
 	}
 }


### PR DESCRIPTION
# Structured Error Schema for Tool Call Failures

## Summary

This PR introduces a structured error schema for tool call failures across the agent tooling layer, replacing string-based `error: "message"` with a 4-field `ToolError` object that carries category, code, message, and details.

## Motivation

Current error handling uses plain strings or boolean `ok` fields, making it hard for:

- **LLM**: to understand error semantics beyond parsing text
- **Telemetry**: to aggregate and classify failures
- **UI**: to render errors with appropriate visual cues (colors, icons, retry hints)
- **Programmatic consumers**: to implement error-specific logic (retry policies, fallback paths)

A structured schema enables all consumers to branch on `category` (6 fixed values) and `code` (29 stable codes), with human-readable `message` for LLM and optional `details` for forensics.

## Design

### Core Schema (`errors.go`)

```go
type ToolError struct {
    Category string         `json:"category"` // 6 fixed: invalid_input, precondition_failed, user_action_required, unsupported, transient, internal
    Code     string         `json:"code"`     // 29 stable codes (invalid_arguments, bridge_timeout, unknown_app, ...)
    Message  string         `json:"message"`  // LLM-facing explanation
    Details  map[string]any `json:"details,omitempty"` // Optional forensics
}
```

- **Category**: LLM uses this to decide whether to retry, ask user, or switch approach
- **Code**: Telemetry/UI use this for aggregation and i18n
- **Message**: Plain English for LLM observation
- **Details**: Contextual data (e.g., `{"app": "WeChat", "platform": "ios"}`)

### Wire Protocol (`BridgeCommandResponse`)

```go
type BridgeCommandResponse struct {
    ID     string     `json:"id"`
    Error  *ToolError `json:"error,omitempty"` // Dropped `OK bool` field
    Method string     `json:"method,omitempty"`
    Data   RawMessage `json:"data,omitempty"`
}
```

Success: `Error == nil`; Failure: `Error != nil`.

### Tool Execution Flow

1. Tool's `Call(ctx, input)` validates args → on failure, calls `SetToolError(ctx, te)` and returns `toolErrorString(te)`
2. `executeToolCall` reads attached error via `ToolErrorFromContext(ctx)` and promotes it to `ToolResult.Error`
3. LLM sees `Output` (equals `Error.Message` on failure); downstream consumers see structured `Error`

### Tool Migration Pattern

**Before:**

```go
if err := validateArgs(args); err != nil {
    return fmt.Sprintf(`{"ok":false,"error":"%s"}`, err), nil
}
```

**After:**

```go
if te := validateArgs(args); te != nil {
    SetToolError(ctx, te)
    return toolErrorString(te), nil
}
```

## Changes

### Schema & Infrastructure (commits 9778e258, cd5c9bf6, bc116f62)

- Add `ToolError` type with 29 codes + 6 categories
- Replace `ToolResult.IsError bool` + `Error string` with `Error *ToolError`
- Enforce `Output == Error.Message` invariant in normalizers
- Drop `toolOutputLooksLikeError` string-sniffing

### Wire Protocol (commit 47efe66a)

- `BridgeCommandResponse.Error` becomes `*ToolError` (was `string`)
- Drop `OK bool` field (redundant with `Error == nil`)
- `daemon` JSONL logger preserves wire shape for audit

### Tool Handlers (commits af9a6de8, a0462c4d, 81961fea, 17d07cfe)

- `EnvironmentBridge.CallTool` returns `(*ToolResult, error)`
- `OpenAppTool`, `ClipboardTool`, `CalendarTool`, `ContactsTool`, `NotificationTool`: migrated to structured errors
- `QuickActionTool`: migrated, with `subtool_failed` wrapping for delegated tool errors

## Testing

- All existing tests pass after assertion updates (drop `ok:true` expectations)
- Added regression tests:
  - `TestOpenAppMissingArgsReturnsInvalidArguments`
  - `TestOpenAppUnknownAppReturnsUnknownApp`
  - `TestQuickActionReservedBinding` (asserts `CodeQuickActionReserved`)
  - `TestQuickActionUnknownAction` (asserts `CodeQuickActionUnknown`)

## Compatibility

**Breaking**: Wire protocol changes. App-side PR (https://github.com/AidenAI-IO/aiden-app/pull/15) must land simultaneously.

**Non-breaking**:

- LLM still sees `Output` string (now equals `Error.Message` on failure)
- Tool names and args unchanged
- Success-path JSON output preserved (only failure paths changed from JSON to plain string)

## Code Registry

All 29 codes map to 1 of 6 categories. Adding a new code requires a registry entry + category assignment:

| Category               | Codes (examples)                                                             |
| ---------------------- | ---------------------------------------------------------------------------- |
| `invalid_input`        | `invalid_arguments`, `tool_not_found`, `unknown_app`, `quick_action_unknown` |
| `precondition_failed`  | `bridge_not_connected`, `app_not_installed`, `module_unavailable`            |
| `user_action_required` | `permission_denied`, `app_backgrounded`                                      |
| `unsupported`          | `quick_action_reserved`, `quick_action_unsupported_platform`                 |
| `transient`            | `bridge_timeout`, `canceled`, `deadline_exceeded`, `app_launch_failed`       |
| `internal`             | `tool_execution_failed`, `command_marshal_failed`, `subtool_failed`          |

## Deployment Plan

1. Merge this PR + app PR atomically
2. Monitor telemetry for code distribution (expect `bridge_timeout`, `unknown_app` as top codes)
3. Future: add retry policies keyed on `category` (e.g., auto-retry `transient`, prompt user for `user_action_required`)

## Related

- App-side PR: https://github.com/AidenAI-IO/aiden-app/pull/15
- Design doc: `docs/superpowers/plans/2026-06-24-tool-call-result-error-schema.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured, code-based `tool_error` details that propagate through tools, bridge calls, runtime events, and server responses.
  * Updated tool-result semantics so failures carry a typed `ToolError` (with consistent message/output) instead of relying on string patterns.

* **Bug Fixes**
  * Remote/transport and cancellation/deadline failures are now classified with the correct codes and HTTP statuses (including coordinate debug tap).
  * Success responses no longer emit unnecessary error markers; error mapping is more predictable.

* **Tests**
  * Expanded coverage to validate structured error codes/messages, HTTP shapes, and invariants end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->