### PR TITLE
feat(agent): route Android FGS bridge queue

### DIFF
--- a/docs/04-agent/phone-bridge-protocol.md
+++ b/docs/04-agent/phone-bridge-protocol.md
@@ -15,6 +15,8 @@ WebSocket is the foreground fast path. The board also exposes `/api/phone-bridge
 
 PiP Bridge is a narrow background queue mode. When the app reports `pip_bridge_enabled=true` while backgrounded, iOS gives PiP priority over the Dynamic Island, so the Dynamic Island return entry is not visible. In that state, the board must not expose `bridge_open_app` as a Phone Bridge tool; only background-safe data tools (`bridge_clipboard`, `bridge_calendar`, `bridge_contacts`, `bridge_notification`) backed by command types (`clipboard_*`, `calendar_*`, `contacts_*`, `notification_send`) may use the HTTP queue.
 
+Android FGS Bridge is also an HTTP queue mode. The foreground service polls `/api/phone-bridge/commands?platform=android&phone_id=<stable>&app_state=background&fgs_bridge_enabled=true&limit=10`; the board treats that as a background queue consumer for background-safe data commands only. It does not treat WebSocket as a reliable Android background transport, and it does not expose `open_app` through the FGS queue.
+
 ## Heartbeat
 
 The app should send a heartbeat message every 10-15 seconds (JSON with id `"heartbeat"` or `"ping"`), and the board will echo it back. The app uses this to detect connection liveness.
@@ -117,7 +119,7 @@ Example:
 }
 ```
 
-The board writes the latest complete environment to the `environment` field of `GET /api/phone-bridge/status`, and keeps `app_state`, `return_entry`, `return_entry_available`, and `pip_bridge_enabled` for Agent runtime context and tool resolution. Runtime context carries compact state facts such as connection status, app foreground/background state, return-entry visibility, PiP/Dynamic Island visibility state, system type/version, language/region/timezone, screen dimensions, and confirmed openable third-party candidate apps. Tool availability is resolved separately: PiP background state hides `bridge_open_app` and keeps only background-safe data tools exposed through the HTTP queue. Environment is cleared on disconnection to avoid using stale information, but the latest app foreground/background state can be retained to decide whether Aiden should be restored through Dynamic Island first.
+The board writes the latest complete environment to the `environment` field of `GET /api/phone-bridge/status`, and keeps `app_state`, `return_entry`, `return_entry_available`, `pip_bridge_enabled`, and `fgs_bridge_enabled` for Agent runtime context and tool resolution. Runtime context carries compact state facts such as connection status, app foreground/background state, return-entry visibility, PiP/Dynamic Island visibility state, Android FGS bridge state, system type/version, language/region/timezone, screen dimensions, and confirmed openable third-party candidate apps. Tool availability is resolved separately: PiP/FGS background state hides `bridge_open_app` and keeps only background-safe data tools exposed through the HTTP queue. Environment is cleared on disconnection to avoid using stale information, but the latest app foreground/background state can be retained to decide whether Aiden should be restored through Dynamic Island first.
 
 `phone_app_state` example:
 

--- a/docs/04-agent/phone-bridge.md
+++ b/docs/04-agent/phone-bridge.md
@@ -41,6 +41,8 @@ The board also exposes `/api/phone-bridge/commands` and `/api/phone-bridge/resul
 
 PiP Bridge is a narrow exception. When the app reports `pip_bridge_enabled=true` while backgrounded, iOS gives PiP priority over the Dynamic Island, so the Dynamic Island return entry is not visible. In that state, the Agent dynamically removes `bridge_open_app` from the Phone Bridge tool catalog and keeps only background-safe data tools (`bridge_clipboard`, `bridge_calendar`, `bridge_contacts`, `bridge_notification`) available through the HTTP queue.
 
+Android FGS Bridge follows the same HTTP queue contract without using WebSocket as a background transport. When the Android foreground service polls `/api/phone-bridge/commands` with `app_state=background` and `fgs_bridge_enabled=true`, the Agent keeps `open_app` unavailable and routes only background-safe data tools through the HTTP queue.
+
 ## App Opening Flow
 
 ```text
