### PR TITLE
fix(agent): align wait_for_stable_screen screenshot cropping

### DIFF
--- a/src/agent/internal/agent/tools_screenshot.go
+++ b/src/agent/internal/agent/tools_screenshot.go
@@ -120,11 +120,12 @@ func (t *ScreenshotTool) Call(_ context.Context, _ string) (string, error) {
 	displayData := jpegData
 	if !alreadyCropped && active.Valid && (active.X != 0 || active.Y != 0 || active.Width != displayWidth || active.Height != displayHeight) {
 		croppedData, croppedWidth, croppedHeight, err := cropJPEGToActiveArea(jpegData, active, screenshotJPEGQuality)
-		if err == nil {
-			displayWidth = croppedWidth
-			displayHeight = croppedHeight
-			displayData = croppedData
+		if err != nil {
+			return "", fmt.Errorf("crop screenshot to active area: %w", err)
 		}
+		displayWidth = croppedWidth
+		displayHeight = croppedHeight
+		displayData = croppedData
 	}
 
 	result := screenshotResult{

--- a/src/agent/internal/agent/tools_wait_stable.go
+++ b/src/agent/internal/agent/tools_wait_stable.go
@@ -181,11 +181,12 @@ func (t *WaitStableScreenTool) captureScreenshot() (screenshotResult, error) {
 	displayData := jpegData
 	if !alreadyCropped && active.Valid && (active.X != 0 || active.Y != 0 || active.Width != displayWidth || active.Height != displayHeight) {
 		croppedData, croppedWidth, croppedHeight, err := cropJPEGToActiveArea(jpegData, active, screenshotJPEGQuality)
-		if err == nil {
-			displayWidth = croppedWidth
-			displayHeight = croppedHeight
-			displayData = croppedData
+		if err != nil {
+			return screenshotResult{}, fmt.Errorf("crop screenshot to active area: %w", err)
 		}
+		displayWidth = croppedWidth
+		displayHeight = croppedHeight
+		displayData = croppedData
 	}
 	result := screenshotResult{
 		Width:  displayWidth,

--- a/src/agent/internal/agent/tools_wait_stable.go
+++ b/src/agent/internal/agent/tools_wait_stable.go
@@ -155,35 +155,44 @@ func (t *WaitStableScreenTool) captureScreenshot() (screenshotResult, error) {
 	if err != nil {
 		return screenshotResult{}, err
 	}
+	if meta.Stale {
+		return screenshotResult{}, fmt.Errorf("frame service: STALE_FRAME")
+	}
 	if meta.PixelFormat != "jpeg" {
 		return screenshotResult{}, fmt.Errorf("expected jpeg format, got %s", meta.PixelFormat)
 	}
 	active := screenActiveArea{}
 	sourceWidth := int(meta.Width)
 	sourceHeight := int(meta.Height)
-	fromSourceMeta := false
+	alreadyCropped := false
 	if fullWidth, fullHeight, sourceActive, ok := frameMetadataSourceActiveArea(meta); ok {
 		sourceWidth = fullWidth
 		sourceHeight = fullHeight
 		active = sourceActive
-		fromSourceMeta = true
+		alreadyCropped = true
 	} else {
 		active = detectScreenshotActiveAreaForScreen(t.screen, jpegData, int(meta.Width), int(meta.Height))
 	}
 	if t.screen != nil {
 		t.screen.UpdateActiveArea(sourceWidth, sourceHeight, active)
 	}
-	result := screenshotResult{
-		Width:  int(meta.Width),
-		Height: int(meta.Height),
-		Format: "jpeg",
-		Size:   len(jpegData),
-		Data:   base64.StdEncoding.EncodeToString(jpegData),
+	displayWidth := int(meta.Width)
+	displayHeight := int(meta.Height)
+	displayData := jpegData
+	if !alreadyCropped && active.Valid && (active.X != 0 || active.Y != 0 || active.Width != displayWidth || active.Height != displayHeight) {
+		croppedData, croppedWidth, croppedHeight, err := cropJPEGToActiveArea(jpegData, active, screenshotJPEGQuality)
+		if err == nil {
+			displayWidth = croppedWidth
+			displayHeight = croppedHeight
+			displayData = croppedData
+		}
 	}
-	if !fromSourceMeta && active.Valid && (active.X != 0 || active.Y != 0 || active.Width != result.Width || active.Height != result.Height) {
-		result.ActiveArea = &active
-		result.ActiveWidth = active.Width
-		result.ActiveHeight = active.Height
+	result := screenshotResult{
+		Width:  displayWidth,
+		Height: displayHeight,
+		Format: "jpeg",
+		Size:   len(displayData),
+		Data:   base64.StdEncoding.EncodeToString(displayData),
 	}
 	return result, nil
 }

--- a/src/agent/internal/agent/tools_wait_stable_test.go
+++ b/src/agent/internal/agent/tools_wait_stable_test.go
@@ -1,11 +1,14 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"image"
+	"image/color"
 	"strings"
 	"testing"
 )
@@ -225,6 +228,91 @@ func TestWaitStableScreenToolUsesJPEGSourceMetadataForSharedScreenState(t *testi
 	if active != want {
 		t.Fatalf("active area = %+v, want %+v", active, want)
 	}
+}
+
+func TestWaitStableScreenToolCropsDetectedActiveAreaForModelObservation(t *testing.T) {
+	rawFrame := make([]byte, 8*4*3/2)
+	for i := range rawFrame {
+		rawFrame[i] = 128
+	}
+	img := image.NewRGBA(image.Rect(0, 0, 8, 4))
+	for y := 0; y < 4; y++ {
+		for x := 2; x < 6; x++ {
+			img.Set(x, y, color.RGBA{255, 255, 255, 255})
+		}
+	}
+	var src []byte
+	for y := 0; y < 4; y++ {
+		for x := 0; x < 8; x++ {
+			r, _, _, _ := img.At(x, y).RGBA()
+			src = append(src, byte(r>>8), byte(r>>8), byte(r>>8))
+		}
+	}
+	fullJPEGData, err := encodeJPEG(src, 8, 4, screenshotJPEGQuality)
+	if err != nil {
+		t.Fatalf("encodeJPEG() error = %v", err)
+	}
+
+	screen := &screenState{}
+	client := &fakeWaitStableFrameClient{
+		rawFrames: []fakeWaitStableFrame{
+			{meta: frameMetadata{Seq: 1, Width: 8, Height: 4, PixelFormat: "nv12"}, data: rawFrame},
+			{meta: frameMetadata{Seq: 2, Width: 8, Height: 4, PixelFormat: "nv12"}, data: rawFrame},
+		},
+		jpegData: fullJPEGData,
+		jpegMeta: frameMetadata{Seq: 99, Width: 8, Height: 4, PixelFormat: "jpeg", Bytes: uint64(len(fullJPEGData))},
+	}
+	tool := &WaitStableScreenTool{
+		client:   client,
+		defaults: ScreenStableDefaults{TimeoutMs: 50, StableMs: 1, DiffThreshold: 2},
+		screen:   screen,
+	}
+
+	out, err := tool.Call(context.Background(), `{}`)
+	if err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+
+	var result waitStableScreenObservationResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("output is not valid wait screenshot JSON: %v", err)
+	}
+	if result.Width != 4 || result.Height != 4 {
+		t.Fatalf("cropped screenshot dimensions = %dx%d, want 4x4", result.Width, result.Height)
+	}
+	if result.ActiveArea != nil || result.ActiveWidth != 0 || result.ActiveHeight != 0 {
+		t.Fatalf("expected cropped observation without active area metadata, got %#v", result.screenshotResult)
+	}
+	if result.Data == base64.StdEncoding.EncodeToString(fullJPEGData) {
+		t.Fatal("expected cropped screenshot bytes, got original full-frame JPEG")
+	}
+	imageBytes, err := base64.StdEncoding.DecodeString(result.Data)
+	if err != nil {
+		t.Fatalf("DecodeString() error = %v", err)
+	}
+	if result.Size != len(imageBytes) {
+		t.Fatalf("result size = %d, want %d", result.Size, len(imageBytes))
+	}
+	decoded, err := jpegDecodeConfig(imageBytes)
+	if err != nil {
+		t.Fatalf("jpegDecodeConfig() error = %v", err)
+	}
+	if decoded.Width != 4 || decoded.Height != 4 {
+		t.Fatalf("decoded cropped jpeg = %dx%d, want 4x4", decoded.Width, decoded.Height)
+	}
+	width, height, active, _, ok := screen.ActiveAreaWithAge()
+	if !ok || width != 8 || height != 4 {
+		t.Fatalf("screen dimensions = %dx%d ok=%v, want 8x4 true", width, height, ok)
+	}
+	want := screenActiveArea{X: 2, Y: 0, Width: 4, Height: 4, Valid: true}
+	if active != want {
+		t.Fatalf("active area = %+v, want %+v", active, want)
+	}
+}
+
+func jpegDecodeConfig(data []byte) (image.Config, error) {
+	config, _, err := image.DecodeConfig(bytes.NewReader(data))
+	return config, err
 }
 
 type fakeWaitStableFrame struct {


### PR DESCRIPTION
## Summary

Align `wait_for_stable_screen` screenshot output with `screenshot` so both tools return the same cropped active-area image semantics to the model.

## Changes

- crop `wait_for_stable_screen` screenshots to the detected active area when the source frame is not already cropped
- keep shared `screenState` active-area updates unchanged for coordinate mapping
- fail screenshot capture instead of silently falling back to the uncropped full-frame JPEG when active-area cropping fails
- apply the same crop-failure behavior to `screenshot` to avoid observation and coordinate-mapping desync
- add a regression test covering full-frame input with a smaller detected active area
- add stale-frame handling in `wait_for_stable_screen` screenshot capture to match `screenshot`

## Why

Previously, `screenshot` returned a cropped active-area image, while `wait_for_stable_screen` could return the full frame plus active-area metadata. This created inconsistent visual semantics for the model and could desynchronize screenshot interpretation from normalized coordinate behavior.

There was also a follow-up correctness issue: if active-area cropping failed after `screenState` had already been updated, the tool could silently return the uncropped image while coordinates still mapped to the cropped region. This change makes that failure explicit instead of returning mismatched state.

## Validation

- `go test ./internal/agent -run "TestWaitStableScreenTool|TestScreenshotTool|TestPostActionScreenshotTool"`
- deployed the updated agent binary to the target board
- restarted the on-device agent service successfully
- verified `screenshot` and `wait_for_stable_screen` return matching dimensions on-device