### PR TITLE
fix(agent): use structured visual artifact errors

### DIFF
--- a/src/agent/internal/agent/tool_execution.go
+++ b/src/agent/internal/agent/tool_execution.go
@@ -266,9 +266,9 @@ func runAfterToolCallHook(ctx context.Context, execution ToolCallExecution, call
 		if visual, ok := call.Spec.Tool.(visualObservationTool); ok && visual.ReturnsVisualObservation() {
 			output, externalized, err := execution.VisualArtifacts.ExternalizeObservation(result.Output)
 			if err != nil {
-				result.IsError = true
-				result.Error = err
-				result.Output = "failed to store visual artifact: " + err.Error()
+				msg := "failed to store visual artifact: " + err.Error()
+				result.Error = NewToolError(CodeToolExecutionFailed, msg)
+				result.Output = msg
 				result.Summary = result.Output
 			} else if externalized {
 				result.Output = output

--- a/src/agent/internal/agent/visual_artifacts_test.go
+++ b/src/agent/internal/agent/visual_artifacts_test.go
@@ -71,11 +71,17 @@ func TestExecuteToolCallFailsWhenVisualObservationCannotBeExternalized(t *testin
 		VisualArtifacts: store,
 	})
 
-	if !result.Result.IsError {
+	if !result.Result.IsError() {
 		t.Fatal("result.IsError = false, want true")
 	}
 	if result.Result.Error == nil {
 		t.Fatal("result.Error = nil, want visual artifact error")
+	}
+	if result.Result.Error.Code != CodeToolExecutionFailed {
+		t.Fatalf("result error code = %q, want %q", result.Result.Error.Code, CodeToolExecutionFailed)
+	}
+	if result.Result.Output != result.Result.Error.Message {
+		t.Fatalf("Output must equal Error.Message, got %q vs %q", result.Result.Output, result.Result.Error.Message)
 	}
 	if !strings.Contains(result.Result.Output, "failed to store visual artifact:") {
 		t.Fatalf("result output = %q, want visual artifact failure", result.Result.Output)
@@ -89,7 +95,7 @@ func TestExecuteToolCallFailsWhenVisualObservationCannotBeExternalized(t *testin
 	if len(callback.results) != 1 {
 		t.Fatalf("callback results = %d, want 1", len(callback.results))
 	}
-	if strings.Contains(callback.results[0].Output, encoded) || !callback.results[0].IsError {
+	if strings.Contains(callback.results[0].Output, encoded) || !callback.results[0].IsError() {
 		t.Fatalf("callback result did not surface sanitized failure: %#v", callback.results[0])
 	}
 }


### PR DESCRIPTION
## Summary
- Wrap visual artifact storage failures in structured ToolError values.
- Update visual artifact regression coverage to use ToolResult.IsError() and preserve Output == Error.Message.

## Test Plan
- go test ./... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when a visual artifact can’t be saved, with a clearer, standardized error message.
  - Error results now consistently mark the tool call as failed and keep the displayed output aligned with the recorded error.
  - Added stronger validation to ensure failed visual-artifact callbacks return sanitized, error-bearing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->