### PR TITLE
feat(llm): merge consecutive same-role messages for provider compatibility

### DIFF
--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -1088,20 +1088,17 @@ func normalizeCompatibleMessages(messages []compatibleMessage) []compatibleMessa
 	}
 
 	if len(systemSegments) == 0 && !preserveSystemParts {
-		return normalized
+		return mergeConsecutiveSameRoleMessages(normalized)
 	}
 	if preserveSystemParts {
-		return append([]compatibleMessage{{Role: "system", Content: systemParts}}, normalized...)
+		return mergeConsecutiveSameRoleMessages(append([]compatibleMessage{{Role: "system", Content: systemParts}}, normalized...))
 	}
 
 	mergedSystem := compatibleMessage{
 		Role:    "system",
 		Content: strings.Join(systemSegments, "\n\n"),
 	}
-	normalized = append([]compatibleMessage{mergedSystem}, normalized...)
-
-	// Merge consecutive messages with the same role (for providers like Claude/Gemini that require strict alternation)
-	return mergeConsecutiveSameRoleMessages(normalized)
+	return mergeConsecutiveSameRoleMessages(append([]compatibleMessage{mergedSystem}, normalized...))
 }
 
 // mergeConsecutiveSameRoleMessages merges consecutive messages with the same role.

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -1098,7 +1098,70 @@ func normalizeCompatibleMessages(messages []compatibleMessage) []compatibleMessa
 		Role:    "system",
 		Content: strings.Join(systemSegments, "\n\n"),
 	}
