### PR TITLE
fix: streaming TTS drain blocking chat completion

### DIFF
--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -1019,13 +1019,7 @@ func (s *Server) handleChatAsync(
 
 		result, err := s.runtime.Run(runCtx, runReq)
 		progress.Cancel()
-		if newStream != nil {
-			closeErr := newStream.closeAndWait()
-			if closeErr != nil && s.logger != nil {
-				s.logger.Error("new TTS stream failed: %v", closeErr)
-			}
-			result.SpeechStreamed = closeErr == nil && newStream.spokeSuccessfully()
-		}
+		result.SpeechStreamed = newStream != nil && streamWriterEmitted(runReq.StreamWriter)
 
 		pending.mu.Lock()
 		if err != nil {
@@ -1092,6 +1086,9 @@ func (s *Server) handleChatAsync(
 		speechText := result.SpokenTextForConfig(s.runtime.config)
 		if s.audioClient != nil && speechText != "" && !result.SpeechStreamed {
 			s.speakFinalText(runCtx, requestID, speechText)
+		}
+		if newStream != nil {
+			s.closeTTSStreamAndLog(newStream)
 		}
 	}()
 }
@@ -1469,6 +1466,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 
 	var newStream *streamSessionWriter
 	unregisterStreamOutput := func() {}
+	streamOutputCleanupDeferred := false
 	ttsManager := s.currentTTSManager()
 	finalStreamWriters := []io.Writer{
 		newChatAssistantFinalStreamWriter(stream, episodeID, req.RequestID),
@@ -1489,19 +1487,20 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	defer unregisterStreamOutput()
+	defer func() {
+		if !streamOutputCleanupDeferred {
+			unregisterStreamOutput()
+		}
+	}()
 	runReq.StreamWriter = newFinalStreamFanoutWriter(finalStreamWriters...)
 
 	result, err := s.runtime.Run(ctx, runReq)
 	progress.Cancel()
-	if newStream != nil {
-		closeErr := newStream.closeAndWait()
-		if closeErr != nil && s.logger != nil {
-			s.logger.Error("new TTS stream failed: %v", closeErr)
-		}
-		result.SpeechStreamed = closeErr == nil && newStream.spokeSuccessfully()
-	}
+	result.SpeechStreamed = newStream != nil && streamWriterEmitted(runReq.StreamWriter)
 	if err != nil {
+		if newStream != nil {
+			go s.closeTTSStreamAndLog(newStream)
+		}
 		canceled := errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled)
 		if req.RequestID != "" && s.liveActivity != nil {
 			if canceled {
@@ -1551,6 +1550,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 	}
 
 	speechText := result.SpokenTextForConfig(s.runtime.config)
+	finalTTSOwnsCleanup := false
 	if s.audioClient != nil && speechText != "" && !result.SpeechStreamed {
 		finalTTSCtx := ctx
 		finishRun := func() {}
@@ -1560,6 +1560,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 			finalTTSCtx = context.Background()
 			finishRun = cleanupRun
 			cleanupRunAtReturn = false
+			finalTTSOwnsCleanup = true
 		}
 		go func(text string, ttsCtx context.Context, finish func()) {
 			defer finish()
@@ -1572,6 +1573,31 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 		Response: result.Output,
 		History:  historySnapshot,
 	})
+
+	if newStream != nil {
+		if req.RequestID != "" {
+			cleanupRunAtReturn = false
+			streamOutputCleanupDeferred = true
+			go func() {
+				if !finalTTSOwnsCleanup {
+					defer cleanupRun()
+				}
+				defer unregisterStreamOutput()
+				s.closeTTSStreamAndLog(newStream)
+			}()
+			return
+		}
+		s.closeTTSStreamAndLog(newStream)
+	}
+}
+
+func (s *Server) closeTTSStreamAndLog(stream *streamSessionWriter) {
+	if stream == nil {
+		return
+	}
+	if err := stream.closeAndWait(); err != nil && s.logger != nil {
+		s.logger.Error("new TTS stream failed: %v", err)
+	}
 }
 
 type chatStreamWriter struct {

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -1016,6 +1016,11 @@ func (s *Server) handleChatAsync(
 			}
 		}
 		defer unregisterStreamOutput()
+		defer func() {
+			if newStream != nil {
+				s.closeTTSStreamAndLog(newStream)
+			}
+		}()
 
 		result, err := s.runtime.Run(runCtx, runReq)
 		progress.Cancel()
@@ -1086,9 +1091,6 @@ func (s *Server) handleChatAsync(
 		speechText := result.SpokenTextForConfig(s.runtime.config)
 		if s.audioClient != nil && speechText != "" && !result.SpeechStreamed {
 			s.speakFinalText(runCtx, requestID, speechText)
-		}
-		if newStream != nil {
-			s.closeTTSStreamAndLog(newStream)
 		}
 	}()
 }