@@ -173,12 +175,12 @@ WebSocket's core value:
 2. Relay app auto-connects to `ws://192.168.42.1:8080/api/phone-bridge` after startup.
 3. App sends periodic heartbeat.
 4. App actively reports `phone_environment` upon connection success and returning from background to foreground, including system version, language/region, timezone, screen/battery, system apps, third-party candidate app availability, etc.
-5. App reports `phone_app_state` when the visible lifecycle state changes among `active`, `background`, and `inactive`, including any available Dynamic Island / Live Activity return entry and PiP Bridge state.
-6. Board maintains `bridge_connected`, `platform`, `last_heartbeat_at`, `app_state`, `return_entry`, `return_entry_available`, `pip_bridge_enabled`, and `environment` status. Complete environment is exposed through status API; Agent runtime context only injects summarized connection state, app foreground/background state, return entry visibility, PiP/Dynamic Island visibility state, system type/version, language/region/timezone, screen dimensions, confirmed openable third-party candidate apps, etc.
+5. App reports `phone_app_state` when the visible lifecycle state changes among `active`, `background`, and `inactive`, including any available Dynamic Island / Live Activity return entry and PiP Bridge state. Android FGS Bridge reports `fgs_bridge_enabled` through HTTP queue polling.
+6. Board maintains `bridge_connected`, `platform`, `last_heartbeat_at`, `app_state`, `return_entry`, `return_entry_available`, `pip_bridge_enabled`, `fgs_bridge_enabled`, and `environment` status. Complete environment is exposed through status API; Agent runtime context only injects summarized connection state, app foreground/background state, return entry visibility, background bridge state, system type/version, language/region/timezone, screen dimensions, confirmed openable third-party candidate apps, etc.
 
 `bridge_connected` only means the WebSocket is currently active. It is not equivalent to USB cable connectivity. After the iOS app enters background, WebSocket may disconnect while USB ECM remains reachable; real-time background Dynamic Island updates should go through Live Activity relay/APNs, not the phone bridge WebSocket.
 
-When `app_state=background|inactive`, `return_entry=dynamic_island`, `return_entry_available=true`, and PiP Bridge mode is not enabled, Phone Bridge tools directly click the Aiden Dynamic Island entry, wait for Phone Bridge recovery, then send commands through tools such as `bridge_open_app` or `bridge_clipboard`. Lock-screen Live Activity entries are not blind-tapped because their screen position is not stable; use screenshot/HID fallback or visual confirmation instead. When `pip_bridge_enabled=true` in the background, PiP hides Dynamic Island; `bridge_open_app` is not exposed, and only background-safe data tools use the HTTP command queue.
+When `app_state=background|inactive`, `return_entry=dynamic_island`, `return_entry_available=true`, and PiP Bridge mode is not enabled, Phone Bridge tools directly click the Aiden Dynamic Island entry, wait for Phone Bridge recovery, then send commands through tools such as `bridge_open_app` or `bridge_clipboard`. Lock-screen Live Activity entries are not blind-tapped because their screen position is not stable; use screenshot/HID fallback or visual confirmation instead. When `pip_bridge_enabled=true` on iOS or `fgs_bridge_enabled=true` on Android in the background, `bridge_open_app` is not exposed, and only background-safe data tools use the HTTP command queue.
 
 ### Command Protocol
 
@@ -517,8 +519,9 @@ The board-side `current_time` tool can provide the model with current timezone b
 
 7. If the iOS Aiden app is backgrounded and `return_entry=dynamic_island` with `return_entry_available=true`, and PiP Bridge mode is not enabled, Phone Bridge tools first click Dynamic Island to restore Aiden, wait for foreground bridge reconnection, then send `bridge_open_app`, `bridge_clipboard`, `bridge_calendar`, `bridge_contacts`, or `bridge_notification` commands.
 8. If `pip_bridge_enabled=true` while Aiden is backgrounded, board-side tool resolution hides `bridge_open_app`; `bridge_clipboard`, `bridge_calendar`, `bridge_contacts`, and `bridge_notification` commands can be routed through the HTTP command queue.
