### PR TITLE
feat(agent): add context dump API endpoint

### DIFF
--- a/src/agent/internal/agent/context_manager/context_manager.go
+++ b/src/agent/internal/agent/context_manager/context_manager.go
@@ -115,6 +115,33 @@ func (c *ContextManager) IsEmpty() bool {
 	return len(c.messageList) == 0
 }
 
+type MessageListDump struct {
+	SessionID string    `json:"session_id"`
+	Messages  []Message `json:"messages"`
+}
+
+func (c *ContextManager) MessageListDump() MessageListDump {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	messages := make([]Message, len(c.messageList))
+	for i, msg := range c.messageList {
+		messages[i] = msg
+		if len(msg.ToolCalls) > 0 {
+			messages[i].ToolCalls = append([]ToolCall(nil), msg.ToolCalls...)
+		}
+		if len(msg.ToolResults) > 0 {
+			messages[i].ToolResults = append([]ToolResult(nil), msg.ToolResults...)
+		}
+		if len(msg.Attachments) > 0 {
+			messages[i].Attachments = append([]Attachment(nil), msg.Attachments...)
+		}
+	}
+	return MessageListDump{
+		SessionID: c.sessionID,
+		Messages:  messages,
+	}
+}
+
 func (c *ContextManager) Reset() {
 	c.mu.Lock()
 	store := c.detachAttachmentStoreLocked()

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1091,6 +1091,10 @@ func (r *Runtime) plannerContextManager() *context_manager.ContextManager {
 	return r.plannerContext
 }
 
+func (r *Runtime) PlannerContextDump() context_manager.MessageListDump {
+	return r.plannerContextManager().MessageListDump()
+}
+
 func (r *Runtime) resetPlannerContext() {
 	r.plannerContextMu.Lock()
 	defer r.plannerContextMu.Unlock()

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -430,6 +430,7 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/api/live-activity/current", s.handleLiveActivityCurrent)
 	mux.HandleFunc("/api/events", s.handleEvents)
 	mux.HandleFunc("/api/history", s.handleHistory)
+	mux.HandleFunc("/api/context-dump", s.handleContextDump)
 	mux.HandleFunc("/api/episodes/", s.handleEpisodes)
 	mux.HandleFunc("/api/setup", s.handleSetup)
 	if s.benchmarkToken() != "" {
@@ -1803,6 +1804,16 @@ func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(historySnapshot)
+}
+
+func (s *Server) handleContextDump(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(s.runtime.PlannerContextDump())
 }
 
 func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
@@ -4102,6 +4113,7 @@ const webUI = `<!DOCTYPE html>
                 <div class="topbar-actions">
                     <a href="/coordinate-debug" class="new-chat-btn" style="text-decoration:none;display:inline-flex;align-items:center;">🎯 Coordinate Debug</a>
                     <a href="/user_files" class="new-chat-btn" style="text-decoration:none;display:inline-flex;align-items:center;">📁 User files</a>
+                    <a href="/api/context-dump" target="_blank" rel="noopener" class="new-chat-btn" style="text-decoration:none;display:inline-flex;align-items:center;">📋 Context dump</a>
                     <button type="button" class="new-chat-btn" onclick="clearHistory()">New chat</button>
                     <button type="button" class="new-chat-btn" onclick="resetAllMemory()" style="background:#c0392b;">Reset all memory</button>
                 </div>

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -28,6 +28,7 @@ import (
 	langtools "github.com/tmc/langchaingo/tools"
 
 	ttsmodule "aiden-agent/internal/agent/tts"
+	"aiden-agent/internal/agent/context_manager"
 )
 
 type stubSTTClient struct {
@@ -1944,6 +1945,42 @@ func TestServerHistoryEndpointIncludesToolMessages(t *testing.T) {
 	}
 	if history[1].Type != runEventToolCall || history[2].Type != "tool_result" {
 		t.Fatalf("unexpected history payload: %#v", history)
+	}
+}
+
+func TestServerContextDumpEndpointReturnsPlannerMessages(t *testing.T) {
+	server := &Server{
+		runtime: NewRuntimeWithDeps(
+			Config{Model: ModelConfig{Provider: "fake"}},
+			&testModelResolver{model: &scriptedModel{}},
+			NewMemoryManager(""),
+			NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{}),
+			NewSkillIndex(),
+		),
+	}
+	manager := server.runtime.plannerContextManager()
+	manager.AppendMessage(context_manager.Message{
+		Role:    context_manager.MessageRoleUser,
+		Content: "hello planner",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/context-dump", nil)
+	rec := httptest.NewRecorder()
+	server.handleContextDump(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var dump context_manager.MessageListDump
+	if err := json.NewDecoder(rec.Body).Decode(&dump); err != nil {
+		t.Fatalf("decode context dump: %v", err)
+	}
+	if dump.SessionID == "" {
+		t.Fatal("expected session_id in context dump")
+	}
+	if len(dump.Messages) != 1 || dump.Messages[0].Content != "hello planner" {
+		t.Fatalf("unexpected context dump payload: %#v", dump)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add new `/api/context-dump` endpoint that exposes the planner's current context
- Add `MessageListDump()` method to context manager for deep copying message list
- Add `PlannerContextDump()` method to Runtime
- Add link in web UI for easy access
- Include test coverage for the new endpoint

## Test plan
- [x] Unit test added for `/api/context-dump` endpoint
- [x] Verified endpoint returns session ID and messages
- [x] Verified deep copy of tool calls, tool results, and attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Context dump” option in the app’s top bar to open the current planner context in a new tab.
  * Introduced a new endpoint that returns the current context as JSON for easier inspection and troubleshooting.

* **Bug Fixes**
  * Improved the consistency of the exported context data by safely copying message details before returning them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->