@@ -1466,6 +1468,8 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 
 	var newStream *streamSessionWriter
 	var ttsStreamWriter io.Writer
+	var cancelTTSStreamContext func()
+	stopFollowingTTSRequestContext := func() {}
 	unregisterStreamOutput := func() {}
 	streamOutputCleanupDeferred := false
 	ttsManager := s.currentTTSManager()
@@ -1474,8 +1478,32 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.runtime.config.VoiceStreamingTTSEnabledOrDefault() && s.audioClient != nil {
 		if ttsManager != nil {
-			streamSession, err := beginManagedTTSStream(ctx, ttsManager, s.audioClient, s.runtime.config)
+			streamCtx := ctx
+			if req.RequestID == "" {
+				detachedCtx, cancelDetached := context.WithCancel(context.Background())
+				cancelTTSStreamContext = cancelDetached
+				stopFollow := make(chan struct{})
+				var stopFollowOnce sync.Once
+				stopFollowingTTSRequestContext = func() {
+					stopFollowOnce.Do(func() {
+						close(stopFollow)
+					})
+				}
+				go func(requestCtx context.Context) {
+					select {
+					case <-requestCtx.Done():
+						cancelDetached()
+					case <-stopFollow:
+					}
+				}(ctx)
+				streamCtx = detachedCtx
+			}
+			streamSession, err := beginManagedTTSStream(streamCtx, ttsManager, s.audioClient, s.runtime.config)
 			if err != nil {
+				stopFollowingTTSRequestContext()
+				if cancelTTSStreamContext != nil {
+					cancelTTSStreamContext()
+				}
 				if s.logger != nil {
 					s.logger.Warn("TTS BeginStream failed: %v", err)
 				}
@@ -1504,13 +1532,16 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 			if newStream == nil {
 				return
 			}
+			stopFollowingTTSRequestContext()
+			finishStreamContext := cancelTTSStreamContext
 			if req.RequestID != "" {
 				cleanupRunAtReturn = false
 				streamOutputCleanupDeferred = true
-				s.closeTTSStreamInBackground(newStream, unregisterStreamOutput, cleanupRun)
+				finishStreamContext = cleanupRun
 			} else {
-				go s.closeTTSStreamAndLog(newStream)
+				streamOutputCleanupDeferred = true
 			}
+			s.closeTTSStreamInBackground(newStream, unregisterStreamOutput, finishStreamContext)
 		}
 		canceled := errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled)
 		if req.RequestID != "" && s.liveActivity != nil {
@@ -1574,6 +1605,8 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 			finishRun = cleanupRun
 			cleanupRunAtReturn = false
 			finalTTSOwnsCleanup = true
+		} else {
+			finalTTSCtx = context.Background()
 		}
 		go func(text string, ttsCtx context.Context, finish func()) {
 			defer finish()
@@ -1588,17 +1621,18 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 	})
 
 	if newStream != nil {
+		stopFollowingTTSRequestContext()
+		streamOutputCleanupDeferred = true
+		finishRun := cancelTTSStreamContext
 		if req.RequestID != "" {
 			cleanupRunAtReturn = false
-			streamOutputCleanupDeferred = true
-			finishRun := cleanupRun
+			finishRun = cleanupRun
 			if finalTTSOwnsCleanup {
 				finishRun = nil
 			}
-			s.closeTTSStreamInBackground(newStream, unregisterStreamOutput, finishRun)
-			return
 		}
-		s.closeTTSStreamAndLog(newStream)
+		s.closeTTSStreamInBackground(newStream, unregisterStreamOutput, finishRun)
+		return
 	}
 }
 

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -1465,6 +1465,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var newStream *streamSessionWriter
+	var ttsStreamWriter io.Writer
 	unregisterStreamOutput := func() {}
 	streamOutputCleanupDeferred := false
 	ttsManager := s.currentTTSManager()
