### PR TITLE
fix(agent): remove screenshot_full quick action

### DIFF
--- a/src/agent/internal/agent/quick_actions.json
+++ b/src/agent/internal/agent/quick_actions.json
@@ -956,26 +956,6 @@
         }
       }
     },
-    "screenshot_full": {
-      "label": "Screenshot Full Screen",
-      "aliases": ["全屏截图", "screenshot_full"],
-      "category": "system_panel",
-      "platforms": {
-        "ios": {
-          "status": "active",
-          "tool": "keyboard_tap",
-          "input": { "keys": ["shift", "meta", "3"], "hold_ms": 120 },
-          "note": "external keyboard: Cmd+Shift+3 full-screen screenshot (HID shift=0x02, meta=0x08, 3=0x20)"
-        },
-        "android": { "status": "reserved" },
-        "mac": {
-          "status": "active",
-          "tool": "keyboard_tap",
-          "input": { "keys": ["shift", "meta", "3"] },
-          "note": "save full-screen screenshot to desktop (Shift+Cmd+3)"
-        }
-      }
-    },
     "screenshot_region": {
       "label": "Screenshot Region",
       "aliases": ["区域截图", "screenshot_region"],

--- a/src/agent/internal/agent/tools_quick_actions.go
+++ b/src/agent/internal/agent/tools_quick_actions.go
@@ -741,7 +741,7 @@ func platformNote(actionID, platform string, binding quickActionBinding) string 
 
 func quickActionBehaviorSummary() string {
 	return strings.Join([]string{
-		"Common actions: back, home, hide_app, quit_app, app_switch, spotlight_search, copy, paste, cut, undo, redo, select_all, delete_backward, delete_forward, find, send, browser_new_tab, browser_close_tab, browser_refresh, browser_address_bar, screenshot_full, screenshot_region.",
+		"Common actions: back, home, hide_app, quit_app, app_switch, spotlight_search, copy, paste, cut, undo, redo, select_all, delete_backward, delete_forward, find, send, browser_new_tab, browser_close_tab, browser_refresh, browser_address_bar, screenshot_region.",
 		"- Infer platform from screenshot/context and pass platform=ios/android/mac.",
 		"- Prefer quick_action before ad-hoc keyboard_tap or touch_gesture when an active catalog entry exists.",
 		"- If status=reserved in a list result or quick_action returns an error message: skip quick_action and use direct input tools instead.",

--- a/src/agent/internal/agent/tools_quick_actions_test.go
+++ b/src/agent/internal/agent/tools_quick_actions_test.go
@@ -129,6 +129,16 @@ func TestQuickActionDescriptionWarnsAgainstActionList(t *testing.T) {
 	}
 }
 
+func TestQuickActionDoesNotExposeScreenshotFull(t *testing.T) {
+	table := newQuickActionsTable()
+	if id, ok := table.resolveActionID("screenshot_full"); ok {
+		t.Fatalf("screenshot_full resolved to %q", id)
+	}
+	if strings.Contains((&QuickActionTool{}).Description(), "screenshot_full") {
+		t.Fatal("description should not mention screenshot_full")
+	}
+}
+
 func TestQuickActionReservedBinding(t *testing.T) {
 	tool := &QuickActionTool{}
 	ctx, _ := WithToolError(context.Background())


### PR DESCRIPTION
Summary:
- Remove screenshot_full from the quick_action catalog.
- Remove screenshot_full from quick_action common-action guidance.
- Add a regression test to keep screenshot_full out of quick_action exposure.

Tests:
- jq empty src/agent/internal/agent/quick_actions.json
- go test ./internal/agent -run 'TestQuickAction'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the full-screen screenshot quick action from the available shortcuts.
  * Updated the quick actions guidance so only region-based screenshot capture is shown as a common option.
  * Added coverage to ensure the removed screenshot action is no longer exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->