### PR TITLE
fix(tts): account for elapsed streaming playback in drain

### DIFF
--- a/src/agent/internal/agent/tts/drain.go
+++ b/src/agent/internal/agent/tts/drain.go
@@ -16,12 +16,25 @@ const (
 // EstimatedPlaybackDrainDuration returns how long to wait for a playback
 // session to finish after its final chunk was accepted by audio_service.
 func EstimatedPlaybackDrainDuration(format AudioFormat, pcmBytes int) time.Duration {
+	return EstimatedPlaybackDrainRemainingDuration(format, pcmBytes, 0, chunkBytes)
+}
+
+// EstimatedPlaybackDrainRemainingDuration returns how long to wait after the
+// final chunk is accepted, subtracting playback time that has already elapsed.
+func EstimatedPlaybackDrainRemainingDuration(format AudioFormat, pcmBytes int, elapsed time.Duration, lastChunkBytes int) time.Duration {
 	bytesPerSecond := format.BytesPerSecond()
 	if bytesPerSecond <= 0 {
 		bytesPerSecond = 16000 * 1 * 2
 	}
 	playback := time.Duration(pcmBytes) * time.Second / time.Duration(bytesPerSecond)
-	return playback + playbackTailDrainGrace(format, chunkBytes)
+	remaining := playback - elapsed
+	if remaining < 0 {
+		remaining = 0
+	}
+	if lastChunkBytes <= 0 {
+		lastChunkBytes = chunkBytes
+	}
+	return remaining + playbackTailDrainGrace(format, lastChunkBytes)
 }
 
 func playbackTailDrainGrace(format AudioFormat, lastChunkBytes int) time.Duration {
@@ -74,6 +87,7 @@ func (f AudioFormat) BytesPerSecond() int {
 }
 
 var waitForEstimatedDrain = waitForEstimatedDrainTimer
+var playbackDrainNow = time.Now
 
 func waitForEstimatedDrainTimer(ctx context.Context, wait time.Duration) error {
 	if wait <= 0 {

--- a/src/agent/internal/agent/tts/sink.go
+++ b/src/agent/internal/agent/tts/sink.go
@@ -17,15 +17,17 @@ const (
 
 // AudioServiceSink implements AudioSink by writing PCM to AudioServiceClient.
 type AudioServiceSink struct {
-	mu        sync.Mutex
-	audio     AudioServiceBackend
-	format    AudioFormat
-	sessionID uint64
-	started   bool
-	stopped   bool
-	finalSent bool
-	pcmBytes  int
-	pending   []byte
+	mu                sync.Mutex
+	audio             AudioServiceBackend
+	format            AudioFormat
+	sessionID         uint64
+	started           bool
+	stopped           bool
+	finalSent         bool
+	pcmBytes          int
+	lastChunkBytes    int
+	playbackStartedAt time.Time
+	pending           []byte
 }
 
 // AudioServiceBackend is a minimal interface over *AudioServiceClient used by the sink.
@@ -70,6 +72,7 @@ func (s *AudioServiceSink) writePCMChunks(data []byte) error {
 		}
 		s.sessionID = id
 		s.started = true
+		s.playbackStartedAt = playbackDrainNow()
 	}
 	for off := 0; off < len(data); off += chunkBytes {
 		end := off + chunkBytes
@@ -79,7 +82,9 @@ func (s *AudioServiceSink) writePCMChunks(data []byte) error {
 		if err := s.audio.WritePlayChunk(s.sessionID, data[off:end], false); err != nil {
 			return fmt.Errorf("write play chunk: %w", err)
 		}
-		s.pcmBytes += end - off
+		written := end - off
+		s.pcmBytes += written
+		s.lastChunkBytes = written
 	}
 	return nil
 }
@@ -166,7 +171,11 @@ func (s *AudioServiceSink) Drain(ctx context.Context) error {
 		}
 		s.finalSent = true
 	}
-	wait := EstimatedPlaybackDrainDuration(s.format, s.pcmBytes)
+	elapsed := time.Duration(0)
+	if !s.playbackStartedAt.IsZero() {
+		elapsed = playbackDrainNow().Sub(s.playbackStartedAt)
+	}
+	wait := EstimatedPlaybackDrainRemainingDuration(s.format, s.pcmBytes, elapsed, s.lastChunkBytes)
 	s.mu.Unlock()
 
 	waitCtx, cancel := context.WithTimeout(ctx, drainTimeout)

--- a/src/agent/internal/agent/tts/sink_test.go
+++ b/src/agent/internal/agent/tts/sink_test.go
@@ -16,6 +16,13 @@ func withDrainWait(t *testing.T, fn func(context.Context, time.Duration) error) 
 	t.Cleanup(func() { waitForEstimatedDrain = original })
 }
 
+func withDrainNow(t *testing.T, fn func() time.Time) {
+	t.Helper()
+	original := playbackDrainNow
+	playbackDrainNow = fn
+	t.Cleanup(func() { playbackDrainNow = original })
+}
+
 func skipDrainWait(t *testing.T) {
 	t.Helper()
 	withDrainWait(t, func(context.Context, time.Duration) error { return nil })
@@ -215,6 +222,38 @@ func TestAudioServiceSinkDrainWaitsForOwnPCMSOnly(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&backend.finalCalls); got != 1 {
 		t.Fatalf("finalCalls = %d, want 1", got)
+	}
+}
+
+func TestAudioServiceSinkDrainSubtractsElapsedPlayback(t *testing.T) {
+	backend := &countingBackend{}
+	format := AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16}
+	sink := NewAudioServiceSink(backend, format)
+	startedAt := time.Unix(100, 0)
+	now := startedAt
+	withDrainNow(t, func() time.Time { return now })
+
+	var waitSeen time.Duration
+	withDrainWait(t, func(_ context.Context, wait time.Duration) error {
+		waitSeen = wait
+		return nil
+	})
+
+	if err := sink.WritePCM(make([]byte, pcmBytesForDuration(format, time.Second))); err != nil {
+		t.Fatalf("WritePCM() error = %v", err)
+	}
+	now = startedAt.Add(1500 * time.Millisecond)
+
+	if err := sink.Drain(context.Background()); err != nil {
+		t.Fatalf("Drain() error = %v", err)
+	}
+
+	want := 1216 * time.Millisecond
+	if waitSeen != want {
+		t.Fatalf("Drain() wait = %s, want %s", waitSeen, want)
+	}
+	if waitSeen >= EstimatedPlaybackDrainDuration(format, pcmBytesForDuration(format, 2*time.Second)) {
+		t.Fatalf("Drain() waited as if no streamed playback had elapsed: %s", waitSeen)
 	}
 }
 


### PR DESCRIPTION
## Summary
- track playback start time and last chunk size in AudioServiceSink
- estimate drain using remaining playback duration instead of total PCM duration
- add regression coverage for streamed playback elapsed before drain

## Tests
- go test ./internal/agent/tts
- go test ./internal/agent -run 'Test.*TTS|Test.*Playback|Test.*Audio'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback drain timing so the app waits only for the remaining audio, instead of starting the countdown too late.
  * Drain behavior now accounts for elapsed playback time and the size of the last streamed audio chunk, making wait times more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->