### PR TITLE
ci: configure GOPROXY for self-hosted builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,10 @@ jobs:
         docker system prune -af || true
         df -h
 
+    - name: Configure Go proxy (self-hosted)
+      if: ${{ inputs.runner == 'self-hosted' || startsWith(inputs.runner, 'aiden-hosted-') }}
+      run: echo "GOPROXY=https://goproxy.cn" >> "$GITHUB_ENV"
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:

--- a/scripts/test_github_actions_self_hosted_safety.sh
+++ b/scripts/test_github_actions_self_hosted_safety.sh
@@ -123,3 +123,12 @@ if ! grep -Fq 'startsWith(inputs.runner, '\''aiden-hosted-'\'')' "$build_workflo
   echo "self-hosted build workflow must treat dedicated Aiden hosted labels as self-hosted runners" >&2
   exit 1
 fi
+
+goproxy_line="$(grep -n 'GOPROXY=https://goproxy.cn' "$build_workflow" | sed 's/:.*//' | head -n 1 || true)"
+setup_go_line="$(grep -n 'actions/setup-go@' "$build_workflow" | sed 's/:.*//' | head -n 1 || true)"
+run_build_line="$(grep -n 'Run build script' "$build_workflow" | sed 's/:.*//' | head -n 1 || true)"
+if [[ -z "$goproxy_line" || -z "$setup_go_line" || -z "$run_build_line" || \
+      "$goproxy_line" -ge "$setup_go_line" || "$goproxy_line" -ge "$run_build_line" ]]; then
+  echo "self-hosted build workflow must configure GOPROXY before Go setup and image build" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Configure self-hosted GitHub Actions builds to use GOPROXY=https://goproxy.cn
- Add a self-hosted workflow safety regression check for the Go proxy setting

## Tests
- bash scripts/test_github_actions_self_hosted_safety.sh
- sh scripts/test_release_ci_scripts.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability on self-hosted and certain hosted runners by ensuring Go dependencies are fetched through a configured module proxy.
  * Tightened build validation so the proxy setting is applied before Go setup and build steps, reducing the chance of flaky build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->