### PR TITLE
  fix(agent): increase default directional swipe distance to 700

### DIFF
--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -45,7 +45,7 @@ const (
 
 	// defaultDirectionalSwipeDistance is the normalized travel for swipe_left/right/up/down.
 	// Coordinates use 0-1000 normalized scale.
-	defaultDirectionalSwipeDistance = 500.0
+	defaultDirectionalSwipeDistance = 700.0
 	directionalSwipeLargeDistance   = 700.0
 	directionalSwipeMediumDistance  = 500.0
 	directionalSwipeSmallDistance   = 200.0


### PR DESCRIPTION
 ## Summary

  Increase `defaultDirectionalSwipeDistance` from 500 to 700 (normalized units, 0-1000 scale) so directional swipe
  gestures cover 70% of screen width/height by default.

  ## Problem

  On iPhone 17 Pro, `swipe_left` with the default distance of 500 (50% screen width) fails to trigger page navigation.
  iOS requires a larger travel distance to recognize a page-flip gesture.

  ## Changes

  - Changed `defaultDirectionalSwipeDistance` from `500.0` to `700.0` in `src/agent/internal/agent/tools_hid.go`

  This aligns the default with `directionalSwipeLargeDistance` (700), making page swipes work reliably without requiring
   explicit `distance` or `strength` parameters.

  ## Testing

  - Build passes (`go build ./cmd/daemon`)
  - Manual test: `{"type": "swipe_left"}` should now trigger iPhone page navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default distance for directional swipe presets, making swipe gestures travel farther when no custom distance is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->