### PR TITLE
fix(agent): honor persist flag to avoid duplicate assistant_output in session history

### DIFF
--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1504,7 +1504,9 @@ func (h *runtimeCallbackHandler) emitRunEventWithPersistence(ctx context.Context
 	if event.EpisodeID == "" {
 		event.EpisodeID = h.episodeID
 	}
-	h.persistSessionEventBestEffort(sessionEventFromRunEvent(event, h), "[memory] persist runtime session event failed")
+	if persist {
+		h.persistSessionEventBestEffort(sessionEventFromRunEvent(event, h), "[memory] persist runtime session event failed")
+	}
 	if h.eventHandler != nil {
 		h.eventHandler(event)
 	}

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1088,6 +1088,30 @@ func TestRuntimeRunDoesNotPersistUnusedSteerProviderAsConversationMessage(t *tes
 	}
 }
 
+func TestRuntimeRunPersistsAssistantOutputOnce(t *testing.T) {
+	storageDir := filepath.Join(t.TempDir(), "memory")
+	memoryManager := NewMemoryManager(storageDir)
+	ctx := context.Background()
+
+	model := &scriptedModel{responses: roleDirectResponses("hello answer")}
+	runtime := NewRuntimeWithDeps(
+		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Answer."},
+		&testModelResolver{model: model},
+		memoryManager,
+		&ToolSet{tools: map[string]langtools.Tool{}},
+		NewSkillIndex(),
+	)
+
+	if _, err := runtime.Run(ctx, RunRequest{Input: "hi"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	events := readSessionEvents(t, filepath.Join(storageDir, "session", "events.jsonl"))
+	if got := sessionEventCount(events, "assistant_output", "assistant", "hello answer"); got != 1 {
+		t.Fatalf("assistant_output count = %d, want 1; events=%#v", got, events)
+	}
+}
+
 func TestRuntimeRunKeepsCurrentExchangeWhenSnapshotWindowIsFull(t *testing.T) {
 	storageDir := filepath.Join(t.TempDir(), "memory")
 	memoryManager := NewMemoryManager(storageDir)


### PR DESCRIPTION
This PR fixes an issue where assistant_output events were being persisted to session history regardless of the persist flag.

## Changes
- Updated  to check the  parameter before persisting session events
- Added test case  to verify assistant_output is only persisted once

## Testing
- New test verifies that assistant_output events are only persisted once in session history
- Existing tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session event persistence so events marked as non-persistent are no longer saved.
  * Prevented duplicate stored assistant output events, ensuring only one assistant response entry is recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->