-	return append([]compatibleMessage{mergedSystem}, normalized...)
+	normalized = append([]compatibleMessage{mergedSystem}, normalized...)
+
+	// Merge consecutive messages with the same role (for providers like Claude/Gemini that require strict alternation)
+	return mergeConsecutiveSameRoleMessages(normalized)
+}
+
+// mergeConsecutiveSameRoleMessages merges consecutive messages with the same role.
+// This is required by some providers (Anthropic Claude, Google Gemini) that enforce
+// strict user/assistant alternation. Tool messages are never merged as they require
+// specific tool_call_id pairing.
+func mergeConsecutiveSameRoleMessages(messages []compatibleMessage) []compatibleMessage {
+	if len(messages) <= 1 {
+		return messages
+	}
+
+	result := make([]compatibleMessage, 0, len(messages))
+	result = append(result, messages[0])
+
+	for i := 1; i < len(messages); i++ {
+		current := messages[i]
+		previous := &result[len(result)-1]
+
+		// Only merge if roles match and neither is a tool message
+		canMerge := current.Role == previous.Role &&
+			current.Role != "tool" &&
+			len(current.ToolCalls) == 0 &&
+			len(previous.ToolCalls) == 0
+
+		if !canMerge {
+			result = append(result, current)
+			continue
+		}
+
+		// Merge content based on type
+		prevContent, prevIsString := previous.Content.(string)
+		currContent, currIsString := current.Content.(string)
+
+		if prevIsString && currIsString {
+			// Both are strings: join with double newline
+			previous.Content = prevContent + "\n\n" + currContent
+		} else if prevIsString && !currIsString {
+			// Previous is string, current is parts: convert previous to parts and merge
+			parts := []compatibleContentPart{{Type: "text", Text: prevContent}}
+			if currParts, ok := current.Content.([]compatibleContentPart); ok {
+				parts = append(parts, currParts...)
+			}
+			previous.Content = parts
+		} else if !prevIsString && currIsString {
+			// Previous is parts, current is string: append as text part
+			if prevParts, ok := previous.Content.([]compatibleContentPart); ok {
+				prevParts = append(prevParts, compatibleContentPart{Type: "text", Text: currContent})
+				previous.Content = prevParts
+			}
+		} else {
+			// Both are parts: concatenate arrays
+			if prevParts, ok := previous.Content.([]compatibleContentPart); ok {
+				if currParts, ok := current.Content.([]compatibleContentPart); ok {
+					previous.Content = append(prevParts, currParts...)
+				}
+			}
+		}
+	}
+
+	return result
 }
 
 func audioFormatFromMIME(mimeType string) string {

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -1152,6 +1152,166 @@ func TestOpenAICompatibleModelMergesSystemMessages(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatibleModelMergesConsecutiveSameRoleMessages(t *testing.T) {
+	var captured struct {
+		Messages []struct {
+			Role      string      `json:"role"`
+			Content   interface{} `json:"content"`
+			ToolCalls []struct {
+				ID   string `json:"id"`
+				Type string `json:"type"`
+			} `json:"tool_calls,omitempty"`
+		} `json:"messages"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	model := newOpenAICompatibleModel(server.URL, "test-model", "", server.Client())
+
+	// Test consecutive user messages (simulating state/notice role conversion)
+	_, err := model.GenerateContent(contextWithRawHTTPLog(context.Background()), []llms.MessageContent{
+		{Role: llms.ChatMessageTypeSystem, Parts: []llms.ContentPart{llms.TextPart("System prompt")}},
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("User message 1")}},
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("User message 2")}},
+		{Role: llms.ChatMessageTypeAI, Parts: []llms.ContentPart{llms.TextPart("Assistant response")}},
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("Another user message")}},
+	})
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	// Should have: system, merged user, assistant, user
+	if len(captured.Messages) != 4 {
+		t.Fatalf("expected 4 messages after normalization, got %d: %#v", len(captured.Messages), captured.Messages)
+	}
+
+	if captured.Messages[0].Role != "system" {
+		t.Fatalf("message 0: expected system, got %#v", captured.Messages[0])
+	}
+
+	if captured.Messages[1].Role != "user" {
+		t.Fatalf("message 1: expected user, got %#v", captured.Messages[1])
+	}
+	userContent, ok := captured.Messages[1].Content.(string)
+	if !ok || userContent != "User message 1\n\nUser message 2" {
+		t.Fatalf("message 1: expected merged user content, got %#v", captured.Messages[1].Content)
+	}
+
+	if captured.Messages[2].Role != "assistant" {
+		t.Fatalf("message 2: expected assistant, got %#v", captured.Messages[2])
+	}
+
+	if captured.Messages[3].Role != "user" {
+		t.Fatalf("message 3: expected user, got %#v", captured.Messages[3])
+	}
+}
+
+func TestOpenAICompatibleModelDoesNotMergeToolMessages(t *testing.T) {
+	var captured struct {
+		Messages []struct {
+			Role       string      `json:"role"`
+			Content    interface{} `json:"content"`
+			ToolCallID string      `json:"tool_call_id,omitempty"`
+		} `json:"messages"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	model := newOpenAICompatibleModel(server.URL, "test-model", "", server.Client())
+
+	// Tool messages should NOT be merged even if consecutive
+	_, err := model.GenerateContent(contextWithRawHTTPLog(context.Background()), []llms.MessageContent{
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("use tools")}},
+		{Role: llms.ChatMessageTypeAI, Parts: []llms.ContentPart{
+			llms.ToolCall{ID: "call1", Type: "function", FunctionCall: &llms.FunctionCall{Name: "tool1", Arguments: "{}"}},
+		}},
+		{Role: llms.ChatMessageTypeTool, Parts: []llms.ContentPart{
+			llms.ToolCallResponse{ToolCallID: "call1", Name: "tool1", Content: "result1"},
+		}},
+		{Role: llms.ChatMessageTypeTool, Parts: []llms.ContentPart{
+			llms.ToolCallResponse{ToolCallID: "call2", Name: "tool2", Content: "result2"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	// Should keep all 4 messages separate (tool messages must not merge)
+	if len(captured.Messages) != 4 {
+		t.Fatalf("expected 4 messages (tool messages should not merge), got %d: %#v", len(captured.Messages), captured.Messages)
+	}
+
+	if captured.Messages[2].Role != "tool" || captured.Messages[2].ToolCallID != "call1" {
+		t.Fatalf("message 2: expected separate tool message, got %#v", captured.Messages[2])
+	}
+
+	if captured.Messages[3].Role != "tool" || captured.Messages[3].ToolCallID != "call2" {
+		t.Fatalf("message 3: expected separate tool message, got %#v", captured.Messages[3])
+	}
+}
+
+func TestOpenAICompatibleModelDoesNotMergeAssistantWithToolCalls(t *testing.T) {
+	var captured struct {
+		Messages []struct {
+			Role      string      `json:"role"`
+			Content   interface{} `json:"content"`
+			ToolCalls []struct {
+				ID string `json:"id"`
+			} `json:"tool_calls,omitempty"`
+		} `json:"messages"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	model := newOpenAICompatibleModel(server.URL, "test-model", "", server.Client())
+
+	// Assistant messages with tool_calls should NOT merge with other assistant messages
+	_, err := model.GenerateContent(contextWithRawHTTPLog(context.Background()), []llms.MessageContent{
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("hello")}},
+		{Role: llms.ChatMessageTypeAI, Parts: []llms.ContentPart{llms.TextPart("text response")}},
+		{Role: llms.ChatMessageTypeAI, Parts: []llms.ContentPart{
+			llms.ToolCall{ID: "call1", Type: "function", FunctionCall: &llms.FunctionCall{Name: "tool1", Arguments: "{}"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	// Should keep 3 messages: user, assistant (text), assistant (tool_calls)
+	if len(captured.Messages) != 3 {
+		t.Fatalf("expected 3 messages (assistant with tool_calls should not merge), got %d: %#v", len(captured.Messages), captured.Messages)
+	}
+
+	if captured.Messages[1].Role != "assistant" || len(captured.Messages[1].ToolCalls) != 0 {
+		t.Fatalf("message 1: expected plain assistant, got %#v", captured.Messages[1])
+	}
+
+	if captured.Messages[2].Role != "assistant" || len(captured.Messages[2].ToolCalls) == 0 {
+		t.Fatalf("message 2: expected assistant with tool_calls, got %#v", captured.Messages[2])
+	}
+}
+
 func TestOpenAICompatibleModelIncludesUsageInGenerationInfo(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -1748,6 +1748,44 @@ func TestOpenAICompatibleModelLiveUsageParsing(t *testing.T) {
 	t.Logf("live model=%s prompt_tokens=%d cached_tokens=%d telemetry=%v", model, prompt, cached, usage)
 }
 
+// TestOpenAICompatibleModelLiveConsecutiveUserMessages verifies that consecutive
+// user messages (which would cause 400 errors on Gemini/Claude without merging)
+// are handled correctly. Run with:
+//
+//	OPENROUTER_API_KEY=sk-or-... go test -run TestOpenAICompatibleModelLiveConsecutiveUserMessages -v
+func TestOpenAICompatibleModelLiveConsecutiveUserMessages(t *testing.T) {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENROUTER_API_KEY not set; skipping live API verification")
+	}
+	// Use Gemini which enforces strict role alternation
+	model := os.Getenv("OPENROUTER_MODEL")
+	if model == "" {
+		model = "google/gemini-2.5-flash"
+	}
+
+	client := newOpenAICompatibleModel("https://openrouter.ai/api/v1", model, apiKey, http.DefaultClient)
+
+	// Simulate the exact scenario that causes issues:
+	// history ends with a visual followup (user role), then new user input arrives
+	t.Log("Sending consecutive user messages (simulating visual followup + new input)...")
+	resp, err := client.GenerateContent(contextWithRawHTTPLog(context.Background()), []llms.MessageContent{
+		{Role: llms.ChatMessageTypeSystem, Parts: []llms.ContentPart{llms.TextPart("You are a terse assistant. Reply in one short sentence.")}},
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("What is 2+2?")}},
+		{Role: llms.ChatMessageTypeAI, Parts: []llms.ContentPart{llms.TextPart("4")}},
+		// This simulates: tool_result followed by visual followup (user) then new user input (user)
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("Screenshot shows a calculator app displaying 4.")}},
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("Now calculate 3+3.")}},
+	}, llms.WithMaxTokens(32), llms.WithTemperature(0))
+	if err != nil {
+		t.Fatalf("GenerateContent() with consecutive user messages failed: %v\n"+
+			"This would have failed WITHOUT message merging on strict providers (Gemini/Claude).", err)
+	}
+
+	t.Logf("SUCCESS: model=%s response=%q", model, resp.Choices[0].Content)
+	t.Log("Message merging correctly handled consecutive user messages.")
+}
+
 func readRawHTTPLog(t *testing.T, logDir string) string {
 	t.Helper()
 	data, err := os.ReadFile(rawHTTPLogPath(logDir))


### PR DESCRIPTION
## Summary

  Add automatic merging of consecutive same-role messages in the `normalizeCompatibleMessages` pipeline to satisfy strict role alternation constraints enforced by some LLM
  providers.

  ## Motivation

  - ContextManager's `state`/`notice` roles both map to `user` after conversion, potentially producing consecutive same-role messages
  - Anthropic Claude and Google Gemini native APIs require strict user/assistant alternation and return 400 on violations
  - OpenRouter currently handles this implicitly in its protocol translation layer, but this behavior is undocumented and not guaranteed
  - Local merging serves as a defensive measure: zero side effects, zero performance overhead, prevents breakage if connecting to providers directly or if OpenRouter changes
   behavior

  ## Changes

  - `openai_compatible_model.go`: Add `mergeConsecutiveSameRoleMessages()`, integrated into `normalizeCompatibleMessages()` after system message consolidation
  - `openai_compatible_model_test.go`: Unit tests and live integration test

  ## Merge Rules

  - Consecutive user/assistant messages with same role: merged (strings joined with `\n\n`, content part arrays concatenated)
  - Tool messages: never merged (require `tool_call_id` pairing)
  - Assistant messages with `tool_calls`: never merged (preserve tool interaction integrity)

  ## References

  - LangChain [`merge_message_runs`](https://python.langchain.com/api_reference/core/messages/langchain_core.messages.utils.merge_message_runs.html) uses the same approach
  - Anthropic docs: [Handle tool calls](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/handle-tool-calls)
  - OpenRouter: [Message Transforms](https://openrouter.ai/docs/guides/features/message-transforms) (context compression only, no role normalization)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAI-compatible message normalization by merging consecutive same-role messages into a single message, while never merging `tool` messages or assistant messages that include tool calls.
  * System content is consolidated appropriately before normalization, with support for preserving original system parts when enabled.

* **Tests**
  * Expanded unit tests for consecutive-user merging, including cases with no system message and with cached system handling.
  * Added/updated a live integration test to validate consecutive-user compatibility with a strict provider configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->