### PR TITLE
fix(agent): preserve critical tool guidance

### DIFF
--- a/src/agent/config/skills/device-operator/SKILL.md
+++ b/src/agent/config/skills/device-operator/SKILL.md
@@ -3,7 +3,31 @@ name: device-operator
 description: Use when controlling a visible target device UI through screenshots, touch, mouse, keyboard, text entry, scrolling, app switching, or capture recovery.
 metadata:
   preferred_model: primary
-  allowed_tools: [screenshot, wait_for_stable_screen, image_diff, quick_action, touch_gesture, mouse_click, mouse_move, mouse_scroll, keyboard_tap, keyboard_text, enter_text_in_field, enter_text_via_bridge, search_launch_app, request_human_handoff, recall_memory, save_memory, skill_read, run_script, list_scripts, read_script, write_script, shell]
+  allowed_tools:
+    [
+      screenshot,
+      wait_for_stable_screen,
+      image_diff,
+      quick_action,
+      touch_gesture,
+      mouse_click,
+      mouse_move,
+      mouse_scroll,
+      keyboard_tap,
+      keyboard_text,
+      enter_text_in_field,
+      enter_text_via_bridge,
+      search_launch_app,
+      request_human_handoff,
+      recall_memory,
+      save_memory,
+      skill_read,
+      run_script,
+      list_scripts,
+      read_script,
+      write_script,
+      shell,
+    ]
 ---
 
 Use this skill when the task requires operating a visible connected device UI. This is the complete generic device-operation playbook; do not split routine app switching, text entry, scrolling, picker, or screenshot recovery work into child skills.
@@ -43,7 +67,9 @@ Before using coordinates:
 
 - Inspect the screenshot and identify the intended target visually.
 - Use `coord_space: "normalized"` with 0-1000 coordinates when possible: `(0,0)` is top-left, `(1000,1000)` is bottom-right, `(500,500)` is center.
-- Avoid edges unless performing an edge gesture.
+- Choose the visual center of the target. For small controls, estimate the control bounds and aim for the midpoint, biased slightly inward.
+- Prefer normalized coordinates over `coord_space: "pixel"`. Use pixel only when calibrated; pixel coordinates need a recent screenshot, go stale after ~30s, and are rejected outside cached bounds.
+- Avoid edges unless performing an edge gesture. For phone edge gestures, do not use conservative insets like 50-100: left-edge `back` starts at normalized `x=1`, and bottom-edge `home` starts at normalized `y=999`.
 - Do not guess a coordinate if the target is not visible or the screen is stale.
 - If a tap misses, observe again before adjusting. Do not repeat the exact same coordinate blindly.
 
@@ -54,7 +80,12 @@ Use `enter_text_in_field` for normal input boxes such as search fields, forms, a
 Required pattern:
 
 ```json
-{"text":"你好","platform":"android","focus":{"x":450,"y":105,"coord_space":"normalized"},"segments":["ni","hao"]}
+{
+  "text": "你好",
+  "platform": "android",
+  "focus": { "x": 450, "y": 105, "coord_space": "normalized" },
+  "segments": ["ni", "hao"]
+}
 ```
 
 - Focus coordinates must come from the latest screenshot.

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -27,6 +27,23 @@ func firstAudioDialogTestMessageOfType(messages []Message, messageType string) (
 	return Message{}, false
 }
 
