### PR TITLE
fix(agent): reduce memory update cancellation

### DIFF
--- a/src/agent/internal/agent/device_memory.go
+++ b/src/agent/internal/agent/device_memory.go
@@ -183,12 +183,20 @@ func (s *DeviceMemoryStore) Upsert(ctx context.Context, item DeviceMemoryItem) (
 }
 
 func (s *DeviceMemoryStore) Update(ctx context.Context, id string, update func(*DeviceMemoryItem)) error {
+	return s.UpdateMany(ctx, []string{id}, update)
+}
+
+func (s *DeviceMemoryStore) UpdateMany(ctx context.Context, ids []string, update func(*DeviceMemoryItem)) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
-	if s == nil || s.rootDir == "" || strings.TrimSpace(id) == "" || update == nil {
+	idSet := map[string]bool{}
+	for _, id := range uniqueNonEmpty(ids) {
+		idSet[id] = true
+	}
+	if s == nil || s.rootDir == "" || len(idSet) == 0 || update == nil {
 		return nil
 	}
 	items, err := s.readAll()
@@ -196,7 +204,7 @@ func (s *DeviceMemoryStore) Update(ctx context.Context, id string, update func(*
 		return err
 	}
 	for _, item := range items {
-		if item.ID != id {
+		if !idSet[item.ID] {
 			continue
 		}
 		oldPath := s.itemPath(item)
@@ -212,7 +220,9 @@ func (s *DeviceMemoryStore) Update(ctx context.Context, id string, update func(*
 				return removeErr
 			}
 		}
-		return err
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/src/agent/internal/agent/long_term_memory.go
+++ b/src/agent/internal/agent/long_term_memory.go
@@ -321,6 +321,10 @@ func (s *LongTermMemoryStore) MarkConflict(ctx context.Context, aID string, bID 
 }
 
 func (s *LongTermMemoryStore) UpdateMemory(ctx context.Context, id string, update func(*MemoryItem)) error {
+	return s.UpdateMemories(ctx, []string{id}, update)
+}
+
+func (s *LongTermMemoryStore) UpdateMemories(ctx context.Context, ids []string, update func(*MemoryItem)) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -329,24 +333,36 @@ func (s *LongTermMemoryStore) UpdateMemory(ctx context.Context, id string, updat
 	if update == nil {
 		return nil
 	}
-	path := s.memoryPath(id)
-	parsed, err := readMemoryMarkdown(path)
-	if err != nil {
-		if os.IsNotExist(err) || errors.Is(err, os.ErrNotExist) {
-			return nil
+	updated := false
+	for _, id := range uniqueNonEmpty(ids) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
 		}
-		return err
+		path := s.memoryPath(id)
+		parsed, err := readMemoryMarkdown(path)
+		if err != nil {
+			if os.IsNotExist(err) || errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return err
+		}
+		update(&parsed.Item)
+		parsed.Item.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		if parsed.Item.Title == "" {
+			parsed.Item.Title = parsed.Title
+		}
+		if parsed.Item.Content == "" {
+			parsed.Item.Content = parsed.Content
+		}
+		if err := writeFileAtomic(path, []byte(formatMemoryMarkdown(parsed.Item)), 0o644); err != nil {
+			return err
+		}
+		updated = true
 	}
-	update(&parsed.Item)
-	parsed.Item.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
-	if parsed.Item.Title == "" {
-		parsed.Item.Title = parsed.Title
-	}
-	if parsed.Item.Content == "" {
-		parsed.Item.Content = parsed.Content
-	}
-	if err := writeFileAtomic(path, []byte(formatMemoryMarkdown(parsed.Item)), 0o644); err != nil {
-		return err
+	if !updated {
+		return nil
 	}
 	return s.RebuildIndex(ctx)
 }

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -77,7 +77,6 @@ type MemoryManager struct {
 	contextWindowFn                ContextWindowFn
 	profileDebouncer               *ProfileDebouncer
 	lockTimeout                    time.Duration
-	archiveCompressTimeout         time.Duration
 	logger                         *Logger
 	sessionBoundaryEnabledOverride *bool
 
@@ -196,13 +195,6 @@ func WithMemoryLogger(logger *Logger) MemoryManagerOption {
 // means "unknown, use the yaml default". The yaml value remains the fallback.
 func WithContextWindowFn(fn ContextWindowFn) MemoryManagerOption {
 	return func(m *MemoryManager) { m.contextWindowFn = fn }
-}
-
-// WithArchiveCompressTimeout overrides the LLM summary timeout used when
-// compressing remaining events during session rotation. Tests may set a short
-// value to avoid waiting for the production default.
-func WithArchiveCompressTimeout(timeout time.Duration) MemoryManagerOption {
-	return func(m *MemoryManager) { m.archiveCompressTimeout = timeout }
 }
 
 // NewMemoryManager creates a new MemoryManager with the specified storage
@@ -1372,13 +1364,6 @@ func (m *MemoryManager) maintainFilesystemMemory(ctx context.Context) error {
 	return nil
 }
 
-func (m *MemoryManager) archiveCompressTimeoutOrDefault() time.Duration {
-	if m != nil && m.archiveCompressTimeout > 0 {
-		return m.archiveCompressTimeout
-	}
-	return 30 * time.Second
-}
-
 // compactionPlan describes the chosen split of the event stream.
 type compactionPlan struct {
 	ok             bool
@@ -1490,19 +1475,18 @@ func (m *MemoryManager) compressRemainingForArchive(sessionDir string) error {
 	if len(events) == 0 {
 		return nil
 	}
+	if summary, err := os.ReadFile(session.summaryPath()); err == nil && strings.TrimSpace(string(summary)) != "" {
+		return nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read existing session summary: %w", err)
+	}
 
-	// Use a bounded context with timeout to prevent slow LLM calls from
-	// blocking rotation indefinitely. If the LLM times out, buildEventSummary
-	// falls back to local summarization.
-	ctx, cancel := context.WithTimeout(context.Background(), m.archiveCompressTimeoutOrDefault())
-	defer cancel()
-
-	summary, structured := m.buildEventSummary(ctx, events)
-	_, err = session.Compress(ctx, CompressOption{
-		Summary:    summary,
-		Structured: structured,
-		Tags:       m.extraction.extractMemoryTags(events),
-		Entities:   m.extraction.extractMemoryEntities(events),
+	// Rotation runs on the next request's begin path. Keep this final archive
+	// chunk local-only so a slow LLM summarizer cannot block the new run.
+	_, err = session.Compress(context.Background(), CompressOption{
+		Summary:  summarizeSessionEvents(events),
+		Tags:     m.extraction.extractMemoryTags(events),
+		Entities: m.extraction.extractMemoryEntities(events),
 	})
 	if err != nil {
 		return fmt.Errorf("compress remaining events: %w", err)

--- a/src/agent/internal/agent/memory.go
+++ b/src/agent/internal/agent/memory.go
@@ -1475,11 +1475,16 @@ func (m *MemoryManager) compressRemainingForArchive(sessionDir string) error {
 	if len(events) == 0 {
 		return nil
 	}
-	if summary, err := os.ReadFile(session.summaryPath()); err == nil && strings.TrimSpace(string(summary)) != "" {
-		return nil
-	} else if err != nil && !os.IsNotExist(err) {
+	existingSummary, err := os.ReadFile(session.summaryPath())
+	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read existing session summary: %w", err)
 	}
+	preserveSummary := strings.TrimSpace(string(existingSummary)) != ""
+	existingSummaryArchive, summaryArchiveErr := os.ReadFile(session.summaryArchivePath())
+	if summaryArchiveErr != nil && !os.IsNotExist(summaryArchiveErr) {
+		return fmt.Errorf("read existing session summary archive: %w", summaryArchiveErr)
+	}
+	hadSummaryArchive := summaryArchiveErr == nil
 
 	// Rotation runs on the next request's begin path. Keep this final archive
 	// chunk local-only so a slow LLM summarizer cannot block the new run.
@@ -1490,6 +1495,20 @@ func (m *MemoryManager) compressRemainingForArchive(sessionDir string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("compress remaining events: %w", err)
+	}
+	if preserveSummary {
+		if err := writeFileAtomic(session.summaryPath(), existingSummary, 0o644); err != nil {
+			return fmt.Errorf("restore existing session summary: %w", err)
+		}
+		if hadSummaryArchive {
+			if err := writeFileAtomic(session.summaryArchivePath(), existingSummaryArchive, 0o644); err != nil {
+				return fmt.Errorf("restore existing session summary archive: %w", err)
+			}
+		} else {
+			if err := os.Remove(session.summaryArchivePath()); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove generated session summary archive: %w", err)
+			}
+		}
 	}
 	if m.logger != nil {
 		m.logger.Info("[memory] pre-archive compression: %d events into final chunk", len(events))

--- a/src/agent/internal/agent/memory_plane.go
+++ b/src/agent/internal/agent/memory_plane.go
@@ -820,20 +820,18 @@ func (p *FilesystemMemoryPlane) updateReferencedMemoryOutcomes(ctx context.Conte
 	if len(refs) == 0 {
 		return nil
 	}
-	for _, id := range refs {
-		if p.longTerm != nil {
-			if err := p.longTerm.UpdateMemory(ctx, id, func(item *MemoryItem) {
-				updateLongTermMemoryFromEpisode(item, episode)
-			}); err != nil {
-				return err
-			}
+	if p.longTerm != nil {
+		if err := p.longTerm.UpdateMemories(ctx, refs, func(item *MemoryItem) {
+			updateLongTermMemoryFromEpisode(item, episode)
+		}); err != nil {
+			return err
 		}
-		if p.device != nil {
-			if err := p.device.Update(ctx, id, func(item *DeviceMemoryItem) {
-				updateDeviceMemoryFromEpisode(item, episode)
-			}); err != nil {
-				return err
-			}
+	}
+	if p.device != nil {
+		if err := p.device.UpdateMany(ctx, refs, func(item *DeviceMemoryItem) {
+			updateDeviceMemoryFromEpisode(item, episode)
+		}); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/src/agent/internal/agent/memory_plane_test.go
+++ b/src/agent/internal/agent/memory_plane_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -756,6 +757,132 @@ func TestMemoryPlaneUpdatesReferencedMemoryOutcomes(t *testing.T) {
 	}
 	if fail.Item.Status != "conflicted" || !containsMemoryPlaneString(fail.Item.ConflictsWith, "ep_success") {
 		t.Fatalf("expected success to conflict with failure memory, got %#v", fail.Item)
+	}
+}
+
+func TestMemoryPlaneUpdatesReferencedLongTermOutcomesInBatch(t *testing.T) {
+	ctx := context.Background()
+	memoryDir := filepath.Join(t.TempDir(), "memory")
+	longTerm := NewLongTermMemoryStore(filepath.Join(memoryDir, "long_term"))
+	refs := []string{"mem_batch_one", "mem_batch_two", "mem_batch_three"}
+	for _, id := range refs {
+		if _, err := longTerm.AddMemory(ctx, MemoryItem{
+			ID:               id,
+			Type:             "procedure",
+			Status:           "active",
+			Priority:         80,
+			Confidence:       0.8,
+			Title:            id,
+			Content:          "Reusable procedure.",
+			EvidenceExcerpts: []string{"Reusable procedure succeeded."},
+			TTL:              "45d",
+		}); err != nil {
+			t.Fatalf("AddMemory(%s): %v", id, err)
+		}
+	}
+	plane := NewFilesystemMemoryPlane(memoryDir, DefaultMemoryExtractionConfig(), nil)
+	plane.device = nil
+
+	limitedCtx := newCancelAfterDoneContext(ctx, 5)
+	if err := plane.updateReferencedMemoryOutcomes(limitedCtx, TaskEpisode{
+		ID:                  "ep_batch_success",
+		RetrievedMemoryRefs: refs,
+		Outcome:             TaskEpisodeOutcome{Success: true},
+	}); err != nil {
+		t.Fatalf("updateReferencedMemoryOutcomes() error = %v", err)
+	}
+
+	for _, id := range refs {
+		parsed, err := readMemoryMarkdown(longTerm.memoryPath(id))
+		if err != nil {
+			t.Fatalf("read %s: %v", id, err)
+		}
+		if parsed.Item.SuccessCount != 1 {
+			t.Fatalf("%s SuccessCount = %d, want 1", id, parsed.Item.SuccessCount)
+		}
+	}
+}
+
+func TestMemoryPlaneUpdatesReferencedDeviceOutcomesInBatch(t *testing.T) {
+	ctx := context.Background()
+	memoryDir := filepath.Join(t.TempDir(), "memory")
+	device := NewDeviceMemoryStore(filepath.Join(memoryDir, "device"))
+	refs := []string{"dev_batch_one", "dev_batch_two", "dev_batch_three"}
+	for _, id := range refs {
+		if _, err := device.Upsert(ctx, DeviceMemoryItem{
+			ID:         id,
+			Type:       "procedure",
+			Status:     "active",
+			Title:      id,
+			Content:    "Device procedure.",
+			DeviceID:   defaultMemoryDeviceID,
+			Confidence: 0.8,
+			TTL:        "45d",
+		}); err != nil {
+			t.Fatalf("Upsert(%s): %v", id, err)
+		}
+	}
+	plane := NewFilesystemMemoryPlane(memoryDir, DefaultMemoryExtractionConfig(), nil)
+	plane.longTerm = nil
+
+	limitedCtx := newCancelAfterDoneContext(ctx, 5)
+	if err := plane.updateReferencedMemoryOutcomes(limitedCtx, TaskEpisode{
+		ID:                  "ep_batch_failure",
+		RetrievedMemoryRefs: refs,
+		Outcome:             TaskEpisodeOutcome{Success: false, FailureReason: "procedure failed"},
+	}); err != nil {
+		t.Fatalf("updateReferencedMemoryOutcomes() error = %v", err)
+	}
+
+	for _, id := range refs {
+		item, found, err := device.Get(ctx, id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if !found {
+			t.Fatalf("Get(%s) not found", id)
+		}
+		if item.FailureCount != 1 {
+			t.Fatalf("%s FailureCount = %d, want 1", id, item.FailureCount)
+		}
+	}
+}
+
+type cancelAfterDoneContext struct {
+	context.Context
+	allowedOpenDoneCalls int
+
+	mu    sync.Mutex
+	calls int
+	done  chan struct{}
+	once  sync.Once
+}
+
+func newCancelAfterDoneContext(parent context.Context, allowedOpenDoneCalls int) *cancelAfterDoneContext {
+	return &cancelAfterDoneContext{
+		Context:              parent,
+		allowedOpenDoneCalls: allowedOpenDoneCalls,
+		done:                 make(chan struct{}),
+	}
+}
+
+func (c *cancelAfterDoneContext) Done() <-chan struct{} {
+	c.mu.Lock()
+	c.calls++
+	if c.calls > c.allowedOpenDoneCalls {
+		c.once.Do(func() { close(c.done) })
+	}
+	done := c.done
+	c.mu.Unlock()
+	return done
+}
+
+func (c *cancelAfterDoneContext) Err() error {
+	select {
+	case <-c.done:
+		return context.Canceled
+	default:
+		return c.Context.Err()
 	}
 }
 

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -1657,6 +1657,40 @@ func TestSessionRotationDetailedCreatesActiveSessionID(t *testing.T) {
 	}
 }
 
+func TestSessionRotationDoesNotBlockOnPreArchiveSummary(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	manager := NewMemoryManager(storageDir,
+		WithSummarizeFn(func(ctx context.Context, events []SessionEvent) string {
+			<-ctx.Done()
+			return ""
+		}),
+	)
+	session := NewSessionMemoryStore(filepath.Join(storageDir, "session"))
+	if _, err := session.AppendEvent(ctx, SessionEvent{
+		EventID: "evt_before_nonblocking_rotate",
+		Ts:      time.Now().UTC().Format(time.RFC3339Nano),
+		Type:    "user_input",
+		Role:    "user",
+		Content: "old task",
+	}); err != nil {
+		t.Fatalf("AppendEvent() error = %v", err)
+	}
+
+	start := time.Now()
+	rotation, err := manager.RotateSessionEventsDetailed()
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("RotateSessionEventsDetailed() error = %v", err)
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("RotateSessionEventsDetailed() elapsed = %s, want under 200ms", elapsed)
+	}
+	if rotation.ArchiveDir == "" || rotation.ActiveSessionID == "" {
+		t.Fatalf("rotation missing archive or active session: %#v", rotation)
+	}
+}
+
 func TestSessionRotationRejectsUnsafeMetadataSessionID(t *testing.T) {
 	ctx := context.Background()
 	storageDir := t.TempDir()
@@ -1840,27 +1874,7 @@ func TestSessionRotationDoesNotDeadlockWithMemoryLoad(t *testing.T) {
 	}
 }
 
-// testSummarizeForRotationAndMaintenance lets archive compression during rotation
-// expire quickly while later maintenance summarize calls block until release.
-func testSummarizeForRotationAndMaintenance(release <-chan struct{}, result string) SummarizeFn {
-	var calls atomic.Int32
-	return func(ctx context.Context, events []SessionEvent) string {
-		if calls.Add(1) == 1 {
-			<-ctx.Done()
-			return ""
-		}
-		select {
-		case <-ctx.Done():
-			return ""
-		case <-release:
-			return result
-		}
-	}
-}
-
 // testBlockingSummarizeOnFirstCall blocks only the first summarize invocation.
-// RotateSessionEvents may call summarize again via compressRemainingForArchive;
-// those later calls must return immediately instead of waiting for the archive timeout.
 func testBlockingSummarizeOnFirstCall(started chan<- struct{}, release <-chan struct{}, result string) SummarizeFn {
 	var calls atomic.Int32
 	var startedOnce sync.Once

--- a/src/agent/internal/agent/memory_test.go
+++ b/src/agent/internal/agent/memory_test.go
@@ -1678,16 +1678,88 @@ func TestSessionRotationDoesNotBlockOnPreArchiveSummary(t *testing.T) {
 	}
 
 	start := time.Now()
-	rotation, err := manager.RotateSessionEventsDetailed()
-	elapsed := time.Since(start)
+	done := make(chan struct {
+		rotation SessionRotationResult
+		err      error
+	}, 1)
+	go func() {
+		rotation, err := manager.RotateSessionEventsDetailed()
+		done <- struct {
+			rotation SessionRotationResult
+			err      error
+		}{rotation: rotation, err: err}
+	}()
+
+	var rotation SessionRotationResult
+	var err error
+	select {
+	case result := <-done:
+		rotation, err = result.rotation, result.err
+		elapsed := time.Since(start)
+		if elapsed > 200*time.Millisecond {
+			t.Fatalf("RotateSessionEventsDetailed() elapsed = %s, want under 200ms", elapsed)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("RotateSessionEventsDetailed() blocked on pre-archive summary")
+	}
 	if err != nil {
 		t.Fatalf("RotateSessionEventsDetailed() error = %v", err)
 	}
-	if elapsed > 200*time.Millisecond {
-		t.Fatalf("RotateSessionEventsDetailed() elapsed = %s, want under 200ms", elapsed)
-	}
 	if rotation.ArchiveDir == "" || rotation.ActiveSessionID == "" {
 		t.Fatalf("rotation missing archive or active session: %#v", rotation)
+	}
+}
+
+func TestSessionRotationPreservesSummaryAndChunksRemainingEvents(t *testing.T) {
+	ctx := context.Background()
+	storageDir := t.TempDir()
+	manager := NewMemoryManager(storageDir)
+	sessionDir := filepath.Join(storageDir, "session")
+	session := NewSessionMemoryStore(sessionDir)
+	oldSummary := "OLD SESSION SUMMARY MUST BE PRESERVED"
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll session dir: %v", err)
+	}
+	if err := os.WriteFile(session.summaryPath(), []byte(oldSummary), 0o644); err != nil {
+		t.Fatalf("WriteFile summary.md: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := session.AppendEvent(ctx, SessionEvent{
+			EventID: fmt.Sprintf("evt_remaining_%d", i),
+			Ts:      time.Now().UTC().Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
+			Type:    "user_input",
+			Role:    "user",
+			Content: fmt.Sprintf("remaining hot event %d", i),
+		}); err != nil {
+			t.Fatalf("AppendEvent(%d) error = %v", i, err)
+		}
+	}
+
+	rotation, err := manager.RotateSessionEventsDetailed()
+	if err != nil {
+		t.Fatalf("RotateSessionEventsDetailed() error = %v", err)
+	}
+	if rotation.ArchiveDir == "" {
+		t.Fatal("ArchiveDir is empty")
+	}
+	archivedSummary, err := os.ReadFile(filepath.Join(rotation.ArchiveDir, "summary.md"))
+	if err != nil {
+		t.Fatalf("ReadFile archived summary.md: %v", err)
+	}
+	if string(archivedSummary) != oldSummary {
+		t.Fatalf("archived summary = %q, want %q", archivedSummary, oldSummary)
+	}
+
+	archivedStore := NewSessionMemoryStore(rotation.ArchiveDir)
+	chunks, err := archivedStore.RecallChunks(ctx, ChunkRecallQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("RecallChunks() error = %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 final chunk, got %#v", chunks)
+	}
+	if len(chunks[0].Evidence) != 2 {
+		t.Fatalf("final chunk evidence len = %d, want 2", len(chunks[0].Evidence))
 	}
 }
 

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -32,7 +32,10 @@ func effectiveMaxIterations(configured int) int {
 	return configured
 }
 
-const currentEnvironmentHintMaxAge = 10 * time.Minute
+const (
+	currentEnvironmentHintMaxAge      = 10 * time.Minute
+	runtimeSessionEventPersistTimeout = 2 * time.Second
+)
 
 type Runtime struct {
 	config             Config
@@ -1410,13 +1413,20 @@ func (h *runtimeCallbackHandler) emitRunEvent(ctx context.Context, event RunEven
 	if event.EpisodeID == "" {
 		event.EpisodeID = h.episodeID
 	}
-	if h.sessionEventAppender != nil {
-		if err := h.sessionEventAppender(ctx, sessionEventFromRunEvent(event, h)); err != nil && h.logger != nil {
-			h.logger.Warn("[memory] persist runtime session event failed: %v", err)
-		}
-	}
+	h.persistSessionEventBestEffort(sessionEventFromRunEvent(event, h), "[memory] persist runtime session event failed")
 	if h.eventHandler != nil {
 		h.eventHandler(event)
+	}
+}
+
+func (h *runtimeCallbackHandler) persistSessionEventBestEffort(event SessionEvent, warnMessage string) {
+	if h.sessionEventAppender == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), runtimeSessionEventPersistTimeout)
+	defer cancel()
+	if err := h.sessionEventAppender(ctx, event); err != nil && h.logger != nil {
+		h.logger.Warn("%s: %v", warnMessage, err)
 	}
 }
 
@@ -1713,9 +1723,7 @@ func (h *runtimeCallbackHandler) HandlePlannerDecision(ctx context.Context, deci
 	if h.sessionEventAppender != nil {
 		event := sessionEventFromPlannerDecision(decision)
 		event.EpisodeID = h.episodeID
-		if err := h.sessionEventAppender(ctx, event); err != nil && h.logger != nil {
-			h.logger.Warn("[memory] persist planner decision failed: %v", err)
-		}
+		h.persistSessionEventBestEffort(event, "[memory] persist planner decision failed")
 	}
 }
 
@@ -1723,9 +1731,7 @@ func (h *runtimeCallbackHandler) HandleVerifierDecision(ctx context.Context, dec
 	if h.sessionEventAppender != nil {
 		event := sessionEventFromVerifierDecision(decision)
 		event.EpisodeID = h.episodeID
-		if err := h.sessionEventAppender(ctx, event); err != nil && h.logger != nil {
-			h.logger.Warn("[memory] persist verifier decision failed: %v", err)
-		}
+		h.persistSessionEventBestEffort(event, "[memory] persist verifier decision failed")
 	}
 }
 

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1766,6 +1766,29 @@ func TestRuntimeCallbackPropagatesToolErrorToEventsAndMessages(t *testing.T) {
 	}
 }
 
+func TestRuntimeCallbackPersistsSessionEventWithCanceledRunContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var appenderCtxErr error
+	handler := &runtimeCallbackHandler{
+		episodeID: "ep-1",
+		runtimeID: "runtime-1",
+		requestID: "req-1",
+		runID:     "run-1",
+		sessionEventAppender: func(ctx context.Context, event SessionEvent) error {
+			appenderCtxErr = ctx.Err()
+			return appenderCtxErr
+		},
+	}
+
+	handler.emitRunEvent(ctx, RunEvent{Type: "tool_result", Content: "ok"})
+
+	if appenderCtxErr != nil {
+		t.Fatalf("sessionEventAppender ctx.Err() = %v, want nil", appenderCtxErr)
+	}
+}
+
 func runEventsOfType(events []RunEvent, eventType string) []RunEvent {
 	var matching []RunEvent
 	for _, event := range events {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -3115,8 +3115,14 @@ func TestRuntimeRunRotatesSessionOnNewBoundary(t *testing.T) {
 
 	releaseMaintenance := make(chan struct{})
 	manager := NewMemoryManager(storageDir,
-		WithArchiveCompressTimeout(time.Millisecond),
-		WithSummarizeFn(testSummarizeForRotationAndMaintenance(releaseMaintenance, "old task summary")),
+		WithSummarizeFn(func(ctx context.Context, events []SessionEvent) string {
+			select {
+			case <-ctx.Done():
+				return ""
+			case <-releaseMaintenance:
+				return "old task summary"
+			}
+		}),
 	)
 	defer func() {
 		close(releaseMaintenance)


### PR DESCRIPTION
## Summary
- Batch referenced long-term memory outcome updates so index rebuilds once per episode.
- Batch referenced device memory updates to avoid repeated full scans.
- Persist runtime session events with an independent short context so canceled runs do not drop best-effort writes.
- Avoid blocking session rotation on pre-archive LLM summaries by using local-only final archive chunking.

## Test Plan
- go test ./internal/agent -run 'TestArchiveGeneratesFinalChunk|TestSessionRotation|TestRuntimeRunRotatesSessionOnNewBoundary|TestMaintainFilesystemMemorySkipsActiveWriteAfterRotation|TestSessionRotationDoesNotBlockOnPreArchiveSummary'\n- go test ./...\n\n## Notes\n- This addresses the session rotation/pre-archive compression blocking path. Search timeout recovery remains a separate tool-error policy change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory updates now support batch updating multiple items in one operation for both long-term and device memories.
* **Bug Fixes**
  * Referenced long-term and device memories are updated in bulk, reducing missed refreshes and keeping related items consistent.
  * Runtime session events are persisted more reliably in a best-effort manner with a bounded timeout, even for canceled runs.
  * Updates avoid stale duplicate records when an item’s type changes.
* **Changes**
  * Archive pre-compression behavior was simplified: the configurable archive-compression timeout option was removed, and summaries are preserved/restored appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->