### PR TITLE
fix(agent): shorten stable screen wait defaults

### DIFF
--- a/src/agent/internal/agent/tool_spec.go
+++ b/src/agent/internal/agent/tool_spec.go
@@ -207,7 +207,7 @@ var builtInToolSpecMetadata = map[string]toolSpecMetadata{
 	"wait_for_stable_screen": {
 		Category:     "observation",
 		InputMode:    toolInputModeJSON,
-		ExampleInput: `{"timeout_ms":3500,"stable_ms":500,"diff_threshold":2}`,
+		ExampleInput: `{"timeout_ms":2200,"stable_ms":250,"diff_threshold":6}`,
 	},
 	"request_human_handoff": {
 		Category:     "handoff",

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -736,7 +736,7 @@ func TestPostActionScreenshotToolFallsBackScreenshotWhenScreenUnstable(t *testin
 	if result.Data != "ZmFrZQ==" {
 		t.Fatalf("screenshot data = %q, want fallback capture", result.Data)
 	}
-	if len(waitStable.inputs) != 1 || waitStable.inputs[0] != `{"timeout_ms":3000,"stable_ms":500,"diff_threshold":5}` {
+	if len(waitStable.inputs) != 1 || waitStable.inputs[0] != `{"timeout_ms":3000,"stable_ms":500,"diff_threshold":6}` {
 		t.Fatalf("wait stable inputs = %#v", waitStable.inputs)
 	}
 	if len(screenshot.inputs) != 1 {

--- a/src/agent/internal/agent/tools_wait_stable.go
+++ b/src/agent/internal/agent/tools_wait_stable.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	defaultStableWaitTimeoutMs = 3500
-	defaultStableDurationMs    = 400
-	defaultDiffThreshold       = 5.0
+	defaultStableWaitTimeoutMs = 2200
+	defaultStableDurationMs    = 250
+	defaultDiffThreshold       = 6.0
 	stableWaitPollInterval     = 200 * time.Millisecond
 )
 


### PR DESCRIPTION
## Summary
- shorten default wait_for_stable_screen timeout and stable window
- raise the default diff threshold to tolerate minor frame changes
- update the tool example and affected post-action screenshot test expectation

## Tests
- go test ./internal/agent -run 'TestWaitStable|TestPostActionScreenshotToolFallsBackScreenshotWhenScreenUnstable|TestToolDescriptorsInclude|TestConfigDefaults|TestLoadConfig'
- go test ./internal/agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default screen-stability wait behavior to respond faster and use a slightly more tolerant change threshold.
  * Refreshed the built-in example values for stability waiting so they match the current defaults.
  * Adjusted automated checks to reflect the updated stability-detection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->