+func waitForAudioDialogRecordSTT(t *testing.T, dialog *AudioDialog) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if dialog.currentRecordSTT() != nil {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for streaming STT session")
+		case <-ticker.C:
+		}
+	}
+}
+
 func TestAudioDialogFinishManualUtterancePreservesTail(t *testing.T) {
 	vad, err := NewAudioVADWithScorer(AudioVADConfig{
 		SampleRate:      16000,
@@ -251,6 +268,7 @@ func TestAudioDialogPrepareTurnInputUsesStreamingTranscriptFromRecording(t *test
 	if err := dialog.StartRecording(); err != nil {
 		t.Fatalf("StartRecording() error = %v", err)
 	}
+	waitForAudioDialogRecordSTT(t, dialog)
 	chunk, err := dialog.ReadRecordChunk(200)
 	if err != nil {
 		t.Fatalf("ReadRecordChunk() error = %v", err)

--- a/src/agent/internal/agent/memory_tools.go
+++ b/src/agent/internal/agent/memory_tools.go
@@ -113,16 +113,12 @@ func (t *RecallMemoryTool) Name() string { return "recall_memory" }
 
 func (t *RecallMemoryTool) Description() string {
 	return strings.Join([]string{
-		"Recall long-term filesystem memories.",
-		"Use when the user asks about remembered preferences, rules, procedures, facts, or failure lessons.",
-		"Do not use for raw recent session details or compressed conversation evidence; use recall_session_chunks for those.",
-		`Input JSON: {"tags":["verification","login"],"entities":["AppName"],"types":["preference"],"limit":5}`,
-		"How to choose filters:",
-		"  - tags: TOPIC/DOMAIN keywords related to the memory content (e.g., 'verification', 'payment', 'expense'). Leave empty [] to match all.",
-		"  - entities: Specific named things (apps, accounts, services, people). Leave empty [] to match all.",
-		"  - types: Memory categories — preference (user likes/dislikes), rule (must/must-not), procedure (how-to steps), fact (stable info), profile (user background). Leave empty [] to match all.",
-		"  - limit: Max results to return (default 5).",
-		"Returns JSON: {\"results\":[{\"id\":\"...\",\"type\":\"preference\",\"title\":\"...\",\"content\":\"...\",\"summary\":\"...\"}]}.",
+		"Recall long-term memories by tags, entities, or types.",
+		"Use for remembered preferences, rules, procedures, facts, or profile info; for raw recent session details use recall_session_chunks instead.",
+		`Input JSON: {"tags":["verification"],"entities":["AppName"],"types":["preference"],"limit":5}.`,
+		"Use tags for topic/domain keywords such as verification, payment, or expense; use entities for named apps, accounts, services, or people. Leave arrays empty to match all.",
+		"Types: preference (likes/dislikes), rule (must/must-not), procedure (how-to), fact (stable info), profile (user background).",
+		"Returns matching memories with id, type, title, content, summary.",
 	}, " ")
 }
 
@@ -166,21 +162,13 @@ func (t *SaveMemoryTool) Name() string { return "save_memory" }
 
 func (t *SaveMemoryTool) Description() string {
 	return strings.Join([]string{
-		"Save a long-term memory for future recall.",
-		"Mandatory use: when the user explicitly asks you to remember, save, record, keep in mind, or use something as a future default, call save_memory before saying it is remembered or saved.",
-		"Do not claim a memory was remembered or saved until this tool returns saved or ignored as a duplicate.",
-		"Also use when you observe a stable user preference, rule, or procedure worth persisting.",
-		`Input JSON: {"type":"preference","title":"short title","content":"what to remember","tags":["tag1"],"entities":["AppName"],"evidence":["exact user quote"],"priority":80}`,
-		"How to choose fields:",
-		"  - type: preference (user likes/dislikes), rule (must/must-not), procedure (how-to steps), fact (stable info), profile (user role/background).",
-		"  - Use type=profile for durable user profile facts such as name, nickname, location, home city, timezone, role, or background so they appear in the synthesized user profile.",
-		"  - Use type=preference or type=rule for future defaults such as the user's default city for weather queries.",
-		"  - Use type=fact only for stable facts that should be recalled but do not need to appear in the synthesized user profile.",
-		"  - tags: TOPIC/DOMAIN keywords for future search (e.g., 'verification', 'payment', 'expense'). NOT time words or vague terms.",
-		"  - entities: Specific named things mentioned (apps, accounts, services, people).",
-		"  - evidence: Original user quotes or context that led to this memory. Helps verify relevance later.",
-		"  - priority: 1-100, higher = more important. Use 80+ for user-stated rules/preferences, 60+ for inferred patterns, 40+ for observations.",
-		"Returns the saved memory ID or indicates the memory was deduplicated.",
+		"Save long-term memory for future recall. Mandatory when the user asks to remember/save; also use for observed stable preferences, rules, or procedures.",
+		"Do not tell the user something was remembered or saved until this tool returns status=saved or status=ignored as a duplicate.",
+		"Types: preference, rule, procedure, fact, profile. Use profile for durable user facts such as name, nickname, location, timezone, home city, role, or background.",
+		"Use preference/rule for future defaults and must/must-not behavior such as a default city; use fact for stable info that should be recalled but not surfaced in the synthesized user profile.",
+		`Input JSON: {"type":"preference","title":"short title","content":"what to remember","tags":["tag1"],"entities":["AppName"],"evidence":["exact user quote"],"priority":80}.`,
+		"Use topic/domain tags, named entities, original evidence quotes, and priority 80+ for user-stated rules/preferences, 60+ for inferred patterns, 40+ for observations.",
+		"Returns status=saved with id, or status=ignored when it is a duplicate.",
 	}, " ")
 }
 
@@ -189,10 +177,10 @@ func (t *SaveMemoryTool) ArgsSchema() map[string]any {
 		"type":     stringEnumArgSchema("Memory category.", "preference", "rule", "procedure", "fact", "profile"),
 		"title":    stringArgSchema("Short title for the memory."),
 		"content":  stringArgSchema("The stable information to remember."),
-		"tags":     stringArrayArgSchema("Topic or domain keywords for future search."),
-		"entities": stringArrayArgSchema("Specific named things mentioned by the memory."),
-		"evidence": stringArrayArgSchema("Original quotes or observations that support this memory."),
-		"priority": rangedIntegerArgSchema("Importance from 1 to 100.", 1, 100),
+		"tags":     stringArrayArgSchema("Topic or domain keywords for future search, e.g. verification, payment, expense. Not time words or vague terms."),
+		"entities": stringArrayArgSchema("Specific named things mentioned by the memory, such as apps, accounts, services, or people."),
+		"evidence": stringArrayArgSchema("Original user quotes or observations that led to this memory, to help verify relevance later."),
+		"priority": rangedIntegerArgSchema("Importance from 1 to 100: 80+ for user-stated rules/preferences, 60+ for inferred patterns, 40+ for observations.", 1, 100),
 	}, "type", "content")
 }
 

--- a/src/agent/internal/agent/memory_tools_test.go
+++ b/src/agent/internal/agent/memory_tools_test.go
@@ -165,13 +165,10 @@ func TestRecallToolDescriptionsGuideAgentUsage(t *testing.T) {
 
 	memoryDescription := NewRecallMemoryTool(NewLongTermMemoryStore(t.TempDir())).Description()
 	for _, want := range []string{
-		"Use when",
 		"long-term",
-		"Do not use",
+		"recall_session_chunks",
 		`"tags":["verification"`,
-		`"entities":["AppName"]`,
-		"How to choose filters",
-		"TOPIC/DOMAIN keywords",
+		"topic/domain keywords",
 		"preference",
 		"rule",
 		"procedure",
@@ -183,14 +180,12 @@ func TestRecallToolDescriptionsGuideAgentUsage(t *testing.T) {
 
 	saveDescription := NewSaveMemoryTool(NewLongTermMemoryStore(t.TempDir())).Description()
 	for _, want := range []string{
-		"Mandatory use",
-		"call save_memory before saying it is remembered or saved",
-		"Do not claim a memory was remembered or saved until this tool returns saved or ignored as a duplicate",
-		"type=profile",
-		"location, home city, timezone",
-		"future defaults",
-		"type=fact only",
+		"Mandatory when the user asks to remember/save",
+		"status=saved or status=ignored as a duplicate",
+		"Use profile for durable user facts",
+		"location, timezone",
 		"synthesized user profile",
+		"preference",
 	} {
 		if !strings.Contains(saveDescription, want) {
 			t.Fatalf("save_memory description missing %q:\n%s", want, saveDescription)

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1091,6 +1091,13 @@ func TestRuntimeRunDoesNotPersistUnusedSteerProviderAsConversationMessage(t *tes
 func TestRuntimeRunPersistsAssistantOutputOnce(t *testing.T) {
 	storageDir := filepath.Join(t.TempDir(), "memory")
 	memoryManager := NewMemoryManager(storageDir)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := memoryManager.WaitMaintenance(ctx); err != nil {
+			t.Fatalf("wait memory maintenance cleanup: %v", err)
+		}
+	})
 	ctx := context.Background()
 
 	model := &scriptedModel{responses: roleDirectResponses("hello answer")}

--- a/src/agent/internal/agent/tool_spec.go
+++ b/src/agent/internal/agent/tool_spec.go
@@ -212,7 +212,7 @@ var builtInToolSpecMetadata = map[string]toolSpecMetadata{
 	"request_human_handoff": {
 		Category:     "handoff",
 		InputMode:    toolInputModeJSON,
-		ExampleInput: `{"reason":"Need user confirmation"}`,
+		ExampleInput: `{"reason":"authentication","details":"Login screen requires password","suggested_action":"Please enter your credentials on the device"}`,
 	},
 	"run_script": {
 		Category:     "demo",

--- a/src/agent/internal/agent/tools_enter_text_in_field.go
+++ b/src/agent/internal/agent/tools_enter_text_in_field.go
@@ -22,28 +22,23 @@ func (t *EnterTextInFieldTool) SetPlatformFn(fn func() string) {
 func (t *EnterTextInFieldTool) Name() string { return "enter_text_in_field" }
 
 func (t *EnterTextInFieldTool) Description() string {
-	return strings.TrimSpace(`Enter target text into a focused input field with automatic input strategy selection and verification. ` +
-		`On iOS/Android, this tool prefers clipboard/paste for CJK, emoji, multiline, or long text when Phone Bridge can provide a reliable current-app clipboard path, then falls back to HID/IME input if clipboard input fails. ` +
-		`On iOS, if the target text was already prepared with clipboard write, it only focuses the current field, pastes, and verifies; it does not restore Aiden from an already open target app just to write clipboard. ` +
-		`For message composition fields with prepared clipboard text, set send_after_commit=true only after the correct chat is open; clipboard mode will focus, paste, verify the field, keyboard-send, then verify the input cleared or changed. ` +
-		`One call runs: focus → type romanization → merged vision read (field + IME + candidates) → select candidates if needed → retry with IME switch on mismatch → verify committed text. ` +
-		`For search boxes only, set mode:"search" to type one pass and hand control back quickly for higher-level search strategy decisions. ` +
-		`Returns committed:true ONLY when the exact target text is fully committed inside the input field (not merely visible in IME candidates/preedit). ` +
-		`Report success only when committed:true and field_text matches target exactly. ` +
-		`For composition/CJK text (Chinese, Japanese, Korean), segments (IME romanization syllables) are REQUIRED — e.g. segments:["ni","hao"] for 你好, segments:["kon","ni","chi","wa"] for こんにちは. ` +
-		`For simple ASCII text, segments can be omitted or pass the full text as a single segment. ` +
-		`ALWAYS prefer enter_text_in_field over keyboard_text for any input field entry, especially for non-ASCII text or when field verification is needed. ` +
-		`keyboard_text is ASCII-only HID keyboard simulation without IME support or verification; use it only for standalone typing outside input fields. ` +
-		`Focus coordinates use the same coord_space system as touch/click tools: prefer coord_space:"normalized" (0-1000 range) over "pixel" unless calibrated. ` +
-		`Example: {"text":"你好","platform":"android","focus":{"x":450,"y":105,"coord_space":"normalized"},"segments":["ni","hao"]}.`)
+	return strings.TrimSpace(`Enter target text into a focused input field with automatic clipboard/paste or HID/IME strategy selection and verification. ` +
+		`On iOS/Android, prefers clipboard/paste for CJK, emoji, multiline, or long text when Phone Bridge can provide a reliable current-app clipboard path, then falls back to HID/IME input if clipboard fails. ` +
+		`On iOS with prepared clipboard text, it focuses the current field, pastes, and verifies; it does not restore Aiden from an already-open target app just to write clipboard. ` +
+		`Prefer this over keyboard_text for any input field entry; keyboard_text is ASCII-only and has no field verification. ` +
+		`For search boxes, mode:"search" types one quick pass and hands control back. For message composers, set send_after_commit=true only after the correct chat is open. ` +
+		`One call runs focus -> type romanization/clipboard -> merged vision read of field/IME/candidates -> candidate selection or IME-switch retry -> committed text verification. ` +
+		`CJK/composition text requires segments (romanization syllables), e.g. segments:["ni","hao"] for 你好; ASCII text can omit segments. ` +
+		`Returns committed:true only when the exact target text is fully committed in the input field, not merely visible in IME candidates/preedit. Report success only when committed:true and field_text matches target exactly. ` +
+		`Focus uses the same coord_space system as touch/click tools; prefer normalized coordinates from the latest screenshot.`)
 }
 
 func (t *EnterTextInFieldTool) ArgsSchema() map[string]any {
 	return objectArgsSchema(map[string]any{
-		"text":         stringArgSchema("Exact text that must appear in the field when done."),
-		"platform":     stringEnumArgSchema("Target platform.", "ios", "android", "mac"),
-		"mode":         stringEnumArgSchema("Interaction mode. Use \"search\" for quick handoff in search boxes; omit for normal form entry.", "form", "search"),
-		"focus":        focusPointArgSchema("Input field coordinates."),
+		"text":              stringArgSchema("Exact text that must appear in the field when done."),
+		"platform":          stringEnumArgSchema("Target platform.", "ios", "android", "mac"),
+		"mode":              stringEnumArgSchema("Interaction mode. Use \"search\" for quick handoff in search boxes; omit for normal form entry.", "form", "search"),
+		"focus":             focusPointArgSchema("Input field coordinates."),
 		"segments":          stringArrayArgSchema("Required for composition/CJK: IME romanization syllables in order, e.g. [\"ni\",\"hao\"] for 你好."),
 		"max_attempts":      integerArgSchema("Retry attempts on verify failure (default 3)."),
 		"send_after_commit": boolArgSchema("After the exact target text is verified in the field, press send/submit and verify the input cleared or changed. Prefer with prepared clipboard text in an already-open message chat."),

--- a/src/agent/internal/agent/tools_enter_text_in_field.go
+++ b/src/agent/internal/agent/tools_enter_text_in_field.go
@@ -24,7 +24,7 @@ func (t *EnterTextInFieldTool) Name() string { return "enter_text_in_field" }
 func (t *EnterTextInFieldTool) Description() string {
 	return strings.TrimSpace(`Enter target text into a focused input field with automatic clipboard/paste or HID/IME strategy selection and verification. ` +
 		`On iOS/Android, prefers clipboard/paste for CJK, emoji, multiline, or long text when Phone Bridge can provide a reliable current-app clipboard path, then falls back to HID/IME input if clipboard fails. ` +
-		`On iOS with prepared clipboard text, it focuses the current field, pastes, and verifies; it does not restore Aiden from an already-open target app just to write clipboard. ` +
+		`On iOS, when prepared clipboard text is already available, it focuses the current field, pastes, and verifies; it does not need to switch back to Aiden just to write the clipboard. ` +
 		`Prefer this over keyboard_text for any input field entry; keyboard_text is ASCII-only and has no field verification. ` +
 		`For search boxes, mode:"search" types one quick pass and hands control back. For message composers, set send_after_commit=true only after the correct chat is open. ` +
 		`One call runs focus -> type romanization/clipboard -> merged vision read of field/IME/candidates -> candidate selection or IME-switch retry -> committed text verification. ` +

--- a/src/agent/internal/agent/tools_enter_text_in_field_test.go
+++ b/src/agent/internal/agent/tools_enter_text_in_field_test.go
@@ -31,6 +31,26 @@ func (s *recordingTextInputTool) Call(_ context.Context, input string) (string, 
 	return s.out, nil
 }
 
+func TestEnterTextInFieldDescriptionDocumentsStrategyAndVerification(t *testing.T) {
+	desc := (&EnterTextInFieldTool{}).Description()
+	for _, want := range []string{
+		"clipboard/paste",
+		"current-app clipboard path",
+		"prepared clipboard text",
+		`mode:"search"`,
+		"send_after_commit=true",
+		"merged vision read",
+		"committed:true",
+		"field_text matches target exactly",
+		"IME candidates/preedit",
+		"normalized coordinates",
+	} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("description missing %q:\n%s", want, desc)
+		}
+	}
+}
+
 func TestEnterTextInFieldASCII(t *testing.T) {
 	vision := &stubTextInputVision{analyses: []textInputScreenAnalysis{{
 		FieldText: "hello",

--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -526,15 +526,11 @@ type KeyboardTapTool struct {
 func (t *KeyboardTapTool) Name() string { return "keyboard_tap" }
 
 func (t *KeyboardTapTool) Description() string {
-	return `Press and release keyboard keys. Input JSON: {"keys": ["ctrl", "c"]}. ` +
-		`For known semantic platform actions such as back, app search, app switching, copy, paste, undo, redo, select all, delete backward/forward, find, send, or browser navigation, prefer quick_action first; use keyboard_tap as a low-level fallback or for custom key input. ` +
-		`Supports: a-z, 0-9, f1-f12, enter, escape, backspace, tab, space, delete, ` +
-		`up, down, left, right, home, end, pageup, pagedown, insert, printscreen. ` +
-		`For normal text deletion in an input field, use backspace; the delete key is forward-delete and should only be used when intentionally deleting the character after the cursor. ` +
-		`Modifiers: ctrl, shift, alt, meta/super/win/cmd. ` +
-		`Modifier-only taps are supported (e.g. {"keys":["meta"]} for Android Home). ` +
-		`Multiple keys are pressed simultaneously (e.g. ctrl+c). ` +
-		`Optional hold_ms keeps the chord pressed before release (default 50ms, 120ms when modifiers are used).`
+	return `Press and release keyboard keys. Prefer quick_action first for semantic platform actions such as back, app search, app switching, copy, paste, undo, redo, select all, delete backward/forward, find, send, or browser navigation; use keyboard_tap as a low-level fallback or for custom key input. ` +
+		`Keys: a-z, 0-9, f1-f12, enter, escape, backspace, tab, space, delete, arrows, home, end, pageup/down, insert, printscreen. ` +
+		`For ordinary text deletion use backspace; delete is forward-delete after the cursor. ` +
+		`Modifiers: ctrl, shift, alt, meta/super/win/cmd. Modifier-only taps are supported (e.g. {"keys":["meta"]} for Android Home). Multiple keys are pressed simultaneously, e.g. ctrl+c. ` +
+		`Optional hold_ms keeps the chord pressed before release; default is 50ms, or 120ms when modifiers are used.`
 }
 
 func (t *KeyboardTapTool) ArgsSchema() map[string]any {
@@ -678,15 +674,11 @@ type MouseClickTool struct {
 func (t *MouseClickTool) Name() string { return "mouse_click" }
 
 func (t *MouseClickTool) Description() string {
-	return `Move mouse to a position and click. Input JSON: {"x": 500, "y": 300, "button": "left", "coord_space": "normalized"}. ` +
-		`coord_space options: "pixel", "normalized", "absolute". Default is "auto": x/y in [0,1000] are treated as normalized, otherwise pixel coordinates are used when a recent screenshot has cached screen dimensions, otherwise HID absolute values in the range 0-32767. ` +
-		`Normalized coordinates use 0-1000 range where (0,0) is top-left, (1000,1000) is bottom-right, (500,500) is center. ` +
-		`Choose the visual center of the target in the latest screenshot; for small controls, estimate the control bounds and click the midpoint, biased inward. ` +
-		`pointer_mode absolute (default): moves to absolute HID coordinates, waits for iOS cursor smoothing, then clicks. ` +
-		`pointer_mode touchscreen (Android): sends a finger down/up at the resolved coordinate. ` +
-		`Use coord_space:"pixel" only when calibrated; pixel coordinates require a recent screenshot, are stale after 30s, and are rejected if outside cached bounds. ` +
-		`Click once and inspect the returned post-action screenshot before repeating. ` +
-		`Button options: "left" (default), "right", "middle".`
+	return `Move mouse to a position and click. Input JSON: {"x":500,"y":300,"button":"left","coord_space":"normalized"}. ` +
+		`coord_space default is auto: x/y in 0-1000 are normalized; otherwise pixel coordinates use a recent screenshot, then absolute HID values. ` +
+		`Prefer normalized coordinates (0-1000) from the latest screenshot and choose the visual center of the target; pixel coordinates require fresh cached screen dimensions. ` +
+		`pointer_mode absolute waits for iOS cursor smoothing before clicking; pointer_mode touchscreen sends a finger down/up at the resolved coordinate. ` +
+		`Click once and inspect the returned post-action screenshot before repeating. Button: left (default), right, middle.`
 }
 
 func (t *MouseClickTool) ArgsSchema() map[string]any {
@@ -777,24 +769,14 @@ type TouchGestureTool struct {
 func (t *TouchGestureTool) Name() string { return "touch_gesture" }
 
 func (t *TouchGestureTool) Description() string {
-	return `Perform a touch-like gesture using the pointer HID device (absolute mouse or touchscreen depending on agent pointer_mode). ` +
-		`For known semantic platform actions such as back, home, app search, app switching, notification shade, quick settings, and browser navigation, prefer quick_action first; use touch_gesture as a low-level fallback or for custom screen gestures. ` +
-		`Input JSON examples: {"type":"tap","point":{"x":500,"y":500}}, {"type":"swipe","start":{"x":200,"y":500},"end":{"x":800,"y":500},"duration_ms":700,"steps":24}, {"type":"swipe_left"}, {"type":"back"}, {"type":"home"}. ` +
-		`IMPORTANT: "point", "start", and "end" must be objects with named keys "x" and "y". NEVER omit the key names: {"x":500,"y":300} is correct, {500,300} is invalid and will error. ` +
-		`Supported types: "tap", "double_tap", "long_press", "drag", "swipe", "swipe_left", "swipe_right", "swipe_up", "swipe_down", "back" (left-edge back), "home" (bottom-edge home). ` +
-		`coord_space defaults to "normalized" (x/y in [0,1000]) and also supports "pixel" and "absolute". ` +
-		`Normalized coordinates use 0-1000 range where (0,0) is top-left, (1000,1000) is bottom-right, (500,500) is center. ` +
-		`Choose the visual center of the target in the latest screenshot; for small controls, estimate the control bounds and touch the midpoint, biased inward. ` +
-		`pointer_mode absolute (default, iOS): every gesture moves to absolute coordinates before pressing; choose tap targets from the latest screenshot center and prefer normalized coordinates. ` +
-		`pointer_mode touchscreen (Android): gestures are sent as single-finger touch down/move/up reports. ` +
-		`Directional swipes accept optional "distance" (normalized 0-1000 travel, default 500), "anchor" (fixed-axis coordinate 0-1000, default 500), and "strength" ("large", "medium", "small", "tiny"). ` +
-		`Directional swipe names describe finger movement, not the content you want to reveal: "swipe_up" moves the finger upward and usually scrolls the viewport down to lower/newer items; "swipe_down" moves the finger downward and usually scrolls the viewport up to upper/older items. For chat or message history where older messages are above, use "swipe_down" (pull down), not "swipe_up". ` +
-		`For precise vertical or horizontal controls, first probe with medium/large, observe the screenshot, then use small/tiny near the target; if you overshoot, reverse direction and reduce strength. ` +
-		`For locally scrollable regions such as pickers, modal lists, embedded scroll views, or partial dialogs, keep start/end coordinates inside the control's visible bounds so the outer container does not capture the gesture. ` +
-		`Absolute-mode gestures wait for iOS HID-cursor smoothing to settle before pressing. ` +
-		`Tap and double_tap accept an optional "hold_ms" (dwell between press and release, default 60ms). ` +
-		`Swipe defaults to a slower 700ms / 24-step motion, applies "hold_before_ms" of 80ms after the press, and releases immediately at the destination by default; pass "hold_after_ms" only when a drag-like end dwell is required. ` +
-		`For phone edge gestures, do not use conservative inset coordinates such as 50-100: "back" starts at normalized x=1 and "home" starts at normalized y=999. Drag keeps the previous 250ms / 12-step motion with 0ms hold defaults to avoid unintended long-press behaviour during slow content drag.`
+	return `Perform touch/pointer gesture via HID. Prefer quick_action for semantic platform actions; use this for custom screen gestures. ` +
+		`Input examples: {"type":"tap","point":{"x":500,"y":500}}, {"type":"swipe","start":{"x":200,"y":500},"end":{"x":800,"y":500},"duration_ms":700,"steps":24}, {"type":"swipe_left"}. ` +
+		`Types: tap, double_tap, long_press, drag, swipe, swipe_left/right/up/down, back, home. ` +
+		`Coordinates: point/start/end must be {"x":N,"y":M} objects; never omit x/y key names. coord_space defaults to normalized (0-1000) and also supports pixel or absolute. ` +
+		`Choose the visual center of the target in the latest screenshot; for small controls, estimate bounds and touch the midpoint, biased inward. ` +
+		`Directional swipes accept optional distance, anchor, and strength (large/medium/small/tiny). Swipe direction is finger movement, not content scroll; for older chat history above, usually use swipe_down. ` +
+		`For precise scrolls or pickers, probe with medium/large, observe the screenshot, then use small/tiny; if overshot, reverse direction and reduce strength. ` +
+		`Keep scroll gestures inside the intended scrollable region so the outer container does not capture them. Edge aliases use real edges: back starts at x=1 and home starts at y=999.`
 }
 
 func (t *TouchGestureTool) ArgsSchema() map[string]any {
@@ -825,7 +807,6 @@ func pointSchema(description string) map[string]any {
 	schema["description"] = description
 	return schema
 }
-
 
 func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, error) {
 	var args struct {

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -1385,7 +1385,7 @@ func TestTouchGestureHomeStartsAtBottomPhysicalEdge(t *testing.T) {
 
 func TestTouchGestureDescriptionDocumentsEdgeGestureAliases(t *testing.T) {
 	desc := (&TouchGestureTool{}).Description()
-	for _, want := range []string{`"back"`, `"home"`, "x=1", "y=999", "prefer quick_action first", "low-level fallback", "finger movement", "older messages", `not "swipe_up"`, "latest screenshot", "locally scrollable regions", "visible bounds"} {
+	for _, want := range []string{"back", "home", "Prefer quick_action", "finger movement", "older chat history", "scrollable region", "x=1", "y=999", "coord_space", "never omit x/y key names", "probe with medium/large", "biased inward"} {
 		if !strings.Contains(desc, want) {
 			t.Fatalf("description missing %q:\n%s", want, desc)
 		}
@@ -1394,7 +1394,7 @@ func TestTouchGestureDescriptionDocumentsEdgeGestureAliases(t *testing.T) {
 
 func TestMouseClickDescriptionDocumentsTargetCenter(t *testing.T) {
 	desc := (&MouseClickTool{}).Description()
-	for _, want := range []string{"visual center", "latest screenshot", "small controls", "midpoint", `coord_space:"pixel" only when calibrated`} {
+	for _, want := range []string{"coord_space default is auto", "normalized", "latest screenshot", "visual center", "pixel coordinates require fresh cached screen dimensions", "pointer_mode absolute", "post-action screenshot"} {
 		if !strings.Contains(desc, want) {
 			t.Fatalf("description missing %q:\n%s", want, desc)
 		}
@@ -1403,7 +1403,7 @@ func TestMouseClickDescriptionDocumentsTargetCenter(t *testing.T) {
 
 func TestKeyboardTapDescriptionDocumentsQuickActionFallback(t *testing.T) {
 	desc := (&KeyboardTapTool{}).Description()
-	for _, want := range []string{"prefer quick_action first", "delete backward/forward", "low-level fallback", "custom key input", "normal text deletion", "use backspace", "delete key is forward-delete"} {
+	for _, want := range []string{"Prefer quick_action", "copy", "paste", "send", "custom key input", "backspace", "forward-delete", "Modifier-only", "hold_ms", "Modifiers"} {
 		if !strings.Contains(desc, want) {
 			t.Fatalf("description missing %q:\n%s", want, desc)
 		}

--- a/src/agent/internal/agent/tools_human_handoff.go
+++ b/src/agent/internal/agent/tools_human_handoff.go
@@ -100,19 +100,12 @@ func (t *HumanHandoffTool) Name() string {
 }
 
 func (t *HumanHandoffTool) Description() string {
-	return `Request human intervention when you encounter a situation that requires human judgment, credentials, or actions beyond your capabilities. ` +
-		`Input JSON: {"reason": "authentication", "details": "Login screen requires password", "suggested_action": "Please enter your credentials"}. ` +
-		`Valid reasons: "authentication" (login/credentials required), "login_method_selection" (the user must choose a login method), ` +
-		`"captcha" (CAPTCHA challenge), "verification_code" (SMS/email code needed), "sensitive_operation" (payment/banking/security), ` +
-		`"redirect_confirmation" (system/app redirect confirmation dialog), "permission_confirmation" (permission dialog confirmation), ` +
-		`"black_screen" (screen not visible), "ambiguous_situation" (unclear what to do), ` +
-		`"unsupported_action" (action not possible with available tools), "stuck" (unable to make progress), "other" (specify in details). ` +
-		`The "details" field should clearly explain the situation. The "suggested_action" field optionally tells the human what to do. ` +
-		`This tool returns immediately with a structured handoff marker. Wait for the user to complete the task and tell you to continue in their next message. ` +
-		`Use this when: you need credentials you don't have, encounter CAPTCHA, need verification codes, face sensitive operations requiring human approval, ` +
-		`need the user to choose a login method, need a system/app redirect or permission dialog confirmed, see a black/blank screen preventing progress, ` +
-		`are genuinely stuck after multiple attempts, or the task fundamentally requires human judgment. ` +
-		`After the user confirms completion in their next message, take a screenshot to verify the result before continuing.`
+	return `Request human intervention for credentials, CAPTCHA, verification codes, sensitive operations, or when stuck. ` +
+		`Input JSON: {"reason":"authentication","details":"Login screen requires password","suggested_action":"Please enter your credentials on the device"}. ` +
+		`Reasons: authentication, login_method_selection, captcha, verification_code, sensitive_operation, redirect_confirmation, permission_confirmation, black_screen, ambiguous_situation, unsupported_action, stuck, other. ` +
+		`Use this when credentials are needed, a CAPTCHA or verification code appears, the user must choose a login method, a sensitive payment/security operation needs approval, a redirect/permission dialog needs confirmation, the screen is black/blank, or multiple attempts are stuck. ` +
+		`details should clearly explain the situation; suggested_action should tell the human what to do without asking them to share private credentials in chat. ` +
+		`This tool returns immediately with a handoff marker; wait for the user to continue, then verify the result with a screenshot before proceeding.`
 }
 
 func (t *HumanHandoffTool) ArgsSchema() map[string]any {

--- a/src/agent/internal/agent/tools_human_handoff_test.go
+++ b/src/agent/internal/agent/tools_human_handoff_test.go
@@ -26,6 +26,12 @@ func TestHumanHandoffTool_Description(t *testing.T) {
 	if !strings.Contains(desc, "returns immediately") {
 		t.Error("Description() doesn't mention non-blocking behavior")
 	}
+	if !strings.Contains(desc, "handoff marker") {
+		t.Error("Description() doesn't mention the handoff marker return contract")
+	}
+	if !strings.Contains(desc, `"reason":"authentication"`) || !strings.Contains(desc, `"details"`) {
+		t.Error("Description() doesn't include a valid handoff JSON example")
+	}
 }
 
 func TestHumanHandoffTool_Call_Success(t *testing.T) {

--- a/src/agent/internal/agent/tools_quick_actions.go
+++ b/src/agent/internal/agent/tools_quick_actions.go
@@ -331,14 +331,9 @@ type QuickActionTool struct {
 func (t *QuickActionTool) Name() string { return "quick_action" }
 
 func (t *QuickActionTool) Description() string {
-	return strings.TrimSpace(`Execute a predefined platform shortcut or system gesture from quick_actions.json. ` +
-		`Prefer this tool first when the requested operation matches a catalog entry. ` +
-		`Input JSON examples: {"action":"back","platform":"ios"}, {"action":"copy","platform":"android"}, {"action":"spotlight_search","platform":"android"}. ` +
-		`Supported platforms: ios, android, mac. ` +
-		`To inspect available actions, pass exactly {"list":true,"platform":"android"}; do not pass {"action":"list"}. ` +
-		`If quick_action returns ok=false, status=reserved, the screen did not change, or the outcome is wrong: do not retry the same binding more than once. ` +
-		`Try alternative=true when alternatives are listed; otherwise fall back immediately to keyboard_tap, touch_gesture, or mouse tools and continue the task. ` +
-		`Do not debate shortcut policy with the user—move on after one failed quick_action attempt unless an alternative binding exists. ` +
+	return strings.TrimSpace(`Execute predefined platform shortcut from quick_actions.json. Prefer before keyboard_tap/touch_gesture when a catalog entry matches. ` +
+		`Input examples: {"action":"back","platform":"ios"}, {"action":"copy","platform":"android"}. ` +
+		`Platforms: ios, android, mac. Use {"list":true,"platform":"android"} to inspect available actions; do not pass {"action":"list"}. ` +
 		quickActionBehaviorSummary())
 }
 
@@ -722,8 +717,8 @@ func quickActionBehaviorSummary() string {
 		"Common actions: back, home, hide_app, quit_app, app_switch, spotlight_search, copy, paste, cut, undo, redo, select_all, delete_backward, delete_forward, find, send, browser_new_tab, browser_close_tab, browser_refresh, browser_address_bar, screenshot_region.",
 		"- Infer platform from screenshot/context and pass platform=ios/android/mac.",
 		"- Prefer quick_action before ad-hoc keyboard_tap or touch_gesture when an active catalog entry exists.",
-		"- If status=reserved in a list result or quick_action returns an error message: skip quick_action and use direct input tools instead.",
-		"- If ok=true but the screenshot shows no expected change: treat as ineffective, try alternative=true once or switch tools.",
+		"- If status=reserved in a list result or quick_action returns ok=false or an error message: skip quick_action and use direct input tools instead.",
+		"- If ok=true but the screenshot shows no expected change or the outcome is wrong: treat as ineffective, try alternative=true once when alternatives are listed, otherwise switch tools.",
 		"- Never loop on the same quick_action binding; change tool or strategy after one failed attempt.",
 	}, "\n")
 }

--- a/src/agent/internal/agent/tools_quick_actions_test.go
+++ b/src/agent/internal/agent/tools_quick_actions_test.go
@@ -119,13 +119,16 @@ func TestQuickActionListActionAlias(t *testing.T) {
 	}
 }
 
-func TestQuickActionDescriptionWarnsAgainstActionList(t *testing.T) {
+func TestQuickActionDescriptionDocumentsListInspection(t *testing.T) {
 	desc := (&QuickActionTool{}).Description()
 	if !strings.Contains(desc, `{"list":true,"platform":"android"}`) {
-		t.Fatalf("description missing list=true example: %s", desc)
+		t.Fatalf("description missing list=true inspection example: %s", desc)
 	}
 	if !strings.Contains(desc, `do not pass {"action":"list"}`) {
 		t.Fatalf("description missing action=list warning: %s", desc)
+	}
+	if !strings.Contains(desc, "Never loop on the same quick_action binding") {
+		t.Fatalf("description missing no-retry guidance: %s", desc)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Keep tool descriptions slimmed while preserving critical call contracts and valid examples
- Move detailed device-operation playbook guidance into device-operator skill
- Add tests that lock important memory, text entry, HID, handoff, and quick action guidance

## Tests
- go test ./... (from src/agent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined skill and in-app tool guidance across device-operator, memory tools, text entry, quick actions, HID input, and human handoff.
  * Improved coordinate/targeting instructions (normalized coordinates, edge-avoidance) and tightened verification criteria (committed-text matching).
  * Updated tool example payloads for clearer multi-line formatting and safer handoff guidance.

* **Tests**
  * Updated tool-description assertion tests to reflect revised documentation.
  * Added coverage validating enter-text strategy/verification messaging.
  * Improved audio-dialog readiness sequencing and added runtime maintenance cleanup waiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->