### PR TITLE
fix(ci): avoid persisting failed buildroot state

### DIFF
--- a/scripts/test_build_scripts.sh
+++ b/scripts/test_build_scripts.sh
@@ -11,6 +11,7 @@ CI_WORKFLOW="$ROOT_DIR/.github/workflows/ci.yml"
 REPACK_SCRIPT="$ROOT_DIR/scripts/repack_ota_update_image.sh"
 GITIGNORE="$ROOT_DIR/.gitignore"
 AIDEN_BOARD_CONFIG="$ROOT_DIR/pico-sdk/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Buildroot-RV1106_Luckfox_Pico_Zero-IPC.mk"
+SYSDRV_MAKEFILE="$ROOT_DIR/pico-sdk/sysdrv/Makefile"
 
 if grep -Eq 'go\.dev/dl|wget .*go|curl .*go|tar .*go\$|GO_TARBALL|GO_TARBALL_SHA256' "$BUILD_SH" "$BUILD_IMAGE_SH"; then
     echo "build scripts must not download or extract Go toolchains" >&2
@@ -292,12 +293,44 @@ for required in \
     'write_at($fh, $inode_offset + 100, "\0" x 4)' \
     'normalize ext4 inode metadata'; do
     if ! grep -Fq -- "$required" "$ROOT_DIR/pico-sdk/project/build.sh" \
-       && ! grep -Fq -- "$required" "$ROOT_DIR/pico-sdk/sysdrv/Makefile" \
+       && ! grep -Fq -- "$required" "$SYSDRV_MAKEFILE" \
        && ! grep -Fq -- "$required" "$ROOT_DIR/pico-sdk/sysdrv/tools/pc/e2fsprogs/mkfs_ext4.sh"; then
         echo "pico-sdk rootfs reproducibility support missing required content: $required" >&2
         exit 1
     fi
 done
+
+refresh_buildroot_state_block=$(sed -n '/^define refresh_buildroot_config_state$/, /^endef$/p' "$SYSDRV_MAKEFILE")
+if printf '%s\n' "$refresh_buildroot_state_block" | grep -Fq 'printf '\''%s\n'\'' "$$state" > "$$stamp"'; then
+    echo "buildroot config refresh must not stamp success before the build completes" >&2
+    exit 1
+fi
+
+for required in \
+    'define buildroot_config_state_value' \
+    'define write_buildroot_config_state_stamp' \
+    '$(call write_buildroot_config_state_stamp)'; do
+    if ! grep -Fq -- "$required" "$SYSDRV_MAKEFILE"; then
+        echo "pico-sdk buildroot state tracking missing required content: $required" >&2
+        exit 1
+    fi
+done
+
+buildroot_target_block=$(sed -n '/^buildroot: prepare$/, /^buildroot_clean:$/p' "$SYSDRV_MAKEFILE")
+refresh_line=$(printf '%s\n' "$buildroot_target_block" | grep -nF '$(call refresh_buildroot_config_state)' | sed 's/:.*//' | head -n 1)
+parallel_build_line=$(printf '%s\n' "$buildroot_target_block" | grep -nF '$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -j$(SYSDRV_JOBS) -C $(BUILDROOT_DIR)/$(BUILDROOT_VER)' | sed 's/:.*//' | head -n 1)
+write_stamp_line=$(printf '%s\n' "$buildroot_target_block" | grep -nF '$(call write_buildroot_config_state_stamp)' | sed 's/:.*//' | head -n 1)
+if [ -z "$refresh_line" ] || [ -z "$parallel_build_line" ] || [ -z "$write_stamp_line" ] || \
+   [ "$refresh_line" -ge "$parallel_build_line" ] || [ "$write_stamp_line" -le "$parallel_build_line" ]; then
+    echo "buildroot state tracking must refresh before the Buildroot compile and stamp only after it succeeds" >&2
+    exit 1
+fi
+
+last_buildroot_command=$(printf '%s\n' "$buildroot_target_block" | sed '1d;$d;/^[[:space:]]*$/d' | tail -n 1 | sed 's/^[[:space:]]*//')
+if [ "$last_buildroot_command" != '$(call write_buildroot_config_state_stamp)' ]; then
+    echo "buildroot state stamp must be the final successful step in the buildroot target" >&2
+    exit 1
+fi
 
 if ! grep -q 'chown -hR 0:0 "\$USERDATA_DIR"' "$REPACK_SCRIPT"; then
     echo "OTA update repack must normalize userdata ownership before rebuilding userdata.img" >&2

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -294,6 +294,7 @@ func TestRuntimeRunRestoresHotWindowHistoryAsChatMessages(t *testing.T) {
 		&ToolSet{tools: map[string]langtools.Tool{}},
 		NewSkillIndex(),
 	)
