### PR TITLE
feat(agent): add Android HID extension keyboard aliases

### DIFF
--- a/benchmark/mobilegym/bridge/test_tools_api.py
+++ b/benchmark/mobilegym/bridge/test_tools_api.py
@@ -447,6 +447,28 @@ def test_invoke_quick_action_handles_mobilegym_common_actions(bridge_server):
         assert state.env.step_count == no_action_count
 
 
+def test_invoke_keyboard_tap_keycode_app_switch_uses_swipe(bridge_server):
+    server, base_url, state = bridge_server
+    state.active_episode_id = "test-episode-keyboard-app-switch"
+
+    req = Request(
+        f"{base_url}/api/tools/keyboard_tap",
+        data=json.dumps({"input": {"keys": ["KEYCODE_APP_SWITCH"]}}).encode(),
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+
+    with urlopen(req, timeout=5) as resp:
+        assert resp.status == 200
+        data = json.loads(resp.read().decode())
+
+    assert data["is_error"] is False
+    assert action_to_dict(state.env.last_action) == {
+        "action_type": "SWIPE",
+        "data": {"point1": [500.0, 1000.0], "point2": [500.0, 500.0], "duration": 900.0},
+    }
+
+
 def test_invoke_keyboard_text_accepts_plain_text_fallback(bridge_server):
     """Matches the Go keyboard_text fallback for bare plain text input."""
     server, base_url, state = bridge_server

--- a/benchmark/mobilegym/bridge/test_tools_api.py
+++ b/benchmark/mobilegym/bridge/test_tools_api.py
@@ -469,6 +469,29 @@ def test_invoke_keyboard_tap_keycode_app_switch_uses_swipe(bridge_server):
     }
 
 
+@pytest.mark.parametrize(
+    ("key_name", "action_type"),
+    [("KEYCODE_BACK", "BACK"), ("KEYCODE_HOME", "HOME")],
+)
+def test_invoke_keyboard_tap_keycode_aliases_preserve_actions(bridge_server, key_name, action_type):
+    server, base_url, state = bridge_server
+    state.active_episode_id = f"test-episode-keyboard-{key_name.lower()}"
+
+    req = Request(
+        f"{base_url}/api/tools/keyboard_tap",
+        data=json.dumps({"input": {"keys": [key_name]}}).encode(),
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+
+    with urlopen(req, timeout=5) as resp:
+        assert resp.status == 200
+        data = json.loads(resp.read().decode())
+
+    assert data["is_error"] is False
+    assert action_to_dict(state.env.last_action) == {"action_type": action_type, "data": {}}
+
+
 def test_invoke_keyboard_text_accepts_plain_text_fallback(bridge_server):
     """Matches the Go keyboard_text fallback for bare plain text input."""
     server, base_url, state = bridge_server

--- a/benchmark/mobilegym/bridge/tools_api.py
+++ b/benchmark/mobilegym/bridge/tools_api.py
@@ -780,6 +780,12 @@ class ToolsAPIHandler:
         normalized_keys = [str(k).strip().lower() for k in keys if str(k).strip()]
         if not normalized_keys:
             return {"output": "error: at least one key or modifier is required", "is_error": True}
+        alias_map = {
+            "keycode_back": "back",
+            "keycode_home": "home",
+            "keycode_app_switch": "app_switch",
+        }
+        normalized_keys = [alias_map.get(k, k) for k in normalized_keys]
         has_meta = any(k in ("meta", "cmd", "super", "win") for k in normalized_keys)
         non_modifiers = [k for k in normalized_keys if k not in ("meta", "cmd", "super", "win", "ctrl", "alt", "shift")]
 
@@ -798,6 +804,8 @@ class ToolsAPIHandler:
                     action = build_action("key", {"key": "home"})
                 elif key in ("back", "escape", "esc"):
                     action = build_action("key", {"key": "back"})
+                elif key in ("app_switch",):
+                    action = build_action("app_switch", {})
                 else:
                     return {"output": f"error: mobilegym keyboard_tap does not support key: {key!r}", "is_error": True}
             else:

--- a/benchmark/mobilegym/bridge/tools_api.py
+++ b/benchmark/mobilegym/bridge/tools_api.py
@@ -55,6 +55,13 @@ MOBILEGYM_RESERVED_QUICK_ACTIONS = {
 }
 
 
+def _mobilegym_app_switch_action() -> Any:
+    return build_action(
+        "swipe",
+        {"start_x": 500, "start_y": 1000, "end_x": 500, "end_y": 500, "duration_ms": 900},
+    )
+
+
 class ToolsAPIHandler:
     """Handler for the environment bridge /api/tools endpoint."""
 
@@ -639,10 +646,7 @@ class ToolsAPIHandler:
                 log_tool_input=tool_input,
             )
         if action == "app_switch":
