### PR TITLE
fix(agent): add phone bridge tool examples

### DIFF
--- a/src/agent/internal/agent/tool_http_catalog_test.go
+++ b/src/agent/internal/agent/tool_http_catalog_test.go
@@ -155,6 +155,29 @@ func TestAvailableToolsIncludesPhoneBridgeToolsWhenConnected(t *testing.T) {
 	}
 }
 
+func TestPhoneBridgeDataToolDescriptorsHaveUsefulExamples(t *testing.T) {
+	runtime := newRuntimeWithTextEntryTools()
+	bridge := newPhoneBridgeForTest()
+	bridge.connected = true
+	runtime.tools.RegisterPhoneBridge(bridge)
+
+	expected := map[string]string{
+		"bridge_clipboard":    `{"action":"read"}`,
+		"bridge_calendar":     `{"action":"query","from":"2026-07-10T00:00:00+08:00","to":"2026-07-11T00:00:00+08:00"}`,
+		"bridge_contacts":     `{"action":"query","query":"Alice","limit":20}`,
+		"bridge_notification": `{"title":"Aiden reminder","body":"Check your phone","sound":true}`,
+	}
+	for name, want := range expected {
+		desc, ok := runtime.ToolDescriptorByName(name)
+		if !ok {
+			t.Fatalf("ToolDescriptorByName missing %s", name)
+		}
+		if desc.ExampleInput != want {
+			t.Fatalf("%s example_input = %q, want %q", name, desc.ExampleInput, want)
+		}
+	}
+}
+
 func TestAvailableToolsHidesOpenAppAndKeepsDataToolsDuringPiPBackground(t *testing.T) {
 	runtime := newRuntimeWithTextEntryTools()
 	bridge := newIOSPiPBackgroundBridge(t)

--- a/src/agent/internal/agent/tool_spec.go
+++ b/src/agent/internal/agent/tool_spec.go
@@ -253,22 +253,22 @@ var builtInToolSpecMetadata = map[string]toolSpecMetadata{
 	toolBridgeClipboard: {
 		Category:     "bridge",
 		InputMode:    toolInputModeJSON,
-		ExampleInput: `{}`,
+		ExampleInput: `{"action":"read"}`,
 	},
 	toolBridgeCalendar: {
 		Category:     "bridge",
 		InputMode:    toolInputModeJSON,
-		ExampleInput: `{}`,
+		ExampleInput: `{"action":"query","from":"2026-07-10T00:00:00+08:00","to":"2026-07-11T00:00:00+08:00"}`,
 	},
 	toolBridgeContacts: {
 		Category:     "bridge",
 		InputMode:    toolInputModeJSON,
-		ExampleInput: `{}`,
+		ExampleInput: `{"action":"query","query":"Alice","limit":20}`,
 	},
 	toolBridgeNotification: {
 		Category:     "bridge",
 		InputMode:    toolInputModeJSON,
-		ExampleInput: `{}`,
+		ExampleInput: `{"title":"Aiden reminder","body":"Check your phone","sound":true}`,
 	},
 }
 


### PR DESCRIPTION
## Summary
- Add ready-to-load `example_input` values for Phone Bridge data tools in the 8080 `/api/tools` catalog.
- Cover `bridge_clipboard`, `bridge_calendar`, `bridge_contacts`, and `bridge_notification`.
- Add a catalog regression test so these dynamically visible tools do not fall back to empty `{}` examples when the bridge is connected.

## Testing
- `go test ./internal/agent -run 'Test(PhoneBridgeDataToolDescriptorsHaveUsefulExamples|AvailableToolsIncludesPhoneBridgeToolsWhenConnected|AvailableToolsHidesOpenAppAndKeepsDataToolsDuringPiPBackground)'`
- `go test ./internal/agent`