### PR TITLE
feat(agent): add prompt cache control

### DIFF
--- a/src/agent/internal/agent/agent_loop.go
+++ b/src/agent/internal/agent/agent_loop.go
@@ -73,7 +73,7 @@ func (l *AgentLoop) Run(ctx context.Context, input string, options ...chains.Cha
 	}
 	preparePlannerContextManager(
 		contextManager,
-		l.Profile.SystemPrompt,
+		l.Profile.SystemPromptSections(),
 		l.ConversationHistory,
 		inputs["input"],
 		l.InputAttachments,

--- a/src/agent/internal/agent/context_manager/context_manager.go
+++ b/src/agent/internal/agent/context_manager/context_manager.go
@@ -46,11 +46,12 @@ func (r MessageRole) ToStandardRole() llms.ChatMessageType {
 }
 
 type Message struct {
-	Role        MessageRole  `json:"role"`
-	Content     string       `json:"content"`
-	ToolCalls   []ToolCall   `json:"tool_calls,omitempty"`
-	ToolResults []ToolResult `json:"tool_results,omitempty"`
-	Attachments []Attachment `json:"attachments,omitempty"`
+	Role           MessageRole     `json:"role"`
+	Content        string          `json:"content"`
+	PromptSections []PromptSection `json:"prompt_sections,omitempty"`
+	ToolCalls      []ToolCall      `json:"tool_calls,omitempty"`
+	ToolResults    []ToolResult    `json:"tool_results,omitempty"`
+	Attachments    []Attachment    `json:"attachments,omitempty"`
 }
 
 type ToolCall struct {
@@ -134,6 +135,9 @@ func (c *ContextManager) MessageListDump() MessageListDump {
 		}
 		if len(msg.Attachments) > 0 {
 			messages[i].Attachments = append([]Attachment(nil), msg.Attachments...)
+		}
+		if len(msg.PromptSections) > 0 {
+			messages[i].PromptSections = append([]PromptSection(nil), msg.PromptSections...)
 		}
 	}
 	return MessageListDump{
@@ -325,6 +329,9 @@ func (c *ContextManager) Fork() *ContextManager {
 		if len(msg.Attachments) > 0 {
 			newMessageList[i].Attachments = append([]Attachment(nil), msg.Attachments...)
 		}
+		if len(msg.PromptSections) > 0 {
+			newMessageList[i].PromptSections = append([]PromptSection(nil), msg.PromptSections...)
+		}
 	}
 	newSessionID := "session_" + uuid.New().String()
 	if c.attachmentStore != nil {
@@ -339,9 +346,19 @@ func (c *ContextManager) Fork() *ContextManager {
 }
 
 func (c *ContextManager) ConvertToStandardMessageList() []llms.MessageContent {
+	messages, _ := c.convertToStandardMessageList()
+	return messages
+}
+
+func (c *ContextManager) ConvertToStandardMessageListWithCacheHints() ([]llms.MessageContent, PromptCacheHints) {
+	return c.convertToStandardMessageList()
+}
+
+func (c *ContextManager) convertToStandardMessageList() ([]llms.MessageContent, PromptCacheHints) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	standardMessageList := make([]llms.MessageContent, len(c.messageList))
+	hints := PromptCacheHints{}
 	for i, message := range c.messageList {
 		newMessage := llms.MessageContent{
 			Role:  message.Role.ToStandardRole(),
@@ -362,7 +379,21 @@ func (c *ContextManager) ConvertToStandardMessageList() []llms.MessageContent {
 			standardMessageList[i] = newMessage
 			continue
 		}
-		if content := strings.TrimSpace(message.Content); content != "" {
+		if message.Role == MessageRoleSystem && len(message.PromptSections) > 0 {
+			partIndex := 0
+			for _, section := range message.PromptSections {
+				if text := strings.TrimSpace(section.Text); text != "" {
+					newMessage.Parts = append(newMessage.Parts, llms.TextPart(text))
+					if section.CacheEphemeral {
+						hints.EphemeralParts = append(hints.EphemeralParts, PromptCachePartHint{
+							MessageIndex: i,
+							PartIndex:    partIndex,
+						})
+					}
+					partIndex++
+				}
+			}
+		} else if content := strings.TrimSpace(message.Content); content != "" {
 			newMessage.Parts = append(newMessage.Parts, llms.TextPart(content))
 		}
 		for toolIndex, call := range message.ToolCalls {
@@ -396,7 +427,7 @@ func (c *ContextManager) ConvertToStandardMessageList() []llms.MessageContent {
 		}
 		standardMessageList[i] = newMessage
 	}
-	return standardMessageList
+	return standardMessageList, hints
 }
 
 func attachmentOmittedMessage(mimeType string, err error) string {

--- a/src/agent/internal/agent/context_manager/prompt_cache_hints.go
+++ b/src/agent/internal/agent/context_manager/prompt_cache_hints.go
@@ -1,0 +1,41 @@
+package context_manager
+
+import "context"
+
+// PromptCachePartHint marks one message part that should receive provider
+// cache_control when explicit prompt caching is enabled.
+type PromptCachePartHint struct {
+	MessageIndex int `json:"message_index"`
+	PartIndex    int `json:"part_index"`
+}
+
+// PromptCacheHints carries cache breakpoints produced by ContextManager conversion.
+type PromptCacheHints struct {
+	EphemeralParts []PromptCachePartHint
+}
+
+func (h PromptCacheHints) ShouldCache(messageIndex, partIndex int) bool {
+	for _, hint := range h.EphemeralParts {
+		if hint.MessageIndex == messageIndex && hint.PartIndex == partIndex {
+			return true
+		}
+	}
+	return false
+}
+
+type promptCacheHintsContextKey struct{}
+
+func WithPromptCacheHints(ctx context.Context, hints PromptCacheHints) context.Context {
+	if len(hints.EphemeralParts) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, promptCacheHintsContextKey{}, hints)
+}
+
+func PromptCacheHintsFromContext(ctx context.Context) (PromptCacheHints, bool) {
+	if ctx == nil {
+		return PromptCacheHints{}, false
+	}
+	hints, ok := ctx.Value(promptCacheHintsContextKey{}).(PromptCacheHints)
+	return hints, ok
+}

--- a/src/agent/internal/agent/context_manager/prompt_cache_hints_test.go
+++ b/src/agent/internal/agent/context_manager/prompt_cache_hints_test.go
@@ -1,0 +1,88 @@
+package context_manager
+
+import (
+	"testing"
+)
+
+func TestConvertToStandardMessageListWithCacheHints(t *testing.T) {
+	manager := NewContextManager()
+	manager.AppendMessage(Message{
+		Role: MessageRoleSystem,
+		PromptSections: []PromptSection{
+			{Text: "stable prefix", CacheEphemeral: true},
+			{Text: "dynamic suffix"},
+		},
+	})
+	manager.AppendMessage(Message{
+		Role:    MessageRoleUser,
+		Content: "hello",
+	})
+
+	messages, hints := manager.ConvertToStandardMessageListWithCacheHints()
+	if len(messages) != 2 {
+		t.Fatalf("messages = %d, want 2", len(messages))
+	}
+	if len(messages[0].Parts) != 2 {
+		t.Fatalf("system parts = %d, want 2", len(messages[0].Parts))
+	}
+	if len(hints.EphemeralParts) != 1 {
+		t.Fatalf("hints = %#v, want one ephemeral part", hints.EphemeralParts)
+	}
+	if got := hints.EphemeralParts[0]; got.MessageIndex != 0 || got.PartIndex != 0 {
+		t.Fatalf("hint = %#v, want message 0 part 0", got)
+	}
+	if !hints.ShouldCache(0, 0) || hints.ShouldCache(0, 1) || hints.ShouldCache(1, 0) {
+		t.Fatalf("unexpected ShouldCache results for hints=%#v", hints.EphemeralParts)
+	}
+}
+
+func TestConvertToStandardMessageListWithCacheHintsSingleStablePart(t *testing.T) {
+	manager := NewContextManager()
+	manager.AppendMessage(Message{
+		Role: MessageRoleSystem,
+		PromptSections: []PromptSection{
+			{Text: "entire stable system prompt", CacheEphemeral: true},
+		},
+	})
+
+	messages, hints := manager.ConvertToStandardMessageListWithCacheHints()
+	if len(messages[0].Parts) != 1 {
+		t.Fatalf("system parts = %d, want single stable part", len(messages[0].Parts))
+	}
+	if !hints.ShouldCache(0, 0) {
+		t.Fatalf("single stable system part should be cacheable")
+	}
+}
+
+func TestWithPromptCacheHintsRoundTrip(t *testing.T) {
+	hints := PromptCacheHints{
+		EphemeralParts: []PromptCachePartHint{{MessageIndex: 0, PartIndex: 0}},
+	}
+	ctx := WithPromptCacheHints(t.Context(), hints)
+	got, ok := PromptCacheHintsFromContext(ctx)
+	if !ok {
+		t.Fatal("expected hints in context")
+	}
+	if !got.ShouldCache(0, 0) {
+		t.Fatalf("round-trip hints = %#v", got.EphemeralParts)
+	}
+}
+
+func TestMessageListDumpCopiesPromptSections(t *testing.T) {
+	manager := NewContextManager()
+	manager.AppendMessage(Message{
+		Role: MessageRoleSystem,
+		PromptSections: []PromptSection{
+			{Text: "stable prefix", CacheEphemeral: true},
+		},
+	})
+
+	dump := manager.MessageListDump()
+	dump.Messages[0].PromptSections[0].Text = "mutated"
+	dump.Messages[0].PromptSections[0].CacheEphemeral = false
+
+	got := manager.MessageListDump().Messages[0].PromptSections[0]
+	if got.Text != "stable prefix" || !got.CacheEphemeral {
+		t.Fatalf("internal prompt section mutated through dump: %#v", got)
+	}
+}

--- a/src/agent/internal/agent/context_manager/prompt_section.go
+++ b/src/agent/internal/agent/context_manager/prompt_section.go
@@ -1,0 +1,20 @@
+package context_manager
+
+import "strings"
+
+// PromptSection is one text block in a system message. CacheEphemeral marks
+// stable prefix blocks that should receive provider cache_control breakpoints.
+type PromptSection struct {
+	Text           string `json:"text"`
+	CacheEphemeral bool   `json:"cache_ephemeral,omitempty"`
+}
+
+func JoinPromptSections(sections []PromptSection) string {
+	parts := make([]string, 0, len(sections))
+	for _, section := range sections {
+		if text := strings.TrimSpace(section.Text); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/src/agent/internal/agent/context_manager_bridge.go
+++ b/src/agent/internal/agent/context_manager_bridge.go
@@ -186,15 +186,15 @@ func mergePromptText(existing, addition string) string {
 
 func seedContextManager(
 	manager *context_manager.ContextManager,
-	systemPrompt string,
+	systemPrompt []context_manager.PromptSection,
 	history []llms.MessageContent,
 	userInput string,
 	attachments []InputAttachment,
 ) {
-	if strings.TrimSpace(systemPrompt) != "" {
+	if len(systemPrompt) > 0 {
 		manager.AppendMessage(context_manager.Message{
-			Role:    context_manager.MessageRoleSystem,
-			Content: strings.TrimSpace(systemPrompt),
+			Role:           context_manager.MessageRoleSystem,
+			PromptSections: append([]context_manager.PromptSection(nil), systemPrompt...),
 		})
 	}
 	for _, item := range history {
@@ -205,7 +205,7 @@ func seedContextManager(
 
 func preparePlannerContextManager(
 	manager *context_manager.ContextManager,
-	systemPrompt string,
+	systemPrompt []context_manager.PromptSection,
 	history []llms.MessageContent,
 	userInput string,
 	attachments []InputAttachment,

--- a/src/agent/internal/agent/context_manager_bridge_test.go
+++ b/src/agent/internal/agent/context_manager_bridge_test.go
@@ -11,9 +11,14 @@ import (
 
 func TestPreparePlannerContextManagerReusesExistingContext(t *testing.T) {
 	manager := context_manager.NewContextManager()
+	systemV1 := []context_manager.PromptSection{
+		{Text: "system v1 stable", CacheEphemeral: true},
+		{Text: "system v1 dynamic"},
+	}
+	systemV2 := []context_manager.PromptSection{{Text: "system v2"}}
 	preparePlannerContextManager(
 		manager,
-		"system v1",
+		systemV1,
 		[]llms.MessageContent{
 			{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("prior user")}},
 			{Role: llms.ChatMessageTypeAI, Parts: []llms.ContentPart{llms.TextPart("prior assistant")}},
@@ -23,7 +28,7 @@ func TestPreparePlannerContextManagerReusesExistingContext(t *testing.T) {
 	)
 	preparePlannerContextManager(
 		manager,
-		"system v2",
+		systemV2,
 		[]llms.MessageContent{
 			{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("duplicate prior user")}},
 		},
@@ -35,8 +40,11 @@ func TestPreparePlannerContextManagerReusesExistingContext(t *testing.T) {
 	if len(messages) != 5 {
 		t.Fatalf("messages = %d, want 5 without duplicated history", len(messages))
 	}
-	if text := messageText(messages[:1]); text != "system v1\n" {
-		t.Fatalf("system prompt = %q, want original system v1", text)
+	if text := messageText(messages[:1]); text != "system v1 stable\nsystem v1 dynamic\n" {
+		t.Fatalf("system prompt = %q, want original system v1 sections", text)
+	}
+	if len(messages[0].Parts) != 2 {
+		t.Fatalf("system message parts = %d, want 2 for cache split", len(messages[0].Parts))
 	}
 	if text := messageText(messages[1:2]); text != "prior user\n" {
 		t.Fatalf("history user = %q", text)

--- a/src/agent/internal/agent/executor/executor.go
+++ b/src/agent/internal/agent/executor/executor.go
@@ -29,7 +29,8 @@ func (e *LLMExecutor) AppendMessage(message context_manager.Message) {
 }
 
 func (e *LLMExecutor) GenerateContent(ctx context.Context, options ...llms.CallOption) (*llms.ContentResponse, error) {
-	messages := e.contextManager.ConvertToStandardMessageList()
+	messages, hints := e.contextManager.ConvertToStandardMessageListWithCacheHints()
+	ctx = context_manager.WithPromptCacheHints(ctx, hints)
 	contentResponse, err := e.model.GenerateContent(ctx, messages, options...)
 	if err != nil {
 		return nil, err

--- a/src/agent/internal/agent/executor/executor_test.go
+++ b/src/agent/internal/agent/executor/executor_test.go
@@ -1,0 +1,55 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"aiden-agent/internal/agent/context_manager"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+type cacheHintCapturingModel struct {
+	messages []llms.MessageContent
+	hints    context_manager.PromptCacheHints
+	hasHints bool
+}
+
+func (m *cacheHintCapturingModel) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+func (m *cacheHintCapturingModel) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	m.messages = messages
+	m.hints, m.hasHints = context_manager.PromptCacheHintsFromContext(ctx)
+	return &llms.ContentResponse{
+		Choices: []*llms.ContentChoice{{Content: "ok"}},
+	}, nil
+}
+
+func TestGenerateContentPassesPromptCacheHints(t *testing.T) {
+	manager := context_manager.NewContextManager()
+	manager.AppendMessage(context_manager.Message{
+		Role: context_manager.MessageRoleSystem,
+		PromptSections: []context_manager.PromptSection{
+			{Text: "stable prefix", CacheEphemeral: true},
+			{Text: "dynamic suffix"},
+		},
+	})
+	manager.AppendMessage(context_manager.Message{
+		Role:    context_manager.MessageRoleUser,
+		Content: "hello",
+	})
+	model := &cacheHintCapturingModel{}
+	executor := NewLLMExecutor(model, manager)
+
+	if _, err := executor.GenerateContent(context.Background()); err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+	if !model.hasHints || !model.hints.ShouldCache(0, 0) {
+		t.Fatalf("model prompt cache hints = %#v, hasHints=%v; want message 0 part 0", model.hints.EphemeralParts, model.hasHints)
+	}
+	if len(model.messages) != 2 || len(model.messages[0].Parts) != 2 {
+		t.Fatalf("model messages = %#v, want split system prompt and user message", model.messages)
+	}
+}

--- a/src/agent/internal/agent/model_metadata.go
+++ b/src/agent/internal/agent/model_metadata.go
@@ -121,11 +121,12 @@ type providerModelMetadataCacheFile struct {
 }
 
 type providerModelMetadataCacheEntry struct {
-	Provider  string    `json:"provider"`
-	Model     string    `json:"model"`
-	Endpoint  string    `json:"endpoint"`
-	Spec      ModelSpec `json:"spec"`
-	FetchedAt time.Time `json:"fetched_at"`
+	Provider          string    `json:"provider"`
+	Model             string    `json:"model"`
+	Endpoint          string    `json:"endpoint"`
+	Spec              ModelSpec `json:"spec"`
+	PromptCachePolicy string    `json:"prompt_cache_policy,omitempty"`
+	FetchedAt         time.Time `json:"fetched_at"`
 }
 
 func (m *ModelManager) readProviderModelSpecCache() (ModelSpec, bool) {
@@ -154,6 +155,9 @@ func (m *ModelManager) readProviderModelSpecCache() (ModelSpec, bool) {
 	if !ok || !m.providerModelSpecCacheEntryMatches(entry) || !hasProviderModelSpecMetadata(entry.Spec) {
 		return ModelSpec{}, false
 	}
+	if entry.PromptCachePolicy != "" {
+		m.storeProviderPromptCachePolicy(PromptCachePolicy(entry.PromptCachePolicy))
+	}
 	return entry.Spec, true
 }
 
@@ -179,13 +183,16 @@ func (m *ModelManager) writeProviderModelSpecCache(spec ModelSpec) error {
 		return err
 	}
 
-	cache.Entries[m.providerModelSpecCacheKey()] = providerModelMetadataCacheEntry{
-		Provider:  normalizedProviderName(m.config.Provider),
-		Model:     normalizedModelName(m.config.Model),
-		Endpoint:  m.providerMetadataEndpoint(),
-		Spec:      spec,
-		FetchedAt: time.Now().UTC(),
+	key := m.providerModelSpecCacheKey()
+	entry := cache.Entries[key]
+	if entry.Provider == "" {
+		entry.Provider = normalizedProviderName(m.config.Provider)
+		entry.Model = normalizedModelName(m.config.Model)
+		entry.Endpoint = m.providerMetadataEndpoint()
 	}
+	entry.Spec = spec
+	entry.FetchedAt = time.Now().UTC()
+	cache.Entries[key] = entry
 
 	encoded, err := json.MarshalIndent(cache, "", "  ")
 	if err != nil {

--- a/src/agent/internal/agent/models.go
+++ b/src/agent/internal/agent/models.go
@@ -34,14 +34,16 @@ type ModelManager struct {
 	proxy  ProxyConfig
 	model  llms.Model
 
-	specMu                    sync.Mutex
-	providerSpec              ModelSpec
-	providerSpecLoaded        bool
-	providerSpecFetchStarted  bool
-	metadataHTTPClient        *http.Client
-	providerMetadataCachePath string
-	rawHTTPLogDir             string
-	rawHTTPLogSessionID       func() string
+	specMu                          sync.Mutex
+	providerSpec                    ModelSpec
+	providerSpecLoaded              bool
+	providerSpecFetchStarted        bool
+	providerPromptCachePolicy       PromptCachePolicy
+	providerPromptCachePolicyLoaded bool
+	metadataHTTPClient              *http.Client
+	providerMetadataCachePath       string
+	rawHTTPLogDir                   string
+	rawHTTPLogSessionID             func() string
 }
 
 type ModelManagerOption func(*ModelManager)
@@ -151,7 +153,7 @@ func (m *ModelManager) build(cfg ModelConfig) (llms.Model, error) {
 			baseURL = "https://openrouter.ai/api/v1"
 		}
 		opts := append(m.openAICompatibleOptions(cfg), withOpenAICompatibleSessionSticky(m.activeSessionID), withOpenAICompatibleRouterMetadata())
-		if openRouterExplicitPromptCacheSupported(cfg.Model) {
+		if m.cachedOpenRouterPromptCachePolicy().UsesExplicitCacheControl() {
 			opts = append(opts, withOpenAICompatibleExplicitPromptCache())
 		}
 		return newOpenAICompatibleModel(baseURL, cfg.Model, token, newRetryHTTPClient(m.proxy), opts...), nil

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"aiden-agent/internal/agent/context_manager"
 	"bufio"
 	"bytes"
 	"context"
@@ -423,8 +424,9 @@ func (m *openAICompatibleModel) GenerateContent(ctx context.Context, messages []
 	}
 
 	requestMessages := make([]compatibleMessage, 0, len(messages))
-	for _, message := range messages {
-		converted, err := convertMessageContent(message, m.explicitPromptCache)
+	cacheHints, _ := context_manager.PromptCacheHintsFromContext(ctx)
+	for messageIndex, message := range messages {
+		converted, err := convertMessageContent(message, messageIndex, m.explicitPromptCache, cacheHints)
 		if err != nil {
 			return nil, err
 		}
@@ -886,7 +888,7 @@ func (m *openAICompatibleModel) withRawHTTPLogFileTime(ctx context.Context) cont
 	return contextWithRawHTTPLogFileSessionID(ctx, m.rawLogger.currentSessionID())
 }
 
-func convertMessageContent(message llms.MessageContent, explicitPromptCache bool) (compatibleMessage, error) {
+func convertMessageContent(message llms.MessageContent, messageIndex int, explicitPromptCache bool, cacheHints context_manager.PromptCacheHints) (compatibleMessage, error) {
 	msg := compatibleMessage{Role: compatibleRole(message.Role)}
 
 	switch message.Role {
@@ -920,7 +922,7 @@ func convertMessageContent(message llms.MessageContent, explicitPromptCache bool
 				Type: "text",
 				Text: typed.Text,
 			}
-			if explicitPromptCache && message.Role == llms.ChatMessageTypeSystem && i == 0 && len(message.Parts) > 1 {
+			if explicitPromptCache && message.Role == llms.ChatMessageTypeSystem && cacheHints.ShouldCache(messageIndex, i) {
 				converted.CacheControl = &compatibleCacheControl{Type: "ephemeral"}
 			}
 			textParts = append(textParts, converted)
@@ -969,7 +971,7 @@ func convertMessageContent(message llms.MessageContent, explicitPromptCache bool
 		msg.ToolCalls = toolCalls
 	}
 
-	if len(textParts) == 1 && textParts[0].Type == "text" {
+	if len(textParts) == 1 && textParts[0].Type == "text" && textParts[0].CacheControl == nil {
 		msg.Content = textParts[0].Text
 		return msg, nil
 	}

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -16,8 +16,16 @@ import (
 	"testing"
 	"time"
 
+	"aiden-agent/internal/agent/context_manager"
+
 	"github.com/tmc/langchaingo/llms"
 )
+
+func promptCacheHintsContext(ephemeralParts ...context_manager.PromptCachePartHint) context.Context {
+	return context_manager.WithPromptCacheHints(context.Background(), context_manager.PromptCacheHints{
+		EphemeralParts: ephemeralParts,
+	})
+}
 
 func TestOpenAICompatibleModelEncodesAudioAsInputAudio(t *testing.T) {
 	var captured struct {
@@ -1576,20 +1584,31 @@ func TestOpenRouterSupportedModelAddsPromptCacheControlToSystemPrefix(t *testing
 		} `json:"messages"`
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
-			t.Fatalf("decode request: %v", err)
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/endpoints"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"endpoints":[{"supported_parameters":["cache_control"]}]}}`))
+		case r.URL.Path == "/chat/completions":
+			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+		default:
+			http.NotFound(w, r)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
 	}))
 	defer server.Close()
 
-	manager := NewModelManager(ModelConfig{Provider: "openrouter", Model: "anthropic/claude-sonnet-4", APIKey: "k", BaseURL: server.URL}, ProxyConfig{})
+	manager := NewModelManager(ModelConfig{Provider: "openrouter", Model: "vendor/cache-control-model", APIKey: "k", BaseURL: server.URL}, ProxyConfig{})
 	model, err := manager.Get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
-	if _, err := model.GenerateContent(context.Background(), []llms.MessageContent{
+	if _, err := model.GenerateContent(promptCacheHintsContext(context_manager.PromptCachePartHint{
+		MessageIndex: 0,
+		PartIndex:    0,
+	}), []llms.MessageContent{
 		{Role: llms.ChatMessageTypeSystem, Parts: []llms.ContentPart{llms.TextPart("stable role prompt"), llms.TextPart("dynamic runtime context")}},
 		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("hello")}},
 	}); err != nil {
@@ -1611,6 +1630,57 @@ func TestOpenRouterSupportedModelAddsPromptCacheControlToSystemPrefix(t *testing
 	}
 }
 
+func TestOpenRouterSupportedModelKeepsCacheControlOnSingleSystemPart(t *testing.T) {
+	var captured struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/endpoints"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"endpoints":[{"supported_parameters":["cache_control"]}]}}`))
+		case r.URL.Path == "/chat/completions":
+			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	manager := NewModelManager(ModelConfig{Provider: "openrouter", Model: "vendor/single-cache-control-model", APIKey: "k", BaseURL: server.URL}, ProxyConfig{})
+	model, err := manager.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if _, err := model.GenerateContent(promptCacheHintsContext(context_manager.PromptCachePartHint{
+		MessageIndex: 0,
+		PartIndex:    0,
+	}), []llms.MessageContent{
+		{Role: llms.ChatMessageTypeSystem, Parts: []llms.ContentPart{llms.TextPart("stable role prompt")}},
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("hello")}},
+	}); err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	if len(captured.Messages) == 0 {
+		t.Fatalf("expected system content, got %#v", captured.Messages)
+	}
+	systemContent := decodePromptCacheSystemContent(t, captured.Messages[0].Content)
+	if len(systemContent) != 1 {
+		t.Fatalf("expected one system content part, got %#v", systemContent)
+	}
+	if got := systemContent[0].CacheControl; got == nil || got.Type != "ephemeral" {
+		t.Fatalf("single system text block should carry cache_control ephemeral, got %#v", systemContent[0])
+	}
+}
+
 func TestOpenRouterUnsupportedModelDoesNotSendPromptCacheControl(t *testing.T) {
 	var captured struct {
 		Messages []struct {
@@ -1619,11 +1689,19 @@ func TestOpenRouterUnsupportedModelDoesNotSendPromptCacheControl(t *testing.T) {
 		} `json:"messages"`
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
-			t.Fatalf("decode request: %v", err)
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/endpoints"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"endpoints":[{"supported_parameters":["temperature"]}]}}`))
+		case r.URL.Path == "/chat/completions":
+			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+		default:
+			http.NotFound(w, r)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
 	}))
 	defer server.Close()
 
@@ -1632,7 +1710,10 @@ func TestOpenRouterUnsupportedModelDoesNotSendPromptCacheControl(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
-	if _, err := model.GenerateContent(context.Background(), []llms.MessageContent{
+	if _, err := model.GenerateContent(promptCacheHintsContext(context_manager.PromptCachePartHint{
+		MessageIndex: 0,
+		PartIndex:    0,
+	}), []llms.MessageContent{
 		{Role: llms.ChatMessageTypeSystem, Parts: []llms.ContentPart{llms.TextPart("stable role prompt"), llms.TextPart("dynamic runtime context")}},
 		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("hello")}},
 	}); err != nil {

--- a/src/agent/internal/agent/prompt_cache_policy.go
+++ b/src/agent/internal/agent/prompt_cache_policy.go
@@ -1,0 +1,257 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// PromptCachePolicy describes how OpenRouter/provider prompt caching should be
+// handled for a model endpoint set.
+type PromptCachePolicy string
+
+const (
+	PromptCachePolicyNone     PromptCachePolicy = "none"
+	PromptCachePolicyImplicit PromptCachePolicy = "implicit"
+	PromptCachePolicyExplicit PromptCachePolicy = "explicit"
+)
+
+func (p PromptCachePolicy) UsesExplicitCacheControl() bool {
+	return p == PromptCachePolicyExplicit
+}
+
+func openRouterPromptCachePolicyFallback(model string) PromptCachePolicy {
+	if openRouterExplicitPromptCacheSupported(model) {
+		return PromptCachePolicyExplicit
+	}
+	return PromptCachePolicyNone
+}
+
+func resolveOpenRouterPromptCachePolicy(endpoints []openRouterEndpointMetadata) PromptCachePolicy {
+	if len(endpoints) == 0 {
+		return PromptCachePolicyNone
+	}
+
+	hasExplicit := false
+	hasImplicit := false
+	hasCachePricing := false
+
+	for _, endpoint := range endpoints {
+		if endpointSupportsExplicitPromptCache(endpoint) {
+			hasExplicit = true
+		}
+		if endpoint.SupportsImplicitCaching != nil && *endpoint.SupportsImplicitCaching {
+			hasImplicit = true
+		}
+		if endpointHasCacheReadPricing(endpoint.Pricing) {
+			hasCachePricing = true
+		}
+	}
+
+	switch {
+	case hasExplicit:
+		return PromptCachePolicyExplicit
+	case hasImplicit || hasCachePricing:
+		return PromptCachePolicyImplicit
+	default:
+		return PromptCachePolicyNone
+	}
+}
+
+func endpointSupportsExplicitPromptCache(endpoint openRouterEndpointMetadata) bool {
+	for _, param := range endpoint.SupportedParameters {
+		switch strings.ToLower(strings.TrimSpace(param)) {
+		case "cache_control", "prompt_cache":
+			return true
+		}
+	}
+	return false
+}
+
+func endpointHasCacheReadPricing(pricing map[string]any) bool {
+	if len(pricing) == 0 {
+		return false
+	}
+	for _, key := range []string{"input_cache_read", "cache_read", "cache_read_input"} {
+		if value, ok := pricing[key]; ok && pricingValuePositive(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func pricingValuePositive(value any) bool {
+	switch typed := value.(type) {
+	case string:
+		typed = strings.TrimSpace(typed)
+		return typed != "" && typed != "0"
+	case float64:
+		return typed > 0
+	case int:
+		return typed > 0
+	default:
+		return value != nil
+	}
+}
+
+func openRouterModelEndpointsURL(baseURL, model string) (string, bool) {
+	model = strings.TrimSpace(model)
+	model = strings.TrimPrefix(model, "~")
+	if idx := strings.Index(model, ":"); idx >= 0 {
+		model = model[:idx]
+	}
+	parts := strings.SplitN(model, "/", 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", false
+	}
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		baseURL = "https://openrouter.ai/api/v1"
+	}
+	return fmt.Sprintf("%s/models/%s/%s/endpoints", baseURL, parts[0], parts[1]), true
+}
+
+type openRouterEndpointsResponse struct {
+	Data openRouterEndpointsData `json:"data"`
+}
+
+type openRouterEndpointsData struct {
+	Endpoints []openRouterEndpointMetadata `json:"endpoints"`
+}
+
+type openRouterEndpointMetadata struct {
+	SupportedParameters     []string       `json:"supported_parameters"`
+	SupportsImplicitCaching *bool          `json:"supports_implicit_caching"`
+	Pricing                 map[string]any `json:"pricing"`
+}
+
+func (m *ModelManager) cachedOpenRouterPromptCachePolicy() PromptCachePolicy {
+	if strings.ToLower(strings.TrimSpace(m.config.Provider)) != "openrouter" {
+		return PromptCachePolicyNone
+	}
+	if policy, ok := m.readProviderPromptCachePolicyCache(); ok {
+		return policy
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), providerModelMetadataTimeout)
+	defer cancel()
+	policy, err := m.fetchOpenRouterPromptCachePolicy(ctx)
+	if err != nil {
+		return openRouterPromptCachePolicyFallback(m.config.Model)
+	}
+	m.storeProviderPromptCachePolicy(policy)
+	if err := m.writeProviderPromptCachePolicyCache(policy); err != nil {
+		log.Printf("[WARN] [model-spec] write prompt cache policy cache %s: %v", m.providerMetadataCachePath, err)
+	}
+	return policy
+}
+
+func (m *ModelManager) fetchOpenRouterPromptCachePolicy(ctx context.Context) (PromptCachePolicy, error) {
+	endpointURL, ok := openRouterModelEndpointsURL(m.config.BaseURL, m.config.Model)
+	if !ok {
+		return openRouterPromptCachePolicyFallback(m.config.Model), nil
+	}
+	token := resolveToken(m.config)
+	if token == "" {
+		return PromptCachePolicyNone, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpointURL, nil)
+	if err != nil {
+		return PromptCachePolicyNone, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := m.modelMetadataHTTPClient().Do(req)
+	if err != nil {
+		return PromptCachePolicyNone, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return PromptCachePolicyNone, fmt.Errorf("openrouter endpoints returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload openRouterEndpointsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return PromptCachePolicyNone, err
+	}
+	return resolveOpenRouterPromptCachePolicy(payload.Data.Endpoints), nil
+}
+
+func (m *ModelManager) storeProviderPromptCachePolicy(policy PromptCachePolicy) {
+	m.specMu.Lock()
+	defer m.specMu.Unlock()
+	m.providerPromptCachePolicy = policy
+	m.providerPromptCachePolicyLoaded = true
+}
+
+func (m *ModelManager) readProviderPromptCachePolicyCache() (PromptCachePolicy, bool) {
+	if strings.TrimSpace(m.providerMetadataCachePath) == "" {
+		return PromptCachePolicyNone, false
+	}
+	data, err := os.ReadFile(m.providerMetadataCachePath)
+	if err != nil {
+		return PromptCachePolicyNone, false
+	}
+	var cache providerModelMetadataCacheFile
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return PromptCachePolicyNone, false
+	}
+	if cache.Version != providerModelMetadataCacheVersion {
+		return PromptCachePolicyNone, false
+	}
+	entry, ok := cache.Entries[m.providerModelSpecCacheKey()]
+	if !ok || !m.providerModelSpecCacheEntryMatches(entry) {
+		return PromptCachePolicyNone, false
+	}
+	if entry.PromptCachePolicy == "" {
+		return PromptCachePolicyNone, false
+	}
+	return PromptCachePolicy(entry.PromptCachePolicy), true
+}
+
+func (m *ModelManager) writeProviderPromptCachePolicyCache(policy PromptCachePolicy) error {
+	if strings.TrimSpace(m.providerMetadataCachePath) == "" || policy == "" {
+		return nil
+	}
+	cache := providerModelMetadataCacheFile{
+		Version: providerModelMetadataCacheVersion,
+		Entries: map[string]providerModelMetadataCacheEntry{},
+	}
+	data, err := os.ReadFile(m.providerMetadataCachePath)
+	if err == nil && len(data) > 0 {
+		var existing providerModelMetadataCacheFile
+		if json.Unmarshal(data, &existing) == nil && existing.Version == providerModelMetadataCacheVersion {
+			cache = existing
+			if cache.Entries == nil {
+				cache.Entries = map[string]providerModelMetadataCacheEntry{}
+			}
+		}
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	key := m.providerModelSpecCacheKey()
+	entry := cache.Entries[key]
+	entry.Provider = normalizedProviderName(m.config.Provider)
+	entry.Model = normalizedModelName(m.config.Model)
+	entry.Endpoint = m.providerMetadataEndpoint()
+	entry.PromptCachePolicy = string(policy)
+	entry.FetchedAt = time.Now().UTC()
+	cache.Entries[key] = entry
+
+	encoded, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+	return writeFileAtomic(m.providerMetadataCachePath, encoded, 0o644)
+}

--- a/src/agent/internal/agent/prompt_cache_policy_test.go
+++ b/src/agent/internal/agent/prompt_cache_policy_test.go
@@ -1,0 +1,194 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"aiden-agent/internal/agent/context_manager"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+func TestResolveOpenRouterPromptCachePolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		endpoints []openRouterEndpointMetadata
+		want      PromptCachePolicy
+	}{
+		{
+			name: "explicit cache_control parameter",
+			endpoints: []openRouterEndpointMetadata{{
+				SupportedParameters: []string{"temperature", "cache_control"},
+			}},
+			want: PromptCachePolicyExplicit,
+		},
+		{
+			name: "implicit caching only",
+			endpoints: []openRouterEndpointMetadata{{
+				SupportedParameters:     []string{"temperature"},
+				SupportsImplicitCaching: boolPtr(true),
+			}},
+			want: PromptCachePolicyImplicit,
+		},
+		{
+			name: "cache read pricing only",
+			endpoints: []openRouterEndpointMetadata{{
+				Pricing: map[string]any{"input_cache_read": "0.0000003"},
+			}},
+			want: PromptCachePolicyImplicit,
+		},
+		{
+			name:      "none",
+			endpoints: []openRouterEndpointMetadata{{SupportedParameters: []string{"temperature"}}},
+			want:      PromptCachePolicyNone,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveOpenRouterPromptCachePolicy(tc.endpoints); got != tc.want {
+				t.Fatalf("resolveOpenRouterPromptCachePolicy() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOpenRouterModelEndpointsURL(t *testing.T) {
+	t.Parallel()
+
+	got, ok := openRouterModelEndpointsURL("https://openrouter.ai/api/v1", "anthropic/claude-sonnet-4")
+	if !ok {
+		t.Fatal("expected valid endpoints URL")
+	}
+	want := "https://openrouter.ai/api/v1/models/anthropic/claude-sonnet-4/endpoints"
+	if got != want {
+		t.Fatalf("endpoints URL = %q, want %q", got, want)
+	}
+}
+
+func TestCachedOpenRouterPromptCachePolicyUsesEndpointsResponse(t *testing.T) {
+	var captured struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/models/vendor/cache-control-model/endpoints":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"endpoints":[{"supported_parameters":["cache_control"]}]}}`))
+		case "/chat/completions":
+			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	manager := NewModelManager(ModelConfig{
+		Provider: "openrouter",
+		Model:    "vendor/cache-control-model",
+		APIKey:   "k",
+		BaseURL:  server.URL,
+	}, ProxyConfig{})
+	model, err := manager.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if _, err := model.GenerateContent(context_manager.WithPromptCacheHints(context.Background(), context_manager.PromptCacheHints{
+		EphemeralParts: []context_manager.PromptCachePartHint{{MessageIndex: 0, PartIndex: 0}},
+	}), []llms.MessageContent{
+		{Role: llms.ChatMessageTypeSystem, Parts: []llms.ContentPart{llms.TextPart("stable"), llms.TextPart("dynamic")}},
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextPart("hello")}},
+	}); err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	systemContent := decodePromptCacheSystemContent(t, captured.Messages[0].Content)
+	if len(systemContent) != 2 {
+		t.Fatalf("expected split system content, got %#v", systemContent)
+	}
+	if got := systemContent[0].CacheControl; got == nil || got.Type != "ephemeral" {
+		t.Fatalf("first system block should carry cache_control ephemeral, got %#v", systemContent[0])
+	}
+}
+
+func TestCachedOpenRouterPromptCachePolicyReadsDiskCache(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "provider-model-metadata.json")
+	manager := NewModelManager(
+		ModelConfig{Provider: "openrouter", Model: "vendor/model-x", APIKey: "k", BaseURL: "http://127.0.0.1:1"},
+		ProxyConfig{},
+		WithProviderModelMetadataCachePath(cachePath),
+	)
+
+	key := manager.providerModelSpecCacheKey()
+	cache := providerModelMetadataCacheFile{
+		Version: providerModelMetadataCacheVersion,
+		Entries: map[string]providerModelMetadataCacheEntry{
+			key: {
+				Provider:          "openrouter",
+				Model:             "vendor/model-x",
+				Endpoint:          openRouterModelsURL("http://127.0.0.1:1"),
+				PromptCachePolicy: string(PromptCachePolicyExplicit),
+			},
+		},
+	}
+	encoded, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal cache: %v", err)
+	}
+	if err := writeFileAtomic(cachePath, append(encoded, '\n'), 0o644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	if got := manager.cachedOpenRouterPromptCachePolicy(); got != PromptCachePolicyExplicit {
+		t.Fatalf("cached policy = %q, want explicit", got)
+	}
+}
+
+func TestBuildAgentProfileSystemPromptSectionsExposeCacheHints(t *testing.T) {
+	originalNow := promptNow
+	promptNow = func() time.Time {
+		return time.Date(2026, time.June, 1, 8, 0, 0, 0, time.FixedZone("CST", 8*60*60))
+	}
+	t.Cleanup(func() { promptNow = originalNow })
+
+	profile := buildAgentProfile(AgentConfig{}, ResolvedSkills{}, nil)
+	sections := profile.SystemPromptSections()
+	if len(sections) != 1 {
+		t.Fatalf("sections = %d, want single stable section without active skills", len(sections))
+	}
+	if !sections[0].CacheEphemeral {
+		t.Fatalf("stable section should be cacheable")
+	}
+	wantDate := "Current date: 2026-06-01"
+	if !strings.Contains(sections[0].Text, wantDate) {
+		t.Fatalf("stable section missing %q: %s", wantDate, sections[0].Text)
+	}
+
+	manager := context_manager.NewContextManager()
+	preparePlannerContextManager(manager, sections, nil, "hello", nil)
+	messages, hints := manager.ConvertToStandardMessageListWithCacheHints()
+	if len(messages[0].Parts) != 1 {
+		t.Fatalf("system parts = %d, want single stable part", len(messages[0].Parts))
+	}
+	if !hints.ShouldCache(0, 0) {
+		t.Fatalf("context hints should mark stable system part as cacheable: %#v", hints.EphemeralParts)
+	}
+}

--- a/src/agent/internal/agent/prompt_test.go
+++ b/src/agent/internal/agent/prompt_test.go
@@ -17,8 +17,8 @@ func TestRolePromptsIncludeCurrentDate(t *testing.T) {
 
 	want := "Current date: 2026-06-01 (星期一)"
 	profile := buildAgentProfile(AgentConfig{}, ResolvedSkills{}, nil)
-	if !strings.Contains(profile.SystemPrompt, want) {
-		t.Fatalf("system prompt missing current date %q:\n%s", want, profile.SystemPrompt)
+	if !strings.Contains(profile.SystemPrompt(), want) {
+		t.Fatalf("system prompt missing current date %q:\n%s", want, profile.SystemPrompt())
 	}
 }
 
@@ -33,11 +33,11 @@ func TestRolePromptsIncludeRealHostRuntimeInfo(t *testing.T) {
 	wantEnvironmentLine := "- You run on the Aiden hardware controller (" + wantLine + "); you are not the device shown in screenshots."
 
 	profile := buildAgentProfile(AgentConfig{}, ResolvedSkills{}, nil)
-	if !strings.Contains(profile.SystemPrompt, wantEnvironmentLine) {
-		t.Fatalf("system prompt missing host info in environment guidance %q:\n%s", wantEnvironmentLine, profile.SystemPrompt)
+	if !strings.Contains(profile.SystemPrompt(), wantEnvironmentLine) {
+		t.Fatalf("system prompt missing host info in environment guidance %q:\n%s", wantEnvironmentLine, profile.SystemPrompt())
 	}
-	if strings.Contains(profile.SystemPrompt, "kernel=") {
-		t.Fatalf("system prompt should not include kernel info:\n%s", profile.SystemPrompt)
+	if strings.Contains(profile.SystemPrompt(), "kernel=") {
+		t.Fatalf("system prompt should not include kernel info:\n%s", profile.SystemPrompt())
 	}
 }
 
@@ -93,8 +93,8 @@ func TestRolePromptsIncludeGlobalEnvironmentAndDeviceGuidance(t *testing.T) {
 		"request confirmation",
 		"Keep detailed UI playbooks in skills",
 	} {
-		if !strings.Contains(profile.SystemPrompt, want) {
-			t.Fatalf("system prompt missing %q:\n%s", want, profile.SystemPrompt)
+		if !strings.Contains(profile.SystemPrompt(), want) {
+			t.Fatalf("system prompt missing %q:\n%s", want, profile.SystemPrompt())
 		}
 	}
 
@@ -112,13 +112,13 @@ func TestRolePromptsIncludeGlobalEnvironmentAndDeviceGuidance(t *testing.T) {
 		"xdotool",
 		"kernel=",
 	} {
-		if strings.Contains(profile.SystemPrompt, unwanted) {
-			t.Fatalf("system prompt should not contain old localized guidance %q:\n%s", unwanted, profile.SystemPrompt)
+		if strings.Contains(profile.SystemPrompt(), unwanted) {
+			t.Fatalf("system prompt should not contain old localized guidance %q:\n%s", unwanted, profile.SystemPrompt())
 		}
 	}
 
-	if strings.Contains(profile.SystemPrompt, "Use long-term memory if relevant") {
-		t.Fatalf("system prompt should not contain legacy memory trigger:\n%s", profile.SystemPrompt)
+	if strings.Contains(profile.SystemPrompt(), "Use long-term memory if relevant") {
+		t.Fatalf("system prompt should not contain legacy memory trigger:\n%s", profile.SystemPrompt())
 	}
 }
 
@@ -210,15 +210,15 @@ func TestRolePromptsRequireToolCallSpeechForExternalStateTools(t *testing.T) {
 		"Do not put the final answer in tool-call assistant content",
 		"Do not use JSON, final_answer fields, or \"Final Answer:\" wrappers for final responses",
 	} {
-		if !strings.Contains(profile.SystemPrompt, want) {
-			t.Fatalf("prompt missing tool-call speech requirement %q:\n%s", want, profile.SystemPrompt)
+		if !strings.Contains(profile.SystemPrompt(), want) {
+			t.Fatalf("prompt missing tool-call speech requirement %q:\n%s", want, profile.SystemPrompt())
 		}
 	}
-	if strings.Contains(profile.SystemPrompt, "user-visible tool") {
-		t.Fatalf("prompt should not use ambiguous user-visible tool wording:\n%s", profile.SystemPrompt)
+	if strings.Contains(profile.SystemPrompt(), "user-visible tool") {
+		t.Fatalf("prompt should not use ambiguous user-visible tool wording:\n%s", profile.SystemPrompt())
 	}
-	if strings.Contains(profile.SystemPrompt, "When voice tool-call speech is enabled") {
-		t.Fatalf("prompt should not ask the model to reason about whether voice tool-call speech is enabled:\n%s", profile.SystemPrompt)
+	if strings.Contains(profile.SystemPrompt(), "When voice tool-call speech is enabled") {
+		t.Fatalf("prompt should not ask the model to reason about whether voice tool-call speech is enabled:\n%s", profile.SystemPrompt())
 	}
 }
 
@@ -247,8 +247,8 @@ func TestRolePromptsGuideSkillCatalogAndPreloadedSkills(t *testing.T) {
 		"## Active skills",
 		"[planner] Make a plan.",
 	} {
-		if !strings.Contains(profile.SystemPrompt, want) {
-			t.Fatalf("system prompt missing %q:\n%s", want, profile.SystemPrompt)
+		if !strings.Contains(profile.SystemPrompt(), want) {
+			t.Fatalf("system prompt missing %q:\n%s", want, profile.SystemPrompt())
 		}
 	}
 }
@@ -260,12 +260,12 @@ func TestRolePromptOmitsRuntimeAndMemoryContext(t *testing.T) {
 		nil,
 	)
 
-	if !strings.Contains(profile.SystemPrompt, "## Role rules") {
-		t.Fatalf("prompt missing role rules section:\n%s", profile.SystemPrompt)
+	if !strings.Contains(profile.SystemPrompt(), "## Role rules") {
+		t.Fatalf("prompt missing role rules section:\n%s", profile.SystemPrompt())
 	}
 	for _, unwanted := range []string{"## Runtime context", "Phone bridge status", "session memory tail"} {
-		if strings.Contains(profile.SystemPrompt, unwanted) {
-			t.Fatalf("system prompt should not include dynamic context %q:\n%s", unwanted, profile.SystemPrompt)
+		if strings.Contains(profile.SystemPrompt(), unwanted) {
+			t.Fatalf("system prompt should not include dynamic context %q:\n%s", unwanted, profile.SystemPrompt())
 		}
 	}
 }

--- a/src/agent/internal/agent/role_profile.go
+++ b/src/agent/internal/agent/role_profile.go
@@ -3,13 +3,36 @@ package agent
 import (
 	"strings"
 
+	"aiden-agent/internal/agent/context_manager"
+
 	langtools "github.com/tmc/langchaingo/tools"
 )
 
 type RoleProfile struct {
-	SystemPrompt              string
-	Skills                    ResolvedSkills
-	Tools                     []langtools.Tool
+	SystemPromptStable  string
+	SystemPromptDynamic string
+	Skills              ResolvedSkills
+	Tools               []langtools.Tool
+}
+
+// SystemPrompt returns the combined system prompt for logging and legacy checks.
+func (p RoleProfile) SystemPrompt() string {
+	return context_manager.JoinPromptSections(p.SystemPromptSections())
+}
+
+// SystemPromptSections returns cacheable system prompt sections for ContextManager.
+func (p RoleProfile) SystemPromptSections() []context_manager.PromptSection {
+	sections := make([]context_manager.PromptSection, 0, 2)
+	if text := strings.TrimSpace(p.SystemPromptStable); text != "" {
+		sections = append(sections, context_manager.PromptSection{
+			Text:           text,
+			CacheEphemeral: true,
+		})
+	}
+	if text := strings.TrimSpace(p.SystemPromptDynamic); text != "" {
+		sections = append(sections, context_manager.PromptSection{Text: text})
+	}
+	return sections
 }
 
 func buildAgentProfile(cfg AgentConfig, skills ResolvedSkills, availableTools []langtools.Tool) RoleProfile {
@@ -66,7 +89,6 @@ func buildRoleProfile(
 ) RoleProfile {
 	staticParts := []string{
 		"You are the Aiden agent.",
-		currentDateContext(),
 		"",
 		"## Base instruction",
 		combinedAgentInstruction(cfg),
@@ -80,23 +102,21 @@ func buildRoleProfile(
 		"## Available skills",
 		skills.CatalogSummary(),
 	}
-	if text := strings.TrimSpace(skills.CombinedInstructions()); text != "" {
-		staticParts = append(staticParts,
-			"",
-			"## Active skills",
-			text,
-		)
-	}
 	staticParts = append(staticParts, "", "## Role rules")
 	for _, rule := range roleRules {
 		staticParts = append(staticParts, "- "+rule)
 	}
+	staticParts = append(staticParts, "", currentDateContext())
 
-	staticPrompt := strings.Join(staticParts, "\n")
+	dynamicParts := make([]string, 0, 1)
+	if text := strings.TrimSpace(skills.CombinedInstructions()); text != "" {
+		dynamicParts = append(dynamicParts, "## Active skills", text)
+	}
 
 	return RoleProfile{
-		SystemPrompt:              staticPrompt,
-		Skills:                    skills,
-		Tools:                     append([]langtools.Tool{}, tools...),
+		SystemPromptStable:  strings.Join(staticParts, "\n"),
+		SystemPromptDynamic: strings.Join(dynamicParts, "\n"),
+		Skills:              skills,
+		Tools:               append([]langtools.Tool{}, tools...),
 	}
 }

--- a/src/agent/internal/agent/single_agent_test.go
+++ b/src/agent/internal/agent/single_agent_test.go
@@ -17,13 +17,13 @@ func TestSingleAgentProfileDoesNotBuildDelegatedRoles(t *testing.T) {
 	)
 
 	for _, want := range []string{"base", "extra", "[ui] inspect first", "You are the Aiden agent."} {
-		if !strings.Contains(profile.SystemPrompt, want) {
-			t.Fatalf("agent prompt missing %q:\n%s", want, profile.SystemPrompt)
+		if !strings.Contains(profile.SystemPrompt(), want) {
+			t.Fatalf("agent prompt missing %q:\n%s", want, profile.SystemPrompt())
 		}
 	}
 	for _, unexpected := range []string{"enter_plan_mode", "commit_plan", "cancel_plan", "planner role", "executor role", "verifier role"} {
-		if strings.Contains(profile.SystemPrompt, unexpected) {
-			t.Fatalf("agent prompt should not contain old delegated role wording %q:\n%s", unexpected, profile.SystemPrompt)
+		if strings.Contains(profile.SystemPrompt(), unexpected) {
+			t.Fatalf("agent prompt should not contain old delegated role wording %q:\n%s", unexpected, profile.SystemPrompt())
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- split stable and dynamic system prompt sections so OpenRouter can cache stable prompt prefixes
- detect explicit prompt-cache support from OpenRouter endpoint metadata and cache the policy
- propagate prompt cache hints through the executor into OpenAI-compatible request encoding

## Tests
- go test ./internal/agent/...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System prompts are now split into stable and dynamic sections, enabling finer-grained prompt handling and better cache reuse.
  * Prompt content can now be preserved and tracked as separate sections for more accurate model requests.

* **Bug Fixes**
  * Improved how system prompts are sent to models, helping ensure cached and non-cached parts are handled correctly.
  * Updated model metadata handling so prompt-cache behavior persists across refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->