-9. Board then verifies via HDMI whether target app opened (only `bridge_open_app`).
-10. Verification failure auto-fallback to HID (only `bridge_open_app`; `bridge_clipboard`/`bridge_calendar`/`bridge_contacts`/`bridge_notification` have no reliable HID/API fallback when neither foreground WebSocket nor PiP-mode HTTP polling is available. If no usable foreground restore path or PiP queue is available, the tool returns a clear bridge unavailable error).
+9. If Android FGS polls with `fgs_bridge_enabled=true` while Aiden is backgrounded, board-side tool resolution hides `bridge_open_app`; `bridge_clipboard`, `bridge_calendar`, `bridge_contacts`, and `bridge_notification` commands can be routed through the HTTP command queue.
+10. Board then verifies via HDMI whether target app opened (only `bridge_open_app`).
+11. Verification failure auto-fallback to HID (only `bridge_open_app`; `bridge_clipboard`/`bridge_calendar`/`bridge_contacts`/`bridge_notification` have no reliable HID/API fallback when neither foreground WebSocket nor PiP/FGS HTTP polling is available. If no usable foreground restore path or background queue is available, the tool returns a clear bridge unavailable error).
 
 ## Final Positioning
 

--- a/src/agent/internal/agent/phone_bridge.go
+++ b/src/agent/internal/agent/phone_bridge.go
@@ -110,6 +110,8 @@ type PhoneBridgeStatus struct {
 	ReturnEntry          string            `json:"return_entry,omitempty"`
 	ReturnEntryAvailable *bool             `json:"return_entry_available,omitempty"`
 	PipBridgeEnabled     *bool             `json:"pip_bridge_enabled,omitempty"`
+	FgsBridgeEnabled     *bool             `json:"fgs_bridge_enabled,omitempty"`
+	FgsBridgeUpdatedAt   *time.Time        `json:"fgs_bridge_updated_at,omitempty"`
 	Environment          *PhoneEnvironment `json:"environment,omitempty"`
 	EnvironmentUpdatedAt *time.Time        `json:"environment_updated_at,omitempty"`
 }