@@ -1483,7 +1484,8 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 				output := newActiveTTSOutput(nil)
 				output.setStream(newStream)
 				unregisterStreamOutput = s.registerActiveOutput(req.RequestID, output)
-				finalStreamWriters = append(finalStreamWriters, newCancelOnFirstWriteWriter(speechStreamWriterForConfig(newStream, s.runtime.config), progress.Cancel))
+				ttsStreamWriter = newCancelOnFirstWriteWriter(speechStreamWriterForConfig(newStream, s.runtime.config), progress.Cancel)
+				finalStreamWriters = append(finalStreamWriters, ttsStreamWriter)
 			}
 		}
 	}
@@ -1496,10 +1498,19 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.runtime.Run(ctx, runReq)
 	progress.Cancel()
-	result.SpeechStreamed = newStream != nil && streamWriterEmitted(runReq.StreamWriter)
+	result.SpeechStreamed = newStream != nil && streamWriterEmitted(ttsStreamWriter)
 	if err != nil {
-		if newStream != nil {
-			go s.closeTTSStreamAndLog(newStream)
+		closeErroredStream := func() {
+			if newStream == nil {
+				return
+			}
+			if req.RequestID != "" {
+				cleanupRunAtReturn = false
+				streamOutputCleanupDeferred = true
+				s.closeTTSStreamInBackground(newStream, unregisterStreamOutput, cleanupRun)
+			} else {
+				go s.closeTTSStreamAndLog(newStream)
+			}
 		}
 		canceled := errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled)
 		if req.RequestID != "" && s.liveActivity != nil {
@@ -1514,6 +1525,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 				s.logger.Info("Agent run canceled: request_id=%s", req.RequestID)
 			}
 			stream.Write(ChatStreamEvent{Type: "error", Error: "request canceled", History: s.historySnapshot()})
+			closeErroredStream()
 			return
 		}
 		errorMessage := Message{
@@ -1531,6 +1543,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 			s.logger.Error("Agent run failed: %v", err)
 		}
 		stream.Write(ChatStreamEvent{Type: "error", Error: err.Error(), History: s.historySnapshot()})
+		closeErroredStream()
 		return
 	}
 
@@ -1578,17 +1591,27 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 		if req.RequestID != "" {
 			cleanupRunAtReturn = false
 			streamOutputCleanupDeferred = true
-			go func() {
-				if !finalTTSOwnsCleanup {
-					defer cleanupRun()
-				}
-				defer unregisterStreamOutput()
-				s.closeTTSStreamAndLog(newStream)
-			}()
+			finishRun := cleanupRun
+			if finalTTSOwnsCleanup {
+				finishRun = nil
+			}
+			s.closeTTSStreamInBackground(newStream, unregisterStreamOutput, finishRun)
 			return
 		}
 		s.closeTTSStreamAndLog(newStream)
 	}
+}
+
+func (s *Server) closeTTSStreamInBackground(stream *streamSessionWriter, unregisterOutput func(), finishRun func()) {
+	go func() {
+		if finishRun != nil {
+			defer finishRun()
+		}
+		if unregisterOutput != nil {
+			defer unregisterOutput()
+		}
+		s.closeTTSStreamAndLog(stream)
+	}()
 }
 
 func (s *Server) closeTTSStreamAndLog(stream *streamSessionWriter) {

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -553,6 +553,145 @@ func TestServerHandleChatStreamEmitsAssistantDeltasBeforeDone(t *testing.T) {
 	}
 }
 
