### PR TITLE
fix(agent): remove chat-specific swipe direction prescription from SKILL

### DIFF
--- a/src/agent/config/skills/device-operator/SKILL.md
+++ b/src/agent/config/skills/device-operator/SKILL.md
@@ -160,10 +160,8 @@ On iOS, if Phone Bridge context says the Aiden companion app is backgrounded/ina
 
 Directional swipe names describe finger movement, not content direction:
 
-- `swipe_up`: finger moves up; content usually moves down to lower/newer items.
-- `swipe_down`: finger moves down; content usually moves up to upper/older items.
-
-In chat/message history, to see older messages above the current viewport, usually use `swipe_down` inside the message list.
+- `swipe_up`: finger moves up → viewport scrolls down → reveals content below.
+- `swipe_down`: finger moves down → viewport scrolls up → reveals content above.
 
 Scrollable region discipline:
 


### PR DESCRIPTION
## Summary
  - LLM was over-generalizing "use swipe_down for older messages" guidance to all feed/list scenarios
   (e.g. browsing Xiaohongshu feed), causing wrong swipe direction
  - Removed the chat-specific prescription, kept only the physical mechanism definition (finger
  direction → viewport movement → what gets revealed)
  - Let the model decide direction based on screenshot context rather than memorized rules

  ## Context
  PR #387 fixed the distance unit issue (0-1 float → 0-1000 scale). This PR addresses the secondary
  problem discovered in the same test session: the direction guidance added in ff009c58 was too
  prescriptive, causing the model to choose `swipe_down` when it should have used `swipe_up` to
  scroll a feed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified swipe gesture guidance for scrolling and picker controls.
  * Specified how finger movement maps to viewport movement when revealing upper or lower items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->