### PR TITLE
test(agent): wait for fake TTS audio writes

### DIFF
--- a/src/agent/internal/agent/tts_provider_integration_test.go
+++ b/src/agent/internal/agent/tts_provider_integration_test.go
@@ -871,13 +871,13 @@ func (s *playbackStartedTransientErrorSession) Flush() error { return nil }
 func (s *recordingTTSSession) Close() error {
 	text := s.buf.String()
 	if text != "" {
-		s.provider.mu.Lock()
-		s.provider.seen = append(s.provider.seen, text)
-		s.provider.mu.Unlock()
 		if err := s.sink.WritePCM(make([]byte, testTTSPlaybackStartPCMBytes)); err != nil {
 			s.err = err
 			return err
 		}
+		s.provider.mu.Lock()
+		s.provider.seen = append(s.provider.seen, text)
+		s.provider.mu.Unlock()
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- record fake TTS text only after the test sink successfully writes PCM to the fake audio socket
- make existing waitForProviderTextCount waits cover socket writes before test cleanup closes the listener

## Testing
- go test ./internal/agent -run 'TestAudioDialogSpeaksToolContentAsynchronously|TestAudioDialogSpeaksToolCallContent|TestAudioDialogRunScriptUsesConfiguredTTS|TestServerSpeakToolContentUsesTTS|TestAudioDialogRunAgentTurnStreamsThroughProviderManager|TestAudioDialogRunAgentTurnStreamsFinalAnswer' -count=20\n- go test ./internal/agent -run 'TestAudioDialog|TestServer.*TTS|TestTTS|TestManagedTTS|TestSpeakText|TestStreamSessionWriter|TestRuntimeRunStreamsFinalAnswerToWriter' -count=1\n- env -u OPENROUTER_API_KEY go test ./...\n\nNote: plain go test ./... in my local environment runs OpenRouter live tests because OPENROUTER_API_KEY is set; those failed on external EOF/403 and are unrelated to this TTS socket fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio session handling so text is only recorded after playback data is successfully written.
  * Prevented partial updates when an audio write fails, making session state more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->