@@ -128,6 +130,9 @@ type PhoneBridge struct {
 	returnEntrySeen  bool
 	pipBridgeEnabled bool
 	pipBridgeSeen    bool
+	fgsBridgeEnabled bool
+	fgsBridgeSeen    bool
+	fgsBridgeAt      time.Time
 	environment      *PhoneEnvironment
 	environmentAt    time.Time
 	clipboardText    string
@@ -608,6 +613,14 @@ func (pb *PhoneBridge) Status() PhoneBridgeStatus {
 		enabled := pb.pipBridgeEnabled
 		status.PipBridgeEnabled = &enabled
 	}
+	if pb.fgsBridgeSeen {
+		enabled := pb.fgsBridgeEnabled
+		status.FgsBridgeEnabled = &enabled
+		if !pb.fgsBridgeAt.IsZero() {
+			t := pb.fgsBridgeAt
+			status.FgsBridgeUpdatedAt = &t
+		}
+	}
 	if pb.connected && pb.environment != nil {
 		env := clonePhoneEnvironment(*pb.environment)
 		status.Environment = &env
@@ -636,7 +649,8 @@ func phoneBridgeRuntimeContext(status PhoneBridgeStatus) string {
 	if !status.Connected &&
 		strings.TrimSpace(status.AppState) == "" &&
 		strings.TrimSpace(status.Platform) == "" &&
-		status.PipBridgeEnabled == nil {
+		status.PipBridgeEnabled == nil &&
+		status.FgsBridgeEnabled == nil {
 		return ""
 	}
 	var builder strings.Builder
@@ -698,6 +712,16 @@ func phoneBridgeRuntimeContext(status PhoneBridgeStatus) string {
 		builder.WriteByte(' ')
 		builder.WriteString("(PiP mode in the background can hide the Dynamic Island return entry)\n")
 	}
+	if status.FgsBridgeEnabled != nil {
+		builder.WriteString("- fgs_bridge: ")
+		builder.WriteString("enabled=")
+		builder.WriteString(fmt.Sprintf("%t", *status.FgsBridgeEnabled))
+		if status.FgsBridgeUpdatedAt != nil {
+			builder.WriteString(" updated_at=")
+			builder.WriteString(status.FgsBridgeUpdatedAt.UTC().Format(time.RFC3339))
+		}
+		builder.WriteByte('\n')
+	}
 	if status.Environment != nil {
 		builder.WriteString("- device environment is available in World State for structured use\n")
 		if status.EnvironmentUpdatedAt != nil {
@@ -706,7 +730,9 @@ func phoneBridgeRuntimeContext(status PhoneBridgeStatus) string {
 			builder.WriteByte('\n')
 		}
 	}
-	if phoneBridgePiPBackgroundEnabled(status) {
+	if phoneBridgeFGSBackgroundEnabled(status) {
+		builder.WriteString("- Android Foreground Service bridge is enabled while Aiden is backgrounded. Background-safe data tools can run through the HTTP command queue; open_app and UI actions still require foreground app control or HID fallback.\n")
+	} else if phoneBridgePiPBackgroundEnabled(status) {
 		builder.WriteString("- PiP Bridge mode is enabled while Aiden is backgrounded. iOS gives PiP priority over the Dynamic Island, so the Dynamic Island return entry is not visible in this state.\n")
 	} else if phoneBridgeAppNeedsForeground(status) {
 		builder.WriteString("- The Aiden companion app is backgrounded or inactive. On iOS, Phone Bridge commands may time out until Aiden returns to foreground.\n")

--- a/src/agent/internal/agent/phone_bridge_http.go
+++ b/src/agent/internal/agent/phone_bridge_http.go
@@ -138,7 +138,11 @@ func (pb *PhoneBridge) handlePollCommands(w http.ResponseWriter, r *http.Request
 		r.URL.Query().Get("pip_bridge_enabled"),
 		r.URL.Query().Get("fgs_bridge_enabled"),
 	)
-	commands := pb.queue.PollForPhone(platform, phoneID, limit)
+
+	var commands []BridgeCommand
+	if !shouldSuppressHTTPCommandPoll(platform, r.URL.Query().Get("app_state"), r.URL.Query().Get("fgs_bridge_enabled")) {
+		commands = pb.queue.PollForPhone(platform, phoneID, limit)
+	}
 
 	if pb.logger != nil && len(commands) > 0 {
 		var cmdIDs []string
@@ -153,6 +157,15 @@ func (pb *PhoneBridge) handlePollCommands(w http.ResponseWriter, r *http.Request
 		Commands:   commands,
 		ServerTime: time.Now().UTC().Format("2006-01-02T15:04:05Z"),
 	})
+}
+
+func shouldSuppressHTTPCommandPoll(platform, appState, fgsBridgeEnabled string) bool {
+	if strings.TrimSpace(strings.ToLower(platform)) != "android" {
+		return false
+	}
+	normalizedAppState, appStateOK := normalizeAppState(appState)
+	fgsEnabled, fgsEnabledOK := parseOptionalBoolQuery(fgsBridgeEnabled)
+	return appStateOK && normalizedAppState == "active" && fgsEnabledOK && !fgsEnabled
 }
 
 func (pb *PhoneBridge) noteHTTPPollState(platform, phoneID, appState, pipBridgeEnabled, fgsBridgeEnabled string) {

--- a/src/agent/internal/agent/phone_bridge_http.go
+++ b/src/agent/internal/agent/phone_bridge_http.go
@@ -136,6 +136,7 @@ func (pb *PhoneBridge) handlePollCommands(w http.ResponseWriter, r *http.Request
 		phoneID,
 		r.URL.Query().Get("app_state"),
 		r.URL.Query().Get("pip_bridge_enabled"),
+		r.URL.Query().Get("fgs_bridge_enabled"),
 	)
 	commands := pb.queue.PollForPhone(platform, phoneID, limit)
 
@@ -154,11 +155,12 @@ func (pb *PhoneBridge) handlePollCommands(w http.ResponseWriter, r *http.Request
 	})
 }
 
-func (pb *PhoneBridge) noteHTTPPollState(platform, phoneID, appState, pipBridgeEnabled string) {
+func (pb *PhoneBridge) noteHTTPPollState(platform, phoneID, appState, pipBridgeEnabled, fgsBridgeEnabled string) {
 	platform = strings.TrimSpace(platform)
 	phoneID = strings.TrimSpace(phoneID)
 	appState, appStateOK := normalizeAppState(appState)
 	enabled, enabledOK := parseOptionalBoolQuery(pipBridgeEnabled)
+	fgsEnabled, fgsEnabledOK := parseOptionalBoolQuery(fgsBridgeEnabled)
 	now := time.Now()
 
 	pb.mu.Lock()
@@ -175,6 +177,11 @@ func (pb *PhoneBridge) noteHTTPPollState(platform, phoneID, appState, pipBridgeE
 	if enabledOK {
 		pb.pipBridgeEnabled = enabled
 		pb.pipBridgeSeen = true
+	}
+	if fgsEnabledOK {
+		pb.fgsBridgeEnabled = fgsEnabled
+		pb.fgsBridgeSeen = true
+		pb.fgsBridgeAt = now
 	}
 	pb.mu.Unlock()
 }

--- a/src/agent/internal/agent/phone_bridge_http_test.go
+++ b/src/agent/internal/agent/phone_bridge_http_test.go
@@ -244,6 +244,45 @@ func TestHTTPPollCommandsRecordsAndroidFGSBridgeState(t *testing.T) {
 	}
 }
 
+func TestHTTPPollCommandsSuppressesAndroidForegroundFGSQueue(t *testing.T) {
+	bridge := NewPhoneBridge(nil)
+	defer bridge.queue.Stop()
+
+	if err := bridge.queue.Enqueue(BridgeCommand{
+		ID:      "fgs_foreground_cmd",
+		Type:    "clipboard_read",
+		PhoneID: "android-abc",
+	}); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/phone-bridge/commands?platform=android&phone_id=android-abc&app_state=active&fgs_bridge_enabled=false", nil)
+	w := httptest.NewRecorder()
+
+	bridge.handlePollCommands(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+	var resp PollCommandsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if len(resp.Commands) != 0 {
+		t.Fatalf("commands = %#v, want empty foreground FGS poll", resp.Commands)
+	}
+	status := bridge.Status()
+	if status.AppState != "active" {
+		t.Fatalf("app_state = %q, want active", status.AppState)
+	}
+	if status.FgsBridgeEnabled == nil || *status.FgsBridgeEnabled {
+		t.Fatalf("fgs_bridge_enabled = %#v, want false", status.FgsBridgeEnabled)
+	}
+	if _, commandStatus := bridge.queue.QueryResult("fgs_foreground_cmd"); commandStatus != StatusQueued {
+		t.Fatalf("command status = %s, want %s", commandStatus, StatusQueued)
+	}
+}
+
 // TestHTTPSubmitResult tests POST /api/phone-bridge/results
 func TestHTTPSubmitResult(t *testing.T) {
 	bridge := NewPhoneBridge(nil)

--- a/src/agent/internal/agent/phone_bridge_http_test.go
+++ b/src/agent/internal/agent/phone_bridge_http_test.go
@@ -214,6 +214,36 @@ func TestHTTPPollCommands(t *testing.T) {
 	}
 }
 
+func TestHTTPPollCommandsRecordsAndroidFGSBridgeState(t *testing.T) {
+	bridge := NewPhoneBridge(nil)
+	defer bridge.queue.Stop()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/phone-bridge/commands?platform=android&phone_id=android-abc&app_state=background&fgs_bridge_enabled=true", nil)
+	w := httptest.NewRecorder()
+
+	bridge.handlePollCommands(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+	status := bridge.Status()
+	if status.Platform != "android" {
+		t.Fatalf("platform = %q, want android", status.Platform)
+	}
+	if status.PhoneID != "android-abc" {
+		t.Fatalf("phone_id = %q, want android-abc", status.PhoneID)
+	}
+	if status.AppState != "background" {
+		t.Fatalf("app_state = %q, want background", status.AppState)
+	}
+	if status.FgsBridgeEnabled == nil || !*status.FgsBridgeEnabled {
+		t.Fatalf("fgs_bridge_enabled = %#v, want true", status.FgsBridgeEnabled)
+	}
+	if status.FgsBridgeUpdatedAt == nil {
+		t.Fatal("fgs_bridge_updated_at is nil")
+	}
+}
+
 // TestHTTPSubmitResult tests POST /api/phone-bridge/results
 func TestHTTPSubmitResult(t *testing.T) {
 	bridge := NewPhoneBridge(nil)

--- a/src/agent/internal/agent/phone_bridge_policy.go
+++ b/src/agent/internal/agent/phone_bridge_policy.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const pipBridgeBackgroundStateMaxAge = 15 * time.Second
+const phoneBridgeBackgroundStateMaxAge = 15 * time.Second
 
 const (
 	toolBridgeOpenApp      = "bridge_open_app"
@@ -47,9 +47,11 @@ func isPhoneBridgeToolName(name string) bool {
 func phoneBridgeToolAvailable(status PhoneBridgeStatus, name string) bool {
 	switch name {
 	case toolBridgeOpenApp:
-		return !phoneBridgePiPBackgroundEnabled(status)
+		return !phoneBridgePiPBackgroundEnabled(status) && !phoneBridgeFGSBackgroundEnabled(status)
 	case toolBridgeClipboard, toolBridgeCalendar, toolBridgeContacts, toolBridgeNotification:
-		return status.Connected || phoneBridgeCanUsePiPBackground(status, phoneBridgeBackgroundCommandTypeForTool(name))
+		return phoneBridgeReadyForCommand(status) ||
+			phoneBridgeCanUsePiPBackground(status, phoneBridgeBackgroundCommandTypeForTool(name)) ||
+			phoneBridgeCanUseFGSBackground(status, phoneBridgeBackgroundCommandTypeForTool(name))
 	default:
 		return true
 	}
@@ -83,7 +85,20 @@ func phoneBridgeCanUsePiPBackground(status PhoneBridgeStatus, commandType string
 	if !phoneBridgePiPBackgroundEnabled(status) {
 		return false
 	}
-	if status.AppStateUpdatedAt == nil || time.Since(*status.AppStateUpdatedAt) > pipBridgeBackgroundStateMaxAge {
+	if status.AppStateUpdatedAt == nil || time.Since(*status.AppStateUpdatedAt) > phoneBridgeBackgroundStateMaxAge {
+		return false
+	}
+	return true
+}
+
+func phoneBridgeCanUseFGSBackground(status PhoneBridgeStatus, commandType string) bool {
+	if !phoneBridgeBackgroundSafeCommandType(commandType) {
+		return false
+	}
+	if !phoneBridgeFGSBackgroundEnabled(status) {
+		return false
+	}
+	if status.FgsBridgeUpdatedAt == nil || time.Since(*status.FgsBridgeUpdatedAt) > phoneBridgeBackgroundStateMaxAge {
 		return false
 	}
 	return true
@@ -100,6 +115,17 @@ func phoneBridgePiPBackgroundEnabled(status PhoneBridgeStatus) bool {
 	}
 	state := strings.ToLower(strings.TrimSpace(status.AppState))
 	return state == "" || state == "background" || state == "inactive"
+}
+
+func phoneBridgeFGSBackgroundEnabled(status PhoneBridgeStatus) bool {
+	if status.FgsBridgeEnabled == nil || !*status.FgsBridgeEnabled {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(status.Platform), "android") {
+		return false
+	}
+	state := strings.ToLower(strings.TrimSpace(status.AppState))
+	return state == "background" || state == "inactive"
 }
 
 func phoneBridgeBackgroundCommandTypeForTool(name string) string {
@@ -141,6 +167,13 @@ func phoneBridgeRecoveryGuidance(status PhoneBridgeStatus) string {
 }
 
 func phoneBridgeRestoreUnavailableError(status PhoneBridgeStatus) error {
+	if phoneBridgeFGSBackgroundEnabled(status) {
+		state := strings.TrimSpace(status.AppState)
+		if state == "" {
+			state = "background"
+		}
+		return fmt.Errorf("phone bridge app is %s with Android FGS Bridge enabled, but this command requires the companion app in foreground", state)
+	}
 	if phoneBridgePiPBackgroundEnabled(status) {
 		state := strings.TrimSpace(status.AppState)
 		if state == "" {

--- a/src/agent/internal/agent/phone_bridge_restore.go
+++ b/src/agent/internal/agent/phone_bridge_restore.go
@@ -135,6 +135,10 @@ func sendRoutedBridgeCommand(ctx context.Context, bridge *PhoneBridge, restorer 
 		return BridgeCommandResponse{}, false, fmt.Errorf("phone bridge is not initialized")
 	}
 	status := bridge.Status()
+	if phoneBridgeCanUseFGSBackground(status, cmd.Type) {
+		resp, err := bridge.SendQueuedCommand(ctx, cmd)
+		return resp, false, err
+	}
 	if phoneBridgeReadyForCommand(status) {
 		resp, err := bridge.SendCommand(ctx, cmd)
 		return resp, false, err

--- a/src/agent/internal/agent/phone_bridge_restore_test.go
+++ b/src/agent/internal/agent/phone_bridge_restore_test.go
@@ -150,9 +150,56 @@ func TestPhoneBridgeCanUsePiPBackgroundOnlyForSafeDataCommands(t *testing.T) {
 	}
 
 	status.PipBridgeEnabled = &enabled
-	status.AppStateUpdatedAt = ptrTime(time.Now().Add(-pipBridgeBackgroundStateMaxAge - time.Second))
+	status.AppStateUpdatedAt = ptrTime(time.Now().Add(-phoneBridgeBackgroundStateMaxAge - time.Second))
 	if phoneBridgeCanUsePiPBackground(status, "clipboard_read") {
 		t.Fatal("stale PiP bridge status should not allow background queue")
+	}
+}
+
+func TestPhoneBridgeCanUseFGSBackgroundOnlyForSafeDataCommands(t *testing.T) {
+	enabled := true
+	status := PhoneBridgeStatus{
+		Platform:           "android",
+		AppState:           "background",
+		AppStateUpdatedAt:  ptrTime(time.Now()),
+		FgsBridgeEnabled:   &enabled,
+		FgsBridgeUpdatedAt: ptrTime(time.Now()),
+	}
+	if !phoneBridgeCanUseFGSBackground(status, "clipboard_read") {
+		t.Fatal("clipboard_read should be allowed in Android FGS background bridge mode")
+	}
+	if phoneBridgeCanUseFGSBackground(status, "open_app") {
+		t.Fatal("open_app must not be allowed in Android FGS background bridge mode")
+	}
+	if phoneBridgeToolAvailable(status, "open_app") {
+		t.Fatal("open_app tool must be hidden while Android FGS background bridge mode is active")
+	}
+	if !phoneBridgeToolAvailable(status, "clipboard") {
+		t.Fatal("clipboard tool should be available through Android FGS background queue")
+	}
+
+	status.AppState = "active"
+	if phoneBridgeCanUseFGSBackground(status, "clipboard_read") {
+		t.Fatal("foreground app should use WebSocket path, not FGS background queue")
+	}
+
+	disabled := false
+	status.AppState = "background"
+	status.FgsBridgeEnabled = &disabled
+	if phoneBridgeCanUseFGSBackground(status, "clipboard_read") {
+		t.Fatal("disabled FGS bridge mode should not allow background queue")
+	}
+
+	status.Platform = "ios"
+	status.FgsBridgeEnabled = &enabled
+	if phoneBridgeCanUseFGSBackground(status, "clipboard_read") {
+		t.Fatal("FGS bridge mode should only apply to Android")
+	}
+
+	status.Platform = "android"
+	status.FgsBridgeUpdatedAt = ptrTime(time.Now().Add(-phoneBridgeBackgroundStateMaxAge - time.Second))
+	if phoneBridgeCanUseFGSBackground(status, "clipboard_read") {
+		t.Fatal("stale FGS bridge status should not allow background queue")
 	}
 }
 
@@ -257,6 +304,66 @@ func TestSendRoutedBridgeCommandChoosesDeliveryPath(t *testing.T) {
 		}
 		if resp.Method != "queued" {
 			t.Fatalf("response method = %q, want queued", resp.Method)
+		}
+	})
+
+	t.Run("android fgs background queue", func(t *testing.T) {
+		bridge := newTestPhoneBridgeWithApp(t, func(cmd BridgeCommand) BridgeCommandResponse {
+			t.Errorf("websocket should not receive command in Android FGS background mode: %+v", cmd)
+			return BridgeCommandResponse{Method: "unexpected_websocket"}
+		})
+		bridge.mu.Lock()
+		bridge.platform = "android"
+		bridge.appState = "background"
+		bridge.appStateAt = time.Now()
+		bridge.fgsBridgeEnabled = true
+		bridge.fgsBridgeSeen = true
+		bridge.fgsBridgeAt = time.Now()
+		bridge.mu.Unlock()
+
+		tapCalled := false
+		restorer := NewPhoneBridgeRestorer(bridge, nil)
+		restorer.tapReturnEntry = func(context.Context, PhoneBridgeStatus) error {
+			tapCalled = true
+			return nil
+		}
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			commands := bridge.queue.PollForPhone("android", "", 10)
+			if len(commands) != 1 {
+				t.Errorf("expected one queued command, got %d", len(commands))
+				return
+			}
+			if commands[0].Type != "clipboard_read" {
+				t.Errorf("queued command type = %q, want clipboard_read", commands[0].Type)
+				return
+			}
+			if err := bridge.queue.SubmitResult(BridgeCommandResponse{
+				ID:     commands[0].ID,
+				Method: "queued_android_fgs",
+			}); err != nil {
+				t.Errorf("SubmitResult() error = %v", err)
+			}
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		resp, restored, err := sendRoutedBridgeCommand(ctx, bridge, restorer, BridgeCommand{
+			ID:        "route_android_fgs",
+			Type:      "clipboard_read",
+			TimeoutMs: 1000,
+		})
+		if err != nil {
+			t.Fatalf("sendRoutedBridgeCommand() error = %v", err)
+		}
+		if restored {
+			t.Fatal("sendRoutedBridgeCommand() restored = true, want false")
+		}
+		if tapCalled {
+			t.Fatal("return entry tap should not be used for Android FGS background queue")
+		}
+		if resp.Method != "queued_android_fgs" {
+			t.Fatalf("response method = %q, want queued_android_fgs", resp.Method)
 		}
 	})
 

--- a/src/agent/internal/agent/phone_bridge_restore_test.go
+++ b/src/agent/internal/agent/phone_bridge_restore_test.go
@@ -171,11 +171,11 @@ func TestPhoneBridgeCanUseFGSBackgroundOnlyForSafeDataCommands(t *testing.T) {
 	if phoneBridgeCanUseFGSBackground(status, "open_app") {
 		t.Fatal("open_app must not be allowed in Android FGS background bridge mode")
 	}
-	if phoneBridgeToolAvailable(status, "open_app") {
-		t.Fatal("open_app tool must be hidden while Android FGS background bridge mode is active")
+	if phoneBridgeToolAvailable(status, toolBridgeOpenApp) {
+		t.Fatal("bridge_open_app tool must be hidden while Android FGS background bridge mode is active")
 	}
-	if !phoneBridgeToolAvailable(status, "clipboard") {
-		t.Fatal("clipboard tool should be available through Android FGS background queue")
+	if !phoneBridgeToolAvailable(status, toolBridgeClipboard) {
+		t.Fatal("bridge_clipboard tool should be available through Android FGS background queue")
 	}
 
 	status.AppState = "active"

--- a/src/agent/internal/agent/tools_phone_bridge_data.go
+++ b/src/agent/internal/agent/tools_phone_bridge_data.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const phoneBridgeBackgroundSafeDataToolNote = `On iOS, when Aiden is backgrounded with PiP Bridge mode active, this data tool can run through the HTTP command queue without restoring Aiden. If PiP is not active but the Dynamic Island return entry is available, the tool restores Aiden to foreground before sending the command. PiP Bridge mode is not a foreground substitute for bridge_open_app or UI actions. `
+const phoneBridgeBackgroundSafeDataToolNote = `When Aiden is backgrounded, this data tool can run through the HTTP command queue if iOS PiP Bridge mode or Android FGS Bridge mode is active. If iOS PiP is not active but the Dynamic Island return entry is available, the tool restores Aiden to foreground before sending the command. Background bridge modes are not foreground substitutes for bridge_open_app or UI actions. `
 
 // nextBridgeCmdID builds a unique command id for a bridge command type. It
 // reuses openAppCmdSeq so every outbound bridge command shares one counter.


### PR DESCRIPTION
## Summary
- record Android fgs_bridge_enabled from Phone Bridge HTTP polling
- route Android background-safe data commands through the existing HTTP Queue when FGS bridge state is fresh
- keep open_app unavailable in Android FGS background mode
- document the Android FGS + HTTP Queue contract

## Tests
- go test ./internal/agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android foreground-service (FGS) bridge support for background-safe phone actions via the HTTP command queue.
  * Phone-bridge status now reports FGS bridge enablement and update time; background polling can be suppressed when FGS is disabled.
* **Bug Fixes**
  * Updated background eligibility/routing: `open_app` stays unavailable while Android FGS is enabled/backgrounded, while safe data tools remain available; improved “bridge unavailable” guidance when recovery isn’t possible.
* **Documentation**
  * Expanded Phone Bridge docs and updated safe-data tool guidance for Android FGS alongside existing iOS PiP/Dynamic Island behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->