+	t.Cleanup(func() { _ = runtime.Close() })
 
 	if _, err := runtime.Run(ctx, RunRequest{Input: "继续上一轮"}); err != nil {
 		t.Fatalf("Run() error = %v", err)
@@ -345,13 +346,15 @@ func TestRuntimeRunContinuesWhenPersistedMemoryCannotLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 	model := &scriptedModel{responses: roleDirectResponses("ok")}
+	manager := NewMemoryManager(memoryDir)
 	runtime := NewRuntimeWithDeps(
 		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Answer directly.", MaxIterations: 1},
 		&testModelResolver{model: model},
-		NewMemoryManager(memoryDir),
+		manager,
 		&ToolSet{tools: map[string]langtools.Tool{}},
 		NewSkillIndex(),
 	)
+	t.Cleanup(func() { _ = runtime.Close() })
 
 	result, err := runtime.Run(context.Background(), RunRequest{Input: "hello"})
 	if err != nil {
@@ -3227,6 +3230,7 @@ func TestRuntimeRunRotatesSessionOnNewBoundary(t *testing.T) {
 		NewSkillIndex(),
 	)
 	runtime.memoryPlane = NewFilesystemMemoryPlane(storageDir, manager.extraction, nil)
+	t.Cleanup(func() { _ = runtime.Close() })
 
 	result, err := runtime.Run(context.Background(), RunRequest{Input: "打开微信"})
 	if err != nil {
@@ -3323,6 +3327,7 @@ func TestRuntimeRunShortGapKeepsActiveSessionWithoutForcedContinuation(t *testin
 		NewSkillIndex(),
 	)
 	runtime.memoryPlane = NewFilesystemMemoryPlane(storageDir, manager.extraction, nil)
+	t.Cleanup(func() { _ = runtime.Close() })
 
 	result, err := runtime.Run(context.Background(), RunRequest{Input: "打开微信"})
 	if err != nil {
@@ -3402,6 +3407,7 @@ func TestRuntimeRunRepairsTruncatedSessionTailBeforeBoundaryRotation(t *testing.
 		NewSkillIndex(),
 	)
 	runtime.memoryPlane = NewFilesystemMemoryPlane(storageDir, manager.extraction, nil)
+	t.Cleanup(func() { _ = runtime.Close() })
 
 	result, err := runtime.Run(context.Background(), RunRequest{Input: "打开微信"})
 	if err != nil {
@@ -3551,6 +3557,7 @@ func TestRuntimeRunRotatesNeutralFollowUpAfterFinishedEpisode(t *testing.T) {
 		NewSkillIndex(),
 	)
 	runtime.memoryPlane = NewFilesystemMemoryPlane(storageDir, manager.extraction, nil)
+	t.Cleanup(func() { _ = runtime.Close() })
 
 	result, err := runtime.Run(context.Background(), RunRequest{Input: "你有什么爱好？"})
 	if err != nil {


### PR DESCRIPTION
## Summary
- update pico-sdk to write the Buildroot config-state stamp only after a successful build
- add regression checks that guard the Makefile ordering and stamp-write behavior
- point the pico-sdk submodule at aiden-sdk main after #20 merged
- prevent CI retries from reusing partially failed Buildroot output trees

## Root Cause
The failed job at https://github.com/AidenAI-IO/aiden-hardware-demo/actions/runs/28572931015/job/84716803060 surfaced in bluez5_utils with a VERSION undeclared error, but that was a secondary symptom. The underlying issue was that a previous failed Buildroot run could still refresh the cached config-state marker, so a later retry skipped cleanup and reused a polluted output tree.

## Testing
- sh -n scripts/test_build_scripts.sh
- inspected the new regression checks and Makefile target ordering

## Submodule
- pico-sdk now points at aiden-sdk main commit b1e13d9c7c36540530daa4f36a808befd34ba526, which includes merged PR #20