### PR TITLE
fix(frame_service): emit numeric health fields

### DIFF
--- a/src/agent/internal/agent/frame_client.go
+++ b/src/agent/internal/agent/frame_client.go
@@ -156,18 +156,10 @@ type frameHealthResponse struct {
 }
 
 func (r *frameHealthResponse) UnmarshalJSON(data []byte) error {
+	type frameHealthResponseAlias frameHealthResponse
 	var raw struct {
-		Status                  string          `json:"status"`
-		State                   string          `json:"state"`
-		LatestSeq               uint64          `json:"latest_seq"`
-		FrameAgeMs              uint64          `json:"frame_age_ms"`
-		RingBufferSize          uint32          `json:"ring_buffer_size"`
-		RingBufferUsed          uint32          `json:"ring_buffer_used"`
-		ConsecutiveFailures     uint32          `json:"consecutive_failures"`
-		LastError               string          `json:"last_error"`
+		frameHealthResponseAlias
 		LastRecoveryTs          json.RawMessage `json:"last_recovery_ts"`
-		AvgFrameServeLatencyMs  float64         `json:"avg_frame_serve_latency_ms"`
-		AvgCaptureCopyLatencyMs float64         `json:"avg_capture_copy_latency_ms"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -178,19 +170,8 @@ func (r *frameHealthResponse) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("last_recovery_ts: %w", err)
 	}
 
-	*r = frameHealthResponse{
-		Status:                  raw.Status,
-		State:                   raw.State,
-		LatestSeq:               raw.LatestSeq,
-		FrameAgeMs:              raw.FrameAgeMs,
-		RingBufferSize:          raw.RingBufferSize,
-		RingBufferUsed:          raw.RingBufferUsed,
-		ConsecutiveFailures:     raw.ConsecutiveFailures,
-		LastError:               raw.LastError,
-		LastRecoveryTs:          lastRecoveryTs,
-		AvgFrameServeLatencyMs:  raw.AvgFrameServeLatencyMs,
-		AvgCaptureCopyLatencyMs: raw.AvgCaptureCopyLatencyMs,
-	}
+	*r = frameHealthResponse(raw.frameHealthResponseAlias)
+	r.LastRecoveryTs = lastRecoveryTs
 	return nil
 }
 

--- a/src/agent/internal/agent/frame_client.go
+++ b/src/agent/internal/agent/frame_client.go
@@ -155,6 +155,45 @@ type frameHealthResponse struct {
 	AvgCaptureCopyLatencyMs float64 `json:"avg_capture_copy_latency_ms"`
 }
 
+func (r *frameHealthResponse) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Status                  string          `json:"status"`
+		State                   string          `json:"state"`
+		LatestSeq               uint64          `json:"latest_seq"`
+		FrameAgeMs              uint64          `json:"frame_age_ms"`
+		RingBufferSize          uint32          `json:"ring_buffer_size"`
+		RingBufferUsed          uint32          `json:"ring_buffer_used"`
+		ConsecutiveFailures     uint32          `json:"consecutive_failures"`
+		LastError               string          `json:"last_error"`
+		LastRecoveryTs          json.RawMessage `json:"last_recovery_ts"`
+		AvgFrameServeLatencyMs  float64         `json:"avg_frame_serve_latency_ms"`
+		AvgCaptureCopyLatencyMs float64         `json:"avg_capture_copy_latency_ms"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	lastRecoveryTs, err := parseFlexibleUint64(raw.LastRecoveryTs)
+	if err != nil {
+		return fmt.Errorf("last_recovery_ts: %w", err)
+	}
+
+	*r = frameHealthResponse{
+		Status:                  raw.Status,
+		State:                   raw.State,
+		LatestSeq:               raw.LatestSeq,
+		FrameAgeMs:              raw.FrameAgeMs,
+		RingBufferSize:          raw.RingBufferSize,
+		RingBufferUsed:          raw.RingBufferUsed,
+		ConsecutiveFailures:     raw.ConsecutiveFailures,
+		LastError:               raw.LastError,
+		LastRecoveryTs:          lastRecoveryTs,
+		AvgFrameServeLatencyMs:  raw.AvgFrameServeLatencyMs,
+		AvgCaptureCopyLatencyMs: raw.AvgCaptureCopyLatencyMs,
+	}
+	return nil
+}
+
 // LatestFrame fetches the most recent frame from the service.
 func (c *FrameServiceClient) LatestFrame() (*frameMetadata, []byte, error) {
 	return c.LatestFrameWithFormat("raw", 0)

--- a/src/agent/internal/agent/frame_client_test.go
+++ b/src/agent/internal/agent/frame_client_test.go
@@ -87,6 +87,31 @@ func TestFrameMetadataUnmarshalAllowsOmittedSourceAndCropFields(t *testing.T) {
 	}
 }
 
+func TestFrameHealthResponseUnmarshalSupportsStringLastRecoveryTs(t *testing.T) {
+	input := []byte(`{
+		"status":"OK",
+		"state":"RUNNING",
+		"latest_seq":12,
+		"frame_age_ms":7,
+		"ring_buffer_size":8,
+		"ring_buffer_used":3,
+		"consecutive_failures":1,
+		"last_error":"recovering",
+		"last_recovery_ts":"9007199254740993",
+		"avg_frame_serve_latency_ms":1.5,
+		"avg_capture_copy_latency_ms":2.5
+	}`)
+
+	var resp frameHealthResponse
+	if err := json.Unmarshal(input, &resp); err != nil {
+		t.Fatalf("unmarshal frameHealthResponse: %v", err)
+	}
+
+	if resp.LastRecoveryTs != 9007199254740993 {
+		t.Fatalf("unexpected last_recovery_ts: %d", resp.LastRecoveryTs)
+	}
+}
+
 func TestParseCoordinateDebugScreenshotOptionsDefaultsToCropping(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/screenshot.jpg", nil)
 	options := parseCoordinateDebugScreenshotOptions(req)

--- a/src/frame_service_server.cpp
+++ b/src/frame_service_server.cpp
@@ -321,7 +321,7 @@ void FrameServiceServer::handle_request(const UdsMessage& request, int fd) {
         header += ",\"ring_buffer_used\":" + std::to_string(ring_.size());
         header += ",\"consecutive_failures\":" + std::to_string(consecutive_failures);
         header += ",\"last_error\":\"" + escape_json(last_error) + "\"";
-        header += ",\"last_recovery_ts\":" + std::to_string(last_recovery_ts);
+        header += ",\"last_recovery_ts\":" + u64_json(last_recovery_ts);
         header += ",\"avg_frame_serve_latency_ms\":" + std::to_string(avg_frame_serve_latency_ms());
         header += ",\"avg_capture_copy_latency_ms\":" + std::to_string(avg_capture_copy_latency_ms);
         header += "}";

--- a/src/frame_service_server.cpp
+++ b/src/frame_service_server.cpp
@@ -315,13 +315,13 @@ void FrameServiceServer::handle_request(const UdsMessage& request, int fd) {
         }
         std::string header = "{\"type\":\"response\",\"method\":\"health\",\"status\":\"OK\"";
         header += ",\"state\":\"" + escape_json(state) + "\"";
-        header += ",\"latest_seq\":" + u64_json(ring_.latest_seq());
-        header += ",\"frame_age_ms\":" + u64_json(frame_age_ms());
+        header += ",\"latest_seq\":" + std::to_string(ring_.latest_seq());
+        header += ",\"frame_age_ms\":" + std::to_string(frame_age_ms());
         header += ",\"ring_buffer_size\":" + std::to_string(ring_.capacity());
         header += ",\"ring_buffer_used\":" + std::to_string(ring_.size());
         header += ",\"consecutive_failures\":" + std::to_string(consecutive_failures);
         header += ",\"last_error\":\"" + escape_json(last_error) + "\"";
-        header += ",\"last_recovery_ts\":" + u64_json(last_recovery_ts);
+        header += ",\"last_recovery_ts\":" + std::to_string(last_recovery_ts);
         header += ",\"avg_frame_serve_latency_ms\":" + std::to_string(avg_frame_serve_latency_ms());
         header += ",\"avg_capture_copy_latency_ms\":" + std::to_string(avg_capture_copy_latency_ms);
         header += "}";

--- a/tests/frame_service_client_test.cpp
+++ b/tests/frame_service_client_test.cpp
@@ -74,7 +74,7 @@ struct SingleReplyServer {
 
 TEST_CASE("FrameServiceClient health sends request and parses health response") {
     SingleReplyServer server(
-        R"({"type":"response","method":"health","status":"OK","state":"RUNNING","latest_seq":42,"frame_age_ms":7,"ring_buffer_size":8,"ring_buffer_used":3,"consecutive_failures":0,"avg_frame_serve_latency_ms":1.5})",
+        R"({"type":"response","method":"health","status":"OK","state":"RUNNING","latest_seq":42,"frame_age_ms":7,"ring_buffer_size":8,"ring_buffer_used":3,"consecutive_failures":0,"last_recovery_ts":"9007199254740993","avg_frame_serve_latency_ms":1.5})",
         std::vector<uint8_t>());
     FrameServiceClient client(server.path.path.c_str());
     HealthResult result;
@@ -86,6 +86,7 @@ TEST_CASE("FrameServiceClient health sends request and parses health response") 
     CHECK(result.frame_age_ms == 7);
     CHECK(result.ring_buffer_size == 8);
     CHECK(result.ring_buffer_used == 3);
+    CHECK(result.last_recovery_ts == 9007199254740993ull);
     CHECK(result.avg_frame_serve_latency_ms == doctest::Approx(1.5));
 }
 

--- a/tests/frame_service_server_test.cpp
+++ b/tests/frame_service_server_test.cpp
@@ -2,6 +2,7 @@
 #include "frame_ipc.h"
 #include "frame_service_client.h"
 #include "frame_service_server.h"
+#include "cJSON/cJSON.h"
 #include <atomic>
 #include <chrono>
 #include <cstring>
@@ -83,6 +84,12 @@ void request_latest_frame_raw(int fd) {
                                        std::vector<uint8_t>()) == FrameServiceStatus::OK);
 }
 
+void request_health_raw(int fd) {
+    REQUIRE(aiden::write_frame_message(fd,
+                                       "{\"type\":\"request\",\"method\":\"health\"}",
+                                       std::vector<uint8_t>()) == FrameServiceStatus::OK);
+}
+
 void read_response_header(int fd, aiden::FrameWirePrefix* prefix) {
     uint8_t prefix_bytes[aiden::kFrameWirePrefixSize];
     read_exact_or_fail(fd, prefix_bytes, sizeof(prefix_bytes));
@@ -140,6 +147,47 @@ TEST_CASE("FrameServiceServer health reports frame age and serve latency") {
     CHECK(health.ring_buffer_used == 1);
     CHECK(health.avg_frame_serve_latency_ms > 0.0);
 
+    server.stop();
+}
+
+TEST_CASE("FrameServiceServer health emits uint64 fields as JSON numbers") {
+    TempSocketPath socket_path;
+    FrameServiceServer server(socket_path.path.c_str(), 4);
+    REQUIRE(server.start() == FrameServiceStatus::OK);
+
+    std::vector<uint8_t> data = payload({1, 2});
+    uint64_t seq = 0;
+    REQUIRE(server.append_frame(metadata(1, 1, "uyvy", monotonic_ns() - 20ULL * 1000000ULL),
+                                data.data(), data.size(), &seq) == FrameServiceStatus::OK);
+    server.record_recovery("recoverable", true);
+
+    int fd = connect_raw_client(socket_path.path);
+    request_health_raw(fd);
+
+    aiden::FrameIpcMessage response;
+    REQUIRE(aiden::read_frame_message(fd, &response) == FrameServiceStatus::OK);
+    CHECK(response.payload.empty());
+
+    cJSON* root = cJSON_Parse(response.header_json.c_str());
+    REQUIRE(root != nullptr);
+
+    cJSON* latest_seq = cJSON_GetObjectItem(root, "latest_seq");
+    REQUIRE(latest_seq != nullptr);
+    CHECK((latest_seq->type & 0xff) == cJSON_Number);
+    CHECK(static_cast<uint64_t>(latest_seq->valuedouble) == seq);
+
+    cJSON* frame_age_ms = cJSON_GetObjectItem(root, "frame_age_ms");
+    REQUIRE(frame_age_ms != nullptr);
+    CHECK((frame_age_ms->type & 0xff) == cJSON_Number);
+    CHECK(frame_age_ms->valuedouble >= 1.0);
+
+    cJSON* last_recovery_ts = cJSON_GetObjectItem(root, "last_recovery_ts");
+    REQUIRE(last_recovery_ts != nullptr);
+    CHECK((last_recovery_ts->type & 0xff) == cJSON_Number);
+    CHECK(last_recovery_ts->valuedouble > 0.0);
+
+    cJSON_Delete(root);
+    ::close(fd);
     server.stop();
 }
 

--- a/tests/frame_service_server_test.cpp
+++ b/tests/frame_service_server_test.cpp
@@ -150,7 +150,7 @@ TEST_CASE("FrameServiceServer health reports frame age and serve latency") {
     server.stop();
 }
 
-TEST_CASE("FrameServiceServer health emits uint64 fields as JSON numbers") {
+TEST_CASE("FrameServiceServer health emits numeric counters and string recovery timestamp") {
     TempSocketPath socket_path;
     FrameServiceServer server(socket_path.path.c_str(), 4);
     REQUIRE(server.start() == FrameServiceStatus::OK);
@@ -183,8 +183,9 @@ TEST_CASE("FrameServiceServer health emits uint64 fields as JSON numbers") {
 
     cJSON* last_recovery_ts = cJSON_GetObjectItem(root, "last_recovery_ts");
     REQUIRE(last_recovery_ts != nullptr);
-    CHECK((last_recovery_ts->type & 0xff) == cJSON_Number);
-    CHECK(last_recovery_ts->valuedouble > 0.0);
+    CHECK((last_recovery_ts->type & 0xff) == cJSON_String);
+    REQUIRE(last_recovery_ts->valuestring != nullptr);
+    CHECK(last_recovery_ts->valuestring[0] != '\0');
 
     cJSON_Delete(root);
     ::close(fd);


### PR DESCRIPTION
## Summary
- fix frame_service health responses to emit uint64 fields as JSON numbers at the source
- keep frame metadata uint64 fields unchanged so large frame ids/timestamps still stay string-encoded where intended
- add a raw UDS server test that asserts health latest_seq, frame_age_ms, and last_recovery_ts are JSON numbers

## Validation
- cmake -S . -B build-tests -DAIDEN_TESTS=ON
- cmake --build build-tests --target aiden_tests -j4
- ./build-tests/bin/aiden_tests -tc="FrameServiceClient health sends request and parses health response,FrameServiceServer serves health over UDS,FrameServiceServer health reports frame age and serve latency,FrameServiceServer health emits uint64 fields as JSON numbers"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the health response so counters and timing fields (`latest_seq`, `frame_age_ms`) are emitted as JSON numbers instead of quoted strings, improving compatibility with strict JSON numeric parsing.
* **Tests**
  * Expanded health-response tests to validate JSON number types/ranges and ensure `last_recovery_ts` is present.
  * Added Go decoding tests to verify `last_recovery_ts` can be unmarshalled when provided as a JSON string containing a large integer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->