### PR TITLE
fix(ci): validate shared Buildroot state inputs

### DIFF
--- a/scripts/test_reproducible_rootfs_policy.sh
+++ b/scripts/test_reproducible_rootfs_policy.sh
@@ -76,18 +76,26 @@ if ! grep -q 'define refresh_buildroot_config_state' "$PICO_SDK/sysdrv/Makefile"
   exit 1
 fi
 
+buildroot_config_state_value="$(sed -n '/^define buildroot_config_state_value$/,/^endef$/p' "$PICO_SDK/sysdrv/Makefile")"
 refresh_buildroot_config_state="$(sed -n '/^define refresh_buildroot_config_state$/,/^endef$/p' "$PICO_SDK/sysdrv/Makefile")"
-if ! printf '%s\n' "$refresh_buildroot_config_state" | grep -q 'SOURCE_DATE_EPOCH'; then
+if ! printf '%s\n' "$refresh_buildroot_config_state" | grep -Fq '$(call buildroot_config_state_value)'; then
+  echo "pico-sdk Buildroot state refresh must use the shared Buildroot state value" >&2
+  exit 1
+fi
+
+buildroot_config_state_policy="$buildroot_config_state_value
+$refresh_buildroot_config_state"
+if ! printf '%s\n' "$buildroot_config_state_policy" | grep -q 'SOURCE_DATE_EPOCH'; then
   echo "pico-sdk Buildroot state must include SOURCE_DATE_EPOCH so stale package outputs are rebuilt when the reproducible epoch changes" >&2
   exit 1
 fi
 
-if ! printf '%s\n' "$refresh_buildroot_config_state" | grep -q 'AIDEN_BUILDROOT_REPRODUCIBLE_STATE_VERSION'; then
+if ! printf '%s\n' "$buildroot_config_state_policy" | grep -q 'AIDEN_BUILDROOT_REPRODUCIBLE_STATE_VERSION'; then
   echo "pico-sdk Buildroot state must include an Aiden reproducibility state version to invalidate older runner caches" >&2
   exit 1
 fi
 
-if ! printf '%s\n' "$refresh_buildroot_config_state" | grep -Fq 'sha256sum "$(SYSDRV_DIR)/Makefile"'; then
+if ! printf '%s\n' "$buildroot_config_state_policy" | grep -Fq 'sha256sum "$(SYSDRV_DIR)/Makefile"'; then
   echo "pico-sdk Buildroot state must include sysdrv/Makefile so reproducibility policy changes invalidate stale package outputs" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- validate the shared Buildroot state value used by refresh_buildroot_config_state
- keep the reproducible rootfs policy check aligned with the current Makefile structure
- require refresh_buildroot_config_state to call the shared state macro

## Tests
- bash scripts/test_reproducible_rootfs_policy.sh
- bash -n scripts/test_reproducible_rootfs_policy.sh
- git diff --check -- scripts/test_reproducible_rootfs_policy.sh

## Notes
- bash scripts/test_build_scripts.sh currently fails before this change because prepare.sh is missing from the working tree.