+func TestServerHandleChatStreamDoneDoesNotWaitForStreamingTTSClose(t *testing.T) {
+	streamingEnabled := true
+	provider := newCloseBlockingTTSProvider()
+	t.Cleanup(provider.release)
+
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			contentResponse(`{"mode":"direct_answer","speech":"stream close should not block done","text":"stream close should not block done","final_answer":"stream close should not block done","reason":"direct"}`),
+		},
+		streamChunks: [][]string{{
+			`{"mode":"direct_answer","speech":"stream close should not block done","text":"stream close should not block done","final_answer":"stream close should not block done","reason":"direct"}`,
+		}},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:                    ModelConfig{Provider: "fake"},
+			Instruction:              "Answer directly.",
+			VoiceStreamingTTSEnabled: &streamingEnabled,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+	server := NewServer(runtime, ":0")
+	server.ttsManager = ttsmodule.NewProviderManager(provider, nil)
+	server.audioClient = NewAudioServiceClient("/tmp/aiden-test-unused-audio.sock")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"hello","request_id":"web-slow-close"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/x-ndjson")
+	req.Header.Set("X-Aiden-Stream", "ndjson")
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		server.handleChat(rec, req)
+		close(done)
+	}()
+
+	waitForTestSignal(t, provider.firstWriteDone(), "streaming TTS write")
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("streaming chat handler waited for TTS Close before returning done")
+	}
+	waitForTestSignal(t, provider.closeStartedSignal(), "streaming TTS Close to start")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var sawDone bool
+	scanner := bufio.NewScanner(strings.NewReader(rec.Body.String()))
+	for scanner.Scan() {
+		var event ChatStreamEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			t.Fatalf("decode stream event %q: %v", scanner.Text(), err)
+		}
+		if event.Type == "done" {
+			sawDone = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan stream: %v", err)
+	}
+	if !sawDone {
+		t.Fatalf("stream response ended without done: %s", rec.Body.String())
+	}
+	if provider.closeDone() {
+		t.Fatal("TTS Close completed before release; test did not exercise slow close")
+	}
+}
+
+func TestServerHandleChatAsyncResultDoesNotWaitForStreamingTTSClose(t *testing.T) {
+	streamingEnabled := true
+	provider := newCloseBlockingTTSProvider()
+	t.Cleanup(provider.release)
+
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			contentResponse(`{"mode":"direct_answer","speech":"async close should not block complete","text":"async close should not block complete","final_answer":"async close should not block complete","reason":"direct"}`),
+		},
+		streamChunks: [][]string{{
+			`{"mode":"direct_answer","speech":"async close should not block complete","text":"async close should not block complete","final_answer":"async close should not block complete","reason":"direct"}`,
+		}},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:                    ModelConfig{Provider: "fake"},
+			Instruction:              "Answer directly.",
+			VoiceStreamingTTSEnabled: &streamingEnabled,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+	server := NewServer(runtime, ":0")
+	server.ttsManager = ttsmodule.NewProviderManager(provider, nil)
+	server.audioClient = NewAudioServiceClient("/tmp/aiden-test-unused-audio.sock")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"hello","request_id":"async-slow-close"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.handleChat(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	waitForTestSignal(t, provider.firstWriteDone(), "async streaming TTS write")
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		resultReq := httptest.NewRequest(http.MethodGet, "/api/chat/result?request_id=async-slow-close", nil)
+		resultRec := httptest.NewRecorder()
+		server.handleChatResult(resultRec, resultReq)
+		if resultRec.Code != http.StatusOK {
+			t.Fatalf("unexpected result status: %d body=%s", resultRec.Code, resultRec.Body.String())
+		}
+		var result ChatResultResponse
+		if err := json.NewDecoder(resultRec.Body).Decode(&result); err != nil {
+			t.Fatalf("decode result: %v", err)
+		}
+		if result.Status == "complete" {
+			if result.Response != "async close should not block complete" {
+				t.Fatalf("response = %q", result.Response)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("chat result did not complete before TTS Close release; last status=%q", result.Status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	waitForTestSignal(t, provider.closeStartedSignal(), "async TTS Close to start")
+	if provider.closeDone() {
+		t.Fatal("TTS Close completed before release; test did not exercise slow close")
+	}
+}
+
 type failingStreamWriter struct {
 	err error
 }
@@ -1967,6 +2106,68 @@ func (s *blockingTTSSession) Close() error {
 func (s *blockingTTSSession) Err() error {
 	return s.ctx.Err()
 }
+
+type closeBlockingTTSProvider struct {
+	firstWrite   chan struct{}
+	closeStarted chan struct{}
+	releaseCh    chan struct{}
+	firstOnce    sync.Once
+	closeOnce    sync.Once
+	releaseOnce  sync.Once
+	done         atomic.Bool
+}
+
+func newCloseBlockingTTSProvider() *closeBlockingTTSProvider {
+	return &closeBlockingTTSProvider{
+		firstWrite:   make(chan struct{}),
+		closeStarted: make(chan struct{}),
+		releaseCh:    make(chan struct{}),
+	}
+}
+
+func (p *closeBlockingTTSProvider) Name() string { return "close-blocking" }
+
+func (p *closeBlockingTTSProvider) Capabilities() ttsmodule.Capabilities {
+	return ttsmodule.Capabilities{SupportedSampleRates: []int{16000}}
+}
+
+func (p *closeBlockingTTSProvider) BeginStream(context.Context, ttsmodule.AudioSink) (ttsmodule.StreamSession, error) {
+	return &closeBlockingTTSSession{provider: p}, nil
+}
+
+func (p *closeBlockingTTSProvider) Close() error { return nil }
+
+func (p *closeBlockingTTSProvider) firstWriteDone() <-chan struct{} { return p.firstWrite }
+
+func (p *closeBlockingTTSProvider) closeStartedSignal() <-chan struct{} { return p.closeStarted }
+
+func (p *closeBlockingTTSProvider) release() {
+	p.releaseOnce.Do(func() { close(p.releaseCh) })
+}
+
+func (p *closeBlockingTTSProvider) closeDone() bool { return p.done.Load() }
+
+type closeBlockingTTSSession struct {
+	provider *closeBlockingTTSProvider
+}
+
+func (s *closeBlockingTTSSession) WriteText(text string) error {
+	if strings.TrimSpace(text) != "" {
+		s.provider.firstOnce.Do(func() { close(s.provider.firstWrite) })
+	}
+	return nil
+}
+
+func (s *closeBlockingTTSSession) Flush() error { return nil }
+
+func (s *closeBlockingTTSSession) Close() error {
+	s.provider.closeOnce.Do(func() { close(s.provider.closeStarted) })
+	<-s.provider.releaseCh
+	s.provider.done.Store(true)
+	return nil
+}
+
+func (s *closeBlockingTTSSession) Err() error { return nil }
 
 func TestServerHistoryEndpointIncludesToolMessages(t *testing.T) {
 	server := &Server{

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -626,6 +626,79 @@ func TestServerHandleChatStreamDoneDoesNotWaitForStreamingTTSClose(t *testing.T)
 	}
 }
 
+func TestServerHandleChatStreamWithoutRequestIDDoneDoesNotWaitForStreamingTTSClose(t *testing.T) {
+	streamingEnabled := true
+	provider := newCloseBlockingTTSProvider()
+	t.Cleanup(provider.release)
+
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			contentResponse(`{"mode":"direct_answer","speech":"stream close should not block done","text":"stream close should not block done","final_answer":"stream close should not block done","reason":"direct"}`),
+		},
+		streamChunks: [][]string{{
+			`{"mode":"direct_answer","speech":"stream close should not block done","text":"stream close should not block done","final_answer":"stream close should not block done","reason":"direct"}`,
+		}},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:                    ModelConfig{Provider: "fake"},
+			Instruction:              "Answer directly.",
+			VoiceStreamingTTSEnabled: &streamingEnabled,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+	server := NewServer(runtime, ":0")
+	server.ttsManager = ttsmodule.NewProviderManager(provider, nil)
+	server.audioClient = NewAudioServiceClient("/tmp/aiden-test-unused-audio.sock")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/x-ndjson")
+	req.Header.Set("X-Aiden-Stream", "ndjson")
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		server.handleChat(rec, req)
+		close(done)
+	}()
+
+	waitForTestSignal(t, provider.firstWriteDone(), "streaming TTS write")
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("streaming chat handler without request_id waited for TTS Close before returning done")
+	}
+	waitForTestSignal(t, provider.closeStartedSignal(), "streaming TTS Close to start")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var sawDone bool
+	scanner := bufio.NewScanner(strings.NewReader(rec.Body.String()))
+	for scanner.Scan() {
+		var event ChatStreamEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			t.Fatalf("decode stream event %q: %v", scanner.Text(), err)
+		}
+		if event.Type == "done" {
+			sawDone = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan stream: %v", err)
+	}
+	if !sawDone {
+		t.Fatalf("stream response ended without done: %s", rec.Body.String())
+	}
+	if provider.closeDone() {
+		t.Fatal("TTS Close completed before release; test did not exercise slow close")
+	}
+}
+
 func TestServerHandleChatStreamFallsBackWhenTTSWriterDoesNotEmit(t *testing.T) {
 	streamingEnabled := true
 	provider := newSilentFirstStreamTTSProvider()
@@ -796,6 +869,62 @@ func TestServerHandleChatAsyncResultDoesNotWaitForStreamingTTSClose(t *testing.T
 	if provider.closeDone() {
 		t.Fatal("TTS Close completed before release; test did not exercise slow close")
 	}
+}
+
+func TestServerHandleChatAsyncErrorClosesStreamingTTS(t *testing.T) {
+	streamingEnabled := true
+	provider := newCloseBlockingTTSProvider()
+	t.Cleanup(provider.release)
+
+	model := streamingThenErrorModel{
+		chunk: `{"mode":"direct_answer","text":"partial text","final_answer":"partial speech","reason":"direct"}`,
+		err:   errors.New("model failed after streaming"),
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:                    ModelConfig{Provider: "fake"},
+			Instruction:              "Answer directly.",
+			VoiceStreamingTTSEnabled: &streamingEnabled,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+	server := NewServer(runtime, ":0")
+	server.ttsManager = ttsmodule.NewProviderManager(provider, nil)
+	server.audioClient = NewAudioServiceClient("/tmp/aiden-test-unused-audio.sock")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"hello","request_id":"async-error-close"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.handleChat(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	waitForTestSignal(t, provider.firstWriteDone(), "async streaming TTS write before model error")
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		resultReq := httptest.NewRequest(http.MethodGet, "/api/chat/result?request_id=async-error-close", nil)
+		resultRec := httptest.NewRecorder()
+		server.handleChatResult(resultRec, resultReq)
+		if resultRec.Code != http.StatusOK {
+			t.Fatalf("unexpected result status: %d body=%s", resultRec.Code, resultRec.Body.String())
+		}
+		var result ChatResultResponse
+		if err := json.NewDecoder(resultRec.Body).Decode(&result); err != nil {
+			t.Fatalf("decode result: %v", err)
+		}
+		if result.Status == "error" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("chat result did not report error; last body=%s", resultRec.Body.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	waitForTestSignal(t, provider.closeStartedSignal(), "async streaming TTS Close after model error")
 }
 
 type failingStreamWriter struct {

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -626,6 +626,112 @@ func TestServerHandleChatStreamDoneDoesNotWaitForStreamingTTSClose(t *testing.T)
 	}
 }
 
+func TestServerHandleChatStreamFallsBackWhenTTSWriterDoesNotEmit(t *testing.T) {
+	streamingEnabled := true
+	provider := newSilentFirstStreamTTSProvider()
+
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			contentResponse(`{"mode":"direct_answer","speech":"fallback speech","text":"fallback text","final_answer":"fallback text","reason":"direct"}`),
+		},
+		streamChunks: [][]string{{
+			`{"mode":"direct_answer","text":"fallback text","reason":"direct"}`,
+		}},
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:                    ModelConfig{Provider: "fake"},
+			Instruction:              "Answer directly.",
+			VoiceStreamingTTSEnabled: &streamingEnabled,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+	server := NewServer(runtime, ":0")
+	server.ttsManager = ttsmodule.NewProviderManager(provider, nil)
+	server.audioClient = NewAudioServiceClient(startTTSPlaybackAudioSocket(t))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"hello","request_id":"web-silent-stream"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/x-ndjson")
+	req.Header.Set("X-Aiden-Stream", "ndjson")
+	rec := httptest.NewRecorder()
+
+	server.handleChat(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	waitForProviderTexts(t, provider, []string{"fallback text"}, 500*time.Millisecond)
+	if got := provider.beginCalls(); got != 2 {
+		t.Fatalf("BeginStream calls = %d, want 2", got)
+	}
+}
+
+func TestServerHandleChatStreamErrorKeepsTTSOutputCancelableUntilClose(t *testing.T) {
+	streamingEnabled := true
+	requestID := "web-error-close"
+	provider := newContextCloseBlockingTTSProvider()
+
+	model := streamingThenErrorModel{
+		chunk: `{"mode":"direct_answer","text":"partial text","final_answer":"partial speech","reason":"direct"}`,
+		err:   errors.New("model failed after streaming"),
+	}
+	runtime := NewRuntimeWithDeps(
+		Config{
+			Model:                    ModelConfig{Provider: "fake"},
+			Instruction:              "Answer directly.",
+			VoiceStreamingTTSEnabled: &streamingEnabled,
+		},
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+		NewSkillIndex(),
+	)
+	server := NewServer(runtime, ":0")
+	server.ttsManager = ttsmodule.NewProviderManager(provider, nil)
+	server.audioClient = NewAudioServiceClient("/tmp/aiden-test-unused-audio.sock")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"hello","request_id":"`+requestID+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/x-ndjson")
+	req.Header.Set("X-Aiden-Stream", "ndjson")
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		server.handleChat(rec, req)
+		close(done)
+	}()
+
+	waitForTestSignal(t, provider.firstWriteDone(), "streaming TTS write before model error")
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("streaming chat error response waited for TTS Close")
+	}
+	waitForTestSignal(t, provider.closeStartedSignal(), "streaming TTS Close after model error")
+
+	cancelReq := httptest.NewRequest(http.MethodPost, "/api/chat/cancel", bytes.NewBufferString(`{"request_id":"`+requestID+`"}`))
+	cancelReq.Header.Set("Content-Type", "application/json")
+	cancelRec := httptest.NewRecorder()
+	server.handleChatCancel(cancelRec, cancelReq)
+
+	if cancelRec.Code != http.StatusOK {
+		t.Fatalf("unexpected cancel status: %d body=%s", cancelRec.Code, cancelRec.Body.String())
+	}
+	var resp ChatCancelResponse
+	if err := json.NewDecoder(cancelRec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode cancel response: %v", err)
+	}
+	if resp.Status != "canceled" || resp.RequestID != requestID {
+		t.Fatalf("unexpected cancel response: %#v", resp)
+	}
+	waitForTestSignal(t, provider.closeDoneSignal(), "streaming TTS Close to finish after cancel")
+}
+
 func TestServerHandleChatAsyncResultDoesNotWaitForStreamingTTSClose(t *testing.T) {
 	streamingEnabled := true
 	provider := newCloseBlockingTTSProvider()
@@ -2168,6 +2274,159 @@ func (s *closeBlockingTTSSession) Close() error {
 }
 
 func (s *closeBlockingTTSSession) Err() error { return nil }
+
+type silentFirstStreamTTSProvider struct {
+	mu    sync.Mutex
+	calls int
+	seen  []string
+}
+
+func newSilentFirstStreamTTSProvider() *silentFirstStreamTTSProvider {
+	return &silentFirstStreamTTSProvider{}
+}
+
+func (p *silentFirstStreamTTSProvider) Name() string { return "silent-first-stream" }
+
+func (p *silentFirstStreamTTSProvider) Capabilities() ttsmodule.Capabilities {
+	return ttsmodule.Capabilities{SupportedSampleRates: []int{16000}}
+}
+
+func (p *silentFirstStreamTTSProvider) BeginStream(context.Context, ttsmodule.AudioSink) (ttsmodule.StreamSession, error) {
+	p.mu.Lock()
+	p.calls++
+	call := p.calls
+	p.mu.Unlock()
+	return &silentFirstStreamTTSSession{provider: p, call: call}, nil
+}
+
+func (p *silentFirstStreamTTSProvider) Close() error { return nil }
+
+func (p *silentFirstStreamTTSProvider) beginCalls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+func (p *silentFirstStreamTTSProvider) texts() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.seen...)
+}
+
+type silentFirstStreamTTSSession struct {
+	provider *silentFirstStreamTTSProvider
+	call     int
+	buf      strings.Builder
+}
+
+func (s *silentFirstStreamTTSSession) WriteText(text string) error {
+	if s.call > 1 {
+		s.buf.WriteString(text)
+	}
+	return nil
+}
+
+func (s *silentFirstStreamTTSSession) Flush() error { return nil }
+
+func (s *silentFirstStreamTTSSession) Close() error {
+	text := s.buf.String()
+	if text != "" {
+		s.provider.mu.Lock()
+		s.provider.seen = append(s.provider.seen, text)
+		s.provider.mu.Unlock()
+	}
+	return nil
+}
+
+func (s *silentFirstStreamTTSSession) Err() error { return nil }
+
+type contextCloseBlockingTTSProvider struct {
+	firstWrite   chan struct{}
+	closeStarted chan struct{}
+	closeDone    chan struct{}
+	firstOnce    sync.Once
+	closeOnce    sync.Once
+	doneOnce     sync.Once
+}
+
+func newContextCloseBlockingTTSProvider() *contextCloseBlockingTTSProvider {
+	return &contextCloseBlockingTTSProvider{
+		firstWrite:   make(chan struct{}),
+		closeStarted: make(chan struct{}),
+		closeDone:    make(chan struct{}),
+	}
+}
+
+func (p *contextCloseBlockingTTSProvider) Name() string { return "context-close-blocking" }
+
+func (p *contextCloseBlockingTTSProvider) Capabilities() ttsmodule.Capabilities {
+	return ttsmodule.Capabilities{SupportedSampleRates: []int{16000}}
+}
+
+func (p *contextCloseBlockingTTSProvider) BeginStream(ctx context.Context, _ ttsmodule.AudioSink) (ttsmodule.StreamSession, error) {
+	return &contextCloseBlockingTTSSession{ctx: ctx, provider: p}, nil
+}
+
+func (p *contextCloseBlockingTTSProvider) Close() error { return nil }
+
+func (p *contextCloseBlockingTTSProvider) firstWriteDone() <-chan struct{} { return p.firstWrite }
+
+func (p *contextCloseBlockingTTSProvider) closeStartedSignal() <-chan struct{} {
+	return p.closeStarted
+}
+
+func (p *contextCloseBlockingTTSProvider) closeDoneSignal() <-chan struct{} { return p.closeDone }
+
+type contextCloseBlockingTTSSession struct {
+	ctx      context.Context
+	provider *contextCloseBlockingTTSProvider
+}
+
+func (s *contextCloseBlockingTTSSession) WriteText(text string) error {
+	if strings.TrimSpace(text) != "" {
+		s.provider.firstOnce.Do(func() { close(s.provider.firstWrite) })
+	}
+	return nil
+}
+
+func (s *contextCloseBlockingTTSSession) Flush() error { return nil }
+
+func (s *contextCloseBlockingTTSSession) Close() error {
+	s.provider.closeOnce.Do(func() { close(s.provider.closeStarted) })
+	<-s.ctx.Done()
+	s.provider.doneOnce.Do(func() { close(s.provider.closeDone) })
+	return s.ctx.Err()
+}
+
+func (s *contextCloseBlockingTTSSession) Err() error { return s.ctx.Err() }
+
+type streamingThenErrorModel struct {
+	chunk string
+	err   error
+}
+
+func (m streamingThenErrorModel) GenerateContent(ctx context.Context, _ []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	var callOptions llms.CallOptions
+	for _, option := range options {
+		option(&callOptions)
+	}
+	if callOptions.StreamingFunc != nil && m.chunk != "" {
+		if err := callOptions.StreamingFunc(ctx, []byte(m.chunk)); err != nil {
+			return nil, err
+		}
+	}
+	if m.err != nil {
+		return nil, m.err
+	}
+	return contentResponse(""), nil
+}
+
+func (m streamingThenErrorModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return "", nil
+}
 
 func TestServerHistoryEndpointIncludesToolMessages(t *testing.T) {
 	server := &Server{

--- a/src/agent/internal/agent/tts_provider_integration_test.go
+++ b/src/agent/internal/agent/tts_provider_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -724,6 +725,25 @@ func waitForTestSignal(t *testing.T, ch <-chan struct{}, name string) {
 	case <-ch:
 	case <-time.After(2 * time.Second):
 		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+type testTTSRecorder interface {
+	texts() []string
+}
+
+func waitForProviderTexts(t *testing.T, provider testTTSRecorder, want []string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		got := provider.texts()
+		if reflect.DeepEqual(got, want) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("provider texts = %#v, want %#v", got, want)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat streaming so speech output is tracked more reliably during both live and async responses.
  * Fixed cancellation and cleanup behavior so streamed audio can finish or stop without delaying the main chat response.
  * Added a fallback for cases where speech output does not emit during streaming, ensuring text still appears as expected.

* **Tests**
  * Expanded coverage for streaming chat, async completion, cancellation timing, and TTS fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->