### PR TITLE
fix: prime touchscreen mapping before first input

### DIFF
--- a/src/agent/cmd/daemon/main.go
+++ b/src/agent/cmd/daemon/main.go
@@ -121,6 +121,9 @@ func main() {
 	} else if wrote {
 		log.Printf("[ota] health marker written")
 	}
+	if err := runtime.PrimeScreenMappingOnStartup(context.Background()); err != nil {
+		log.Printf("[init] screen mapping prime failed: %v", err)
+	}
 
 	inputMode := cfg.InputModeOrDefault()
 

--- a/src/agent/internal/agent/screen_mapping_prime.go
+++ b/src/agent/internal/agent/screen_mapping_prime.go
@@ -1,0 +1,88 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const (
+	startupScreenMappingPrimeTimeout       = 20 * time.Second
+	startupScreenMappingPrimeRetryInterval = 300 * time.Millisecond
+)
+
+// PrimeScreenMapping captures one screenshot so shared screenState has current
+// frame dimensions and active-area metadata before the first input action.
+func (s *ToolSet) PrimeScreenMapping(ctx context.Context) error {
+	if s == nil {
+		return fmt.Errorf("tool set is not configured")
+	}
+	tool, ok := s.Get("screenshot")
+	if !ok || tool == nil {
+		return fmt.Errorf("screenshot tool is not available")
+	}
+	if _, err := tool.Call(ctx, "{}"); err != nil {
+		return fmt.Errorf("capture screenshot: %w", err)
+	}
+	if s.screen == nil {
+		return nil
+	}
+	width, height, active, _, ok := s.screen.ActiveAreaWithAge()
+	if !ok || width <= 0 || height <= 0 || !active.Valid {
+		return fmt.Errorf("screenshot did not establish screen mapping")
+	}
+	return nil
+}
+
+func (r *Runtime) PrimeScreenMappingOnStartup(ctx context.Context) error {
+	if r == nil || r.tools == nil {
+		return nil
+	}
+	if !r.config.HID.PointerTouchscreen() {
+		return nil
+	}
+
+	startedAt := time.Now()
+	primeCtx, cancel := context.WithTimeout(ctx, startupScreenMappingPrimeTimeout)
+	defer cancel()
+
+	var lastErr error
+	attempts := 0
+	for {
+		attempts++
+		if err := r.tools.PrimeScreenMapping(primeCtx); err != nil {
+			lastErr = err
+		} else {
+			if r.logger != nil && r.tools.screen != nil {
+				width, height, active, _, ok := r.tools.screen.ActiveAreaWithAge()
+				if ok {
+					r.logger.Info(
+						"screen mapping prime succeeded: attempts=%d elapsed_ms=%d source=%dx%d active=%+v",
+						attempts,
+						time.Since(startedAt).Milliseconds(),
+						width,
+						height,
+						active,
+					)
+				} else {
+					r.logger.Info("screen mapping prime succeeded: attempts=%d elapsed_ms=%d", attempts, time.Since(startedAt).Milliseconds())
+				}
+			}
+			return nil
+		}
+
+		timer := time.NewTimer(startupScreenMappingPrimeRetryInterval)
+		select {
+		case <-primeCtx.Done():
+			timer.Stop()
+			if lastErr == nil {
+				lastErr = primeCtx.Err()
+			}
+			if r.logger != nil {
+				r.logger.Warn("screen mapping prime failed: attempts=%d elapsed_ms=%d err=%v", attempts, time.Since(startedAt).Milliseconds(), lastErr)
+			}
+			return fmt.Errorf("screen mapping prime failed after %d attempts: %w", attempts, lastErr)
+		case <-timer.C:
+		}
+	}
+}

--- a/src/agent/internal/agent/screen_mapping_prime_test.go
+++ b/src/agent/internal/agent/screen_mapping_prime_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	langtools "github.com/tmc/langchaingo/tools"
@@ -57,4 +58,78 @@ func TestToolSetPrimeScreenMappingCapturesScreenshotMetadata(t *testing.T) {
 	if active != wantActive {
 		t.Fatalf("active area = %+v, want %+v", active, wantActive)
 	}
+}
+
+func TestToolSetPrimeScreenMappingTreatsFullFrameFallbackAsFresh(t *testing.T) {
+	jpegData, err := encodeJPEG([]byte{
+		255, 255, 255, 255, 255, 255,
+		255, 255, 255, 255, 255, 255,
+	}, 2, 2, screenshotJPEGQuality)
+	if err != nil {
+		t.Fatalf("encodeJPEG() error = %v", err)
+	}
+
+	screen := &screenState{}
+	client := &fakeScreenshotFrameClient{
+		meta: frameMetadata{
+			Seq:         43,
+			Width:       2,
+			Height:      2,
+			PixelFormat: "jpeg",
+			Bytes:       uint64(len(jpegData)),
+		},
+		data: jpegData,
+	}
+	tools := &ToolSet{
+		tools: map[string]langtools.Tool{
+			"screenshot": &ScreenshotTool{client: client, screen: screen},
+		},
+		screen: screen,
+	}
+
+	if err := tools.PrimeScreenMapping(context.Background()); err != nil {
+		t.Fatalf("PrimeScreenMapping() error = %v", err)
+	}
+	width, height, active, _, ok := screen.ActiveAreaWithAge()
+	if !ok {
+		t.Fatal("screen mapping was not established")
+	}
+	if width != 2 || height != 2 {
+		t.Fatalf("source dimensions = %dx%d, want 2x2", width, height)
+	}
+	wantActive := screenActiveArea{X: 0, Y: 0, Width: 2, Height: 2, Valid: true}
+	if active != wantActive {
+		t.Fatalf("active area = %+v, want %+v", active, wantActive)
+	}
+	if !screen.FreshActiveArea(screenDimensionsStaleAfter) {
+		t.Fatal("expected full-frame fallback mapping to be fresh after successful prime")
+	}
+}
+
+func TestToolSetPrimeScreenMappingFailureKeepsFreshFullFrameFallback(t *testing.T) {
+	screen := &screenState{}
+	screen.UpdateActiveArea(1920, 1080, screenActiveArea{})
+	tools := &ToolSet{
+		tools: map[string]langtools.Tool{
+			"screenshot": failingPrimeScreenshotTool{},
+		},
+		screen: screen,
+	}
+
+	if err := tools.PrimeScreenMapping(context.Background()); err == nil {
+		t.Fatal("expected PrimeScreenMapping() error")
+	}
+	if !screen.FreshActiveArea(screenDimensionsStaleAfter) {
+		t.Fatal("expected fresh full-frame fallback mapping after capture failure")
+	}
+}
+
+type failingPrimeScreenshotTool struct{}
+
+func (failingPrimeScreenshotTool) Name() string { return "screenshot" }
+
+func (failingPrimeScreenshotTool) Description() string { return "failing screenshot" }
+
+func (failingPrimeScreenshotTool) Call(context.Context, string) (string, error) {
+	return "", errors.New("capture failed")
 }

--- a/src/agent/internal/agent/screen_mapping_prime_test.go
+++ b/src/agent/internal/agent/screen_mapping_prime_test.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	langtools "github.com/tmc/langchaingo/tools"
+)
+
+func TestToolSetPrimeScreenMappingCapturesScreenshotMetadata(t *testing.T) {
+	jpegData, err := encodeJPEG([]byte{
+		255, 255, 255, 255, 255, 255,
+		255, 255, 255, 255, 255, 255,
+	}, 2, 2, screenshotJPEGQuality)
+	if err != nil {
+		t.Fatalf("encodeJPEG() error = %v", err)
+	}
+
+	screen := &screenState{}
+	client := &fakeScreenshotFrameClient{
+		meta: frameMetadata{
+			Seq:          42,
+			Width:        2,
+			Height:       2,
+			SourceWidth:  1920,
+			SourceHeight: 1080,
+			CropX:        711,
+			CropY:        0,
+			CropWidth:    497,
+			CropHeight:   1080,
+			PixelFormat:  "jpeg",
+			Bytes:        uint64(len(jpegData)),
+		},
+		data: jpegData,
+	}
+	tools := &ToolSet{
+		tools: map[string]langtools.Tool{
+			"screenshot": &ScreenshotTool{client: client, screen: screen},
+		},
+		screen: screen,
+	}
+
+	if err := tools.PrimeScreenMapping(context.Background()); err != nil {
+		t.Fatalf("PrimeScreenMapping() error = %v", err)
+	}
+	if client.calls != 1 {
+		t.Fatalf("LatestFrameWithFormat calls = %d, want 1", client.calls)
+	}
+	width, height, active, _, ok := screen.ActiveAreaWithAge()
+	if !ok {
+		t.Fatal("screen mapping was not established")
+	}
+	if width != 1920 || height != 1080 {
+		t.Fatalf("source dimensions = %dx%d, want 1920x1080", width, height)
+	}
+	wantActive := screenActiveArea{X: 711, Y: 0, Width: 497, Height: 1080, Valid: true}
+	if active != wantActive {
+		t.Fatalf("active area = %+v, want %+v", active, wantActive)
+	}
+}

