### PR TITLE
fix(agent): eliminate runtime and audio test races

### DIFF
--- a/src/agent/internal/agent/agent_loop.go
+++ b/src/agent/internal/agent/agent_loop.go
@@ -19,6 +19,8 @@ import (
 
 const agentLoopOutputKey = "output"
 
+var errSteerInterruptToolCancel = errors.New("steer interrupt tool cancel")
+
 type AgentLoop struct {
 	Model                  llms.Model
 	Profile                RoleProfile
@@ -229,19 +231,19 @@ func (l *AgentLoop) executeToolCall(ctx context.Context, execution ToolCallExecu
 		return executeToolCall(ctx, execution)
 	}
 
-	toolCtx, cancel := context.WithCancel(ctx)
+	toolCtx, cancel := context.WithCancelCause(ctx)
 	done := make(chan struct{})
 	go func() {
 		select {
 		case <-interruptCh:
-			cancel()
+			cancel(errSteerInterruptToolCancel)
 		case <-toolCtx.Done():
 		case <-done:
 		}
 	}()
 	result := executeToolCall(toolCtx, execution)
 	close(done)
-	cancel()
+	cancel(nil)
 	return result
 }
 

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -27,6 +27,26 @@ func firstAudioDialogTestMessageOfType(messages []Message, messageType string) (
 	return Message{}, false
 }
 
+// waitForRecordSTT polls until StartRecording's asynchronous streaming STT
+// goroutine has installed the active session, or until the timeout elapses.
+// StartRecording intentionally sets up streaming STT on a background goroutine
+// so the audible cue is not delayed by the network handshake; tests that stop
+// recording immediately must wait for that goroutine to land, otherwise the
+// finalize path is skipped and the transcript comes back empty (a flake).
+func waitForRecordSTT(t *testing.T, dialog *AudioDialog, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if dialog.currentRecordSTT() != nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("streaming STT session not established within %s", timeout)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
 func TestAudioDialogFinishManualUtterancePreservesTail(t *testing.T) {
 	vad, err := NewAudioVADWithScorer(AudioVADConfig{
 		SampleRate:      16000,
@@ -251,6 +271,11 @@ func TestAudioDialogPrepareTurnInputUsesStreamingTranscriptFromRecording(t *test
 	if err := dialog.StartRecording(); err != nil {
 		t.Fatalf("StartRecording() error = %v", err)
 	}
+	// StartRecording kicks off the streaming STT session asynchronously;
+	// wait for it to be installed before reading/stopping so the chunk is
+	// uploaded and the finalize path runs (otherwise the test races the
+	// goroutine and flakily reports an empty transcript).
+	waitForRecordSTT(t, dialog, 2*time.Second)
 	chunk, err := dialog.ReadRecordChunk(200)
 	if err != nil {
 		t.Fatalf("ReadRecordChunk() error = %v", err)

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -824,12 +824,13 @@ func TestRuntimeRunSteerInterruptDoesNotPauseAfterNonCancelableTool(t *testing.T
 	toolStarted := make(chan struct{})
 	releaseTool := make(chan struct{})
 	tool := &blockingTool{
-		name:         "slow",
-		description:  "Slow tool.",
-		output:       "tool output",
-		started:      toolStarted,
-		release:      releaseTool,
-		ignoreCancel: true,
+		name:          "slow",
+		description:   "Slow tool.",
+		output:        "tool output",
+		started:       toolStarted,
+		release:       releaseTool,
+		interruptSeen: make(chan struct{}),
+		ignoreCancel:  true,
 	}
 	runtime := NewRuntimeWithDeps(
 		Config{Model: ModelConfig{Provider: "fake"}, Instruction: "Use tools."},
@@ -868,6 +869,11 @@ func TestRuntimeRunSteerInterruptDoesNotPauseAfterNonCancelableTool(t *testing.T
 		t.Fatal("tool did not start")
 	}
 	close(interruptCh)
+	select {
+	case <-tool.interruptSeen:
+	case <-time.After(time.Second):
+		t.Fatal("tool context was not canceled after steer interrupt")
+	}
 	close(releaseTool)
 
 	var runResult struct {
@@ -1101,6 +1107,7 @@ func TestRuntimeRunPersistsAssistantOutputOnce(t *testing.T) {
 		&ToolSet{tools: map[string]langtools.Tool{}},
 		NewSkillIndex(),
 	)
+	t.Cleanup(func() { _ = runtime.Close() })
 
 	if _, err := runtime.Run(ctx, RunRequest{Input: "hi"}); err != nil {
 		t.Fatalf("Run() error = %v", err)
@@ -1190,6 +1197,7 @@ func TestRuntimeRunPersistsRootInputBeforeModelFailure(t *testing.T) {
 		&ToolSet{tools: map[string]langtools.Tool{}},
 		NewSkillIndex(),
 	)
+	t.Cleanup(func() { _ = runtime.Close() })
 
 	_, err := runtime.Run(context.Background(), RunRequest{
 		Input:     "打开微信，进入 den 群，发送100块钱红包",
@@ -1225,6 +1233,7 @@ func TestRuntimeRunPersistsCanonicalVoiceInputBeforeModelFailure(t *testing.T) {
 		&ToolSet{tools: map[string]langtools.Tool{}},
 		NewSkillIndex(),
 	)
+	t.Cleanup(func() { _ = runtime.Close() })
 
 	_, err := runtime.Run(context.Background(), RunRequest{
 		Turn: TurnInput{
@@ -1286,6 +1295,7 @@ func TestRuntimeRunPersistsAttachmentArtifactsWithoutBinary(t *testing.T) {
 		&ToolSet{tools: map[string]langtools.Tool{}},
 		NewSkillIndex(),
 	)
+	t.Cleanup(func() { _ = runtime.Close() })
 
 	_, err := runtime.Run(context.Background(), RunRequest{
 		Input: "Describe the uploaded image.",
@@ -2059,14 +2069,15 @@ func (t *stubTool) Call(_ context.Context, input string) (string, error) {
 }
 
 type blockingTool struct {
-	name         string
-	description  string
-	output       string
-	inputs       []string
-	started      chan struct{}
-	release      chan struct{}
-	canceled     chan struct{}
-	ignoreCancel bool
+	name          string
+	description   string
+	output        string
+	inputs        []string
+	started       chan struct{}
+	release       chan struct{}
+	canceled      chan struct{}
+	interruptSeen chan struct{}
+	ignoreCancel  bool
 }
 
 func (t *blockingTool) Name() string { return t.name }
@@ -2079,6 +2090,12 @@ func (t *blockingTool) Call(ctx context.Context, input string) (string, error) {
 		close(t.started)
 	}
 	if t.ignoreCancel {
+		if t.interruptSeen != nil {
+			go func() {
+				<-ctx.Done()
+				close(t.interruptSeen)
+			}()
+		}
 		if t.release != nil {
 			<-t.release
 		}

--- a/src/agent/internal/agent/tool_execution.go
+++ b/src/agent/internal/agent/tool_execution.go
@@ -165,7 +165,7 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 		}
 		result := *remote
 		result.Duration = time.Since(call.StartedAt)
-		if ctxErr := ctx.Err(); ctxErr != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil && !(errors.Is(context.Cause(ctx), errSteerInterruptToolCancel) && result.Error == nil) {
 			if errors.Is(ctxErr, context.Canceled) {
 				result.Error = NewToolError(CodeCanceled, ctxErr.Error())
 			} else if errors.Is(ctxErr, context.DeadlineExceeded) {
@@ -187,6 +187,9 @@ func executeToolCall(ctx context.Context, execution ToolCallExecution) ToolCallE
 	output, err := spec.Tool.Call(ctx2, input)
 	var toolErr *ToolError
 	hardErr := ctx.Err()
+	if hardErr != nil && errors.Is(context.Cause(ctx), errSteerInterruptToolCancel) && err == nil {
+		hardErr = nil
+	}
 	if hardErr != nil {
 		if errors.Is(hardErr, context.Canceled) {
 			toolErr = NewToolError(CodeCanceled, hardErr.Error())


### PR DESCRIPTION
## Summary
- wait for async streaming STT setup in audio dialog tests before stopping recording
- tag steer-interrupt tool cancellation with a dedicated cause so successful non-cancelable tools are not rewritten into context-canceled failures
- tighten runtime steer-interrupt coverage so the test proves cancellation was delivered before the tool is released

## Testing
- go test -count=100 -run 'TestRuntimeRunSteerInterruptDoesNotPauseAfterNonCancelableTool|TestRuntimeRunSteerInterruptCancelsCancelableToolWithoutWaitingForSteer' ./internal/agent
- go test -count=1 ./internal/agent
- go test -count=1 ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how steer interrupts are handled during tool execution, so cancellations now carry a clearer result and are less likely to be misreported as tool errors.
  * Prevented valid tool results from being replaced by cancellation errors when an interrupt occurs.
  * Fixed interrupt handling for tools that do not stop immediately, making interruption behavior more reliable.
  * Added cleanup for runtime-based tests to reduce leftover state between runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->