-            action = build_action(
-                "swipe",
-                {"start_x": 500, "start_y": 1000, "end_x": 500, "end_y": 500, "duration_ms": 900},
-            )
+            action = _mobilegym_app_switch_action()
             return self._execute_action(state, action, episode_id, tool_name="quick_action", tool_input=tool_input)
         if action == "spotlight_search":
             return self._call_touch_gesture(
@@ -805,7 +809,7 @@ class ToolsAPIHandler:
                 elif key in ("back", "escape", "esc"):
                     action = build_action("key", {"key": "back"})
                 elif key in ("app_switch",):
-                    action = build_action("app_switch", {})
+                    action = _mobilegym_app_switch_action()
                 else:
                     return {"output": f"error: mobilegym keyboard_tap does not support key: {key!r}", "is_error": True}
             else:

--- a/docs/03-services/usb-hid.md
+++ b/docs/03-services/usb-hid.md
@@ -87,8 +87,11 @@ sudo ./build/bin/example_usb_hid cleanup
 [hid]
 keyboard_device = "/dev/hidg0"
 mouse_device = "/dev/hidg1"
+android_keyboard_device = "/dev/hidg2"
 frame_socket = "/run/frame_service/frame_service.sock"
 ```
+
+When `pointer_mode = "touchscreen"` (Android mode), the firmware also binds `hid.usb2` as `/dev/hidg2`. This second keyboard-like interface advertises Consumer Control usages for Android extension keys such as Back, Home, App Switch, Search, Power, and Volume. In the default `absolute` mode used for iOS cursor control, `hid.usb2` is not exposed.
 
 Built-in Agent tools:
 

--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -51,7 +51,7 @@ The page fields cover the following config sections (all detailed later on this 
 - `tts`: provider, api_key, model, voice_id, emotion, speed
 - `audio`: socket, sample_rate, channels, bit_width
 - `log`: LLM HTTP log retention
-- `hid`: keyboard_device, mouse_device, frame_socket
+- `hid`: keyboard_device, mouse_device, android_keyboard_device, frame_socket, pointer_mode
 - `env`: shell-style environment text written to `/userdata/system/env`, including optional proxy variables such as `http_proxy`, `HTTPS_PROXY`, and `NO_PROXY`
 - Wi-Fi: SSID / PSK etc. (written to `/userdata/wpa_supplicant.conf`)
 
@@ -88,6 +88,7 @@ llm_http_retention_days = 7
 [hid]
 keyboard_device = "/dev/hidg0"
 mouse_device = "/dev/hidg1"
+android_keyboard_device = "/dev/hidg2"
 frame_socket = "/run/frame_service/frame_service.sock"
 ```
 
@@ -141,6 +142,7 @@ bit_width = 16
 [hid]
 keyboard_device = "/dev/hidg0"
 mouse_device = "/dev/hidg1"
+android_keyboard_device = "/dev/hidg2"
 frame_socket = "/run/frame_service/frame_service.sock"
 ```
 
@@ -219,7 +221,9 @@ When `vad_helper_path` is still the built-in default, switching `vad_backend` au
 | --- | --- | --- |
 | `keyboard_device` | `/dev/hidg0` | Keyboard HID device |
 | `mouse_device` | `/dev/hidg1` | Mouse/touch HID device |
+| `android_keyboard_device` | `/dev/hidg2` | Android extension-key HID device (`hid.usb2`) used for consumer/system-style keys such as Back, Home, App Switch, Search, Power, and Volume when `pointer_mode = "touchscreen"` |
 | `frame_socket` | `/run/frame_service/frame_service.sock` | Frame Service socket used by the screenshot tool |
+| `pointer_mode` | `absolute` | `absolute` for iOS-style cursor mode on `hid.usb1`; `touchscreen` for Android digitizer mode and to expose `hid.usb2` Android extension keys |
 
 ## `[live_activity]`
 

--- a/overlay/etc/init.d/S49usbhid
+++ b/overlay/etc/init.d/S49usbhid
@@ -70,6 +70,7 @@ start() {
 		rm -f "$GADGET_DIR"/configs/c.1/ecm.* 2>/dev/null
 		rmdir "$GADGET_DIR"/functions/hid.usb0 2>/dev/null
 		rmdir "$GADGET_DIR"/functions/hid.usb1 2>/dev/null
+		rmdir "$GADGET_DIR"/functions/hid.usb2 2>/dev/null
 		rmdir "$GADGET_DIR"/functions/ecm.usb0 2>/dev/null
 		rmdir "$GADGET_DIR"/configs/c.1/strings/0x409 2>/dev/null
 		rmdir "$GADGET_DIR"/configs/c.1 2>/dev/null
@@ -124,6 +125,15 @@ start() {
 			> "$GADGET_DIR/functions/hid.usb1/report_desc"
 	fi
 
+	if [ "$POINTER_MODE" = "touchscreen" ]; then
+		mkdir -p "$GADGET_DIR/functions/hid.usb2"
+		echo 0 > "$GADGET_DIR/functions/hid.usb2/protocol"
+		echo 0 > "$GADGET_DIR/functions/hid.usb2/subclass"
+		echo 2 > "$GADGET_DIR/functions/hid.usb2/report_length"
+		printf '\x05\x0c\x09\x01\xa1\x01\x15\x00\x26\xff\x03\x1a\x00\x00\x2a\xff\x03\x75\x10\x95\x01\x81\x00\xc0' \
+			> "$GADGET_DIR/functions/hid.usb2/report_desc"
+	fi
+
 	# CDC ECM function (usb0 network interface)
 	mkdir -p "$GADGET_DIR/functions/ecm.usb0"
 	echo "$ECM_HOST_MAC" > "$GADGET_DIR/functions/ecm.usb0/host_addr"
@@ -132,6 +142,9 @@ start() {
 	# Link all functions, THEN bind UDC (configfs requires this order)
 	ln -s "$GADGET_DIR/functions/hid.usb0" "$GADGET_DIR/configs/c.1/hid.usb0" 2>/dev/null
 	ln -s "$GADGET_DIR/functions/hid.usb1" "$GADGET_DIR/configs/c.1/hid.usb1" 2>/dev/null
+	if [ "$POINTER_MODE" = "touchscreen" ]; then
+		ln -s "$GADGET_DIR/functions/hid.usb2" "$GADGET_DIR/configs/c.1/hid.usb2" 2>/dev/null
+	fi
 	ln -s "$GADGET_DIR/functions/ecm.usb0" "$GADGET_DIR/configs/c.1/ecm.usb0" 2>/dev/null
 
 	echo "$UDC" > "$GADGET_DIR/UDC"
@@ -153,7 +166,11 @@ start() {
 		echo "usb0 did not appear; ECM may not be bound"
 	fi
 
-	echo "Aiden USB composite ready: /dev/hidg0 (keyboard) /dev/hidg1 (pointer:$POINTER_MODE) usb0 (ECM)"
+	if [ "$POINTER_MODE" = "touchscreen" ]; then
+		echo "Aiden USB composite ready: /dev/hidg0 (keyboard) /dev/hidg1 (pointer:$POINTER_MODE) /dev/hidg2 (android-extension) usb0 (ECM)"
+	else
+		echo "Aiden USB composite ready: /dev/hidg0 (keyboard) /dev/hidg1 (pointer:$POINTER_MODE) usb0 (ECM)"
+	fi
 }
 
 stop() {

--- a/overlay/etc/init.d/S49usbhid
+++ b/overlay/etc/init.d/S49usbhid
@@ -132,6 +132,7 @@ start() {
 		echo 2 > "$GADGET_DIR/functions/hid.usb2/report_length"
 		printf '\x05\x0c\x09\x01\xa1\x01\x15\x00\x26\xff\x03\x1a\x00\x00\x2a\xff\x03\x75\x10\x95\x01\x81\x00\xc0' \
 			> "$GADGET_DIR/functions/hid.usb2/report_desc"
+
 	fi
 
 	# CDC ECM function (usb0 network interface)

--- a/overlay/userdata/agent/agent.toml
+++ b/overlay/userdata/agent/agent.toml
@@ -104,9 +104,10 @@ speed = 1.0                   # Speech speed: 0.5 - 2.0
 [hid]
 # keyboard_device = "/dev/hidg0"
 # mouse_device = "/dev/hidg1"
+# android_keyboard_device = "/dev/hidg2"  # Android extension keys (Back/Home/App Switch/Search/Power/Volume) when pointer_mode = "touchscreen"
 # frame_socket = "/run/frame_service/frame_service.sock"
 # pointer_mode = "absolute"     # default, iOS AssistiveTouch / absolute mouse
-# pointer_mode = "touchscreen"  # Android HID touch screen / digitizer
+# pointer_mode = "touchscreen"  # Android HID touch screen / digitizer + hid.usb2 extension keys
 
 # Web search tool configuration
 # provider: "duckduckgo" (free, no key), "brave" (Brave Search, needs api_key), or "tavily" (needs api_key)

--- a/src/agent/cmd/daemon/config_commands.go
+++ b/src/agent/cmd/daemon/config_commands.go
@@ -141,10 +141,11 @@ type logDTO struct {
 }
 
 type hidDTO struct {
-	KeyboardDevice string `json:"keyboard_device"`
-	MouseDevice    string `json:"mouse_device"`
-	FrameSocket    string `json:"frame_socket"`
-	PointerMode    string `json:"pointer_mode"`
+	KeyboardDevice        string `json:"keyboard_device"`
+	MouseDevice           string `json:"mouse_device"`
+	AndroidKeyboardDevice string `json:"android_keyboard_device"`
+	FrameSocket           string `json:"frame_socket"`
+	PointerMode           string `json:"pointer_mode"`
 }
 
 type searchDTO struct {
@@ -295,10 +296,11 @@ func (d webConfigDTO) toAgentConfig() agent.Config {
 			LLMHTTPRetentionDays: d.Log.LLMHTTPRetentionDays,
 		},
 		HID: agent.HIDConfig{
-			KeyboardDevice: d.HID.KeyboardDevice,
-			MouseDevice:    d.HID.MouseDevice,
-			FrameSocket:    d.HID.FrameSocket,
-			PointerMode:    d.HID.PointerMode,
+			KeyboardDevice:        d.HID.KeyboardDevice,
+			MouseDevice:           d.HID.MouseDevice,
+			AndroidKeyboardDevice: d.HID.AndroidKeyboardDevice,
+			FrameSocket:           d.HID.FrameSocket,
+			PointerMode:           d.HID.PointerMode,
 		},
 		Search: agent.SearchConfig{
 			Provider: d.Search.Provider,
@@ -424,10 +426,11 @@ func webConfigDTOFromAgentConfig(cfg agent.Config) webConfigDTO {
 			LLMHTTPRetentionDays: cfg.Log.LLMHTTPRetentionDaysOrDefault(),
 		},
 		HID: hidDTO{
-			KeyboardDevice: cfg.HID.KeyboardDeviceOrDefault(),
-			MouseDevice:    cfg.HID.MouseDeviceOrDefault(),
-			FrameSocket:    cfg.HID.FrameSocketOrDefault(),
-			PointerMode:    cfg.HID.PointerModeOrDefault(),
+			KeyboardDevice:        cfg.HID.KeyboardDeviceOrDefault(),
+			MouseDevice:           cfg.HID.MouseDeviceOrDefault(),
+			AndroidKeyboardDevice: cfg.HID.AndroidKeyboardDeviceOrDefault(),
+			FrameSocket:           cfg.HID.FrameSocketOrDefault(),
+			PointerMode:           cfg.HID.PointerModeOrDefault(),
 		},
 		Search: searchDTO{
 			Provider:  cfg.Search.ProviderOrDefault(),

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -349,11 +349,12 @@ func (a AudioConfig) BitWidthOrDefault() int {
 }
 
 type HIDConfig struct {
-	KeyboardDevice string `toml:"keyboard_device,omitempty"`
-	MouseDevice    string `toml:"mouse_device,omitempty"`
-	FrameSocket    string `toml:"frame_socket,omitempty"`
+	KeyboardDevice        string `toml:"keyboard_device,omitempty"`
+	MouseDevice           string `toml:"mouse_device,omitempty"`
+	AndroidKeyboardDevice string `toml:"android_keyboard_device,omitempty"`
+	FrameSocket           string `toml:"frame_socket,omitempty"`
 	// PointerMode selects the hid.usb1 report format: "absolute" (iOS AssistiveTouch)
-	// or "touchscreen" (Android HID digitizer).
+	// or "touchscreen" (Android HID digitizer + hid.usb2 Android extension keys).
 	PointerMode string `toml:"pointer_mode,omitempty"`
 }
 
@@ -382,6 +383,13 @@ func (h HIDConfig) MouseDeviceOrDefault() string {
 		return h.MouseDevice
 	}
 	return defaultMouseDevice
+}
+
+func (h HIDConfig) AndroidKeyboardDeviceOrDefault() string {
+	if h.AndroidKeyboardDevice != "" {
+		return h.AndroidKeyboardDevice
+	}
+	return defaultAndroidKeyboardDevice
 }
 
 func (h HIDConfig) FrameSocketOrDefault() string {

--- a/src/agent/internal/agent/config_defaults.go
+++ b/src/agent/internal/agent/config_defaults.go
@@ -33,6 +33,7 @@ const (
 	defaultLLMHTTPLogRetentionDays = 7
 	defaultKeyboardDevice          = "/dev/hidg0"
 	defaultMouseDevice             = "/dev/hidg1"
+	defaultAndroidKeyboardDevice   = "/dev/hidg2"
 	defaultFrameServiceSocket      = "/run/frame_service/frame_service.sock"
 	defaultPointerMode             = "absolute"
 	defaultInputMode               = "text"
@@ -94,10 +95,11 @@ func DefaultConfig() Config {
 			LLMHTTPRetentionDays: defaultLLMHTTPLogRetentionDays,
 		},
 		HID: HIDConfig{
-			KeyboardDevice: defaultKeyboardDevice,
-			MouseDevice:    defaultMouseDevice,
-			FrameSocket:    defaultFrameServiceSocket,
-			PointerMode:    defaultPointerMode,
+			KeyboardDevice:        defaultKeyboardDevice,
+			MouseDevice:           defaultMouseDevice,
+			AndroidKeyboardDevice: defaultAndroidKeyboardDevice,
+			FrameSocket:           defaultFrameServiceSocket,
+			PointerMode:           defaultPointerMode,
 		},
 		Search: SearchConfig{
 			Provider: searchProviderDuckDuckGo,

--- a/src/agent/internal/agent/config_meta.go
+++ b/src/agent/internal/agent/config_meta.go
@@ -220,6 +220,7 @@ func ConfigMeta() ConfigMetadata {
 						Default: defaults.HID.PointerMode},
 					{Key: "keyboard_device", Widget: WidgetText, Default: defaults.HID.KeyboardDevice},
 					{Key: "mouse_device", Widget: WidgetText, Default: defaults.HID.MouseDevice},
+					{Key: "android_keyboard_device", Widget: WidgetText, Default: defaults.HID.AndroidKeyboardDevice},
 					{Key: "frame_socket", Widget: WidgetText, Default: defaults.HID.FrameSocket},
 				},
 			},

--- a/src/agent/internal/agent/quick_actions.json
+++ b/src/agent/internal/agent/quick_actions.json
@@ -14,8 +14,8 @@
         "android": {
           "status": "active",
           "tool": "keyboard_tap",
-          "input": { "keys": ["escape"] },
-          "note": "verified: Esc back / dismiss",
+          "input": { "keys": ["KEYCODE_BACK"] },
+          "note": "Android extension key via hid.usb2 consumer control",
           "alternatives": [
             {
               "status": "active",
@@ -53,8 +53,18 @@
           ]
         },
         "android": {
-          "status": "reserved",
-          "note": "no verified keyboard home shortcut; Meta alone opens app search (see spotlight_search)"
+          "status": "active",
+          "tool": "keyboard_tap",
+          "input": { "keys": ["KEYCODE_HOME"] },
+          "note": "Android extension key via hid.usb2 consumer control",
+          "alternatives": [
+            {
+              "status": "active",
+              "tool": "touch_gesture",
+              "input": { "type": "home" },
+              "note": "edge swipe fallback"
+            }
+          ]
         },
         "mac": {
           "status": "reserved",
@@ -84,8 +94,16 @@
         "android": {
           "status": "active",
           "tool": "keyboard_tap",
-          "input": { "keys": ["meta", "tab"], "hold_ms": 120 },
-          "note": "verified: Meta+Tab open app management center / recents"
+          "input": { "keys": ["KEYCODE_APP_SWITCH"] },
+          "note": "Android extension key via hid.usb2 consumer control",
+          "alternatives": [
+            {
+              "status": "active",
+              "tool": "keyboard_tap",
+              "input": { "keys": ["meta", "tab"], "hold_ms": 120 },
+              "note": "external keyboard fallback"
+            }
+          ]
         },
         "mac": {
           "status": "active",

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -466,6 +466,7 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/api/coordinate-debug/tap", s.handleCoordinateDebugTap)
 	mux.HandleFunc("/coordinate-debug", s.handleCoordinateDebug)
 	mux.HandleFunc("/coordinate-debug.html", s.handleCoordinateDebug)
+	mux.HandleFunc("/keyboard-tap-android-keys", s.handleKeyboardTapAndroidKeys)
 
 	mux.HandleFunc("/user_files", s.handleUserFiles)
 	mux.HandleFunc("/user_files/regenerate", s.handleUserFilesRegenerate)
@@ -3075,7 +3076,247 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(html))
 }
 
+func (s *Server) handleKeyboardTapAndroidKeys(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/keyboard-tap-android-keys" {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(keyboardTapAndroidKeysGuideHTML))
+}
+
 const coordinateDebugNavLink = `<a href="/coordinate-debug" class="new-chat-btn" style="text-decoration:none;display:inline-flex;align-items:center;">🎯 Coordinate Debug</a>`
+
+const keyboardTapAndroidKeysGuideHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>keyboard_tap Android key guide</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f3efe6;
+            --panel: #fffdf8;
+            --line: rgba(52, 56, 49, 0.14);
+            --text: #1e241d;
+            --muted: #697063;
+            --accent: #1f7a63;
+            --accent-strong: #155646;
+            --code: #f4eee3;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+            background: var(--bg);
+            color: var(--text);
+        }
+
+        main {
+            max-width: 1120px;
+            margin: 0 auto;
+            padding: 32px 20px 48px;
+        }
+
+        h1, h2 {
+            margin: 0 0 12px;
+        }
+
+        p, li {
+            line-height: 1.6;
+        }
+
+        .eyebrow {
+            margin: 0 0 8px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+        }
+
+        .panel,
+        .callout {
+            background: var(--panel);
+            border: 1px solid var(--line);
+            border-radius: 18px;
+            padding: 18px 20px;
+            margin-top: 18px;
+        }
+
+        .callout {
+            border-left: 4px solid var(--accent);
+        }
+
+        code {
+            background: var(--code);
+            border-radius: 8px;
+            padding: 2px 6px;
+            font-family: "SFMono-Regular", "Menlo", monospace;
+            font-size: 0.95em;
+        }
+
+        a {
+            color: var(--accent);
+        }
+
+        a:hover {
+            color: var(--accent-strong);
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 14px;
+            background: var(--panel);
+            border: 1px solid var(--line);
+            border-radius: 16px;
+            overflow: hidden;
+        }
+
+        th,
+        td {
+            padding: 12px 14px;
+            border-bottom: 1px solid var(--line);
+            text-align: left;
+            vertical-align: top;
+        }
+
+        th {
+            background: rgba(31, 122, 99, 0.08);
+            font-size: 0.83rem;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+        }
+
+        tr:last-child td {
+            border-bottom: 0;
+        }
+
+        .examples {
+            margin-top: 10px;
+        }
+
+        .examples li {
+            margin-top: 8px;
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <p class="eyebrow">Aiden Agent</p>
+        <h1>keyboard_tap Android key guide</h1>
+        <p>
+            These aliases use <code>hid.usb2</code> and send one 16-bit Consumer Control usage at a time.
+            They require <code>hid.pointer_mode = "touchscreen"</code> and a valid
+            <code>hid.android_keyboard_device</code> such as <code>/dev/hidg2</code>.
+        </p>
+
+        <div class="callout">
+            <strong>Rules:</strong>
+            <ul>
+                <li>Use one Android extension key at a time.</li>
+                <li>Do not combine <code>KEYCODE_*</code> or <code>KEY_USAGE_*</code> with <code>ctrl</code>, <code>alt</code>, <code>shift</code>, <code>meta</code>, or standard keyboard keys.</li>
+                <li>Raw short names such as <code>app_switch</code> or <code>refresh</code> are also accepted where listed below.</li>
+                <li>Android and vendor ROMs may react differently to some usages even when AOSP maps them.</li>
+            </ul>
+        </div>
+
+        <div class="panel">
+            <h2>Examples</h2>
+            <ul class="examples">
+                <li><code>{"keys":["KEYCODE_BACK"]}</code></li>
+                <li><code>{"keys":["KEYCODE_APP_SWITCH"]}</code></li>
+                <li><code>{"keys":["KEYCODE_MEDIA_PLAY_PAUSE"]}</code></li>
+                <li><code>{"keys":["KEY_USAGE_SETTINGS"]}</code></li>
+                <li><code>{"keys":["KEY_USAGE_REFRESH"]}</code></li>
+            </ul>
+        </div>
+
+        <h2>KEYCODE aliases</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>Alias</th>
+                    <th>Raw name</th>
+                    <th>Usage</th>
+                    <th>AOSP action</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr><td><code>KEYCODE_BACK</code></td><td><code>android_back</code></td><td><code>0x0c0224</code></td><td>Back</td></tr>
+                <tr><td><code>KEYCODE_HOME</code></td><td><code>android_home</code></td><td><code>0x0c0223</code></td><td>Home</td></tr>
+                <tr><td><code>KEYCODE_APP_SWITCH</code></td><td><code>app_switch</code></td><td><code>0x0c029F</code></td><td>Recent Apps</td></tr>
+                <tr><td><code>KEYCODE_MENU</code></td><td><code>menu</code></td><td><code>0x0c0040</code></td><td>Menu</td></tr>
+                <tr><td><code>KEYCODE_SEARCH</code></td><td><code>search</code></td><td><code>0x0c0221</code></td><td>Search</td></tr>
+                <tr><td><code>KEYCODE_POWER</code></td><td><code>power</code></td><td><code>0x0c0030</code></td><td>Power</td></tr>
+                <tr><td><code>KEYCODE_SLEEP</code></td><td><code>sleep</code></td><td><code>0x0c0032</code></td><td>Sleep</td></tr>
+                <tr><td><code>KEYCODE_VOLUME_MUTE</code></td><td><code>volume_mute</code></td><td><code>0x0c00E2</code></td><td>Volume Mute</td></tr>
+                <tr><td><code>KEYCODE_VOLUME_UP</code></td><td><code>volume_up</code></td><td><code>0x0c00E9</code></td><td>Volume Up</td></tr>
+                <tr><td><code>KEYCODE_VOLUME_DOWN</code></td><td><code>volume_down</code></td><td><code>0x0c00EA</code></td><td>Volume Down</td></tr>
+                <tr><td><code>KEYCODE_MEDIA_PLAY_PAUSE</code></td><td><code>media_play_pause</code></td><td><code>0x0c00CD</code></td><td>Media Play/Pause</td></tr>
+                <tr><td><code>KEYCODE_MEDIA_STOP</code></td><td><code>media_stop</code></td><td><code>0x0c00B7</code></td><td>Media Stop</td></tr>
+                <tr><td><code>KEYCODE_MEDIA_NEXT</code></td><td><code>media_next</code></td><td><code>0x0c00B5</code></td><td>Media Next</td></tr>
+                <tr><td><code>KEYCODE_MEDIA_PREVIOUS</code></td><td><code>media_previous</code></td><td><code>0x0c00B6</code></td><td>Media Previous</td></tr>
+                <tr><td><code>KEYCODE_MEDIA_REWIND</code></td><td><code>media_rewind</code></td><td><code>0x0c00B4</code></td><td>Media Rewind</td></tr>
+                <tr><td><code>KEYCODE_MEDIA_FAST_FORWARD</code></td><td><code>media_fast_forward</code></td><td><code>0x0c00B3</code></td><td>Media Fast Forward</td></tr>
+            </tbody>
+        </table>
+
+        <h2>KEY_USAGE aliases</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>Alias</th>
+                    <th>Raw name</th>
+                    <th>Usage</th>
+                    <th>AOSP action</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr><td><code>KEY_USAGE_SCREENSHOT</code></td><td><code>screenshot</code></td><td><code>0x0c0065</code></td><td>Screenshot</td></tr>
+                <tr><td><code>KEY_USAGE_WINDOW</code></td><td><code>window</code></td><td><code>0x0c0067</code></td><td>Window</td></tr>
+                <tr><td><code>KEY_USAGE_BRIGHTNESS_UP</code></td><td><code>brightness_up</code></td><td><code>0x0c006F</code></td><td>Brightness Up</td></tr>
+                <tr><td><code>KEY_USAGE_BRIGHTNESS_DOWN</code></td><td><code>brightness_down</code></td><td><code>0x0c0070</code></td><td>Brightness Down</td></tr>
+                <tr><td><code>KEY_USAGE_DICTATE</code></td><td><code>dictate</code></td><td><code>0x0c00D8</code></td><td>Dictate</td></tr>
+                <tr><td><code>KEY_USAGE_EMOJI_PICKER</code></td><td><code>emoji_picker</code></td><td><code>0x0c00D9</code></td><td>Emoji Picker</td></tr>
+                <tr><td><code>KEY_USAGE_MEDIA_AUDIO_TRACK</code></td><td><code>media_audio_track</code></td><td><code>0x0c0173</code></td><td>Media Audio Track</td></tr>
+                <tr><td><code>KEY_USAGE_PROFILE_SWITCH</code></td><td><code>profile_switch</code></td><td><code>0x0c019C</code></td><td>Profile Switch</td></tr>
+                <tr><td><code>KEY_USAGE_SETTINGS</code></td><td><code>settings</code></td><td><code>0x0c019F</code></td><td>Settings</td></tr>
+                <tr><td><code>KEY_USAGE_NEW</code></td><td><code>new</code></td><td><code>0x0c0201</code></td><td>New</td></tr>
+                <tr><td><code>KEY_USAGE_CLOSE</code></td><td><code>close</code></td><td><code>0x0c0203</code></td><td>Close</td></tr>
+                <tr><td><code>KEY_USAGE_PRINT</code></td><td><code>print</code></td><td><code>0x0c0208</code></td><td>Print</td></tr>
+                <tr><td><code>KEY_USAGE_REFRESH</code></td><td><code>refresh</code></td><td><code>0x0c0227</code></td><td>Refresh</td></tr>
+                <tr><td><code>KEY_USAGE_FULLSCREEN</code></td><td><code>fullscreen</code></td><td><code>0x0c0232</code></td><td>Fullscreen</td></tr>
+                <tr><td><code>KEY_USAGE_LANGUAGE_SWITCH</code></td><td><code>language_switch</code></td><td><code>0x0c029D</code></td><td>Language Switch</td></tr>
+            </tbody>
+        </table>
+
+        <div class="panel">
+            <h2>Notes</h2>
+            <p>
+                AOSP resolves HID usage mappings before Linux scan-code mappings. That is why
+                <code>KEYCODE_APP_SWITCH</code> uses <code>0x0c029F</code> rather than
+                <code>0x0c01A2</code>: the former maps to Recent Apps, while the latter maps to All Apps.
+            </p>
+            <p>
+                <code>KEYCODE_WAKEUP</code>, <code>KEYCODE_SOFT_SLEEP</code>, and <code>KEYCODE_NOTIFICATION</code>
+                are reserved aliases but currently return explicit unsupported errors on this gadget.
+            </p>
+            <p>
+                Return to the <a href="/">main UI</a> when you are done.
+            </p>
+        </div>
+    </main>
+</body>
+</html>
+`
 
 const webUI = `<!DOCTYPE html>
 <html lang="en">
@@ -3208,6 +3449,17 @@ const webUI = `<!DOCTYPE html>
         .sidebar-note {
             line-height: 1.45;
             font-size: 0.82rem;
+        }
+
+        .sidebar-note a {
+            color: var(--accent);
+            font-weight: 600;
+            text-decoration: none;
+        }
+
+        .sidebar-note a:hover {
+            color: var(--accent-strong);
+            text-decoration: underline;
         }
 
         .sidebar-kicker {
@@ -4401,13 +4653,28 @@ const webUI = `<!DOCTYPE html>
                 toolSelectEl.value = tool.name;
             }
 
-            toolDescriptionEl.textContent = tool.description || '';
+            renderToolDescription(tool);
             toolInputEl.placeholder = tool.example_input || '';
             if (switched) {
                 toolInputEl.value = tool.example_input || '';
                 toolInputEl.dataset.toolName = tool.name;
             }
             toolStatusEl.classList.remove('error');
+        }
+
+        function renderToolDescription(tool) {
+            toolDescriptionEl.textContent = tool.description || '';
+            if (!tool || tool.name !== 'keyboard_tap') {
+                return;
+            }
+
+            toolDescriptionEl.appendChild(document.createTextNode(' '));
+            const link = document.createElement('a');
+            link.href = '/keyboard-tap-android-keys';
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            link.textContent = 'Open Android key guide';
+            toolDescriptionEl.appendChild(link);
         }
 
         function loadSelectedToolExample() {

--- a/src/agent/internal/agent/tools.go
+++ b/src/agent/internal/agent/tools.go
@@ -92,12 +92,16 @@ func newHardwareToolSet(hidCfg HIDConfig, audioCfg AudioConfig, searchCfg Search
 	}
 
 	kbDev := NewHIDDevice(hidCfg.KeyboardDeviceOrDefault())
+	var androidKbDev *HIDDevice
+	if hidCfg.PointerTouchscreen() {
+		androidKbDev = NewHIDDevice(hidCfg.AndroidKeyboardDeviceOrDefault())
+	}
 	screen := &screenState{}
 	pointer := newPointerController(hidCfg)
 	screenshot := NewScreenshotTool(hidCfg.FrameSocketOrDefault(), screen)
 	screenStable := toolOptions.screenStable.Resolved()
 	waitStable := NewWaitStableScreenTool(hidCfg.FrameSocketOrDefault(), screenStable, screen)
-	keyboardTap := &KeyboardTapTool{dev: kbDev}
+	keyboardTap := &KeyboardTapTool{dev: kbDev, androidDev: androidKbDev}
 	keyboardText := &KeyboardTextTool{dev: kbDev}
 	touchGesture := &TouchGestureTool{pc: pointer, screen: screen}
 	quickAction := &QuickActionTool{keyboard: keyboardTap, touch: touchGesture}

--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -129,24 +129,57 @@ var hidModifierMap = map[string]uint8{
 }
 
 var androidExtensionUsageMap = map[string]uint16{
-	"android_back":              0x0224,
-	"android_home":              0x0223,
-	"menu":                      0x0040,
-	"search":                    0x0221,
-	"power":                     0x0030,
-	"volume_mute":               0x00e2,
-	"volumeup":                  0x00e9,
-	"volume_up":                 0x00e9,
-	"volumedown":                0x00ea,
-	"volume_down":               0x00ea,
-	"settings":                  0x019f,
-	"key_usage_settings":        0x019f,
-	"language_switch":           0x029d,
-	"key_usage_language_switch": 0x029d,
+	"android_back":                0x0224,
+	"android_home":                0x0223,
+	"menu":                        0x0040,
+	"search":                      0x0221,
+	"power":                       0x0030,
+	"sleep":                       0x0032,
+	"volume_mute":                 0x00e2,
+	"volumeup":                    0x00e9,
+	"volume_up":                   0x00e9,
+	"volumedown":                  0x00ea,
+	"volume_down":                 0x00ea,
+	"media_fast_forward":          0x00b3,
+	"media_rewind":                0x00b4,
+	"media_next":                  0x00b5,
+	"media_previous":              0x00b6,
+	"media_stop":                  0x00b7,
+	"media_play_pause":            0x00cd,
+	"screenshot":                  0x0065,
+	"key_usage_screenshot":        0x0065,
+	"window":                      0x0067,
+	"key_usage_window":            0x0067,
+	"brightness_up":               0x006f,
+	"key_usage_brightness_up":     0x006f,
+	"brightness_down":             0x0070,
+	"key_usage_brightness_down":   0x0070,
+	"dictate":                     0x00d8,
+	"key_usage_dictate":           0x00d8,
+	"emoji_picker":                0x00d9,
+	"key_usage_emoji_picker":      0x00d9,
+	"media_audio_track":           0x0173,
+	"key_usage_media_audio_track": 0x0173,
+	"profile_switch":              0x019c,
+	"key_usage_profile_switch":    0x019c,
+	"settings":                    0x019f,
+	"key_usage_settings":          0x019f,
+	"new":                         0x0201,
+	"key_usage_new":               0x0201,
+	"close":                       0x0203,
+	"key_usage_close":             0x0203,
+	"print":                       0x0208,
+	"key_usage_print":             0x0208,
+	"refresh":                     0x0227,
+	"key_usage_refresh":           0x0227,
+	"fullscreen":                  0x0232,
+	"key_usage_fullscreen":        0x0232,
+	"language_switch":             0x029d,
+	"key_usage_language_switch":   0x029d,
 	// AOSP Generic.kl checks HID usage codes before Linux scan codes.
 	// 0x0c01A2 is mapped to ALL_APPS, while 0x0c029F is mapped to
 	// RECENT_APPS / KEYCODE_APP_SWITCH.
-	"app_switch": 0x029f,
+	"app_switch":                  0x029f,
 }
 
 type androidKeyboardTapAlias struct {
@@ -195,6 +228,18 @@ var androidKeyboardTapAliases = map[string]androidKeyboardTapAlias{
 		Keycode:     26,
 		Replacement: "power",
 	},
+	"keycode_sleep": {
+		Keycode:     223,
+		Replacement: "sleep",
+	},
+	"keycode_wakeup": {
+		Keycode:           224,
+		UnsupportedReason: "wakeup requires a Generic Desktop/System Control HID path beyond the current hid.usb2 Consumer Control interface",
+	},
+	"keycode_soft_sleep": {
+		Keycode:           276,
+		UnsupportedReason: "soft sleep has no verified standard Consumer Control usage on this gadget",
+	},
 	"keycode_notification": {
 		Keycode:           83,
 		UnsupportedReason: "notification center has no verified standard Consumer Control usage on this gadget; use quick_action notification_center or touch_gesture instead",
@@ -214,6 +259,30 @@ var androidKeyboardTapAliases = map[string]androidKeyboardTapAlias{
 	"keycode_volume_down": {
 		Keycode:     25,
 		Replacement: "volume_down",
+	},
+	"keycode_media_play_pause": {
+		Keycode:     85,
+		Replacement: "media_play_pause",
+	},
+	"keycode_media_stop": {
+		Keycode:     86,
+		Replacement: "media_stop",
+	},
+	"keycode_media_next": {
+		Keycode:     87,
+		Replacement: "media_next",
+	},
+	"keycode_media_previous": {
+		Keycode:     88,
+		Replacement: "media_previous",
+	},
+	"keycode_media_rewind": {
+		Keycode:     89,
+		Replacement: "media_rewind",
+	},
+	"keycode_media_fast_forward": {
+		Keycode:     90,
+		Replacement: "media_fast_forward",
 	},
 	"keycode_app_switch": {
 		Keycode:     187,
@@ -632,7 +701,7 @@ func (t *KeyboardTapTool) Description() string {
 		`up, down, left, right, home, end, pageup, pagedown, insert, printscreen. ` +
 		`For normal text deletion in an input field, use backspace; the delete key is forward-delete and should only be used when intentionally deleting the character after the cursor. ` +
 		`Modifiers: ctrl, shift, alt, meta/super/win/cmd. ` +
-		`Android extension keys on hid.usb2: KEYCODE_BACK, KEYCODE_HOME, KEYCODE_APP_SWITCH, KEYCODE_MENU, KEYCODE_SEARCH, KEYCODE_POWER, KEYCODE_VOLUME_MUTE, KEYCODE_VOLUME_UP, KEYCODE_VOLUME_DOWN, KEY_USAGE_SETTINGS, KEY_USAGE_LANGUAGE_SWITCH, plus raw app_switch/menu/search/power/settings/language_switch/volume_* names. ` +
+		`Android extension keys on hid.usb2 use KEYCODE_* and KEY_USAGE_* aliases; see the Android key guide for the full list. ` +
 		`Android extension keys are single-key taps only and cannot be combined with standard keyboard modifiers/chords; unsupported Android-only aliases return an explicit error. ` +
 		`Modifier-only taps are supported (e.g. {"keys":["meta"]}). ` +
 		`Multiple keys are pressed simultaneously (e.g. ctrl+c). ` +
@@ -666,7 +735,8 @@ func (t *KeyboardTapTool) Call(ctx context.Context, input string) (string, error
 	if err != nil {
 		return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 	}
-	if resolved.AndroidUsage != 0 {
+
+	if resolved.AndroidExtensionKey != "" {
 		holdMs := args.HoldMs
 		if holdMs <= 0 {
 			holdMs = defaultKeyboardTapHoldMs

--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -128,6 +128,105 @@ var hidModifierMap = map[string]uint8{
 	"super": 0x08, "win": 0x08, "cmd": 0x08,
 }
 
+var androidExtensionUsageMap = map[string]uint16{
+	"android_back":              0x0224,
+	"android_home":              0x0223,
+	"menu":                      0x0040,
+	"search":                    0x0221,
+	"power":                     0x0030,
+	"volume_mute":               0x00e2,
+	"volumeup":                  0x00e9,
+	"volume_up":                 0x00e9,
+	"volumedown":                0x00ea,
+	"volume_down":               0x00ea,
+	"settings":                  0x019f,
+	"key_usage_settings":        0x019f,
+	"language_switch":           0x029d,
+	"key_usage_language_switch": 0x029d,
+	// AOSP Generic.kl checks HID usage codes before Linux scan codes.
+	// 0x0c01A2 is mapped to ALL_APPS, while 0x0c029F is mapped to
+	// RECENT_APPS / KEYCODE_APP_SWITCH.
+	"app_switch": 0x029f,
+}
+
+type androidKeyboardTapAlias struct {
+	Keycode           int
+	Replacement       string
+	UnsupportedReason string
+}
+
+// Keep Android framework keycodes separate from the generic HID usage table.
+// They are routed through hid.usb2, which advertises a Consumer Control
+// interface instead of the boot keyboard report used by hid.usb0.
+var androidKeyboardTapAliases = map[string]androidKeyboardTapAlias{
+	"keycode_call": {
+		Keycode:           5,
+		UnsupportedReason: "call pickup requires an Android telephony/media key path beyond the current hid.usb2 Consumer Control interface",
+	},
+	"keycode_endcall": {
+		Keycode:           6,
+		UnsupportedReason: "call hangup requires an Android telephony/media key path beyond the current hid.usb2 Consumer Control interface",
+	},
+	"keycode_home": {
+		Keycode:     3,
+		Replacement: "android_home",
+	},
+	"keycode_menu": {
+		Keycode:     82,
+		Replacement: "menu",
+	},
+	"keycode_back": {
+		Keycode:     4,
+		Replacement: "android_back",
+	},
+	"keycode_search": {
+		Keycode:     84,
+		Replacement: "search",
+	},
+	"keycode_camera": {
+		Keycode:           27,
+		UnsupportedReason: "camera shutter requires a camera/media key path beyond the current hid.usb2 Consumer Control interface",
+	},
+	"keycode_focus": {
+		Keycode:           80,
+		UnsupportedReason: "camera focus requires a camera/media key path beyond the current hid.usb2 Consumer Control interface",
+	},
+	"keycode_power": {
+		Keycode:     26,
+		Replacement: "power",
+	},
+	"keycode_notification": {
+		Keycode:           83,
+		UnsupportedReason: "notification center has no verified standard Consumer Control usage on this gadget; use quick_action notification_center or touch_gesture instead",
+	},
+	"keycode_mute": {
+		Keycode:           91,
+		UnsupportedReason: "KEYCODE_MUTE is microphone mute, not speaker mute; hid.usb2 only exposes system speaker/stream volume mute",
+	},
+	"keycode_volume_mute": {
+		Keycode:     164,
+		Replacement: "volume_mute",
+	},
+	"keycode_volume_up": {
+		Keycode:     24,
+		Replacement: "volume_up",
+	},
+	"keycode_volume_down": {
+		Keycode:     25,
+		Replacement: "volume_down",
+	},
+	"keycode_app_switch": {
+		Keycode:     187,
+		Replacement: "app_switch",
+	},
+}
+
+type keyboardTapResolvedInput struct {
+	Keys                []string
+	AndroidExtensionKey string
+	AndroidUsage        uint16
+}
+
 // HIDDevice manages a single HID device file with lazy open and auto-reopen.
 type HIDDevice struct {
 	path         string
@@ -520,7 +619,8 @@ func hidWriteWouldBlock(err error) bool {
 
 // KeyboardTapTool sends a key press then release via HID.
 type KeyboardTapTool struct {
-	dev *HIDDevice
+	dev        *HIDDevice
+	androidDev *HIDDevice
 }
 
 func (t *KeyboardTapTool) Name() string { return "keyboard_tap" }
@@ -528,11 +628,13 @@ func (t *KeyboardTapTool) Name() string { return "keyboard_tap" }
 func (t *KeyboardTapTool) Description() string {
 	return `Press and release keyboard keys. Input JSON: {"keys": ["ctrl", "c"]}. ` +
 		`For known semantic platform actions such as back, app search, app switching, copy, paste, undo, redo, select all, delete backward/forward, find, send, or browser navigation, prefer quick_action first; use keyboard_tap as a low-level fallback or for custom key input. ` +
-		`Supports: a-z, 0-9, f1-f12, enter, escape, backspace, tab, space, delete, ` +
+		`Supports on the standard boot keyboard path: a-z, 0-9, f1-f12, enter, escape, backspace, tab, space, delete, ` +
 		`up, down, left, right, home, end, pageup, pagedown, insert, printscreen. ` +
 		`For normal text deletion in an input field, use backspace; the delete key is forward-delete and should only be used when intentionally deleting the character after the cursor. ` +
 		`Modifiers: ctrl, shift, alt, meta/super/win/cmd. ` +
-		`Modifier-only taps are supported (e.g. {"keys":["meta"]} for Android Home). ` +
+		`Android extension keys on hid.usb2: KEYCODE_BACK, KEYCODE_HOME, KEYCODE_APP_SWITCH, KEYCODE_MENU, KEYCODE_SEARCH, KEYCODE_POWER, KEYCODE_VOLUME_MUTE, KEYCODE_VOLUME_UP, KEYCODE_VOLUME_DOWN, KEY_USAGE_SETTINGS, KEY_USAGE_LANGUAGE_SWITCH, plus raw app_switch/menu/search/power/settings/language_switch/volume_* names. ` +
+		`Android extension keys are single-key taps only and cannot be combined with standard keyboard modifiers/chords; unsupported Android-only aliases return an explicit error. ` +
+		`Modifier-only taps are supported (e.g. {"keys":["meta"]}). ` +
 		`Multiple keys are pressed simultaneously (e.g. ctrl+c). ` +
 		`Optional hold_ms keeps the chord pressed before release (default 50ms, 120ms when modifiers are used).`
 }
@@ -560,10 +662,28 @@ func (t *KeyboardTapTool) Call(ctx context.Context, input string) (string, error
 		return toolErrorResultString(ctx, CodeInvalidArguments, "keys array is required"), nil
 	}
 
+	resolved, err := resolveKeyboardTapKeys(args.Keys)
+	if err != nil {
+		return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
+	}
+	if resolved.AndroidUsage != 0 {
+		holdMs := args.HoldMs
+		if holdMs <= 0 {
+			holdMs = defaultKeyboardTapHoldMs
+		}
+		if err := t.tapAndroidExtension(resolved.AndroidExtensionKey, resolved.AndroidUsage, holdMs); err != nil {
+			code := CodeToolExecutionFailed
+			if errors.Is(err, errAndroidExtensionUnavailable) {
+				code = CodeModuleUnavailable
+			}
+			return toolErrorResultf(ctx, code, "%v", err), nil
+		}
+		return "ok", nil
+	}
+
 	var modifier uint8
 	var keys []uint8
-	for _, k := range args.Keys {
-		k = strings.ToLower(strings.TrimSpace(k))
+	for _, k := range resolved.Keys {
 		if mod, ok := hidModifierMap[k]; ok {
 			modifier |= mod
 		} else if code, ok := hidKeyboardMap[k]; ok {
@@ -588,6 +708,62 @@ func (t *KeyboardTapTool) Call(ctx context.Context, input string) (string, error
 		return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 	}
 	return "ok", nil
+}
+
+func resolveKeyboardTapKeys(rawKeys []string) (keyboardTapResolvedInput, error) {
+	resolved := keyboardTapResolvedInput{Keys: make([]string, 0, len(rawKeys))}
+	androidKeys := make([]string, 0, 1)
+	for _, key := range rawKeys {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if normalized == "" {
+			continue
+		}
+		if alias, ok := androidKeyboardTapAliases[normalized]; ok {
+			if alias.UnsupportedReason != "" {
+				return keyboardTapResolvedInput{}, fmt.Errorf("android-only key %q (keycode %d) is not supported by keyboard_tap: %s", normalized, alias.Keycode, alias.UnsupportedReason)
+			}
+			normalized = alias.Replacement
+		}
+		if usage, ok := androidExtensionUsageMap[normalized]; ok {
+			androidKeys = append(androidKeys, normalized)
+			resolved.AndroidUsage = usage
+			continue
+		}
+		resolved.Keys = append(resolved.Keys, normalized)
+	}
+	if len(androidKeys) > 1 {
+		return keyboardTapResolvedInput{}, fmt.Errorf("keyboard_tap supports one Android extension key at a time, got %v", androidKeys)
+	}
+	if len(androidKeys) == 1 {
+		if len(resolved.Keys) > 0 {
+			return keyboardTapResolvedInput{}, fmt.Errorf("Android extension key %q cannot be combined with standard keyboard keys or modifiers", androidKeys[0])
+		}
+		resolved.AndroidExtensionKey = androidKeys[0]
+		return resolved, nil
+	}
+	if len(resolved.Keys) == 0 {
+		return keyboardTapResolvedInput{}, fmt.Errorf("at least one key or modifier is required")
+	}
+	if len(resolved.Keys) > 6 {
+		return keyboardTapResolvedInput{}, fmt.Errorf("keyboard_tap supports at most 6 simultaneous keys after alias expansion")
+	}
+	return resolved, nil
+}
+
+var errAndroidExtensionUnavailable = errors.New("android extension keyboard device is not configured")
+
+func (t *KeyboardTapTool) tapAndroidExtension(key string, usage uint16, holdMs int) error {
+	if t.androidDev == nil {
+		return fmt.Errorf("%w; set hid.pointer_mode=\"touchscreen\" and ensure hid.android_keyboard_device exists to use %s", errAndroidExtensionUnavailable, key)
+	}
+	report := []byte{byte(usage), byte(usage >> 8)}
+	if err := t.androidDev.Write(report); err != nil {
+		return err
+	}
+	if holdMs > 0 {
+		sleepMs(holdMs)
+	}
+	return t.androidDev.Write([]byte{0x00, 0x00})
 }
 
 func (t *KeyboardTapTool) tapKeyboardChord(modifier uint8, keys []uint8, holdMs int) error {
@@ -825,7 +1001,6 @@ func pointSchema(description string) map[string]any {
 	schema["description"] = description
 	return schema
 }
-
 
 func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, error) {
 	var args struct {

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -1176,6 +1177,55 @@ func TestKeyboardTapSupportsAndroidAppSwitchAlias(t *testing.T) {
 	}
 }
 
+func TestKeyboardTapSupportsAdditionalAndroidKeycodeAliases(t *testing.T) {
+	testCases := []struct {
+		input  string
+		mapKey string
+	}{
+		{input: "KEYCODE_SLEEP", mapKey: "sleep"},
+		{input: "KEYCODE_MEDIA_PLAY_PAUSE", mapKey: "media_play_pause"},
+		{input: "KEYCODE_MEDIA_STOP", mapKey: "media_stop"},
+		{input: "KEYCODE_MEDIA_NEXT", mapKey: "media_next"},
+		{input: "KEYCODE_MEDIA_PREVIOUS", mapKey: "media_previous"},
+		{input: "KEYCODE_MEDIA_REWIND", mapKey: "media_rewind"},
+		{input: "KEYCODE_MEDIA_FAST_FORWARD", mapKey: "media_fast_forward"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			dev, path := newTestHIDDevice(t)
+			androidDev, androidPath := newTestHIDDevice(t)
+			tool := &KeyboardTapTool{dev: dev, androidDev: androidDev}
+
+			out, err := tool.Call(context.Background(), fmt.Sprintf(`{"keys":["%s"]}`, tc.input))
+			if err != nil {
+				t.Fatalf("Call failed: %v", err)
+			}
+			if out != "ok" {
+				t.Fatalf("unexpected output: %s", out)
+			}
+
+			dev.Close()
+			androidDev.Close()
+			if data, err := os.ReadFile(path); err != nil {
+				t.Fatalf("ReadFile keyboard path: %v", err)
+			} else if len(data) != 0 {
+				t.Fatalf("standard keyboard path bytes = %v, want none for android extension key", data)
+			}
+			data, err := os.ReadFile(androidPath)
+			if err != nil {
+				t.Fatalf("ReadFile android path: %v", err)
+			}
+			if len(data) != 4 {
+				t.Fatalf("report bytes = %d, want 4 (consumer usage + release)", len(data))
+			}
+			if got := uint16(data[0]) | uint16(data[1])<<8; got != androidExtensionUsageMap[tc.mapKey] {
+				t.Fatalf("usage = 0x%04x, want 0x%04x", got, androidExtensionUsageMap[tc.mapKey])
+			}
+		})
+	}
+}
+
 func TestKeyboardTapSupportsAndroidSettingsUsageAlias(t *testing.T) {
 	dev, path := newTestHIDDevice(t)
 	androidDev, androidPath := newTestHIDDevice(t)
@@ -1237,6 +1287,90 @@ func TestKeyboardTapSupportsAndroidLanguageSwitchUsageAlias(t *testing.T) {
 	}
 	if got := uint16(data[0]) | uint16(data[1])<<8; got != androidExtensionUsageMap["key_usage_language_switch"] {
 		t.Fatalf("android language_switch usage = 0x%04x, want 0x%04x", got, androidExtensionUsageMap["key_usage_language_switch"])
+	}
+}
+
+func TestKeyboardTapSupportsAdditionalAndroidUsageAliases(t *testing.T) {
+	testCases := []struct {
+		input  string
+		mapKey string
+	}{
+		{input: "KEY_USAGE_SCREENSHOT", mapKey: "key_usage_screenshot"},
+		{input: "KEY_USAGE_WINDOW", mapKey: "key_usage_window"},
+		{input: "KEY_USAGE_BRIGHTNESS_UP", mapKey: "key_usage_brightness_up"},
+		{input: "KEY_USAGE_BRIGHTNESS_DOWN", mapKey: "key_usage_brightness_down"},
+		{input: "KEY_USAGE_DICTATE", mapKey: "key_usage_dictate"},
+		{input: "KEY_USAGE_EMOJI_PICKER", mapKey: "key_usage_emoji_picker"},
+		{input: "KEY_USAGE_MEDIA_AUDIO_TRACK", mapKey: "key_usage_media_audio_track"},
+		{input: "KEY_USAGE_PROFILE_SWITCH", mapKey: "key_usage_profile_switch"},
+		{input: "KEY_USAGE_NEW", mapKey: "key_usage_new"},
+		{input: "KEY_USAGE_CLOSE", mapKey: "key_usage_close"},
+		{input: "KEY_USAGE_PRINT", mapKey: "key_usage_print"},
+		{input: "KEY_USAGE_REFRESH", mapKey: "key_usage_refresh"},
+		{input: "KEY_USAGE_FULLSCREEN", mapKey: "key_usage_fullscreen"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			dev, path := newTestHIDDevice(t)
+			androidDev, androidPath := newTestHIDDevice(t)
+			tool := &KeyboardTapTool{dev: dev, androidDev: androidDev}
+
+			out, err := tool.Call(context.Background(), fmt.Sprintf(`{"keys":["%s"]}`, tc.input))
+			if err != nil {
+				t.Fatalf("Call failed: %v", err)
+			}
+			if out != "ok" {
+				t.Fatalf("unexpected output: %s", out)
+			}
+
+			dev.Close()
+			androidDev.Close()
+			if data, err := os.ReadFile(path); err != nil {
+				t.Fatalf("ReadFile keyboard path: %v", err)
+			} else if len(data) != 0 {
+				t.Fatalf("standard keyboard path bytes = %v, want none for android extension key", data)
+			}
+			data, err := os.ReadFile(androidPath)
+			if err != nil {
+				t.Fatalf("ReadFile android path: %v", err)
+			}
+			if len(data) != 4 {
+				t.Fatalf("report bytes = %d, want 4 (consumer usage + release)", len(data))
+			}
+			if got := uint16(data[0]) | uint16(data[1])<<8; got != androidExtensionUsageMap[tc.mapKey] {
+				t.Fatalf("usage = 0x%04x, want 0x%04x", got, androidExtensionUsageMap[tc.mapKey])
+			}
+		})
+	}
+}
+
+func TestKeyboardTapRejectsUnsupportedAndroidKeycodeAliases(t *testing.T) {
+	testCases := []struct {
+		input      string
+		messageSub string
+	}{
+		{input: "KEYCODE_WAKEUP", messageSub: "Generic Desktop/System Control HID path"},
+		{input: "KEYCODE_SOFT_SLEEP", messageSub: "no verified standard Consumer Control usage"},
+		{input: "KEYCODE_NOTIFICATION", messageSub: "notification center has no verified standard Consumer Control usage"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			ctx, _ := WithToolError(context.Background())
+			tool := &KeyboardTapTool{}
+
+			out, err := tool.Call(ctx, fmt.Sprintf(`{"keys":["%s"]}`, tc.input))
+			if err != nil {
+				t.Fatalf("Call returned error: %v", err)
+			}
+			if !strings.Contains(out, strings.ToLower(tc.input)) || !strings.Contains(out, tc.messageSub) {
+				t.Fatalf("output = %q, want alias and reason substring %q", out, tc.messageSub)
+			}
+			if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeInvalidArguments || got.Message != out {
+				t.Fatalf("ToolError = %+v, want invalid_arguments with output message", got)
+			}
+		})
 	}
 }
 
@@ -1605,9 +1739,9 @@ func TestKeyboardTapDescriptionDocumentsQuickActionFallback(t *testing.T) {
 	}
 }
 
-func TestKeyboardTapDescriptionDocumentsAndroidAliases(t *testing.T) {
+func TestKeyboardTapDescriptionReferencesAndroidGuidePage(t *testing.T) {
 	desc := (&KeyboardTapTool{}).Description()
-	for _, want := range []string{"KEYCODE_BACK", "KEYCODE_HOME", "KEYCODE_APP_SWITCH", "KEYCODE_VOLUME_DOWN", "KEY_USAGE_SETTINGS", "KEY_USAGE_LANGUAGE_SWITCH", "raw app_switch/menu/search/power/settings/language_switch/volume_* names", "single-key taps only"} {
+	for _, want := range []string{"KEYCODE_*", "KEY_USAGE_*", "Android key guide", "single-key taps only"} {
 		if !strings.Contains(desc, want) {
 			t.Fatalf("description missing %q:\n%s", want, desc)
 		}

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -1077,6 +1077,201 @@ func TestKeyboardTapSendsModifierChordWithHold(t *testing.T) {
 	}
 }
 
+func TestKeyboardTapSupportsAndroidBackAlias(t *testing.T) {
+	dev, path := newTestHIDDevice(t)
+	androidDev, androidPath := newTestHIDDevice(t)
+	tool := &KeyboardTapTool{dev: dev, androidDev: androidDev}
+
+	out, err := tool.Call(context.Background(), `{"keys":["KEYCODE_BACK"]}`)
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+
+	dev.Close()
+	androidDev.Close()
+	if data, err := os.ReadFile(path); err != nil {
+		t.Fatalf("ReadFile keyboard path: %v", err)
+	} else if len(data) != 0 {
+		t.Fatalf("standard keyboard path bytes = %v, want none for android extension key", data)
+	}
+	data, err := os.ReadFile(androidPath)
+	if err != nil {
+		t.Fatalf("ReadFile android path: %v", err)
+	}
+	if len(data) != 4 {
+		t.Fatalf("report bytes = %d, want 4 (consumer usage + release)", len(data))
+	}
+	if got := uint16(data[0]) | uint16(data[1])<<8; got != androidExtensionUsageMap["android_back"] {
+		t.Fatalf("android back usage = 0x%04x, want 0x%04x", got, androidExtensionUsageMap["android_back"])
+	}
+	if data[2] != 0 || data[3] != 0 {
+		t.Fatalf("android back release = %v, want [0 0]", data[2:4])
+	}
+}
+
+func TestKeyboardTapSupportsAndroidVolumeAlias(t *testing.T) {
+	dev, path := newTestHIDDevice(t)
+	androidDev, androidPath := newTestHIDDevice(t)
+	tool := &KeyboardTapTool{dev: dev, androidDev: androidDev}
+
+	out, err := tool.Call(context.Background(), `{"keys":["KEYCODE_VOLUME_UP"]}`)
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+
+	dev.Close()
+	androidDev.Close()
+	if data, err := os.ReadFile(path); err != nil {
+		t.Fatalf("ReadFile keyboard path: %v", err)
+	} else if len(data) != 0 {
+		t.Fatalf("standard keyboard path bytes = %v, want none for android extension key", data)
+	}
+	data, err := os.ReadFile(androidPath)
+	if err != nil {
+		t.Fatalf("ReadFile android path: %v", err)
+	}
+	if len(data) != 4 {
+		t.Fatalf("report bytes = %d, want 4 (consumer usage + release)", len(data))
+	}
+	if got := uint16(data[0]) | uint16(data[1])<<8; got != androidExtensionUsageMap["volume_up"] {
+		t.Fatalf("android volume_up usage = 0x%04x, want 0x%04x", got, androidExtensionUsageMap["volume_up"])
+	}
+}
+
+func TestKeyboardTapSupportsAndroidAppSwitchAlias(t *testing.T) {
+	dev, path := newTestHIDDevice(t)
+	androidDev, androidPath := newTestHIDDevice(t)
+	tool := &KeyboardTapTool{dev: dev, androidDev: androidDev}
+
+	out, err := tool.Call(context.Background(), `{"keys":["KEYCODE_APP_SWITCH"]}`)
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+
+	dev.Close()
+	androidDev.Close()
+	if data, err := os.ReadFile(path); err != nil {
+		t.Fatalf("ReadFile keyboard path: %v", err)
+	} else if len(data) != 0 {
+		t.Fatalf("standard keyboard path bytes = %v, want none for android extension key", data)
+	}
+	data, err := os.ReadFile(androidPath)
+	if err != nil {
+		t.Fatalf("ReadFile android path: %v", err)
+	}
+	if len(data) != 4 {
+		t.Fatalf("report bytes = %d, want 4 (consumer usage + release)", len(data))
+	}
+	if got := uint16(data[0]) | uint16(data[1])<<8; got != androidExtensionUsageMap["app_switch"] {
+		t.Fatalf("android app_switch usage = 0x%04x, want 0x%04x", got, androidExtensionUsageMap["app_switch"])
+	}
+}
+
+func TestKeyboardTapSupportsAndroidSettingsUsageAlias(t *testing.T) {
+	dev, path := newTestHIDDevice(t)
+	androidDev, androidPath := newTestHIDDevice(t)
+	tool := &KeyboardTapTool{dev: dev, androidDev: androidDev}
+
+	out, err := tool.Call(context.Background(), `{"keys":["KEY_USAGE_SETTINGS"]}`)
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+
+	dev.Close()
+	androidDev.Close()
+	if data, err := os.ReadFile(path); err != nil {
+		t.Fatalf("ReadFile keyboard path: %v", err)
+	} else if len(data) != 0 {
+		t.Fatalf("standard keyboard path bytes = %v, want none for android extension key", data)
+	}
+	data, err := os.ReadFile(androidPath)
+	if err != nil {
+		t.Fatalf("ReadFile android path: %v", err)
+	}
+	if len(data) != 4 {
+		t.Fatalf("report bytes = %d, want 4 (consumer usage + release)", len(data))
+	}
+	if got := uint16(data[0]) | uint16(data[1])<<8; got != androidExtensionUsageMap["key_usage_settings"] {
+		t.Fatalf("android settings usage = 0x%04x, want 0x%04x", got, androidExtensionUsageMap["key_usage_settings"])
+	}
+}
+
+func TestKeyboardTapSupportsAndroidLanguageSwitchUsageAlias(t *testing.T) {
+	dev, path := newTestHIDDevice(t)
+	androidDev, androidPath := newTestHIDDevice(t)
+	tool := &KeyboardTapTool{dev: dev, androidDev: androidDev}
+
+	out, err := tool.Call(context.Background(), `{"keys":["KEY_USAGE_LANGUAGE_SWITCH"]}`)
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+
+	dev.Close()
+	androidDev.Close()
+	if data, err := os.ReadFile(path); err != nil {
+		t.Fatalf("ReadFile keyboard path: %v", err)
+	} else if len(data) != 0 {
+		t.Fatalf("standard keyboard path bytes = %v, want none for android extension key", data)
+	}
+	data, err := os.ReadFile(androidPath)
+	if err != nil {
+		t.Fatalf("ReadFile android path: %v", err)
+	}
+	if len(data) != 4 {
+		t.Fatalf("report bytes = %d, want 4 (consumer usage + release)", len(data))
+	}
+	if got := uint16(data[0]) | uint16(data[1])<<8; got != androidExtensionUsageMap["key_usage_language_switch"] {
+		t.Fatalf("android language_switch usage = 0x%04x, want 0x%04x", got, androidExtensionUsageMap["key_usage_language_switch"])
+	}
+}
+
+func TestKeyboardTapRejectsAndroidExtensionWithoutAndroidDevice(t *testing.T) {
+	tool := &KeyboardTapTool{}
+	ctx, _ := WithToolError(context.Background())
+
+	out, err := tool.Call(ctx, `{"keys":["KEYCODE_HOME"]}`)
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if !strings.Contains(out, "android extension keyboard device is not configured") || !strings.Contains(out, "hid.pointer_mode=\"touchscreen\"") {
+		t.Fatalf("output = %q, want android extension device error", out)
+	}
+	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeModuleUnavailable || got.Message != out {
+		t.Fatalf("ToolError = %+v, want module_unavailable with output message", got)
+	}
+}
+
+func TestKeyboardTapRejectsMixedAndroidExtensionChord(t *testing.T) {
+	tool := &KeyboardTapTool{}
+	ctx, _ := WithToolError(context.Background())
+
+	out, err := tool.Call(ctx, `{"keys":["ctrl","KEYCODE_BACK"]}`)
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if !strings.Contains(out, `Android extension key "android_back" cannot be combined`) {
+		t.Fatalf("output = %q, want mixed-chord error", out)
+	}
+	if got := ToolErrorFromContext(ctx); got == nil || got.Code != CodeInvalidArguments || got.Message != out {
+		t.Fatalf("ToolError = %+v, want invalid_arguments with output message", got)
+	}
+}
+
 func readMouseReports(t *testing.T, dev *HIDDevice, path string) []mouseReport {
 	t.Helper()
 
@@ -1404,6 +1599,15 @@ func TestMouseClickDescriptionDocumentsTargetCenter(t *testing.T) {
 func TestKeyboardTapDescriptionDocumentsQuickActionFallback(t *testing.T) {
 	desc := (&KeyboardTapTool{}).Description()
 	for _, want := range []string{"prefer quick_action first", "delete backward/forward", "low-level fallback", "custom key input", "normal text deletion", "use backspace", "delete key is forward-delete"} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("description missing %q:\n%s", want, desc)
+		}
+	}
+}
+
+func TestKeyboardTapDescriptionDocumentsAndroidAliases(t *testing.T) {
+	desc := (&KeyboardTapTool{}).Description()
+	for _, want := range []string{"KEYCODE_BACK", "KEYCODE_HOME", "KEYCODE_APP_SWITCH", "KEYCODE_VOLUME_DOWN", "KEY_USAGE_SETTINGS", "KEY_USAGE_LANGUAGE_SWITCH", "raw app_switch/menu/search/power/settings/language_switch/volume_* names", "single-key taps only"} {
 		if !strings.Contains(desc, want) {
 			t.Fatalf("description missing %q:\n%s", want, desc)
 		}

--- a/src/agent_toml.cpp
+++ b/src/agent_toml.cpp
@@ -357,6 +357,7 @@ void apply_kv(AgentToml& cfg,
     } else if (section == "hid") {
         if (key == "keyboard_device") assign_string(&cfg.hid.keyboard_device, raw, &sub_err);
         else if (key == "mouse_device") assign_string(&cfg.hid.mouse_device, raw, &sub_err);
+        else if (key == "android_keyboard_device") assign_string(&cfg.hid.android_keyboard_device, raw, &sub_err);
         else if (key == "frame_socket") assign_string(&cfg.hid.frame_socket, raw, &sub_err);
         else if (key == "pointer_mode") assign_string(&cfg.hid.pointer_mode, raw, &sub_err);
         if (!sub_err.empty()) fail(sub_err);
@@ -693,6 +694,7 @@ bool save_agent_toml(const char* path, const AgentToml& cfg, std::string* error)
     out << "[hid]\n";
     emit_string(out, "keyboard_device", cfg.hid.keyboard_device);
     emit_string(out, "mouse_device", cfg.hid.mouse_device);
+    emit_string(out, "android_keyboard_device", cfg.hid.android_keyboard_device);
     emit_string(out, "frame_socket", cfg.hid.frame_socket);
     if (!cfg.hid.pointer_mode.empty()) emit_string(out, "pointer_mode", cfg.hid.pointer_mode);
     out << "\n";

--- a/src/agent_toml.h
+++ b/src/agent_toml.h
@@ -60,6 +60,7 @@ struct LogToml {
 struct HIDToml {
     std::string keyboard_device;
     std::string mouse_device;
+    std::string android_keyboard_device;
     std::string frame_socket;
     std::string pointer_mode;
 };

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -5562,13 +5562,19 @@ ApiResponse handle_config_test(const Options& options, const std::string& body) 
         }
         cJSON_AddItemToArray(results, r);
     } else if (section == "hid") {
+        cJSON* pointer_item = cJSON_GetObjectItem(values, "pointer_mode");
+        std::string pointer_mode = json_is_string(pointer_item) ? normalize_pointer_mode(pointer_item->valuestring) : "absolute";
         const char* dev_keys[] = {"keyboard_device", "mouse_device", "android_keyboard_device", NULL};
         for (int i = 0; dev_keys[i]; ++i) {
             cJSON* item = cJSON_GetObjectItem(values, dev_keys[i]);
             std::string path = json_is_string(item) ? trim_copy(item->valuestring) : "";
             cJSON* r = cJSON_CreateObject();
             cJSON_AddStringToObject(r, "check", dev_keys[i]);
-            if (path.empty()) {
+            if (strcmp(dev_keys[i], "android_keyboard_device") == 0 && pointer_mode != "touchscreen") {
+                cJSON_AddBoolToObject(r, "passed", 1);
+                std::string detail = "not required when pointer_mode is " + pointer_mode;
+                cJSON_AddStringToObject(r, "detail", detail.c_str());
+            } else if (path.empty()) {
                 cJSON_AddBoolToObject(r, "passed", 0);
                 cJSON_AddStringToObject(r, "detail", "path is empty");
                 all_passed = false;
@@ -5583,8 +5589,6 @@ ApiResponse handle_config_test(const Options& options, const std::string& body) 
             }
             cJSON_AddItemToArray(results, r);
         }
-        cJSON* pointer_item = cJSON_GetObjectItem(values, "pointer_mode");
-        std::string pointer_mode = json_is_string(pointer_item) ? normalize_pointer_mode(pointer_item->valuestring) : "absolute";
         cJSON* r = cJSON_CreateObject();
         cJSON_AddStringToObject(r, "check", "pointer_mode");
         bool valid = pointer_mode == "absolute" || pointer_mode == "touchscreen";

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -625,6 +625,7 @@ bool validate_known_config_field_types(cJSON* root, std::string* error) {
         {"log", "llm_http_retention_days", CONFIG_FIELD_NUMBER},
         {"hid", "keyboard_device", CONFIG_FIELD_STRING},
         {"hid", "mouse_device", CONFIG_FIELD_STRING},
+        {"hid", "android_keyboard_device", CONFIG_FIELD_STRING},
         {"hid", "frame_socket", CONFIG_FIELD_STRING},
         {"hid", "pointer_mode", CONFIG_FIELD_STRING},
         {"search", "provider", CONFIG_FIELD_STRING},
@@ -2319,6 +2320,7 @@ cJSON* config_to_json(const aiden::AgentToml& config, bool include_secrets = fal
     cJSON* hid = add_object(root, "hid");
     cJSON_AddStringToObject(hid, "keyboard_device", config.hid.keyboard_device.c_str());
     cJSON_AddStringToObject(hid, "mouse_device", config.hid.mouse_device.c_str());
+    cJSON_AddStringToObject(hid, "android_keyboard_device", config.hid.android_keyboard_device.c_str());
     cJSON_AddStringToObject(hid, "frame_socket", config.hid.frame_socket.c_str());
     cJSON_AddStringToObject(hid, "pointer_mode", normalize_pointer_mode(config.hid.pointer_mode).c_str());
 
@@ -2599,6 +2601,7 @@ void update_config_from_json(cJSON* root, aiden::AgentToml* config) {
     if (json_is_object(hid)) {
         set_json_str(&config->hid.keyboard_device, hid, "keyboard_device");
         set_json_str(&config->hid.mouse_device, hid, "mouse_device");
+        set_json_str(&config->hid.android_keyboard_device, hid, "android_keyboard_device");
         set_json_str(&config->hid.frame_socket, hid, "frame_socket");
         set_json_str(&config->hid.pointer_mode, hid, "pointer_mode");
     }
@@ -5559,7 +5562,7 @@ ApiResponse handle_config_test(const Options& options, const std::string& body) 
         }
         cJSON_AddItemToArray(results, r);
     } else if (section == "hid") {
-        const char* dev_keys[] = {"keyboard_device", "mouse_device", NULL};
+        const char* dev_keys[] = {"keyboard_device", "mouse_device", "android_keyboard_device", NULL};
         for (int i = 0; dev_keys[i]; ++i) {
             cJSON* item = cJSON_GetObjectItem(values, dev_keys[i]);
             std::string path = json_is_string(item) ? trim_copy(item->valuestring) : "";

--- a/src/config_web_html.h
+++ b/src/config_web_html.h
@@ -285,6 +285,7 @@ static const char* CONFIG_WEB_HTML =
     "            <div class=\"field\"><label>pointer_mode</label><select id=\"hid_pointer_mode\" data-section=\"hid\"></select></div>\n"
     "            <div class=\"field wide\"><label>keyboard_device</label><input id=\"hid_keyboard_device\" data-section=\"hid\"></div>\n"
     "            <div class=\"field wide\"><label>mouse_device</label><input id=\"hid_mouse_device\" data-section=\"hid\"></div>\n"
+    "            <div class=\"field wide\"><label>android_keyboard_device</label><input id=\"hid_android_keyboard_device\" data-section=\"hid\"></div>\n"
     "            <div class=\"field wide\"><label>frame_socket</label><input id=\"hid_frame_socket\" data-section=\"hid\"></div>\n"
     "          </div>\n"
     "        </div>\n"

--- a/src/example_usb_hid.cpp
+++ b/src/example_usb_hid.cpp
@@ -152,6 +152,20 @@ const uint8_t kTouchscreenDescriptor[] = {
     0xc0,                   // End Collection (Application)
 };
 
+const uint8_t kAndroidExtensionDescriptor[] = {
+    0x05, 0x0c,             // Usage Page (Consumer)
+    0x09, 0x01,             // Usage (Consumer Control)
+    0xa1, 0x01,             // Collection (Application)
+    0x15, 0x00,             //   Logical Minimum (0)
+    0x26, 0xff, 0x03,       //   Logical Maximum (1023)
+    0x1a, 0x00, 0x00,       //   Usage Minimum (0)
+    0x2a, 0xff, 0x03,       //   Usage Maximum (1023)
+    0x75, 0x10,             //   Report Size (16)
+    0x95, 0x01,             //   Report Count (1)
+    0x81, 0x00,             //   Input (Data, Ary, Abs)
+    0xc0,                   // End Collection (Application)
+};
+
 std::string gadget_path(const Options& options) {
     return options.gadget_root + "/" + options.gadget_name;
 }
@@ -511,6 +525,16 @@ void setup_touch_function(const std::string& gadget, const Options& options) {
     ensure_symlink(function_path, gadget + "/configs/c.1/hid.usb1");
 }
 
+void setup_android_extension_function(const std::string& gadget) {
+    std::string function_path = gadget + "/functions/hid.usb2";
+    ensure_dir(function_path);
+    write_text_file(function_path + "/protocol", "0");
+    write_text_file(function_path + "/subclass", "0");
+    write_text_file(function_path + "/report_length", "2");
+    write_binary_file(function_path + "/report_desc", kAndroidExtensionDescriptor, sizeof(kAndroidExtensionDescriptor));
+    ensure_symlink(function_path, gadget + "/configs/c.1/hid.usb2");
+}
+
 void cleanup_gadget(const Options& options) {
     std::string gadget = gadget_path(options);
     if (!path_exists(gadget)) {
@@ -524,8 +548,10 @@ void cleanup_gadget(const Options& options) {
 
     remove_if_exists(gadget + "/configs/c.1/hid.usb0");
     remove_if_exists(gadget + "/configs/c.1/hid.usb1");
+    remove_if_exists(gadget + "/configs/c.1/hid.usb2");
     rmdir_if_exists(gadget + "/functions/hid.usb0");
     rmdir_if_exists(gadget + "/functions/hid.usb1");
+    rmdir_if_exists(gadget + "/functions/hid.usb2");
     rmdir_if_exists(gadget + "/configs/c.1/strings/0x409");
     rmdir_if_exists(gadget + "/configs/c.1");
     rmdir_if_exists(gadget + "/strings/0x409");
@@ -580,6 +606,9 @@ void setup_gadget(const Options& options, const std::string& mode) {
     }
     if (mode == "touch" || mode == "composite") {
         setup_touch_function(gadget, options);
+    }
+    if ((mode == "keyboard" || mode == "composite") && options.pointer_touchscreen) {
+        setup_android_extension_function(gadget);
     }
 
     std::string udc = options.udc.empty() ? first_udc_name() : options.udc;

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -1116,6 +1116,35 @@ TEST_CASE("config_web: hid config test only requires android keyboard device in 
     CHECK((touchscreen_mode_passed->type & 0xff) == cJSON_True);
     CHECK(required_json_string(touchscreen_mode, "detail") == "effective mode: touchscreen");
     cJSON_Delete(touchscreen_json);
+
+    const std::string touchscreen_valid_body =
+        "{\"section\":\"hid\",\"values\":{"
+        "\"keyboard_device\":\"/dev/null\","
+        "\"mouse_device\":\"/dev/null\","
+        "\"android_keyboard_device\":\"/dev/null\","
+        "\"pointer_mode\":\"touchscreen\""
+        "}}";
+
+    HttpResponse touchscreen_valid_resp = http_request(handle->port, "POST", "/api/config/test", touchscreen_valid_body);
+    REQUIRE(touchscreen_valid_resp.status == 200);
+    cJSON* touchscreen_valid_json = cJSON_Parse(touchscreen_valid_resp.body.c_str());
+    REQUIRE(touchscreen_valid_json != nullptr);
+    cJSON* touchscreen_valid_ok = cJSON_GetObjectItem(touchscreen_valid_json, "ok");
+    REQUIRE(touchscreen_valid_ok != nullptr);
+    CHECK((touchscreen_valid_ok->type & 0xff) == cJSON_True);
+    cJSON* touchscreen_valid_android = required_test_result(touchscreen_valid_json, "android_keyboard_device");
+    REQUIRE(touchscreen_valid_android != nullptr);
+    cJSON* touchscreen_valid_android_passed = cJSON_GetObjectItem(touchscreen_valid_android, "passed");
+    REQUIRE(touchscreen_valid_android_passed != nullptr);
+    CHECK((touchscreen_valid_android_passed->type & 0xff) == cJSON_True);
+    CHECK(required_json_string(touchscreen_valid_android, "detail") == "/dev/null exists");
+    cJSON* touchscreen_valid_mode = required_test_result(touchscreen_valid_json, "pointer_mode");
+    REQUIRE(touchscreen_valid_mode != nullptr);
+    cJSON* touchscreen_valid_mode_passed = cJSON_GetObjectItem(touchscreen_valid_mode, "passed");
+    REQUIRE(touchscreen_valid_mode_passed != nullptr);
+    CHECK((touchscreen_valid_mode_passed->type & 0xff) == cJSON_True);
+    CHECK(required_json_string(touchscreen_valid_mode, "detail") == "effective mode: touchscreen");
+    cJSON_Delete(touchscreen_valid_json);
 }
 
 TEST_CASE("config_web: config test rejects wakeup trigger for text input") {

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -188,6 +188,22 @@ int required_json_int(cJSON* object, const char* key) {
     return item->valueint;
 }
 
+cJSON* required_test_result(cJSON* root, const char* check) {
+    cJSON* results = cJSON_GetObjectItem(root, "results");
+    REQUIRE(results != nullptr);
+    REQUIRE((results->type & 0xff) == cJSON_Array);
+    const int count = cJSON_GetArraySize(results);
+    for (int i = 0; i < count; ++i) {
+        cJSON* item = cJSON_GetArrayItem(results, i);
+        REQUIRE(item != nullptr);
+        cJSON* check_item = cJSON_GetObjectItem(item, "check");
+        if (check_item != nullptr && check_item->valuestring != nullptr && std::strcmp(check_item->valuestring, check) == 0) {
+            return item;
+        }
+    }
+    return nullptr;
+}
+
 std::string replace_all(std::string text, const std::string& needle, const std::string& replacement) {
     size_t pos = 0;
     while ((pos = text.find(needle, pos)) != std::string::npos) {
@@ -1037,6 +1053,69 @@ TEST_CASE("config_web: config test rejects blank search api key without stored m
     CHECK(test_resp.status == 200);
     CHECK(test_resp.body.find("\"ok\":false") != std::string::npos);
     CHECK(test_resp.body.find("required for brave") != std::string::npos);
+}
+
+TEST_CASE("config_web: hid config test only requires android keyboard device in touchscreen mode") {
+    StubEnv env;
+    auto handle = start_server(env);
+
+    const std::string absolute_body =
+        "{\"section\":\"hid\",\"values\":{"
+        "\"keyboard_device\":\"/dev/null\","
+        "\"mouse_device\":\"/dev/null\","
+        "\"android_keyboard_device\":\"\","
+        "\"pointer_mode\":\"absolute\""
+        "}}";
+
+    HttpResponse absolute_resp = http_request(handle->port, "POST", "/api/config/test", absolute_body);
+    REQUIRE(absolute_resp.status == 200);
+    cJSON* absolute_json = cJSON_Parse(absolute_resp.body.c_str());
+    REQUIRE(absolute_json != nullptr);
+    cJSON* absolute_ok = cJSON_GetObjectItem(absolute_json, "ok");
+    REQUIRE(absolute_ok != nullptr);
+    CHECK((absolute_ok->type & 0xff) == cJSON_True);
+    cJSON* absolute_android = required_test_result(absolute_json, "android_keyboard_device");
+    REQUIRE(absolute_android != nullptr);
+    cJSON* absolute_android_passed = cJSON_GetObjectItem(absolute_android, "passed");
+    REQUIRE(absolute_android_passed != nullptr);
+    CHECK((absolute_android_passed->type & 0xff) == cJSON_True);
+    CHECK(required_json_string(absolute_android, "detail") == "not required when pointer_mode is absolute");
+    cJSON* absolute_mode = required_test_result(absolute_json, "pointer_mode");
+    REQUIRE(absolute_mode != nullptr);
+    cJSON* absolute_mode_passed = cJSON_GetObjectItem(absolute_mode, "passed");
+    REQUIRE(absolute_mode_passed != nullptr);
+    CHECK((absolute_mode_passed->type & 0xff) == cJSON_True);
+    CHECK(required_json_string(absolute_mode, "detail") == "effective mode: absolute");
+    cJSON_Delete(absolute_json);
+
+    const std::string touchscreen_body =
+        "{\"section\":\"hid\",\"values\":{"
+        "\"keyboard_device\":\"/dev/null\","
+        "\"mouse_device\":\"/dev/null\","
+        "\"android_keyboard_device\":\"\","
+        "\"pointer_mode\":\"touchscreen\""
+        "}}";
+
+    HttpResponse touchscreen_resp = http_request(handle->port, "POST", "/api/config/test", touchscreen_body);
+    REQUIRE(touchscreen_resp.status == 200);
+    cJSON* touchscreen_json = cJSON_Parse(touchscreen_resp.body.c_str());
+    REQUIRE(touchscreen_json != nullptr);
+    cJSON* touchscreen_ok = cJSON_GetObjectItem(touchscreen_json, "ok");
+    REQUIRE(touchscreen_ok != nullptr);
+    CHECK((touchscreen_ok->type & 0xff) == cJSON_False);
+    cJSON* touchscreen_android = required_test_result(touchscreen_json, "android_keyboard_device");
+    REQUIRE(touchscreen_android != nullptr);
+    cJSON* touchscreen_android_passed = cJSON_GetObjectItem(touchscreen_android, "passed");
+    REQUIRE(touchscreen_android_passed != nullptr);
+    CHECK((touchscreen_android_passed->type & 0xff) == cJSON_False);
+    CHECK(required_json_string(touchscreen_android, "detail") == "path is empty");
+    cJSON* touchscreen_mode = required_test_result(touchscreen_json, "pointer_mode");
+    REQUIRE(touchscreen_mode != nullptr);
+    cJSON* touchscreen_mode_passed = cJSON_GetObjectItem(touchscreen_mode, "passed");
+    REQUIRE(touchscreen_mode_passed != nullptr);
+    CHECK((touchscreen_mode_passed->type & 0xff) == cJSON_True);
+    CHECK(required_json_string(touchscreen_mode, "detail") == "effective mode: touchscreen");
+    cJSON_Delete(touchscreen_json);
 }
 
 TEST_CASE("config_web: config test rejects wakeup trigger for text input") {

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -1145,6 +1145,35 @@ TEST_CASE("config_web: hid config test only requires android keyboard device in 
     CHECK((touchscreen_valid_mode_passed->type & 0xff) == cJSON_True);
     CHECK(required_json_string(touchscreen_valid_mode, "detail") == "effective mode: touchscreen");
     cJSON_Delete(touchscreen_valid_json);
+
+    const std::string touchscreen_missing_body =
+        "{\"section\":\"hid\",\"values\":{"
+        "\"keyboard_device\":\"/dev/null\","
+        "\"mouse_device\":\"/dev/null\","
+        "\"android_keyboard_device\":\"/dev/definitely-missing-hidg9\","
+        "\"pointer_mode\":\"touchscreen\""
+        "}}";
+
+    HttpResponse touchscreen_missing_resp = http_request(handle->port, "POST", "/api/config/test", touchscreen_missing_body);
+    REQUIRE(touchscreen_missing_resp.status == 200);
+    cJSON* touchscreen_missing_json = cJSON_Parse(touchscreen_missing_resp.body.c_str());
+    REQUIRE(touchscreen_missing_json != nullptr);
+    cJSON* touchscreen_missing_ok = cJSON_GetObjectItem(touchscreen_missing_json, "ok");
+    REQUIRE(touchscreen_missing_ok != nullptr);
+    CHECK((touchscreen_missing_ok->type & 0xff) == cJSON_False);
+    cJSON* touchscreen_missing_android = required_test_result(touchscreen_missing_json, "android_keyboard_device");
+    REQUIRE(touchscreen_missing_android != nullptr);
+    cJSON* touchscreen_missing_android_passed = cJSON_GetObjectItem(touchscreen_missing_android, "passed");
+    REQUIRE(touchscreen_missing_android_passed != nullptr);
+    CHECK((touchscreen_missing_android_passed->type & 0xff) == cJSON_False);
+    CHECK(required_json_string(touchscreen_missing_android, "detail") == "/dev/definitely-missing-hidg9 not found");
+    cJSON* touchscreen_missing_mode = required_test_result(touchscreen_missing_json, "pointer_mode");
+    REQUIRE(touchscreen_missing_mode != nullptr);
+    cJSON* touchscreen_missing_mode_passed = cJSON_GetObjectItem(touchscreen_missing_mode, "passed");
+    REQUIRE(touchscreen_missing_mode_passed != nullptr);
+    CHECK((touchscreen_missing_mode_passed->type & 0xff) == cJSON_True);
+    CHECK(required_json_string(touchscreen_missing_mode, "detail") == "effective mode: touchscreen");
+    cJSON_Delete(touchscreen_missing_json);
 }
 
 TEST_CASE("config_web: config test rejects wakeup trigger for text input") {

--- a/tests/config_web_source_test.cpp
+++ b/tests/config_web_source_test.cpp
@@ -1676,6 +1676,20 @@ TEST_CASE("config web preserves hid pointer mode and avoids hot-restarting usbhi
     CHECK(html.find("poweroff command sent") != std::string::npos);
 }
 
+TEST_CASE("config web hid validation skips android keyboard device outside touchscreen mode") {
+    const std::string source_path = std::string(AIDEN_SOURCE_DIR) + "/src/config_web.cpp";
+    std::ifstream source_in(source_path.c_str());
+    REQUIRE(source_in.good());
+
+    std::ostringstream source_buffer;
+    source_buffer << source_in.rdbuf();
+    const std::string source = source_buffer.str();
+
+    CHECK(source.find("std::string pointer_mode = json_is_string(pointer_item) ? normalize_pointer_mode(pointer_item->valuestring) : \"absolute\";") != std::string::npos);
+    CHECK(source.find("strcmp(dev_keys[i], \"android_keyboard_device\") == 0 && pointer_mode != \"touchscreen\"") != std::string::npos);
+    CHECK(source.find("not required when pointer_mode is ") != std::string::npos);
+}
+
 TEST_CASE("config web usbhid init script does not orchestrate dependent service restarts") {
     const std::string script_path = std::string(AIDEN_SOURCE_DIR) + "/overlay/etc/init.d/S49usbhid";
     std::ifstream script_in(script_path.c_str());

--- a/tests/config_web_source_test.cpp
+++ b/tests/config_web_source_test.cpp
@@ -1676,20 +1676,6 @@ TEST_CASE("config web preserves hid pointer mode and avoids hot-restarting usbhi
     CHECK(html.find("poweroff command sent") != std::string::npos);
 }
 
-TEST_CASE("config web hid validation skips android keyboard device outside touchscreen mode") {
-    const std::string source_path = std::string(AIDEN_SOURCE_DIR) + "/src/config_web.cpp";
-    std::ifstream source_in(source_path.c_str());
-    REQUIRE(source_in.good());
-
-    std::ostringstream source_buffer;
-    source_buffer << source_in.rdbuf();
-    const std::string source = source_buffer.str();
-
-    CHECK(source.find("std::string pointer_mode = json_is_string(pointer_item) ? normalize_pointer_mode(pointer_item->valuestring) : \"absolute\";") != std::string::npos);
-    CHECK(source.find("strcmp(dev_keys[i], \"android_keyboard_device\") == 0 && pointer_mode != \"touchscreen\"") != std::string::npos);
-    CHECK(source.find("not required when pointer_mode is ") != std::string::npos);
-}
-
 TEST_CASE("config web usbhid init script does not orchestrate dependent service restarts") {
     const std::string script_path = std::string(AIDEN_SOURCE_DIR) + "/overlay/etc/init.d/S49usbhid";
     std::ifstream script_in(script_path.c_str());


### PR DESCRIPTION
## Summary
- add hid.usb2-backed Android extension keyboard support for `keyboard_tap`
- add Android `KEYCODE_*` and `KEY_USAGE_*` aliases plus the keyboard_tap Android key guide
- add an experimental `KEYCODE_NOTIFICATION` mapping via Consumer usage `0x0c01C8`

## Testing
- `go test ./internal/agent -run 'KeyboardTap'`
- `./build.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android “extension key” support for `keyboard_tap` and related quick actions (including Back, Home, and App Switch).
  * Added `android_keyboard_device` HID configuration and touchscreen behavior to expose an additional HID interface when enabled.
* **Bug Fixes**
  * Improved Android key/alias handling so recognized keys now trigger the correct actions, with clear errors when misconfigured.
* **Documentation**
  * Updated USB HID and agent configuration docs, plus added an Android key guide page to the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->