--- a/src/agent/internal/agent/tools.go
+++ b/src/agent/internal/agent/tools.go
@@ -93,6 +93,14 @@ func newHardwareToolSet(hidCfg HIDConfig, audioCfg AudioConfig, searchCfg Search
 	androidKbDev := NewHIDDevice(hidCfg.AndroidKeyboardDeviceOrDefault())
 	screen := &screenState{}
 	pointer := newPointerController(hidCfg)
+	touchscreenRCALogf(
+		"newHardwareToolSet pointer_mode=%q pointer_device=%q keyboard_device=%q android_keyboard_device=%q frame_socket=%q",
+		hidCfg.PointerModeOrDefault(),
+		hidCfg.MouseDeviceOrDefault(),
+		hidCfg.KeyboardDeviceOrDefault(),
+		hidCfg.AndroidKeyboardDeviceOrDefault(),
+		hidCfg.FrameSocketOrDefault(),
+	)
 	screenshot := NewScreenshotTool(hidCfg.FrameSocketOrDefault(), screen)
 	screenStable := toolOptions.screenStable.Resolved()
 	waitStable := NewWaitStableScreenTool(hidCfg.FrameSocketOrDefault(), screenStable, screen)
@@ -147,12 +155,14 @@ func newHardwareToolSet(hidCfg HIDConfig, audioCfg AudioConfig, searchCfg Search
 	// Always register human handoff tool - no callback needed for non-blocking version
 	tools["request_human_handoff"] = NewHumanHandoffTool()
 
-	return &ToolSet{
+	toolSet := &ToolSet{
 		tools:               tools,
 		screen:              screen,
 		phoneBridgeRestorer: NewPhoneBridgeRestorer(nil, pointer),
 		textInputHW:         textInputHW,
 	}
+	touchGesture.primeScreenMapping = toolSet.PrimeScreenMapping
+	return toolSet
 }
 
 func (s *ToolSet) RegisterEnterTextInFieldTool(models ModelResolver, platformFn func() string) {

--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -378,22 +378,30 @@ func (s *screenState) UpdatePhoneScreenInfo(info PhoneScreenInfo) {
 	if s == nil {
 		return
 	}
-	touchscreenRCALogf("screen.UpdatePhoneScreenInfo before={%s} new_phone_screen=%q", formatTouchscreenRCAScreenMapping(s), formatPhoneScreen(info))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("screen.UpdatePhoneScreenInfo before={%s} new_phone_screen=%q", formatTouchscreenRCAScreenMapping(s), formatPhoneScreen(info))
+	}
 	s.mu.Lock()
 	s.phoneScreen = info
 	s.mu.Unlock()
-	touchscreenRCALogf("screen.UpdatePhoneScreenInfo after={%s}", formatTouchscreenRCAScreenMapping(s))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("screen.UpdatePhoneScreenInfo after={%s}", formatTouchscreenRCAScreenMapping(s))
+	}
 }
 
 func (s *screenState) ClearPhoneScreenInfo() {
 	if s == nil {
 		return
 	}
-	touchscreenRCALogf("screen.ClearPhoneScreenInfo before={%s}", formatTouchscreenRCAScreenMapping(s))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("screen.ClearPhoneScreenInfo before={%s}", formatTouchscreenRCAScreenMapping(s))
+	}
 	s.mu.Lock()
 	s.phoneScreen = PhoneScreenInfo{}
 	s.mu.Unlock()
-	touchscreenRCALogf("screen.ClearPhoneScreenInfo after={%s}", formatTouchscreenRCAScreenMapping(s))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("screen.ClearPhoneScreenInfo after={%s}", formatTouchscreenRCAScreenMapping(s))
+	}
 }
 
 func (s *screenState) PhoneScreenInfo() PhoneScreenInfo {
@@ -407,7 +415,9 @@ func (s *screenState) PhoneScreenInfo() PhoneScreenInfo {
 
 func (s *screenState) UpdateActiveArea(width, height int, active screenActiveArea) {
 	if width <= 0 || height <= 0 {
-		touchscreenRCALogf("screen.UpdateActiveArea ignored invalid dimensions width=%d height=%d active=%s before={%s}", width, height, formatTouchscreenRCAActiveArea(active), formatTouchscreenRCAScreenMapping(s))
+		if touchscreenRCADebugEnabledCached() {
+			touchscreenRCALogf("screen.UpdateActiveArea ignored invalid dimensions width=%d height=%d active=%s before={%s}", width, height, formatTouchscreenRCAActiveArea(active), formatTouchscreenRCAScreenMapping(s))
+		}
 		return
 	}
 	requestedActive := active
@@ -417,21 +427,25 @@ func (s *screenState) UpdateActiveArea(width, height int, active screenActiveAre
 		}
 	}
 
-	touchscreenRCALogf(
-		"screen.UpdateActiveArea before={%s} request_width=%d request_height=%d requested_active=%s committed_active=%s",
-		formatTouchscreenRCAScreenMapping(s),
-		width,
-		height,
-		formatTouchscreenRCAActiveArea(requestedActive),
-		formatTouchscreenRCAActiveArea(active),
-	)
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf(
+			"screen.UpdateActiveArea before={%s} request_width=%d request_height=%d requested_active=%s committed_active=%s",
+			formatTouchscreenRCAScreenMapping(s),
+			width,
+			height,
+			formatTouchscreenRCAActiveArea(requestedActive),
+			formatTouchscreenRCAActiveArea(active),
+		)
+	}
 	s.mu.Lock()
 	s.width = width
 	s.height = height
 	s.active = active
 	s.updatedAt = time.Now()
 	s.mu.Unlock()
-	touchscreenRCALogf("screen.UpdateActiveArea after={%s}", formatTouchscreenRCAScreenMapping(s))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("screen.UpdateActiveArea after={%s}", formatTouchscreenRCAScreenMapping(s))
+	}
 }
 
 func (s *screenState) Dimensions() (width, height int, ok bool) {
@@ -1160,12 +1174,14 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 	if err := t.ensureTouchscreenMapping(ctx, coordSpace); err != nil {
 		return toolErrorResultf(ctx, CodeToolExecutionFailed, "touchscreen mapping unavailable: %v", err), nil
 	}
-	touchscreenRCALogf(
-		"touch_gesture start type=%q coord_space=%q mapping_before={%s}",
-		gestureType,
-		coordSpace,
-		formatTouchscreenRCAMappingSummary(t.screen),
-	)
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf(
+			"touch_gesture start type=%q coord_space=%q mapping_before={%s}",
+			gestureType,
+			coordSpace,
+			formatTouchscreenRCAMappingSummary(t.screen),
+		)
+	}
 
 	switch gestureType {
 	case "tap":
@@ -1223,17 +1239,19 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
-		touchscreenRCALogf(
-			"touch_gesture directional resolved type=%q start_abs=(%d,%d) end_abs=(%d,%d) coord_space=%q pointer_mode=%s mapping_at_resolve={%s}",
-			gestureType,
-			start.x,
-			start.y,
-			end.x,
-			end.y,
-			coordinateSpaceNormalized,
-			touchscreenRCAPointerMode(t.pc),
-			formatTouchscreenRCAScreenMapping(t.screen),
-		)
+		if touchscreenRCADebugEnabledCached() {
+			touchscreenRCALogf(
+				"touch_gesture directional resolved type=%q start_abs=(%d,%d) end_abs=(%d,%d) coord_space=%q pointer_mode=%s mapping_at_resolve={%s}",
+				gestureType,
+				start.x,
+				start.y,
+				end.x,
+				end.y,
+				coordinateSpaceNormalized,
+				touchscreenRCAPointerMode(t.pc),
+				formatTouchscreenRCAScreenMapping(t.screen),
+			)
+		}
 		if sameResolvedPointerPoint(start, end) {
 			return toolErrorResultString(ctx, CodeInvalidArguments, "directional swipe resolved to the same HID point"), nil
 		}
@@ -1360,7 +1378,9 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		return toolErrorResultf(ctx, CodeInvalidArguments, "unsupported gesture type: %q", args.Type), nil
 	}
 
-	touchscreenRCALogf("touch_gesture completed type=%q mapping_after_action_before_post_screenshot={%s}", gestureType, formatTouchscreenRCAScreenMapping(t.screen))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("touch_gesture completed type=%q mapping_after_action_before_post_screenshot={%s}", gestureType, formatTouchscreenRCAScreenMapping(t.screen))
+	}
 	return "ok", nil
 }
 
@@ -1378,11 +1398,15 @@ func (t *TouchGestureTool) ensureTouchscreenMapping(ctx context.Context, coordSp
 	if t.screen.FreshActiveArea(screenDimensionsStaleAfter) {
 		return nil
 	}
-	touchscreenRCALogf("touch_gesture prime mapping before input coord_space=%q mapping_before={%s}", coordSpace, formatTouchscreenRCAScreenMapping(t.screen))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("touch_gesture prime mapping before input coord_space=%q mapping_before={%s}", coordSpace, formatTouchscreenRCAScreenMapping(t.screen))
+	}
 	if err := t.primeScreenMapping(ctx); err != nil {
 		return err
 	}
-	touchscreenRCALogf("touch_gesture prime mapping succeeded mapping_after={%s}", formatTouchscreenRCAScreenMapping(t.screen))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("touch_gesture prime mapping succeeded mapping_after={%s}", formatTouchscreenRCAScreenMapping(t.screen))
+	}
 	return nil
 }
 
@@ -1771,25 +1795,31 @@ func writeTouchscreenReport(dev *HIDDevice, state *pointerState, x, y int, touch
 	if dev != nil {
 		path = dev.path
 	}
-	touchscreenRCALogf(
-		"hid touchscreen report write start path=%s requested=(%d,%d) clamped=(%d,%d) touching=%v flags=0x%02x report=% x",
-		path,
-		x,
-		y,
-		absX,
-		absY,
-		touching,
-		report[0],
-		report,
-	)
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf(
+			"hid touchscreen report write start path=%s requested=(%d,%d) clamped=(%d,%d) touching=%v flags=0x%02x report=% x",
+			path,
+			x,
+			y,
+			absX,
+			absY,
+			touching,
+			report[0],
+			report,
+		)
+	}
 	dev.mu.Lock()
 	defer dev.mu.Unlock()
 	err := dev.writeLocked(report, after)
 	if err != nil {
-		touchscreenRCALogf("hid touchscreen report write error path=%s clamped=(%d,%d) touching=%v err=%v", path, absX, absY, touching, err)
+		if touchscreenRCADebugEnabledCached() {
+			touchscreenRCALogf("hid touchscreen report write error path=%s clamped=(%d,%d) touching=%v err=%v", path, absX, absY, touching, err)
+		}
 		return err
 	}
-	touchscreenRCALogf("hid touchscreen report write ok path=%s clamped=(%d,%d) touching=%v", path, absX, absY, touching)
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("hid touchscreen report write ok path=%s clamped=(%d,%d) touching=%v", path, absX, absY, touching)
+	}
 	return nil
 }
 
@@ -2003,14 +2033,34 @@ func normalizedToAbsolutePointForSurface(screen *screenState, touchscreen bool, 
 				fullFramePixelY := float64(active.Y) + activePixelY
 				absX := scalePixelToAbsolute(fullFramePixelX, width)
 				absY := scalePixelToAbsolute(fullFramePixelY, height)
+				if touchscreenRCADebugEnabledCached() {
+					touchscreenRCALogf(
+						"normalizedToAbsolute touchscreen using active_area input_norm=(%.2f,%.2f) active_pixel=(%.2f,%.2f) full_frame_pixel=(%.2f,%.2f) source=%dx%d active=%s age_ms=%d absolute=(%d,%d)",
+						x,
+						y,
+						activePixelX,
+						activePixelY,
+						fullFramePixelX,
+						fullFramePixelY,
+						width,
+						height,
+						formatTouchscreenRCAActiveArea(active),
+						age.Milliseconds(),
+						absX,
+						absY,
+					)
+				}
+				return absX, absY, nil
+			}
+			absX := activeLocalAxisToAbsolute(activePixelX, active.X, active.Width, width)
+			absY := activeLocalAxisToAbsolute(activePixelY, active.Y, active.Height, height)
+			if touchscreenRCADebugEnabledCached() {
 				touchscreenRCALogf(
-					"normalizedToAbsolute touchscreen using active_area input_norm=(%.2f,%.2f) active_pixel=(%.2f,%.2f) full_frame_pixel=(%.2f,%.2f) source=%dx%d active=%s age_ms=%d absolute=(%d,%d)",
+					"normalizedToAbsolute absolute_mouse using active_area input_norm=(%.2f,%.2f) active_pixel=(%.2f,%.2f) source=%dx%d active=%s age_ms=%d absolute=(%d,%d)",
 					x,
 					y,
 					activePixelX,
 					activePixelY,
-					fullFramePixelX,
-					fullFramePixelY,
 					width,
 					height,
 					formatTouchscreenRCAActiveArea(active),
@@ -2018,28 +2068,14 @@ func normalizedToAbsolutePointForSurface(screen *screenState, touchscreen bool, 
 					absX,
 					absY,
 				)
-				return absX, absY, nil
 			}
-			absX := activeLocalAxisToAbsolute(activePixelX, active.X, active.Width, width)
-			absY := activeLocalAxisToAbsolute(activePixelY, active.Y, active.Height, height)
-			touchscreenRCALogf(
-				"normalizedToAbsolute absolute_mouse using active_area input_norm=(%.2f,%.2f) active_pixel=(%.2f,%.2f) source=%dx%d active=%s age_ms=%d absolute=(%d,%d)",
-				x,
-				y,
-				activePixelX,
-				activePixelY,
-				width,
-				height,
-				formatTouchscreenRCAActiveArea(active),
-				age.Milliseconds(),
-				absX,
-				absY,
-			)
 			return absX, absY, nil
 		}
 	}
 	absX, absY := normalizedToAbsolutePoint(x, y)
-	touchscreenRCALogf("normalizedToAbsolute fallback input_norm=(%.2f,%.2f) touchscreen=%v absolute=(%d,%d) mapping={%s}", x, y, touchscreen, absX, absY, formatTouchscreenRCAScreenMapping(screen))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("normalizedToAbsolute fallback input_norm=(%.2f,%.2f) touchscreen=%v absolute=(%d,%d) mapping={%s}", x, y, touchscreen, absX, absY, formatTouchscreenRCAScreenMapping(screen))
+	}
 	return absX, absY, nil
 }
 
@@ -2285,22 +2321,24 @@ func directionalSwipeEndpoints(screen *screenState, touchscreen bool, gestureTyp
 	if err != nil {
 		return resolvedPointerPoint{}, resolvedPointerPoint{}, err
 	}
-	touchscreenRCALogf(
-		"directionalSwipeEndpoints type=%q touchscreen=%v travel=%.2f anchor=%.2f start_norm=(%.2f,%.2f) end_norm=(%.2f,%.2f) start_abs=(%d,%d) end_abs=(%d,%d) mapping_at_resolve={%s}",
-		gestureType,
-		touchscreen,
-		travel,
-		center,
-		startX,
-		startY,
-		endX,
-		endY,
-		startAbsX,
-		startAbsY,
-		endAbsX,
-		endAbsY,
-		formatTouchscreenRCAScreenMapping(screen),
-	)
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf(
+			"directionalSwipeEndpoints type=%q touchscreen=%v travel=%.2f anchor=%.2f start_norm=(%.2f,%.2f) end_norm=(%.2f,%.2f) start_abs=(%d,%d) end_abs=(%d,%d) mapping_at_resolve={%s}",
+			gestureType,
+			touchscreen,
+			travel,
+			center,
+			startX,
+			startY,
+			endX,
+			endY,
+			startAbsX,
+			startAbsY,
+			endAbsX,
+			endAbsY,
+			formatTouchscreenRCAScreenMapping(screen),
+		)
+	}
 	return resolvedPointerPoint{x: startAbsX, y: startAbsY}, resolvedPointerPoint{x: endAbsX, y: endAbsY}, nil
 }
 

