### PR TITLE
fix(ci): verify android tools span compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,9 @@ jobs:
         git submodule update --init --depth=1 pico-sdk
         git -C pico-sdk clean -f -- .gitmodules
 
+    - name: Verify android-tools compatibility patches
+      run: sh scripts/test_android_tools_aiden_compat.sh
+
     - name: Verify reproducible rootfs policy
       run: bash scripts/test_reproducible_rootfs_policy.sh
 

--- a/scripts/test_android_tools_aiden_compat.sh
+++ b/scripts/test_android_tools_aiden_compat.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+PKG_DIR="$ROOT_DIR/pico-sdk/sysdrv/tools/board/buildroot/android-tools-aiden"
+VERSION="30.0.5p1"
+TARBALL="$PKG_DIR/android-tools-aiden-$VERSION.tar.xz"
+
+if [ ! -f "$TARBALL" ]; then
+    echo "android-tools-aiden source tarball is missing: $TARBALL" >&2
+    exit 1
+fi
+
+WORK_DIR=$(mktemp -d)
+cleanup() {
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT INT TERM
+
+tar -C "$WORK_DIR" -xf "$TARBALL"
+SRC_DIR="$WORK_DIR/android-tools-aiden-$VERSION"
+
+for patch_file in "$PKG_DIR"/*.patch; do
+    patch -d "$SRC_DIR" -p1 --batch --silent < "$patch_file"
+done
+
+client_source="$SRC_DIR/vendor/core/adb/client/file_sync_client.cpp"
+compression_header="$SRC_DIR/vendor/core/adb/compression_utils.h"
+
+if grep -nF 'std::span' "$client_source" "$compression_header"; then
+    echo "android-tools-aiden patches must remove std::span from adb sync/decompression code" >&2
+    exit 1
+fi
+
+if ! grep -Fq 'CharSpan buffer_span' "$client_source"; then
+    echo "file_sync_client.cpp must construct decoder buffers with CharSpan" >&2
+    exit 1
+fi
+
+if ! grep -Fq 'using CharSpan = adb_compat::span<char>;' "$compression_header"; then
+    echo "compression_utils.h must define CharSpan via the GCC 8.3 compatibility shim" >&2
+    exit 1
+fi
+
+echo "android-tools-aiden compatibility patch tests passed"


### PR DESCRIPTION
## Summary
- update the pico-sdk submodule to the merged android-tools span compatibility fix
- add a lightweight test that applies android-tools-aiden Buildroot patches to the vendored tarball
- run the compatibility check before the full image build starts

## Dependency
- AidenAI-IO/aiden-sdk#21 is merged; pico-sdk now points at aiden-sdk/main commit 3679acc45

## Tests
- sh scripts/test_android_tools_aiden_compat.sh
- bash scripts/test_reproducible_rootfs_policy.sh