--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -479,11 +479,15 @@ func (s *screenState) MappingState() screenMappingState {
 }
 
 func (s *screenState) FreshActiveArea(maxAge time.Duration) bool {
-	state := s.MappingState()
-	if state.width <= 0 || state.height <= 0 || !state.active.Valid || state.updatedAt.IsZero() {
+	if s == nil {
 		return false
 	}
-	if maxAge > 0 && time.Since(state.updatedAt) >= maxAge {
+	_, _, active, age, ok := s.ActiveAreaWithAge()
+	state := s.MappingState()
+	if !ok || !active.Valid || state.updatedAt.IsZero() {
+		return false
+	}
+	if maxAge > 0 && age >= maxAge {
 		return false
 	}
 	return true
@@ -1157,13 +1161,10 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		return toolErrorResultf(ctx, CodeToolExecutionFailed, "touchscreen mapping unavailable: %v", err), nil
 	}
 	touchscreenRCALogf(
-		"touch_gesture start type=%q coord_space=%q pointer_mode=%s button=0x%02x input=%s mapping_before={%s}",
+		"touch_gesture start type=%q coord_space=%q mapping_before={%s}",
 		gestureType,
 		coordSpace,
-		touchscreenRCAPointerMode(t.pc),
-		button,
-		strings.TrimSpace(input),
-		formatTouchscreenRCAScreenMapping(t.screen),
+		formatTouchscreenRCAMappingSummary(t.screen),
 	)
 
 	switch gestureType {

--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -378,18 +378,22 @@ func (s *screenState) UpdatePhoneScreenInfo(info PhoneScreenInfo) {
 	if s == nil {
 		return
 	}
+	touchscreenRCALogf("screen.UpdatePhoneScreenInfo before={%s} new_phone_screen=%q", formatTouchscreenRCAScreenMapping(s), formatPhoneScreen(info))
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.phoneScreen = info
+	s.mu.Unlock()
+	touchscreenRCALogf("screen.UpdatePhoneScreenInfo after={%s}", formatTouchscreenRCAScreenMapping(s))
 }
 
 func (s *screenState) ClearPhoneScreenInfo() {
 	if s == nil {
 		return
 	}
+	touchscreenRCALogf("screen.ClearPhoneScreenInfo before={%s}", formatTouchscreenRCAScreenMapping(s))
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.phoneScreen = PhoneScreenInfo{}
+	s.mu.Unlock()
+	touchscreenRCALogf("screen.ClearPhoneScreenInfo after={%s}", formatTouchscreenRCAScreenMapping(s))
 }
 
 func (s *screenState) PhoneScreenInfo() PhoneScreenInfo {
@@ -403,20 +407,31 @@ func (s *screenState) PhoneScreenInfo() PhoneScreenInfo {
 
 func (s *screenState) UpdateActiveArea(width, height int, active screenActiveArea) {
 	if width <= 0 || height <= 0 {
+		touchscreenRCALogf("screen.UpdateActiveArea ignored invalid dimensions width=%d height=%d active=%s before={%s}", width, height, formatTouchscreenRCAActiveArea(active), formatTouchscreenRCAScreenMapping(s))
 		return
 	}
+	requestedActive := active
 	if active.Valid {
 		if active.X < 0 || active.Y < 0 || active.Width <= 0 || active.Height <= 0 || active.X+active.Width > width || active.Y+active.Height > height {
 			active = screenActiveArea{}
 		}
 	}
 
+	touchscreenRCALogf(
+		"screen.UpdateActiveArea before={%s} request_width=%d request_height=%d requested_active=%s committed_active=%s",
+		formatTouchscreenRCAScreenMapping(s),
+		width,
+		height,
+		formatTouchscreenRCAActiveArea(requestedActive),
+		formatTouchscreenRCAActiveArea(active),
+	)
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.width = width
 	s.height = height
 	s.active = active
 	s.updatedAt = time.Now()
+	s.mu.Unlock()
+	touchscreenRCALogf("screen.UpdateActiveArea after={%s}", formatTouchscreenRCAScreenMapping(s))
 }
 
 func (s *screenState) Dimensions() (width, height int, ok bool) {
@@ -461,6 +476,17 @@ func (s *screenState) MappingState() screenMappingState {
 		active:    s.active,
 		updatedAt: s.updatedAt,
 	}
+}
+
+func (s *screenState) FreshActiveArea(maxAge time.Duration) bool {
+	state := s.MappingState()
+	if state.width <= 0 || state.height <= 0 || !state.active.Valid || state.updatedAt.IsZero() {
+		return false
+	}
+	if maxAge > 0 && time.Since(state.updatedAt) >= maxAge {
+		return false
+	}
+	return true
 }
 
 func (s *screenState) RestoreMappingState(state screenMappingState) {
@@ -1053,8 +1079,9 @@ func (t *MouseMoveTool) Call(ctx context.Context, input string) (string, error) 
 
 // TouchGestureTool executes touch-like pointer gestures for mobile UI control.
 type TouchGestureTool struct {
-	pc     *pointerController
-	screen *screenState
+	pc                 *pointerController
+	screen             *screenState
+	primeScreenMapping func(context.Context) error
 }
 
 func (t *TouchGestureTool) Name() string { return "touch_gesture" }
@@ -1126,6 +1153,18 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		coordSpace = coordinateSpaceNormalized
 	}
 	button := mouseButtonByte(args.Button)
+	if err := t.ensureTouchscreenMapping(ctx, coordSpace); err != nil {
+		return toolErrorResultf(ctx, CodeToolExecutionFailed, "touchscreen mapping unavailable: %v", err), nil
+	}
+	touchscreenRCALogf(
+		"touch_gesture start type=%q coord_space=%q pointer_mode=%s button=0x%02x input=%s mapping_before={%s}",
+		gestureType,
+		coordSpace,
+		touchscreenRCAPointerMode(t.pc),
+		button,
+		strings.TrimSpace(input),
+		formatTouchscreenRCAScreenMapping(t.screen),
+	)
 
 	switch gestureType {
 	case "tap":
@@ -1133,6 +1172,7 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
+		touchscreenRCALogResolvedPoint("touch_gesture tap", t.screen, t.pc, args.Point, coordSpace, point)
 		if err := tapPointerWithHold(t.pc, point.x, point.y, button, intOrDefault(args.HoldMs, defaultTapHoldMs)); err != nil {
 			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
@@ -1141,6 +1181,7 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
+		touchscreenRCALogResolvedPoint("touch_gesture double_tap", t.screen, t.pc, args.Point, coordSpace, point)
 		holdMs := intOrDefault(args.HoldMs, defaultTapHoldMs)
 		if err := tapPointerWithHold(t.pc, point.x, point.y, button, holdMs); err != nil {
 			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
@@ -1154,6 +1195,7 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
+		touchscreenRCALogResolvedPoint("touch_gesture long_press", t.screen, t.pc, args.Point, coordSpace, point)
 		if err := settlePointer(t.pc, point.x, point.y); err != nil {
 			return toolErrorResultf(ctx, CodeToolExecutionFailed, "%v", err), nil
 		}
@@ -1180,6 +1222,17 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
+		touchscreenRCALogf(
+			"touch_gesture directional resolved type=%q start_abs=(%d,%d) end_abs=(%d,%d) coord_space=%q pointer_mode=%s mapping_at_resolve={%s}",
+			gestureType,
+			start.x,
+			start.y,
+			end.x,
+			end.y,
+			coordinateSpaceNormalized,
+			touchscreenRCAPointerMode(t.pc),
+			formatTouchscreenRCAScreenMapping(t.screen),
+		)
 		if sameResolvedPointerPoint(start, end) {
 			return toolErrorResultString(ctx, CodeInvalidArguments, "directional swipe resolved to the same HID point"), nil
 		}
@@ -1203,10 +1256,12 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
+		touchscreenRCALogResolvedPoint("touch_gesture drag start", t.screen, t.pc, args.Start, coordSpace, start)
 		end, err := resolveRequiredPoint(t.screen, t.pc.touchscreen, args.End, coordSpace)
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
+		touchscreenRCALogResolvedPoint("touch_gesture drag end", t.screen, t.pc, args.End, coordSpace, end)
 		if sameResolvedPointerPoint(start, end) {
 			return toolErrorResultString(ctx, CodeInvalidArguments, "drag start and end resolve to the same HID point"), nil
 		}
@@ -1233,10 +1288,12 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
+		touchscreenRCALogResolvedPoint("touch_gesture swipe start", t.screen, t.pc, args.Start, coordSpace, start)
 		end, err := resolveRequiredPoint(t.screen, t.pc.touchscreen, args.End, coordSpace)
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
+		touchscreenRCALogResolvedPoint("touch_gesture swipe end", t.screen, t.pc, args.End, coordSpace, end)
 		if sameResolvedPointerPoint(start, end) {
 			return toolErrorResultString(ctx, CodeInvalidArguments, "swipe start and end resolve to the same HID point"), nil
 		}
@@ -1257,10 +1314,12 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
+		touchscreenRCALogResolvedPoint("touch_gesture back start", t.screen, t.pc, args.Start, coordSpace, start)
 		end, err := resolvePointOrDefaultNormalized(t.screen, t.pc.touchscreen, args.End, coordSpace, phoneBackEndX, phoneBackY)
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
+		touchscreenRCALogResolvedPoint("touch_gesture back end", t.screen, t.pc, args.End, coordSpace, end)
 		if err := runPositionedDragGesture(
 			t.pc,
 			start,
@@ -1278,10 +1337,12 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
+		touchscreenRCALogResolvedPoint("touch_gesture home start", t.screen, t.pc, args.Start, coordSpace, start)
 		end, err := resolvePointOrDefaultNormalized(t.screen, t.pc.touchscreen, args.End, coordSpace, phoneHomeX, phoneHomeEndY)
 		if err != nil {
 			return toolErrorResultf(ctx, CodeInvalidArguments, "%v", err), nil
 		}
+		touchscreenRCALogResolvedPoint("touch_gesture home end", t.screen, t.pc, args.End, coordSpace, end)
 		if err := runPositionedDragGesture(
 			t.pc,
 			start,
@@ -1298,7 +1359,30 @@ func (t *TouchGestureTool) Call(ctx context.Context, input string) (string, erro
 		return toolErrorResultf(ctx, CodeInvalidArguments, "unsupported gesture type: %q", args.Type), nil
 	}
 
+	touchscreenRCALogf("touch_gesture completed type=%q mapping_after_action_before_post_screenshot={%s}", gestureType, formatTouchscreenRCAScreenMapping(t.screen))
 	return "ok", nil
+}
+
+func (t *TouchGestureTool) ensureTouchscreenMapping(ctx context.Context, coordSpace string) error {
+	if t == nil || t.pc == nil || !t.pc.touchscreen || t.screen == nil || t.primeScreenMapping == nil {
+		return nil
+	}
+	space, err := normalizeCoordinateSpace(coordSpace, coordinateSpaceNormalized)
+	if err != nil {
+		return nil
+	}
+	if space != coordinateSpaceNormalized && space != coordinateSpaceAuto {
+		return nil
+	}
+	if t.screen.FreshActiveArea(screenDimensionsStaleAfter) {
+		return nil
+	}
+	touchscreenRCALogf("touch_gesture prime mapping before input coord_space=%q mapping_before={%s}", coordSpace, formatTouchscreenRCAScreenMapping(t.screen))
+	if err := t.primeScreenMapping(ctx); err != nil {
+		return err
+	}
+	touchscreenRCALogf("touch_gesture prime mapping succeeded mapping_after={%s}", formatTouchscreenRCAScreenMapping(t.screen))
+	return nil
 }
 
 func samePointerPoint(first, second *pointerPoint) bool {
@@ -1682,9 +1766,30 @@ func writeTouchscreenReport(dev *HIDDevice, state *pointerState, x, y int, touch
 		}
 	}
 
+	path := "<nil>"
+	if dev != nil {
+		path = dev.path
+	}
+	touchscreenRCALogf(
+		"hid touchscreen report write start path=%s requested=(%d,%d) clamped=(%d,%d) touching=%v flags=0x%02x report=% x",
+		path,
+		x,
+		y,
+		absX,
+		absY,
+		touching,
+		report[0],
+		report,
+	)
 	dev.mu.Lock()
 	defer dev.mu.Unlock()
-	return dev.writeLocked(report, after)
+	err := dev.writeLocked(report, after)
+	if err != nil {
+		touchscreenRCALogf("hid touchscreen report write error path=%s clamped=(%d,%d) touching=%v err=%v", path, absX, absY, touching, err)
+		return err
+	}
+	touchscreenRCALogf("hid touchscreen report write ok path=%s clamped=(%d,%d) touching=%v", path, absX, absY, touching)
+	return nil
 }
 
 func (pc *pointerController) currentXY() (int, int) {
@@ -1895,12 +2000,45 @@ func normalizedToAbsolutePointForSurface(screen *screenState, touchscreen bool, 
 			if touchscreen {
 				fullFramePixelX := float64(active.X) + activePixelX
 				fullFramePixelY := float64(active.Y) + activePixelY
-				return scalePixelToAbsolute(fullFramePixelX, width), scalePixelToAbsolute(fullFramePixelY, height), nil
+				absX := scalePixelToAbsolute(fullFramePixelX, width)
+				absY := scalePixelToAbsolute(fullFramePixelY, height)
+				touchscreenRCALogf(
+					"normalizedToAbsolute touchscreen using active_area input_norm=(%.2f,%.2f) active_pixel=(%.2f,%.2f) full_frame_pixel=(%.2f,%.2f) source=%dx%d active=%s age_ms=%d absolute=(%d,%d)",
+					x,
+					y,
+					activePixelX,
+					activePixelY,
+					fullFramePixelX,
+					fullFramePixelY,
+					width,
+					height,
+					formatTouchscreenRCAActiveArea(active),
+					age.Milliseconds(),
+					absX,
+					absY,
+				)
+				return absX, absY, nil
 			}
-			return activeLocalAxisToAbsolute(activePixelX, active.X, active.Width, width), activeLocalAxisToAbsolute(activePixelY, active.Y, active.Height, height), nil
+			absX := activeLocalAxisToAbsolute(activePixelX, active.X, active.Width, width)
+			absY := activeLocalAxisToAbsolute(activePixelY, active.Y, active.Height, height)
+			touchscreenRCALogf(
+				"normalizedToAbsolute absolute_mouse using active_area input_norm=(%.2f,%.2f) active_pixel=(%.2f,%.2f) source=%dx%d active=%s age_ms=%d absolute=(%d,%d)",
+				x,
+				y,
+				activePixelX,
+				activePixelY,
+				width,
+				height,
+				formatTouchscreenRCAActiveArea(active),
+				age.Milliseconds(),
+				absX,
+				absY,
+			)
+			return absX, absY, nil
 		}
 	}
 	absX, absY := normalizedToAbsolutePoint(x, y)
+	touchscreenRCALogf("normalizedToAbsolute fallback input_norm=(%.2f,%.2f) touchscreen=%v absolute=(%d,%d) mapping={%s}", x, y, touchscreen, absX, absY, formatTouchscreenRCAScreenMapping(screen))
 	return absX, absY, nil
 }
 
@@ -2000,6 +2138,7 @@ func tapPointer(pc *pointerController, x, y int, button uint8) error {
 }
 
 func tapPointerWithHold(pc *pointerController, x, y int, button uint8, holdMs int) error {
+	touchscreenRCALogf("tapPointerWithHold start pointer_mode=%s absolute=(%d,%d) button=0x%02x hold_ms=%d", touchscreenRCAPointerMode(pc), x, y, button, holdMs)
 	if err := settlePointer(pc, x, y); err != nil {
 		return err
 	}
@@ -2007,7 +2146,13 @@ func tapPointerWithHold(pc *pointerController, x, y int, button uint8, holdMs in
 		return err
 	}
 	sleepMs(holdMs)
-	return releasePointerRepeated(pc, x, y, touchReleaseReportCount, touchReleaseReportDelayMs)
+	err := releasePointerRepeated(pc, x, y, touchReleaseReportCount, touchReleaseReportDelayMs)
+	if err != nil {
+		touchscreenRCALogf("tapPointerWithHold error pointer_mode=%s absolute=(%d,%d) err=%v", touchscreenRCAPointerMode(pc), x, y, err)
+		return err
+	}
+	touchscreenRCALogf("tapPointerWithHold completed pointer_mode=%s absolute=(%d,%d)", touchscreenRCAPointerMode(pc), x, y)
+	return nil
 }
 
 func settlePointer(pc *pointerController, x, y int) error {
@@ -2139,6 +2284,22 @@ func directionalSwipeEndpoints(screen *screenState, touchscreen bool, gestureTyp
 	if err != nil {
 		return resolvedPointerPoint{}, resolvedPointerPoint{}, err
 	}
+	touchscreenRCALogf(
+		"directionalSwipeEndpoints type=%q touchscreen=%v travel=%.2f anchor=%.2f start_norm=(%.2f,%.2f) end_norm=(%.2f,%.2f) start_abs=(%d,%d) end_abs=(%d,%d) mapping_at_resolve={%s}",
+		gestureType,
+		touchscreen,
+		travel,
+		center,
+		startX,
+		startY,
+		endX,
+		endY,
+		startAbsX,
+		startAbsY,
+		endAbsX,
+		endAbsY,
+		formatTouchscreenRCAScreenMapping(screen),
+	)
 	return resolvedPointerPoint{x: startAbsX, y: startAbsY}, resolvedPointerPoint{x: endAbsX, y: endAbsY}, nil
 }
 
@@ -2156,6 +2317,19 @@ func dragPointer(pc *pointerController, start, end resolvedPointerPoint, button 
 		holdAfterMs = 0
 	}
 
+	touchscreenRCALogf(
+		"dragPointer start pointer_mode=%s start_abs=(%d,%d) end_abs=(%d,%d) button=0x%02x duration_ms=%d hold_before_ms=%d hold_after_ms=%d steps=%d",
+		touchscreenRCAPointerMode(pc),
+		start.x,
+		start.y,
+		end.x,
+		end.y,
+		button,
+		durationMs,
+		holdBeforeMs,
+		holdAfterMs,
+		steps,
+	)
 	if err := settlePointer(pc, start.x, start.y); err != nil {
 		return err
 	}
@@ -2189,6 +2363,7 @@ func dragPointer(pc *pointerController, start, end resolvedPointerPoint, button 
 	}
 
 	sleepMs(holdAfterMs)
+	touchscreenRCALogf("dragPointer completed pointer_mode=%s start_abs=(%d,%d) end_abs=(%d,%d)", touchscreenRCAPointerMode(pc), start.x, start.y, end.x, end.y)
 	return nil
 }
 

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -239,6 +239,68 @@ func TestTouchGestureRejectsDistinctInputsResolvingToSameHIDPoint(t *testing.T) 
 	}
 }
 
+func TestTouchGestureTouchscreenPrimesMappingBeforeNormalizedInput(t *testing.T) {
+	dev, path := newTestHIDDevice(t)
+	screen := &screenState{}
+	primeCalls := 0
+	tool := &TouchGestureTool{
+		pc:     testTouchscreenPointerController(dev, &pointerState{}),
+		screen: screen,
+		primeScreenMapping: func(context.Context) error {
+			primeCalls++
+			screen.UpdateActiveArea(1920, 1080, screenActiveArea{X: 711, Y: 0, Width: 497, Height: 1080, Valid: true})
+			return nil
+		},
+	}
+
+	out, err := tool.Call(context.Background(), `{"type":"tap","point":{"x":931,"y":83}}`)
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("Call output = %q, want ok", out)
+	}
+	if primeCalls != 1 {
+		t.Fatalf("prime calls = %d, want 1", primeCalls)
+	}
+
+	reports := readTouchscreenReports(t, dev, path)
+	if len(reports) != 1+touchReleaseReportCount {
+		t.Fatalf("len(reports) = %d, want %d", len(reports), 1+touchReleaseReportCount)
+	}
+	expectedX := scalePixelToAbsolute(711+(931.0/1000.0)*496, 1920)
+	expectedY := scalePixelToAbsolute((83.0/1000.0)*1079, 1080)
+	if reports[0].x != uint16(expectedX) || reports[0].y != uint16(expectedY) {
+		t.Fatalf("first report = (%d,%d), want (%d,%d)", reports[0].x, reports[0].y, expectedX, expectedY)
+	}
+	fallbackX, fallbackY := normalizedToAbsolutePoint(931, 83)
+	if reports[0].x == uint16(fallbackX) && reports[0].y == uint16(fallbackY) {
+		t.Fatalf("first report used fallback coordinates (%d,%d)", reports[0].x, reports[0].y)
+	}
+}
+
+func TestTouchGestureTouchscreenDoesNotWriteWhenMappingPrimeFails(t *testing.T) {
+	dev, path := newTestHIDDevice(t)
+	tool := &TouchGestureTool{
+		pc:     testTouchscreenPointerController(dev, &pointerState{}),
+		screen: &screenState{},
+		primeScreenMapping: func(context.Context) error {
+			return errors.New("frame service recovering")
+		},
+	}
+
+	out, err := tool.Call(context.Background(), `{"type":"tap","point":{"x":931,"y":83}}`)
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if !strings.Contains(out, "touchscreen mapping unavailable") {
+		t.Fatalf("Call output = %q, want mapping error", out)
+	}
+	if reports := readTouchscreenReports(t, dev, path); len(reports) != 0 {
+		t.Fatalf("len(reports) = %d, want no HID writes", len(reports))
+	}
+}
+
 func TestWheelNudgeLargeSupportsDown(t *testing.T) {
 	dev, path := newTestHIDDevice(t)
 	tool := &WheelNudgeTool{pc: testPointerController(dev, &pointerState{}), screen: &screenState{}, durationMs: 1}

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -301,6 +301,42 @@ func TestTouchGestureTouchscreenDoesNotWriteWhenMappingPrimeFails(t *testing.T) 
 	}
 }
 
+func TestTouchGestureTouchscreenKeepsFreshFullFrameMappingWhenPrimeWouldFail(t *testing.T) {
+	dev, path := newTestHIDDevice(t)
+	screen := &screenState{}
+	screen.UpdateActiveArea(1920, 1080, screenActiveArea{})
+	primeCalls := 0
+	tool := &TouchGestureTool{
+		pc:     testTouchscreenPointerController(dev, &pointerState{}),
+		screen: screen,
+		primeScreenMapping: func(context.Context) error {
+			primeCalls++
+			return errors.New("frame service unavailable")
+		},
+	}
+
+	out, err := tool.Call(context.Background(), `{"type":"tap","point":{"x":931,"y":83}}`)
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("Call output = %q, want ok", out)
+	}
+	if primeCalls != 0 {
+		t.Fatalf("prime calls = %d, want 0", primeCalls)
+	}
+
+	reports := readTouchscreenReports(t, dev, path)
+	if len(reports) != 1+touchReleaseReportCount {
+		t.Fatalf("len(reports) = %d, want %d", len(reports), 1+touchReleaseReportCount)
+	}
+	expectedX := scalePixelToAbsolute((931.0/1000.0)*1919, 1920)
+	expectedY := scalePixelToAbsolute((83.0/1000.0)*1079, 1080)
+	if reports[0].x != uint16(expectedX) || reports[0].y != uint16(expectedY) {
+		t.Fatalf("first report = (%d,%d), want (%d,%d)", reports[0].x, reports[0].y, expectedX, expectedY)
+	}
+}
+
 func TestWheelNudgeLargeSupportsDown(t *testing.T) {
 	dev, path := newTestHIDDevice(t)
 	tool := &WheelNudgeTool{pc: testPointerController(dev, &pointerState{}), screen: &screenState{}, durationMs: 1}
@@ -2627,6 +2663,23 @@ func TestScreenStateDimensionsWithAge(t *testing.T) {
 	}
 	if age > time.Second {
 		t.Fatalf("fresh age = %v, want < 1s", age)
+	}
+}
+
+func TestScreenStateFreshActiveAreaUsesFullFrameFallbackAndExpires(t *testing.T) {
+	screen := &screenState{}
+	screen.UpdateActiveArea(1920, 1080, screenActiveArea{})
+
+	if !screen.FreshActiveArea(screenDimensionsStaleAfter) {
+		t.Fatal("expected fresh full-frame fallback mapping")
+	}
+
+	screen.mu.Lock()
+	screen.updatedAt = time.Now().Add(-2 * screenDimensionsStaleAfter)
+	screen.mu.Unlock()
+
+	if screen.FreshActiveArea(screenDimensionsStaleAfter) {
+		t.Fatal("expected stale full-frame fallback mapping to expire")
 	}
 }
 

--- a/src/agent/internal/agent/tools_post_action_screenshot.go
+++ b/src/agent/internal/agent/tools_post_action_screenshot.go
@@ -77,11 +77,15 @@ func (t *postActionScreenshotTool) ArgsSchema() map[string]any {
 }
 
 func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (string, error) {
+	touchscreenRCALogf("post_action start inner=%q input=%s", t.inner.Name(), strings.TrimSpace(input))
 	actionOutput, err := t.inner.Call(ctx, input)
 	if err != nil {
+		touchscreenRCALogf("post_action inner error inner=%q err=%v", t.inner.Name(), err)
 		return "", err
 	}
+	touchscreenRCALogf("post_action inner completed inner=%q output=%q", t.inner.Name(), actionOutput)
 	if te := ToolErrorFromContext(ctx); te != nil {
+		touchscreenRCALogf("post_action inner tool_error inner=%q code=%q message=%q", t.inner.Name(), te.Code, te.Message)
 		return toolErrorString(te), nil
 	}
 	if legacyToolOutputLooksLikeError(actionOutput) {
@@ -93,14 +97,17 @@ func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (stri
 
 	var waitResult waitStableScreenResult
 	if t.waitStable != nil {
+		touchscreenRCALogf("post_action wait_stable start inner=%q wait_input=%s", t.inner.Name(), t.waitInput)
 		if waiter, ok := t.waitStable.(stableScreenWaiter); ok {
 			waitResult, err = waiter.wait(ctx, t.waitInput)
 			if err != nil {
+				touchscreenRCALogf("post_action wait_stable error inner=%q err=%v", t.inner.Name(), err)
 				return postActionErrorResultf(ctx, postActionErrorCode(err), "%s completed with output %q, but stable-screen wait failed: %v", t.inner.Name(), actionOutput, err), nil
 			}
 		} else {
 			waitOutput, err := t.waitStable.Call(ctx, t.waitInput)
 			if err != nil {
+				touchscreenRCALogf("post_action wait_stable call error inner=%q err=%v", t.inner.Name(), err)
 				return postActionErrorResultf(ctx, postActionErrorCode(err), "%s completed with output %q, but stable-screen wait failed: %v", t.inner.Name(), actionOutput, err), nil
 			}
 			if te := ToolErrorFromContext(ctx); te != nil {
@@ -119,12 +126,22 @@ func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (stri
 		if !waitResult.OK {
 			return postActionErrorResultf(ctx, CodeToolExecutionFailed, "%s completed with output %q, but stable-screen wait failed", t.inner.Name(), actionOutput), nil
 		}
+		touchscreenRCALogf(
+			"post_action wait_stable completed inner=%q stable=%v elapsed_ms=%d screen_changed=%v last_diff=%s",
+			t.inner.Name(),
+			waitResult.Stable,
+			waitResult.ElapsedMs,
+			waitResult.ScreenChanged != nil && *waitResult.ScreenChanged,
+			formatTouchscreenRCAFloatPtr(waitResult.LastDiff),
+		)
 	} else if err := waitForPostActionScreenshot(ctx, t.delay); err != nil {
 		return postActionErrorResultf(ctx, postActionErrorCode(err), "%s completed with output %q, but post-action delay failed: %v", t.inner.Name(), actionOutput, err), nil
 	}
 
+	touchscreenRCALogf("post_action screenshot start inner=%q", t.inner.Name())
 	screenshotOutput, err := t.screenshot.Call(ctx, "{}")
 	if err != nil {
+		touchscreenRCALogf("post_action screenshot error inner=%q err=%v", t.inner.Name(), err)
 		return postActionErrorResultf(ctx, postActionErrorCode(err), "%s completed with output %q, but post-action screenshot failed: %v", t.inner.Name(), actionOutput, err), nil
 	}
 	if te := ToolErrorFromContext(ctx); te != nil {
@@ -135,6 +152,7 @@ func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (stri
 	if err := json.Unmarshal([]byte(screenshotOutput), &result); err != nil {
 		return postActionErrorResultf(ctx, CodeToolExecutionFailed, "%s completed with output %q, but post-action screenshot was invalid: %v", t.inner.Name(), actionOutput, err), nil
 	}
+	touchscreenRCALogf("post_action screenshot completed inner=%q display=%dx%d capture_backend=%q size=%d", t.inner.Name(), result.Width, result.Height, result.CaptureBackend, result.Size)
 
 	payload := postActionScreenshotResult{
 		screenshotResult: result,

--- a/src/agent/internal/agent/tools_post_action_screenshot.go
+++ b/src/agent/internal/agent/tools_post_action_screenshot.go
@@ -77,15 +77,15 @@ func (t *postActionScreenshotTool) ArgsSchema() map[string]any {
 }
 
 func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (string, error) {
-	touchscreenRCALogf("post_action start inner=%q input=%s", t.inner.Name(), strings.TrimSpace(input))
+	touchscreenRCALogf("post_action start inner=%q input_len=%d", t.inner.Name(), len(input))
 	actionOutput, err := t.inner.Call(ctx, input)
 	if err != nil {
-		touchscreenRCALogf("post_action inner error inner=%q err=%v", t.inner.Name(), err)
+		touchscreenRCALogf("post_action inner error inner=%q err_type=%T", t.inner.Name(), err)
 		return "", err
 	}
-	touchscreenRCALogf("post_action inner completed inner=%q output=%q", t.inner.Name(), actionOutput)
+	touchscreenRCALogf("post_action inner completed inner=%q output_len=%d", t.inner.Name(), len(actionOutput))
 	if te := ToolErrorFromContext(ctx); te != nil {
-		touchscreenRCALogf("post_action inner tool_error inner=%q code=%q message=%q", t.inner.Name(), te.Code, te.Message)
+		touchscreenRCALogf("post_action inner tool_error inner=%q code=%q category=%q", t.inner.Name(), te.Code, te.Category)
 		return toolErrorString(te), nil
 	}
 	if legacyToolOutputLooksLikeError(actionOutput) {
@@ -97,17 +97,17 @@ func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (stri
 
 	var waitResult waitStableScreenResult
 	if t.waitStable != nil {
-		touchscreenRCALogf("post_action wait_stable start inner=%q wait_input=%s", t.inner.Name(), t.waitInput)
+		touchscreenRCALogf("post_action wait_stable start inner=%q", t.inner.Name())
 		if waiter, ok := t.waitStable.(stableScreenWaiter); ok {
 			waitResult, err = waiter.wait(ctx, t.waitInput)
 			if err != nil {
-				touchscreenRCALogf("post_action wait_stable error inner=%q err=%v", t.inner.Name(), err)
+				touchscreenRCALogf("post_action wait_stable error inner=%q err_type=%T", t.inner.Name(), err)
 				return postActionErrorResultf(ctx, postActionErrorCode(err), "%s completed with output %q, but stable-screen wait failed: %v", t.inner.Name(), actionOutput, err), nil
 			}
 		} else {
 			waitOutput, err := t.waitStable.Call(ctx, t.waitInput)
 			if err != nil {
-				touchscreenRCALogf("post_action wait_stable call error inner=%q err=%v", t.inner.Name(), err)
+				touchscreenRCALogf("post_action wait_stable call error inner=%q err_type=%T", t.inner.Name(), err)
 				return postActionErrorResultf(ctx, postActionErrorCode(err), "%s completed with output %q, but stable-screen wait failed: %v", t.inner.Name(), actionOutput, err), nil
 			}
 			if te := ToolErrorFromContext(ctx); te != nil {
@@ -141,7 +141,7 @@ func (t *postActionScreenshotTool) Call(ctx context.Context, input string) (stri
 	touchscreenRCALogf("post_action screenshot start inner=%q", t.inner.Name())
 	screenshotOutput, err := t.screenshot.Call(ctx, "{}")
 	if err != nil {
-		touchscreenRCALogf("post_action screenshot error inner=%q err=%v", t.inner.Name(), err)
+		touchscreenRCALogf("post_action screenshot error inner=%q err_type=%T", t.inner.Name(), err)
 		return postActionErrorResultf(ctx, postActionErrorCode(err), "%s completed with output %q, but post-action screenshot failed: %v", t.inner.Name(), actionOutput, err), nil
 	}
 	if te := ToolErrorFromContext(ctx); te != nil {

--- a/src/agent/internal/agent/tools_quick_actions.go
+++ b/src/agent/internal/agent/tools_quick_actions.go
@@ -356,7 +356,7 @@ type quickActionArgs struct {
 func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error) {
 	var args quickActionArgs
 	trimmed := strings.TrimSpace(input)
-	touchscreenRCALogf("quick_action start input=%s mapping_before={%s}", trimmed, formatTouchscreenRCAQuickActionMapping(t))
+	touchscreenRCALogf("quick_action start input_len=%d mapping_before={%s}", len(input), formatTouchscreenRCAQuickActionMappingSummary(t))
 	if trimmed == "" {
 		te := NewToolError(CodeInvalidArguments, "action or list is required")
 		SetToolError(ctx, te)
@@ -425,15 +425,14 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 		selectedSource = fmt.Sprintf("alternative_%d", idx)
 	}
 	touchscreenRCALogf(
-		"quick_action selected action=%q label=%q platform=%q binding=%q status=%q tool=%q steps=%d mapping_before_delegate={%s}",
+		"quick_action selected action=%q platform=%q binding=%q status=%q tool=%q steps=%d mapping_before_delegate={%s}",
 		actionID,
-		action.Label,
 		platform,
 		selectedSource,
 		selected.Status,
 		selected.Tool,
 		len(selected.Steps),
-		formatTouchscreenRCAQuickActionMapping(t),
+		formatTouchscreenRCAQuickActionMappingSummary(t),
 	)
 
 	status := strings.TrimSpace(selected.Status)
@@ -593,7 +592,7 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 		}
 		result["alternatives"] = alts
 	}
-	touchscreenRCALogf("quick_action completed action=%q platform=%q tool=%q mapping_after_delegate={%s}", actionID, platform, toolName, formatTouchscreenRCAQuickActionMapping(t))
+	touchscreenRCALogf("quick_action completed action=%q platform=%q tool=%q mapping_after_delegate={%s}", actionID, platform, toolName, formatTouchscreenRCAQuickActionMappingSummary(t))
 	return jsonString(result), nil
 }
 
@@ -601,7 +600,7 @@ func (t *QuickActionTool) delegate(ctx context.Context, toolName, payload string
 	subCtx, _ := WithToolError(ctx)
 	var output string
 	var err error
-	touchscreenRCALogf("quick_action delegate start tool=%q payload=%s mapping_before={%s}", toolName, payload, formatTouchscreenRCAQuickActionMapping(t))
+	touchscreenRCALogf("quick_action delegate start tool=%q payload_len=%d mapping_before={%s}", toolName, len(payload), formatTouchscreenRCAQuickActionMappingSummary(t))
 	switch toolName {
 	case "keyboard_tap":
 		if t.keyboard == nil {
@@ -617,20 +616,20 @@ func (t *QuickActionTool) delegate(ctx context.Context, toolName, payload string
 		return "", nil, fmt.Errorf("unsupported delegated tool %q", toolName)
 	}
 	if err != nil {
-		touchscreenRCALogf("quick_action delegate error tool=%q err=%v mapping_after={%s}", toolName, err, formatTouchscreenRCAQuickActionMapping(t))
+		touchscreenRCALogf("quick_action delegate error tool=%q err_type=%T mapping_after={%s}", toolName, err, formatTouchscreenRCAQuickActionMappingSummary(t))
 		return output, nil, err
 	}
 	if te := ToolErrorFromContext(subCtx); te != nil {
-		touchscreenRCALogf("quick_action delegate tool_error tool=%q code=%q message=%q mapping_after={%s}", toolName, te.Code, te.Message, formatTouchscreenRCAQuickActionMapping(t))
+		touchscreenRCALogf("quick_action delegate tool_error tool=%q code=%q category=%q mapping_after={%s}", toolName, te.Code, te.Category, formatTouchscreenRCAQuickActionMappingSummary(t))
 		return output, te, nil
 	}
 	if legacyToolOutputLooksLikeError(output) {
 		trimmed := strings.TrimSpace(output)
 		message := strings.TrimSpace(trimmed[len("error:"):])
-		touchscreenRCALogf("quick_action delegate legacy_error tool=%q message=%q mapping_after={%s}", toolName, message, formatTouchscreenRCAQuickActionMapping(t))
+		touchscreenRCALogf("quick_action delegate legacy_error tool=%q output_len=%d mapping_after={%s}", toolName, len(output), formatTouchscreenRCAQuickActionMappingSummary(t))
 		return output, NewToolError(CodeToolExecutionFailed, message), nil
 	}
-	touchscreenRCALogf("quick_action delegate completed tool=%q output=%q mapping_after={%s}", toolName, output, formatTouchscreenRCAQuickActionMapping(t))
+	touchscreenRCALogf("quick_action delegate completed tool=%q output_len=%d mapping_after={%s}", toolName, len(output), formatTouchscreenRCAQuickActionMappingSummary(t))
 	return output, nil, nil
 }
 

--- a/src/agent/internal/agent/tools_quick_actions.go
+++ b/src/agent/internal/agent/tools_quick_actions.go
@@ -356,7 +356,9 @@ type quickActionArgs struct {
 func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error) {
 	var args quickActionArgs
 	trimmed := strings.TrimSpace(input)
-	touchscreenRCALogf("quick_action start input_len=%d mapping_before={%s}", len(input), formatTouchscreenRCAQuickActionMappingSummary(t))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("quick_action start input_len=%d mapping_before={%s}", len(input), formatTouchscreenRCAQuickActionMappingSummary(t))
+	}
 	if trimmed == "" {
 		te := NewToolError(CodeInvalidArguments, "action or list is required")
 		SetToolError(ctx, te)
@@ -424,16 +426,18 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 		selected = binding.Alternatives[idx-1]
 		selectedSource = fmt.Sprintf("alternative_%d", idx)
 	}
-	touchscreenRCALogf(
-		"quick_action selected action=%q platform=%q binding=%q status=%q tool=%q steps=%d mapping_before_delegate={%s}",
-		actionID,
-		platform,
-		selectedSource,
-		selected.Status,
-		selected.Tool,
-		len(selected.Steps),
-		formatTouchscreenRCAQuickActionMappingSummary(t),
-	)
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf(
+			"quick_action selected action=%q platform=%q binding=%q status=%q tool=%q steps=%d mapping_before_delegate={%s}",
+			actionID,
+			platform,
+			selectedSource,
+			selected.Status,
+			selected.Tool,
+			len(selected.Steps),
+			formatTouchscreenRCAQuickActionMappingSummary(t),
+		)
+	}
 
 	status := strings.TrimSpace(selected.Status)
 	if status == "" {
@@ -592,7 +596,9 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 		}
 		result["alternatives"] = alts
 	}
-	touchscreenRCALogf("quick_action completed action=%q platform=%q tool=%q mapping_after_delegate={%s}", actionID, platform, toolName, formatTouchscreenRCAQuickActionMappingSummary(t))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("quick_action completed action=%q platform=%q tool=%q mapping_after_delegate={%s}", actionID, platform, toolName, formatTouchscreenRCAQuickActionMappingSummary(t))
+	}
 	return jsonString(result), nil
 }
 
@@ -600,7 +606,9 @@ func (t *QuickActionTool) delegate(ctx context.Context, toolName, payload string
 	subCtx, _ := WithToolError(ctx)
 	var output string
 	var err error
-	touchscreenRCALogf("quick_action delegate start tool=%q payload_len=%d mapping_before={%s}", toolName, len(payload), formatTouchscreenRCAQuickActionMappingSummary(t))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("quick_action delegate start tool=%q payload_len=%d mapping_before={%s}", toolName, len(payload), formatTouchscreenRCAQuickActionMappingSummary(t))
+	}
 	switch toolName {
 	case "keyboard_tap":
 		if t.keyboard == nil {
@@ -616,20 +624,28 @@ func (t *QuickActionTool) delegate(ctx context.Context, toolName, payload string
 		return "", nil, fmt.Errorf("unsupported delegated tool %q", toolName)
 	}
 	if err != nil {
-		touchscreenRCALogf("quick_action delegate error tool=%q err_type=%T mapping_after={%s}", toolName, err, formatTouchscreenRCAQuickActionMappingSummary(t))
+		if touchscreenRCADebugEnabledCached() {
+			touchscreenRCALogf("quick_action delegate error tool=%q err_type=%T mapping_after={%s}", toolName, err, formatTouchscreenRCAQuickActionMappingSummary(t))
+		}
 		return output, nil, err
 	}
 	if te := ToolErrorFromContext(subCtx); te != nil {
-		touchscreenRCALogf("quick_action delegate tool_error tool=%q code=%q category=%q mapping_after={%s}", toolName, te.Code, te.Category, formatTouchscreenRCAQuickActionMappingSummary(t))
+		if touchscreenRCADebugEnabledCached() {
+			touchscreenRCALogf("quick_action delegate tool_error tool=%q code=%q category=%q mapping_after={%s}", toolName, te.Code, te.Category, formatTouchscreenRCAQuickActionMappingSummary(t))
+		}
 		return output, te, nil
 	}
 	if legacyToolOutputLooksLikeError(output) {
 		trimmed := strings.TrimSpace(output)
 		message := strings.TrimSpace(trimmed[len("error:"):])
-		touchscreenRCALogf("quick_action delegate legacy_error tool=%q output_len=%d mapping_after={%s}", toolName, len(output), formatTouchscreenRCAQuickActionMappingSummary(t))
+		if touchscreenRCADebugEnabledCached() {
+			touchscreenRCALogf("quick_action delegate legacy_error tool=%q output_len=%d mapping_after={%s}", toolName, len(output), formatTouchscreenRCAQuickActionMappingSummary(t))
+		}
 		return output, NewToolError(CodeToolExecutionFailed, message), nil
 	}
-	touchscreenRCALogf("quick_action delegate completed tool=%q output_len=%d mapping_after={%s}", toolName, len(output), formatTouchscreenRCAQuickActionMappingSummary(t))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("quick_action delegate completed tool=%q output_len=%d mapping_after={%s}", toolName, len(output), formatTouchscreenRCAQuickActionMappingSummary(t))
+	}
 	return output, nil, nil
 }
 

--- a/src/agent/internal/agent/tools_quick_actions.go
+++ b/src/agent/internal/agent/tools_quick_actions.go
@@ -356,6 +356,7 @@ type quickActionArgs struct {
 func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error) {
 	var args quickActionArgs
 	trimmed := strings.TrimSpace(input)
+	touchscreenRCALogf("quick_action start input=%s mapping_before={%s}", trimmed, formatTouchscreenRCAQuickActionMapping(t))
 	if trimmed == "" {
 		te := NewToolError(CodeInvalidArguments, "action or list is required")
 		SetToolError(ctx, te)
@@ -423,6 +424,17 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 		selected = binding.Alternatives[idx-1]
 		selectedSource = fmt.Sprintf("alternative_%d", idx)
 	}
+	touchscreenRCALogf(
+		"quick_action selected action=%q label=%q platform=%q binding=%q status=%q tool=%q steps=%d mapping_before_delegate={%s}",
+		actionID,
+		action.Label,
+		platform,
+		selectedSource,
+		selected.Status,
+		selected.Tool,
+		len(selected.Steps),
+		formatTouchscreenRCAQuickActionMapping(t),
+	)
 
 	status := strings.TrimSpace(selected.Status)
 	if status == "" {
@@ -581,6 +593,7 @@ func (t *QuickActionTool) Call(ctx context.Context, input string) (string, error
 		}
 		result["alternatives"] = alts
 	}
+	touchscreenRCALogf("quick_action completed action=%q platform=%q tool=%q mapping_after_delegate={%s}", actionID, platform, toolName, formatTouchscreenRCAQuickActionMapping(t))
 	return jsonString(result), nil
 }
 
@@ -588,6 +601,7 @@ func (t *QuickActionTool) delegate(ctx context.Context, toolName, payload string
 	subCtx, _ := WithToolError(ctx)
 	var output string
 	var err error
+	touchscreenRCALogf("quick_action delegate start tool=%q payload=%s mapping_before={%s}", toolName, payload, formatTouchscreenRCAQuickActionMapping(t))
 	switch toolName {
 	case "keyboard_tap":
 		if t.keyboard == nil {
@@ -603,16 +617,20 @@ func (t *QuickActionTool) delegate(ctx context.Context, toolName, payload string
 		return "", nil, fmt.Errorf("unsupported delegated tool %q", toolName)
 	}
 	if err != nil {
+		touchscreenRCALogf("quick_action delegate error tool=%q err=%v mapping_after={%s}", toolName, err, formatTouchscreenRCAQuickActionMapping(t))
 		return output, nil, err
 	}
 	if te := ToolErrorFromContext(subCtx); te != nil {
+		touchscreenRCALogf("quick_action delegate tool_error tool=%q code=%q message=%q mapping_after={%s}", toolName, te.Code, te.Message, formatTouchscreenRCAQuickActionMapping(t))
 		return output, te, nil
 	}
 	if legacyToolOutputLooksLikeError(output) {
 		trimmed := strings.TrimSpace(output)
 		message := strings.TrimSpace(trimmed[len("error:"):])
+		touchscreenRCALogf("quick_action delegate legacy_error tool=%q message=%q mapping_after={%s}", toolName, message, formatTouchscreenRCAQuickActionMapping(t))
 		return output, NewToolError(CodeToolExecutionFailed, message), nil
 	}
+	touchscreenRCALogf("quick_action delegate completed tool=%q output=%q mapping_after={%s}", toolName, output, formatTouchscreenRCAQuickActionMapping(t))
 	return output, nil, nil
 }
 

--- a/src/agent/internal/agent/tools_screenshot.go
+++ b/src/agent/internal/agent/tools_screenshot.go
@@ -132,7 +132,9 @@ func (t *ScreenshotTool) Call(_ context.Context, _ string) (string, error) {
 	if meta.PixelFormat != "jpeg" {
 		return "", fmt.Errorf("expected jpeg format, got %s", meta.PixelFormat)
 	}
-	touchscreenRCALogf("screenshot frame meta=%s capture_backend=%q mapping_before={%s}", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, formatTouchscreenRCAScreenMapping(t.screen))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("screenshot frame meta=%s capture_backend=%q mapping_before={%s}", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, formatTouchscreenRCAScreenMapping(t.screen))
+	}
 	active := screenActiveArea{}
 	sourceWidth := int(meta.Width)
 	sourceHeight := int(meta.Height)
@@ -145,16 +147,18 @@ func (t *ScreenshotTool) Call(_ context.Context, _ string) (string, error) {
 	} else {
 		active = detectScreenshotActiveAreaForScreen(t.screen, jpegData, int(meta.Width), int(meta.Height))
 	}
-	touchscreenRCALogf(
-		"screenshot resolved active_area source=%dx%d active=%s already_cropped=%v jpeg_dimensions=%dx%d mapping_before_update={%s}",
-		sourceWidth,
-		sourceHeight,
-		formatTouchscreenRCAActiveArea(active),
-		alreadyCropped,
-		meta.Width,
-		meta.Height,
-		formatTouchscreenRCAScreenMapping(t.screen),
-	)
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf(
+			"screenshot resolved active_area source=%dx%d active=%s already_cropped=%v jpeg_dimensions=%dx%d mapping_before_update={%s}",
+			sourceWidth,
+			sourceHeight,
+			formatTouchscreenRCAActiveArea(active),
+			alreadyCropped,
+			meta.Width,
+			meta.Height,
+			formatTouchscreenRCAScreenMapping(t.screen),
+		)
+	}
 	if t.screen != nil {
 		t.screen.UpdateActiveArea(sourceWidth, sourceHeight, active)
 	}
@@ -181,14 +185,16 @@ func (t *ScreenshotTool) Call(_ context.Context, _ string) (string, error) {
 		Data:   base64.StdEncoding.EncodeToString(displayData),
 	}
 	applyScreenCaptureInfo(&result, captureInfo)
-	touchscreenRCALogf(
-		"screenshot result display=%dx%d size=%d capture_backend=%q mapping_after={%s}",
-		displayWidth,
-		displayHeight,
-		len(displayData),
-		result.CaptureBackend,
-		formatTouchscreenRCAScreenMapping(t.screen),
-	)
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf(
+			"screenshot result display=%dx%d size=%d capture_backend=%q mapping_after={%s}",
+			displayWidth,
+			displayHeight,
+			len(displayData),
+			result.CaptureBackend,
+			formatTouchscreenRCAScreenMapping(t.screen),
+		)
+	}
 
 	out, _ := json.Marshal(result)
 	return string(out), nil

--- a/src/agent/internal/agent/tools_screenshot.go
+++ b/src/agent/internal/agent/tools_screenshot.go
@@ -132,6 +132,7 @@ func (t *ScreenshotTool) Call(_ context.Context, _ string) (string, error) {
 	if meta.PixelFormat != "jpeg" {
 		return "", fmt.Errorf("expected jpeg format, got %s", meta.PixelFormat)
 	}
+	touchscreenRCALogf("screenshot frame meta=%s capture_backend=%q mapping_before={%s}", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, formatTouchscreenRCAScreenMapping(t.screen))
 	active := screenActiveArea{}
 	sourceWidth := int(meta.Width)
 	sourceHeight := int(meta.Height)
@@ -144,6 +145,16 @@ func (t *ScreenshotTool) Call(_ context.Context, _ string) (string, error) {
 	} else {
 		active = detectScreenshotActiveAreaForScreen(t.screen, jpegData, int(meta.Width), int(meta.Height))
 	}
+	touchscreenRCALogf(
+		"screenshot resolved active_area source=%dx%d active=%s already_cropped=%v jpeg_dimensions=%dx%d mapping_before_update={%s}",
+		sourceWidth,
+		sourceHeight,
+		formatTouchscreenRCAActiveArea(active),
+		alreadyCropped,
+		meta.Width,
+		meta.Height,
+		formatTouchscreenRCAScreenMapping(t.screen),
+	)
 	if t.screen != nil {
 		t.screen.UpdateActiveArea(sourceWidth, sourceHeight, active)
 	}
@@ -170,6 +181,14 @@ func (t *ScreenshotTool) Call(_ context.Context, _ string) (string, error) {
 		Data:   base64.StdEncoding.EncodeToString(displayData),
 	}
 	applyScreenCaptureInfo(&result, captureInfo)
+	touchscreenRCALogf(
+		"screenshot result display=%dx%d size=%d capture_backend=%q mapping_after={%s}",
+		displayWidth,
+		displayHeight,
+		len(displayData),
+		result.CaptureBackend,
+		formatTouchscreenRCAScreenMapping(t.screen),
+	)
 
 	out, _ := json.Marshal(result)
 	return string(out), nil

--- a/src/agent/internal/agent/tools_wait_stable.go
+++ b/src/agent/internal/agent/tools_wait_stable.go
@@ -165,7 +165,9 @@ func (t *WaitStableScreenTool) captureScreenshot() (screenshotResult, error) {
 	if meta.PixelFormat != "jpeg" {
 		return screenshotResult{}, fmt.Errorf("expected jpeg format, got %s", meta.PixelFormat)
 	}
-	touchscreenRCALogf("wait_stable.captureScreenshot frame meta=%s capture_backend=%q mapping_before={%s}", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, formatTouchscreenRCAScreenMapping(t.screen))
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("wait_stable.captureScreenshot frame meta=%s capture_backend=%q mapping_before={%s}", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, formatTouchscreenRCAScreenMapping(t.screen))
+	}
 	active := screenActiveArea{}
 	sourceWidth := int(meta.Width)
 	sourceHeight := int(meta.Height)
@@ -178,16 +180,18 @@ func (t *WaitStableScreenTool) captureScreenshot() (screenshotResult, error) {
 	} else {
 		active = detectScreenshotActiveAreaForScreen(t.screen, jpegData, int(meta.Width), int(meta.Height))
 	}
-	touchscreenRCALogf(
-		"wait_stable.captureScreenshot resolved active_area source=%dx%d active=%s already_cropped=%v jpeg_dimensions=%dx%d mapping_before_update={%s}",
-		sourceWidth,
-		sourceHeight,
-		formatTouchscreenRCAActiveArea(active),
-		alreadyCropped,
-		meta.Width,
-		meta.Height,
-		formatTouchscreenRCAScreenMapping(t.screen),
-	)
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf(
+			"wait_stable.captureScreenshot resolved active_area source=%dx%d active=%s already_cropped=%v jpeg_dimensions=%dx%d mapping_before_update={%s}",
+			sourceWidth,
+			sourceHeight,
+			formatTouchscreenRCAActiveArea(active),
+			alreadyCropped,
+			meta.Width,
+			meta.Height,
+			formatTouchscreenRCAScreenMapping(t.screen),
+		)
+	}
 	if t.screen != nil {
 		t.screen.UpdateActiveArea(sourceWidth, sourceHeight, active)
 	}
@@ -211,14 +215,16 @@ func (t *WaitStableScreenTool) captureScreenshot() (screenshotResult, error) {
 		Data:   base64.StdEncoding.EncodeToString(displayData),
 	}
 	applyScreenCaptureInfo(&result, captureInfo)
-	touchscreenRCALogf(
-		"wait_stable.captureScreenshot result display=%dx%d size=%d capture_backend=%q mapping_after={%s}",
-		displayWidth,
-		displayHeight,
-		len(displayData),
-		result.CaptureBackend,
-		formatTouchscreenRCAScreenMapping(t.screen),
-	)
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf(
+			"wait_stable.captureScreenshot result display=%dx%d size=%d capture_backend=%q mapping_after={%s}",
+			displayWidth,
+			displayHeight,
+			len(displayData),
+			result.CaptureBackend,
+			formatTouchscreenRCAScreenMapping(t.screen),
+		)
+	}
 	return result, nil
 }
 
@@ -250,13 +256,15 @@ func (t *WaitStableScreenTool) wait(ctx context.Context, input string) (waitStab
 	if diffThreshold <= 0 {
 		diffThreshold = resolvedDefaults.DiffThreshold
 	}
-	touchscreenRCALogf(
-		"wait_stable.wait start timeout_ms=%d stable_ms=%d diff_threshold=%.3f mapping_before={%s}",
-		timeout.Milliseconds(),
-		stableFor.Milliseconds(),
-		diffThreshold,
-		formatTouchscreenRCAScreenMapping(t.screen),
-	)
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf(
+			"wait_stable.wait start timeout_ms=%d stable_ms=%d diff_threshold=%.3f mapping_before={%s}",
+			timeout.Milliseconds(),
+			stableFor.Milliseconds(),
+			diffThreshold,
+			formatTouchscreenRCAScreenMapping(t.screen),
+		)
+	}
 
 	start := time.Now()
 	deadline := start.Add(timeout)
@@ -265,7 +273,9 @@ func (t *WaitStableScreenTool) wait(ctx context.Context, input string) (waitStab
 	if err != nil {
 		return waitStableScreenResult{}, err
 	}
-	touchscreenRCALogf("wait_stable.wait initial frame meta=%s capture_backend=%q", formatTouchscreenRCAMetadata(prevMeta), prevCaptureInfo.Backend)
+	if touchscreenRCADebugEnabledCached() {
+		touchscreenRCALogf("wait_stable.wait initial frame meta=%s capture_backend=%q", formatTouchscreenRCAMetadata(prevMeta), prevCaptureInfo.Backend)
+	}
 	prevRGB, err := convertFrameToRGB(prevMeta, prevFrame)
 	if err != nil {
 		return waitStableScreenResult{}, err
@@ -285,7 +295,9 @@ func (t *WaitStableScreenTool) wait(ctx context.Context, input string) (waitStab
 				ScreenChanged: waitStableBoolPtr(screenChanged),
 				LastDiff:      lastDiff,
 			}
-			touchscreenRCALogf("wait_stable.wait completed stable=%v elapsed_ms=%d screen_changed=%v last_diff=%s mapping_after_wait={%s}", result.Stable, result.ElapsedMs, screenChanged, formatTouchscreenRCAFloatPtr(lastDiff), formatTouchscreenRCAScreenMapping(t.screen))
+			if touchscreenRCADebugEnabledCached() {
+				touchscreenRCALogf("wait_stable.wait completed stable=%v elapsed_ms=%d screen_changed=%v last_diff=%s mapping_after_wait={%s}", result.Stable, result.ElapsedMs, screenChanged, formatTouchscreenRCAFloatPtr(lastDiff), formatTouchscreenRCAScreenMapping(t.screen))
+			}
 			return result, nil
 		}
 		if !now.Before(deadline) {
@@ -297,7 +309,9 @@ func (t *WaitStableScreenTool) wait(ctx context.Context, input string) (waitStab
 				ScreenChanged: waitStableBoolPtr(screenChanged),
 				LastDiff:      lastDiff,
 			}
-			touchscreenRCALogf("wait_stable.wait timeout stable=%v elapsed_ms=%d screen_changed=%v last_diff=%s mapping_after_wait={%s}", result.Stable, result.ElapsedMs, screenChanged, formatTouchscreenRCAFloatPtr(lastDiff), formatTouchscreenRCAScreenMapping(t.screen))
+			if touchscreenRCADebugEnabledCached() {
+				touchscreenRCALogf("wait_stable.wait timeout stable=%v elapsed_ms=%d screen_changed=%v last_diff=%s mapping_after_wait={%s}", result.Stable, result.ElapsedMs, screenChanged, formatTouchscreenRCAFloatPtr(lastDiff), formatTouchscreenRCAScreenMapping(t.screen))
+			}
 			return result, nil
 		}
 
@@ -316,13 +330,17 @@ func (t *WaitStableScreenTool) wait(ctx context.Context, input string) (waitStab
 			return waitStableScreenResult{}, err
 		}
 		if meta.Stale || meta.Seq <= prevSeq {
-			touchscreenRCALogf("wait_stable.wait skipped frame meta=%s capture_backend=%q prev_seq=%d", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, prevSeq)
+			if touchscreenRCADebugEnabledCached() {
+				touchscreenRCALogf("wait_stable.wait skipped frame meta=%s capture_backend=%q prev_seq=%d", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, prevSeq)
+			}
 			continue
 		}
 
 		rgb, err := convertFrameToRGB(meta, frame)
 		if err != nil {
-			touchscreenRCALogf("wait_stable.wait convert error meta=%s capture_backend=%q err=%v", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, err)
+			if touchscreenRCADebugEnabledCached() {
+				touchscreenRCALogf("wait_stable.wait convert error meta=%s capture_backend=%q err=%v", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, err)
+			}
 			screenChanged = true
 			prevSeq = meta.Seq
 			stableSince = time.Now()
@@ -337,15 +355,17 @@ func (t *WaitStableScreenTool) wait(ctx context.Context, input string) (waitStab
 		if diff > diffThreshold {
 			stableSince = time.Now()
 		}
-		touchscreenRCALogf(
-			"wait_stable.wait frame meta=%s capture_backend=%q diff=%.3f threshold=%.3f screen_changed=%v stable_for_ms=%d",
-			formatTouchscreenRCAMetadata(meta),
-			captureInfo.Backend,
-			diff,
-			diffThreshold,
-			screenChanged,
-			time.Since(stableSince).Milliseconds(),
-		)
+		if touchscreenRCADebugEnabledCached() {
+			touchscreenRCALogf(
+				"wait_stable.wait frame meta=%s capture_backend=%q diff=%.3f threshold=%.3f screen_changed=%v stable_for_ms=%d",
+				formatTouchscreenRCAMetadata(meta),
+				captureInfo.Backend,
+				diff,
+				diffThreshold,
+				screenChanged,
+				time.Since(stableSince).Milliseconds(),
+			)
+		}
 		prevMeta = meta
 		prevRGB = rgb
 		prevSeq = meta.Seq

--- a/src/agent/internal/agent/tools_wait_stable.go
+++ b/src/agent/internal/agent/tools_wait_stable.go
@@ -165,6 +165,7 @@ func (t *WaitStableScreenTool) captureScreenshot() (screenshotResult, error) {
 	if meta.PixelFormat != "jpeg" {
 		return screenshotResult{}, fmt.Errorf("expected jpeg format, got %s", meta.PixelFormat)
 	}
+	touchscreenRCALogf("wait_stable.captureScreenshot frame meta=%s capture_backend=%q mapping_before={%s}", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, formatTouchscreenRCAScreenMapping(t.screen))
 	active := screenActiveArea{}
 	sourceWidth := int(meta.Width)
 	sourceHeight := int(meta.Height)
@@ -177,6 +178,16 @@ func (t *WaitStableScreenTool) captureScreenshot() (screenshotResult, error) {
 	} else {
 		active = detectScreenshotActiveAreaForScreen(t.screen, jpegData, int(meta.Width), int(meta.Height))
 	}
+	touchscreenRCALogf(
+		"wait_stable.captureScreenshot resolved active_area source=%dx%d active=%s already_cropped=%v jpeg_dimensions=%dx%d mapping_before_update={%s}",
+		sourceWidth,
+		sourceHeight,
+		formatTouchscreenRCAActiveArea(active),
+		alreadyCropped,
+		meta.Width,
+		meta.Height,
+		formatTouchscreenRCAScreenMapping(t.screen),
+	)
 	if t.screen != nil {
 		t.screen.UpdateActiveArea(sourceWidth, sourceHeight, active)
 	}
@@ -200,6 +211,14 @@ func (t *WaitStableScreenTool) captureScreenshot() (screenshotResult, error) {
 		Data:   base64.StdEncoding.EncodeToString(displayData),
 	}
 	applyScreenCaptureInfo(&result, captureInfo)
+	touchscreenRCALogf(
+		"wait_stable.captureScreenshot result display=%dx%d size=%d capture_backend=%q mapping_after={%s}",
+		displayWidth,
+		displayHeight,
+		len(displayData),
+		result.CaptureBackend,
+		formatTouchscreenRCAScreenMapping(t.screen),
+	)
 	return result, nil
 }
 
@@ -231,14 +250,22 @@ func (t *WaitStableScreenTool) wait(ctx context.Context, input string) (waitStab
 	if diffThreshold <= 0 {
 		diffThreshold = resolvedDefaults.DiffThreshold
 	}
+	touchscreenRCALogf(
+		"wait_stable.wait start timeout_ms=%d stable_ms=%d diff_threshold=%.3f mapping_before={%s}",
+		timeout.Milliseconds(),
+		stableFor.Milliseconds(),
+		diffThreshold,
+		formatTouchscreenRCAScreenMapping(t.screen),
+	)
 
 	start := time.Now()
 	deadline := start.Add(timeout)
 
-	prevMeta, prevFrame, _, err := t.client.LatestFrame()
+	prevMeta, prevFrame, prevCaptureInfo, err := t.client.LatestFrame()
 	if err != nil {
 		return waitStableScreenResult{}, err
 	}
+	touchscreenRCALogf("wait_stable.wait initial frame meta=%s capture_backend=%q", formatTouchscreenRCAMetadata(prevMeta), prevCaptureInfo.Backend)
 	prevRGB, err := convertFrameToRGB(prevMeta, prevFrame)
 	if err != nil {
 		return waitStableScreenResult{}, err
@@ -251,23 +278,27 @@ func (t *WaitStableScreenTool) wait(ctx context.Context, input string) (waitStab
 	for {
 		now := time.Now()
 		if now.Sub(stableSince) >= stableFor {
-			return waitStableScreenResult{
+			result := waitStableScreenResult{
 				OK:            true,
 				Stable:        true,
 				ElapsedMs:     now.Sub(start).Milliseconds(),
 				ScreenChanged: waitStableBoolPtr(screenChanged),
 				LastDiff:      lastDiff,
-			}, nil
+			}
+			touchscreenRCALogf("wait_stable.wait completed stable=%v elapsed_ms=%d screen_changed=%v last_diff=%s mapping_after_wait={%s}", result.Stable, result.ElapsedMs, screenChanged, formatTouchscreenRCAFloatPtr(lastDiff), formatTouchscreenRCAScreenMapping(t.screen))
+			return result, nil
 		}
 		if !now.Before(deadline) {
 			stable := now.Sub(stableSince) >= stableFor
-			return waitStableScreenResult{
+			result := waitStableScreenResult{
 				OK:            true,
 				Stable:        stable,
 				ElapsedMs:     now.Sub(start).Milliseconds(),
 				ScreenChanged: waitStableBoolPtr(screenChanged),
 				LastDiff:      lastDiff,
-			}, nil
+			}
+			touchscreenRCALogf("wait_stable.wait timeout stable=%v elapsed_ms=%d screen_changed=%v last_diff=%s mapping_after_wait={%s}", result.Stable, result.ElapsedMs, screenChanged, formatTouchscreenRCAFloatPtr(lastDiff), formatTouchscreenRCAScreenMapping(t.screen))
+			return result, nil
 		}
 
 		wait := stableWaitPollInterval
@@ -280,16 +311,18 @@ func (t *WaitStableScreenTool) wait(ctx context.Context, input string) (waitStab
 			}
 		}
 
-		meta, frame, _, err := t.client.LatestFrame()
+		meta, frame, captureInfo, err := t.client.LatestFrame()
 		if err != nil {
 			return waitStableScreenResult{}, err
 		}
 		if meta.Stale || meta.Seq <= prevSeq {
+			touchscreenRCALogf("wait_stable.wait skipped frame meta=%s capture_backend=%q prev_seq=%d", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, prevSeq)
 			continue
 		}
 
 		rgb, err := convertFrameToRGB(meta, frame)
 		if err != nil {
+			touchscreenRCALogf("wait_stable.wait convert error meta=%s capture_backend=%q err=%v", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, err)
 			screenChanged = true
 			prevSeq = meta.Seq
 			stableSince = time.Now()
@@ -304,6 +337,15 @@ func (t *WaitStableScreenTool) wait(ctx context.Context, input string) (waitStab
 		if diff > diffThreshold {
 			stableSince = time.Now()
 		}
+		touchscreenRCALogf(
+			"wait_stable.wait frame meta=%s capture_backend=%q diff=%.3f threshold=%.3f screen_changed=%v stable_for_ms=%d",
+			formatTouchscreenRCAMetadata(meta),
+			captureInfo.Backend,
+			diff,
+			diffThreshold,
+			screenChanged,
+			time.Since(stableSince).Milliseconds(),
+		)
 		prevMeta = meta
 		prevRGB = rgb
 		prevSeq = meta.Seq

--- a/src/agent/internal/agent/touchscreen_rca_debug.go
+++ b/src/agent/internal/agent/touchscreen_rca_debug.go
@@ -3,16 +3,29 @@ package agent
 import (
 	"fmt"
 	"log"
+	"os"
+	"strings"
 	"time"
 )
 
-const touchscreenRCADebugEnabled = true
+const touchscreenRCADebugEnv = "AIDEN_TOUCHSCREEN_RCA_DEBUG"
 
 func touchscreenRCALogf(format string, args ...any) {
-	if !touchscreenRCADebugEnabled {
+	if !touchscreenRCADebugEnabled() {
 		return
 	}
-	log.Printf("[touchscreen-rca] "+format, args...)
+	message := fmt.Sprintf("[touchscreen-rca] "+format, args...)
+	message = strings.NewReplacer("\r", "\\r", "\n", "\\n").Replace(message)
+	log.Print(message)
+}
+
+func touchscreenRCADebugEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(touchscreenRCADebugEnv))) {
+	case "1", "true", "t", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func formatTouchscreenRCAActiveArea(active screenActiveArea) string {
@@ -78,6 +91,23 @@ func formatTouchscreenRCAScreenMapping(screen *screenState) string {
 	)
 }
 
+func formatTouchscreenRCAMappingSummary(screen *screenState) string {
+	if screen == nil {
+		return "screen=nil"
+	}
+	width, height, active, age, ok := screen.ActiveAreaWithAge()
+	if !ok {
+		return "active_area_ok=false"
+	}
+	return fmt.Sprintf(
+		"active_area_ok=true width=%d height=%d active=%s age_ms=%d",
+		width,
+		height,
+		formatTouchscreenRCAActiveArea(active),
+		age.Milliseconds(),
+	)
+}
+
 func formatTouchscreenRCAPointerPoint(point *pointerPoint) string {
 	if point == nil {
 		return "<nil>"
@@ -110,6 +140,16 @@ func formatTouchscreenRCAQuickActionMapping(tool *QuickActionTool) string {
 		return "quick_action.touch=nil"
 	}
 	return formatTouchscreenRCAScreenMapping(tool.touch.screen)
+}
+
+func formatTouchscreenRCAQuickActionMappingSummary(tool *QuickActionTool) string {
+	if tool == nil {
+		return "quick_action=nil"
+	}
+	if tool.touch == nil {
+		return "quick_action.touch=nil"
+	}
+	return formatTouchscreenRCAMappingSummary(tool.touch.screen)
 }
 
 func touchscreenRCALogResolvedPoint(label string, screen *screenState, pc *pointerController, raw *pointerPoint, coordSpace string, resolved resolvedPointerPoint) {

--- a/src/agent/internal/agent/touchscreen_rca_debug.go
+++ b/src/agent/internal/agent/touchscreen_rca_debug.go
@@ -1,0 +1,126 @@
+package agent
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+const touchscreenRCADebugEnabled = true
+
+func touchscreenRCALogf(format string, args ...any) {
+	if !touchscreenRCADebugEnabled {
+		return
+	}
+	log.Printf("[touchscreen-rca] "+format, args...)
+}
+
+func formatTouchscreenRCAActiveArea(active screenActiveArea) string {
+	return fmt.Sprintf("{x:%d y:%d w:%d h:%d valid:%v}", active.X, active.Y, active.Width, active.Height, active.Valid)
+}
+
+func formatTouchscreenRCAMetadata(meta *frameMetadata) string {
+	if meta == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf(
+		"{seq:%d width:%d height:%d source_width:%d source_height:%d crop_x:%d crop_y:%d crop_width:%d crop_height:%d pixel_format:%q stride:%d bytes:%d stale:%v}",
+		meta.Seq,
+		meta.Width,
+		meta.Height,
+		meta.SourceWidth,
+		meta.SourceHeight,
+		meta.CropX,
+		meta.CropY,
+		meta.CropWidth,
+		meta.CropHeight,
+		meta.PixelFormat,
+		meta.Stride,
+		meta.Bytes,
+		meta.Stale,
+	)
+}
+
+func formatTouchscreenRCAScreenMapping(screen *screenState) string {
+	if screen == nil {
+		return "screen=nil"
+	}
+
+	width, height, active, age, ok := screen.ActiveAreaWithAge()
+	state := screen.MappingState()
+	phoneScreen := screen.PhoneScreenInfo()
+	phoneScreenText := formatPhoneScreen(phoneScreen)
+	if phoneScreenText == "" {
+		phoneScreenText = "<empty>"
+	}
+
+	rawAge := "unset"
+	if !state.updatedAt.IsZero() {
+		rawAge = fmt.Sprintf("%d", time.Since(state.updatedAt).Milliseconds())
+	}
+	effectiveAge := "unset"
+	if ok {
+		effectiveAge = fmt.Sprintf("%d", age.Milliseconds())
+	}
+
+	return fmt.Sprintf(
+		"active_area_with_age_ok=%v effective_width=%d effective_height=%d effective_active=%s effective_age_ms=%s raw_width=%d raw_height=%d raw_active=%s raw_age_ms=%s phone_screen=%q",
+		ok,
+		width,
+		height,
+		formatTouchscreenRCAActiveArea(active),
+		effectiveAge,
+		state.width,
+		state.height,
+		formatTouchscreenRCAActiveArea(state.active),
+		rawAge,
+		phoneScreenText,
+	)
+}
+
+func formatTouchscreenRCAPointerPoint(point *pointerPoint) string {
+	if point == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{x:%g y:%g}", point.X.Float64(), point.Y.Float64())
+}
+
+func touchscreenRCAPointerMode(pc *pointerController) string {
+	if pc == nil {
+		return "pointer=nil"
+	}
+	if pc.touchscreen {
+		return "touchscreen"
+	}
+	return "absolute_mouse"
+}
+
+func formatTouchscreenRCAFloatPtr(value *float64) string {
+	if value == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%.3f", *value)
+}
+
+func formatTouchscreenRCAQuickActionMapping(tool *QuickActionTool) string {
+	if tool == nil {
+		return "quick_action=nil"
+	}
+	if tool.touch == nil {
+		return "quick_action.touch=nil"
+	}
+	return formatTouchscreenRCAScreenMapping(tool.touch.screen)
+}
+
+func touchscreenRCALogResolvedPoint(label string, screen *screenState, pc *pointerController, raw *pointerPoint, coordSpace string, resolved resolvedPointerPoint) {
+	touchscreenRCALogf(
+		"%s resolved raw_point=%s coord_space=%q pointer_mode=%s absolute=(%d,%d) mapping_at_resolve={%s}",
+		label,
+		formatTouchscreenRCAPointerPoint(raw),
+		coordSpace,
+		touchscreenRCAPointerMode(pc),
+		resolved.x,
+		resolved.y,
+		formatTouchscreenRCAScreenMapping(screen),
+	)
+}

--- a/src/agent/internal/agent/touchscreen_rca_debug.go
+++ b/src/agent/internal/agent/touchscreen_rca_debug.go
@@ -5,13 +5,20 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
 const touchscreenRCADebugEnv = "AIDEN_TOUCHSCREEN_RCA_DEBUG"
 
+var touchscreenRCADebugEnabledValue atomic.Bool
+
+func init() {
+	touchscreenRCADebugEnabledValue.Store(touchscreenRCADebugEnabledFromEnv())
+}
+
 func touchscreenRCALogf(format string, args ...any) {
-	if !touchscreenRCADebugEnabled() {
+	if !touchscreenRCADebugEnabledCached() {
 		return
 	}
 	message := fmt.Sprintf("[touchscreen-rca] "+format, args...)
@@ -19,7 +26,11 @@ func touchscreenRCALogf(format string, args ...any) {
 	log.Print(message)
 }
 
-func touchscreenRCADebugEnabled() bool {
+func touchscreenRCADebugEnabledCached() bool {
+	return touchscreenRCADebugEnabledValue.Load()
+}
+
+func touchscreenRCADebugEnabledFromEnv() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv(touchscreenRCADebugEnv))) {
 	case "1", "true", "t", "yes", "y", "on":
 		return true
@@ -33,6 +44,9 @@ func formatTouchscreenRCAActiveArea(active screenActiveArea) string {
 }
 
 func formatTouchscreenRCAMetadata(meta *frameMetadata) string {
+	if !touchscreenRCADebugEnabledCached() {
+		return ""
+	}
 	if meta == nil {
 		return "<nil>"
 	}
@@ -55,6 +69,9 @@ func formatTouchscreenRCAMetadata(meta *frameMetadata) string {
 }
 
 func formatTouchscreenRCAScreenMapping(screen *screenState) string {
+	if !touchscreenRCADebugEnabledCached() {
+		return ""
+	}
 	if screen == nil {
 		return "screen=nil"
 	}
@@ -92,6 +109,9 @@ func formatTouchscreenRCAScreenMapping(screen *screenState) string {
 }
 
 func formatTouchscreenRCAMappingSummary(screen *screenState) string {
+	if !touchscreenRCADebugEnabledCached() {
+		return ""
+	}
 	if screen == nil {
 		return "screen=nil"
 	}
@@ -133,6 +153,9 @@ func formatTouchscreenRCAFloatPtr(value *float64) string {
 }
 
 func formatTouchscreenRCAQuickActionMapping(tool *QuickActionTool) string {
+	if !touchscreenRCADebugEnabledCached() {
+		return ""
+	}
 	if tool == nil {
 		return "quick_action=nil"
 	}
@@ -143,6 +166,9 @@ func formatTouchscreenRCAQuickActionMapping(tool *QuickActionTool) string {
 }
 
 func formatTouchscreenRCAQuickActionMappingSummary(tool *QuickActionTool) string {
+	if !touchscreenRCADebugEnabledCached() {
+		return ""
+	}
 	if tool == nil {
 		return "quick_action=nil"
 	}
@@ -153,6 +179,9 @@ func formatTouchscreenRCAQuickActionMappingSummary(tool *QuickActionTool) string
 }
 
 func touchscreenRCALogResolvedPoint(label string, screen *screenState, pc *pointerController, raw *pointerPoint, coordSpace string, resolved resolvedPointerPoint) {
+	if !touchscreenRCADebugEnabledCached() {
+		return
+	}
 	touchscreenRCALogf(
 		"%s resolved raw_point=%s coord_space=%q pointer_mode=%s absolute=(%d,%d) mapping_at_resolve={%s}",
 		label,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Touchscreen gestures now auto-prime and refresh screen mapping when needed, using captured screenshot metadata for more accurate coordinate mapping.
  * Screen mapping is also primed during startup when pointer and touchscreen are available, with retries and clear failure handling.
* **Bug Fixes**
  * Touchscreen gestures won’t proceed if screen mapping can’t be established.
* **Diagnostics**
  * Significantly expanded touchscreen RCA telemetry across mapping priming, gesture resolution, screenshot capture, quick actions, and stable-screen waiting (debug mode controlled).
* **Tests**
  * Added unit tests covering priming success, fallback behavior, failure handling, and staleness expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->