### PR TITLE
docs: update architecture documentation to reflect single-agent model

### DIFF
--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -464,5 +464,4 @@ Optional. Place `memory/extraction.yaml` under the config directory to control s
 ## Known limitations
 
 - `preferred_model`, `allowed_children`, and `model_text` are currently parsed but not fully wired into execution;
-- The Agent loop has been split into three RoleProfiles: `planner`, `executor`, and `verifier`; skill instructions go into each role profile, function tools are exposed only to the executor, and the tool catalog is given to other roles as planning/review reference; the `verifier` validates against the original task and completion criteria;
 - Example skills may reference old tools and should be checked before production use.

--- a/docs/04-agent/context-lifecycle.md
+++ b/docs/04-agent/context-lifecycle.md
@@ -14,7 +14,7 @@ Each run is assembled from several layers. Some layers are persisted memory, whi
 | Runtime context | `RunRequest.RuntimeContext`, for example phone bridge state | Agent | not persisted |
 | Tool catalog | resolved built-in tools plus skill tools | Agent can call | not persisted in memory |
 | Retrieved memory context | `MemoryPlane.Retrieve` output | Agent | filesystem memory |
-| Conversation history | hot-window memory, optional compressed-history markers, optional persisted chat history | Agent | filesystem memory |
+| Conversation history | hot-window memory, optional compressed-history markers | Agent | filesystem memory |
 | Input attachments | `RunRequest.Attachments` | Agent user messages | current run only |
 
 ## Agent Execution Loop

--- a/docs/04-agent/context-lifecycle.md
+++ b/docs/04-agent/context-lifecycle.md
@@ -8,81 +8,45 @@ Each run is assembled from several layers. Some layers are persisted memory, whi
 
 | Layer | Source | Visibility | Persistence |
 | --- | --- | --- | --- |
-| Base instruction | built-in runtime instruction, optional `agent.toml` `custom_instruction`, and `additional_prompt` | planner and executor | configuration |
-| Runtime defaults | built-in prompt rules, current date, host runtime information | planner and executor receive all defaults; verifier receives current date and verifier role rules only | not persisted |
-| Skills | skill index plus active `SKILL.md` content | planner and executor | skill files and skill state |
-| Runtime context | `RunRequest.RuntimeContext`, for example phone bridge state | planner and executor | not persisted |
-| Tool catalog | resolved built-in tools plus skill tools | planner and executor can call; verifier does not receive a tool catalog | not persisted in memory |
-| Planner loop meta tools | `use_simple_mode`, `enter_plan_mode`, `commit_plan`, `cancel_plan` | planner only | not persisted in memory |
-| Executor loop meta tools | `finish_step`, `abort_step` | executor only | not persisted in memory |
-| Retrieved memory context | `MemoryPlane.Retrieve` output | planner receives common and planner memory; verifier receives failure/conflict caution memory only | filesystem memory |
-| Planner conversation history | hot-window memory, optional compressed-history markers, optional persisted chat history | planner only | filesystem memory |
-| Role loop state | phase, objective, plan, `plan_step_index`, next step, tool evidence, verifier feedback, world state | role-specific | current run only |
-| Input attachments | `RunRequest.Attachments`; verifier-only latest screenshot image when world state has one | role user messages | current run only |
+| Base instruction | built-in runtime instruction, optional `agent.toml` `custom_instruction`, and `additional_prompt` | Agent | configuration |
+| Runtime defaults | built-in prompt rules, current date, host runtime information | Agent | not persisted |
+| Skills | skill index plus active `SKILL.md` content | Agent | skill files and skill state |
+| Runtime context | `RunRequest.RuntimeContext`, for example phone bridge state | Agent | not persisted |
+| Tool catalog | resolved built-in tools plus skill tools | Agent can call | not persisted in memory |
+| Retrieved memory context | `MemoryPlane.Retrieve` output | Agent | filesystem memory |
+| Conversation history | hot-window memory, optional compressed-history markers, optional persisted chat history | Agent | filesystem memory |
+| Input attachments | `RunRequest.Attachments` | Agent user messages | current run only |
 
-The executor intentionally does not receive global memory or full conversation history. It receives the planner-approved `next_step`, latest world state, and the latest local execution result only.
+## Agent Execution Loop
 
-## Phased Role Loop
+The Agent uses a streamlined execution loop that processes user input through tool calls and generates responses directly. All runs share a single iteration budget controlled by `MaxIterations`.
 
-`roleCollaborativeExecutor` drives a three-phase state machine. All phases share one global `MaxIterations` budget.
-
-| Phase | Planner behavior | Other roles |
-| --- | --- | --- |
-| `decision` | Route to direct answer, `default`, or `plan` before ordinary tools are exposed | not used |
-| `default` | Call built-in tools directly, return a final answer when done, or call `enter_plan_mode` for complex work | not used |
-| `plan` | Explore with tools, maintain a draft plan, then call `commit_plan` or `cancel_plan` | not used |
-| `execution` | not called | `executor` runs one approved step, then `verifier` reviews evidence |
-
-Phase transitions:
+Execution flow:
 
 ```text
-Run starts in decision
+Run starts
   |
-  +-- direct_answer --> run ends (no verifier)
+  v
+Agent receives user input and context
   |
-  +-- simple / use_simple_mode --> default
-  |     |
-  |     +-- planner finishes --> run ends (no verifier)
-  |     |
-  |     +-- planner calls domain tool --> default
-  |     |
-  |     +-- enter_plan_mode --> plan
+  v
+Agent decides on action (tool call or final answer)
   |
-  +-- plan / enter_plan_mode --> plan
-        |
-        +-- cancel_plan --> default
-        |
-        +-- commit_plan --> execution
-              |
-              +-- executor finish_step / abort_step --> verifier
-                    |
-                    +-- verifier can_finish --> run ends
-                    |
-                    +-- verifier needs_replan --> plan
-                    |
-                    +-- verifier continues and plan has more steps --> next execution step
-                    |
-                    +-- verifier continues and plan is exhausted --> plan
+  v
+Execute tool calls as needed
+  |
+  v
+Generate final response
+  |
+  v
+Run ends
 ```
 
-Planner loop meta tools are visible only to the planner and are intercepted by the runtime controller. Executor loop meta tools are visible only to the executor for step-boundary review. They never reach the device tool layer.
-
-| Meta tool | Role | Allowed in | Effect |
-| --- | --- | --- | --- |
-| `use_simple_mode` | planner | `decision` | route to `default` |
-| `enter_plan_mode` | planner | `decision`, `default` | switch to `plan` |
-| `commit_plan` | planner | `plan` only | commit objective, completion criteria, and plan steps; switch to `execution` |
-| `cancel_plan` | planner | `plan` | clear draft planning state; switch to `default` |
-| `finish_step` | executor | `execution` | mark the current step ready for verifier review |
-| `abort_step` | executor | `execution` | mark the current step blocked or failed for verifier review |
-
-After `commit_plan`, runtime owns step progression. `plan_step_index` selects the current committed step, and `next_step` is synchronized from that index before each executor turn. The executor must not reorder or rewrite the plan.
-
-Simple tasks should stay in `default` (direct answer, one tool call, or at most two short steps). If completing the request will likely need three or more steps, the planner must call `enter_plan_mode` before executing further. Also use `plan` for branching, sustained tracking, or explicit completion criteria before delegation.
+The Agent has access to all registered tools throughout execution and manages its own task breakdown strategy based on the request complexity.
 
 ## Prompt Shape
 
-For the current multi-role loop, `Runtime.Run` builds `RoleProfiles` before execution. Planner and executor system prompts contain:
+For the current execution loop, `Runtime.Run` builds a `RoleProfile` before execution. The Agent system prompt contains:
 
 1. role identity;
 2. base instruction;
@@ -92,50 +56,22 @@ For the current multi-role loop, `Runtime.Run` builds `RoleProfiles` before exec
 6. request-local runtime context, if provided;
 7. role rules;
 8. available tool information;
-9. role-specific rendered memory context, if any.
+9. rendered memory context, if any.
 
-The verifier system prompt is intentionally narrower. It contains the current date, verifier role rules, and an optional `## Verifier memory cautions` block. It does not receive base instruction, default behavior, skills, runtime context, tool catalog, common memory, or planner memory.
-
-The per-call user message is then built from the current loop state:
-
-- planner sees the current loop mode, world state, original request, conversation history, draft or committed plan, executor results, and verifier feedback;
-- executor sees the current world state and the planner-approved `next_step`;
-- verifier sees the current world state, the step under verification (`step_index`, `step_text`, `is_final_committed_step`), the latest executor result for that step, and the latest world-state screenshot image when available.
-
-Planner and executor receive tool scratchpads after tools have run. `WorldState.LatestScreenshot` is retained as verifier-only visual evidence: planner and executor do not receive it through World State, which keeps their world-state prompt prefix stable for model cache reuse.
+The per-call user message is built from the current loop state, including the original request, conversation history, world state, and any previous tool results.
 
 ## Retrieved Memory Context
 
-`MemoryPlane.Retrieve` builds a `MemoryContext` with three buckets:
-
-```go
-type MemoryContext struct {
-    Planner  RoleMemoryContext
-    Verifier RoleMemoryContext
-    Common   RoleMemoryContext
-}
-```
-
-`Common` is rendered into planner memory context. It currently includes:
+`MemoryPlane.Retrieve` builds a `MemoryContext` that is rendered into the Agent's memory context. It currently includes:
 
 - `session/summary.md`, the compressed session summary;
-- `long_term/profile.md`, the synthesized user profile.
-
-Planner-specific retrieval includes:
-
+- `long_term/profile.md`, the synthesized user profile;
 - device profile;
 - app profiles;
 - verified procedures and navigation memory;
 - similar successful episodes;
-- calibration notes.
-
-Verifier-specific retrieval includes:
-
-- failure memories;
-- conflicting memories;
-- failed task episodes relevant to the current request.
-
-Verifier-specific retrieval is rendered as `## Verifier memory cautions`. These entries are historical failure/conflict warnings only; they are not proof of completion. Verifier approval must still be based on the current executor outcome, tool observations, screenshots, or current step evidence.
+- calibration notes;
+- failure memories and conflicting memories as cautions.
 
 Each hit is filtered by applicability, ranked by the store search logic, routed by memory type, and trimmed per category before rendering.
 
@@ -162,10 +98,10 @@ MemoryPlane.Retrieve(input, attachments, skills, tools, current hints)
 start EpisodeRecorder
   |
   v
-build role profiles and planner memory
+build role profile and agent memory
   |
   v
-phased role loop (decision / default / plan / execution)
+agent execution loop
   |
   v
 commit session: append assistant output and save snapshot
@@ -177,7 +113,7 @@ request session-memory maintenance
 commit task episode and extract reusable memory
 ```
 
-`CurrentEnvironmentHints` are lightweight facts already known to runtime, such as screenshot size, language, and last observed app name. They must not perform device actions. If fresh screen evidence is needed, the planner must ask the executor to use tools.
+`CurrentEnvironmentHints` are lightweight facts already known to runtime, such as screenshot size, language, and last observed app name. They must not perform device actions. If fresh screen evidence is needed, the Agent must use tools.
 
 ## Update Mechanisms
 
@@ -210,7 +146,7 @@ memory/session/events.jsonl
 ```
 
 At prompt time, retained hot-window events are converted into native chat
-messages and inserted between the planner system prompt and the current planner
+messages and inserted between the system prompt and the current
 task message. Prompt construction does not render them inside a
 `Conversation history:` text block and does not add hot-window labels or
 boundary markers.
@@ -268,17 +204,13 @@ Within one runtime, memory tools, `MemoryPlane`, and profile rebuilding share a 
 
 ### Device And Episode Memory
 
-The episode recorder captures loop phase changes, default-mode finishes, planner decisions, planner and executor tool calls, tool results, verifier decisions, observed world state, and outcome data during the run. `MemoryPlane.CommitEpisode` writes the task episode, extracts reusable lessons, updates device memory, and updates outcomes on referenced memories.
+The episode recorder captures tool calls, tool results, observed world state, and outcome data during the run. `MemoryPlane.CommitEpisode` writes the task episode, extracts reusable lessons, updates device memory, and updates outcomes on referenced memories.
 
 Common episode event types:
 
 | Event type | When recorded |
 | --- | --- |
-| `loop_phase` | `enter_plan_mode`, `commit_plan`, `cancel_plan`, `plan_exhausted`, or `needs_replan` |
-| `default_finish` | planner returns a final answer directly in `default` |
-| `planner_decision` | `commit_plan` commits objective, criteria, and plan steps |
-| `tool_call` / `tool_result` | planner tool use in `default`/`plan`, or executor tool use in `execution` |
-| `verifier_decision` | verifier review in `execution` |
+| `tool_call` / `tool_result` | Agent tool use during execution |
 
 The main stores are:
 
@@ -292,11 +224,11 @@ Successful episodes can create or update procedures, navigation memory, app prof
 
 ### Persisted Chat History
 
-**NOTE: As of this branch, chat_history injection into planner context is DISABLED.**
+**NOTE: As of the current architecture, chat_history injection into Agent context is DISABLED.**
 
-The `chat_history/` store persists UI-level conversation logs but is NOT automatically injected into the planner's context. This prevents:
+The `chat_history/` store persists UI-level conversation logs but is NOT automatically injected into the Agent's context. This prevents:
 - Duplicate, uncompressed context competing with the session system
-- Unbounded growth of planner prompts
+- Unbounded growth of Agent prompts
 - Confusion between active session and archived history
 
 For "resume interrupted task" scenarios, use explicit session restore or recall tools instead. The session system already provides comprehensive history management with compaction, archiving, and recall capabilities.
@@ -342,11 +274,6 @@ The chat_history store remains available for:
   session summaries are logs and are not prompt or recall context.
 - Hot-window labels or boundary markers are not injected into prompts or
   durable memory.
-- Planner owns plans and sees retrieved experience memory.
-- In `default`, planner may call tools and finish the run without verifier review.
-- In `execution`, executor executes exactly one approved step and does not receive global memory.
-- In `execution`, verifier validates only the current committed step; intermediate step success advances the plan, and `can_finish` is allowed only on the final committed step.
-- `commit_plan` is only valid in `plan`; runtime owns `plan_step_index` after commit.
-- Loop meta tools are planner/executor control tools handled by the runtime controller, not the device tool layer.
+- The Agent sees retrieved experience memory and manages its own execution strategy.
 - Tool results and screenshots are evidence for the current run; reusable lessons are written only after episode commit or explicit memory-tool calls.
 - Device actions must be based on current tool observations or screenshots, not on stale remembered state alone.

--- a/docs/04-agent/context-lifecycle.md
+++ b/docs/04-agent/context-lifecycle.md
@@ -220,7 +220,7 @@ memory/episodes/
 memory/lifecycle/
 ```
 
-Successful episodes can create or update procedures, navigation memory, app profiles, calibration notes, and task summaries. Failed episodes can create failure memories that are routed to verifier on future similar tasks.
+Successful episodes can create or update procedures, navigation memory, app profiles, calibration notes, and task summaries. Failed episodes can create failure memories that are retrieved as cautions on future similar tasks.
 
 ### Persisted Chat History
 

--- a/docs/04-agent/memory-plane.md
+++ b/docs/04-agent/memory-plane.md
@@ -10,16 +10,14 @@ The existing Go Agent memory already has several capabilities:
 - `SessionMemoryStore` compresses older events from the active session into chunks, writes `session/summary.md`, and provides `recall_session_chunks` for active-session chunks only.
 - `LongTermMemoryStore` stores profile, rule, preference, procedure, fact as markdown frontmatter, generates `long_term/index.yaml` and `long_term/profile.md`, and provides `recall_memory`, `save_memory`, `forget_memory`.
 - `Runtime.Run` reads only the current active `session/summary.md` and `long_term/profile.md` for prompt context. Long-term memory retrieval mainly depends on the model calling tools; it is not stable input for every planning pass. Closed sessions under `session_archive/` are logs and are not prompt or recall context.
-- Agent loop is split into `planner`, `executor`, `verifier`, and uses a `default` / `plan` / `execution` three-phase state machine. Simple tasks in `default` have planner directly call tools and finish; complex tasks go through `enter_plan_mode` -> `commit_plan` into `execution`, then `executor` / `verifier` collaborate. `planner` and `verifier` can see history and world state; `executor` is deliberately limited to only executing the planner's committed `next_step`.
-
-The new design should preserve this layering: automatic retrieval goes to `planner` and `verifier`, don't expose all historical experience directly to `executor`.
+- Agent uses a streamlined execution loop that handles tool calls and generates responses directly in a unified flow.
 
 ## Design Goals
 
 1. Automatically retrieve device experience before running, reducing warm-up cost for each task.
 2. Automatically write task episodes after running, saving goal, environment, state sequence, tool sequence, result, and experience.
 3. Long-term memory supports TTL, evidence, applicability conditions, and conflict handling, avoiding expired experience polluting planning.
-4. Similar successful tasks go to planner, failed experience goes to verifier; if a separate policy role is added in the future, the same failed experience can be directly routed to policy.
+4. Similar successful tasks and failure experience are retrieved for the Agent to inform its execution strategy.
 5. Continue using existing filesystem persistence, atomic writes, index rebuilding, and lifecycle validation approach; do not introduce database yet.
 
 ## Overall Structure
@@ -37,7 +35,7 @@ MemoryPlane.Retrieve
   └─ task episode retrieval
   │
   ▼
-phased role loop (default / plan / execution)
+agent execution loop
   │
   ▼
 TaskEpisodeWriter
@@ -52,13 +50,12 @@ Suggested new code boundaries:
 
 | File | Responsibility |
 | --- | --- |
-| `memory_plane.go` | `MemoryPlane.Retrieve`, role memory context routing, ranking |
+| `memory_plane.go` | `MemoryPlane.Retrieve`, memory context routing, ranking |
 | `device_memory.go` | device/app/procedure/calibration/failure schema, store, search |
 | `task_episode.go` | `TaskEpisode`, `TaskEpisodeStore`, `TaskEpisodeWriter` |
 | `memory_lifecycle.go` or extend `lifecycle.go` | TTL, expiration cleanup, traceability verification |
-| Extend `runtime.go` | Retrieve before building role profiles, CommitEpisode after run ends |
-| Extend `role_profile.go` | planner/verifier use different memory context |
-| Extend `role_executor.go` | Output structured planner/verifier/tool trace to writer |
+| Extend `runtime.go` | Retrieve before building role profile, CommitEpisode after run ends |
+| Extend `role_profile.go` | Agent uses unified memory context |
 
 ## Storage Layout
 
@@ -129,14 +126,12 @@ type MemoryRetrieveRequest struct {
 }
 ```
 
-`CurrentHints` should not actively operate on devices. It only carries information already known to runtime, such as configured frame socket, most recent screenshot dimensions, last recognized app/page. Whether to take screenshots should still be decided by planner.
+`CurrentHints` should not actively operate on devices. It only carries information already known to runtime, such as configured frame socket, most recent screenshot dimensions, last recognized app/page. Whether to take screenshots should still be decided by the Agent.
 
-`MemoryContext` splits by role:
+`MemoryContext` provides retrieved memory for the Agent:
 
 ```go
 type MemoryContext struct {
-    Planner  RoleMemoryContext
-    Verifier RoleMemoryContext
     Common   RoleMemoryContext
 }
 
@@ -151,13 +146,7 @@ type RoleMemoryContext struct {
 }
 ```
 
-Routing rules:
-
-- `planner` receives Device Profile, App Profile, Interaction Procedures, Calibration Memory, similar successful Task Episodes.
-- `verifier` receives Failure Memory, conflicting memories, validation experience related to the task, and key evidence references used by planner.
-- `executor` does not receive global memory by default; it still only sees `next_step`, latest world state, and previous step local result. When experience needs to be used, planner compresses experience into specific next steps.
-
-Current code has no independent `policy` role, so failure experience goes to `verifier` first. When policy is added in the future, can directly reuse `MemoryContext.Verifier.FailureModes` as `PolicyHints`.
+The Agent receives Device Profile, App Profile, Interaction Procedures, Calibration Memory, similar successful Task Episodes, Failure Memory, and conflicting memories to inform its execution strategy.
 
 ## Data Models
 
@@ -266,7 +255,7 @@ ttl: 30d
 
 ### Failure Memory
 
-Failure modes go to verifier/policy, avoiding repeated bad paths.
+Failure modes are retrieved as cautions, helping the Agent avoid repeated bad paths.
 
 ```yaml
 id: fail_direct_chinese_input
@@ -312,7 +301,7 @@ initial_state:
 outcome:
   success: true
   final_state: "Zhang San chat page"
-  verifier_reason: "visible chat title matches target"
+  completion_reason: "visible chat title matches target"
 retrieved_memory_refs:
   - proc_open_app_system_search
 reusable_lessons:
@@ -324,10 +313,10 @@ conflicts: []
 `events.jsonl` records complete sequence:
 
 ```json
-{"type":"planner_decision","plan":["home","system search","open WeChat"],"next_step":"go home"}
 {"type":"tool_call","tool_name":"touch_gesture","tool_input":"{\"type\":\"home\"}"}
 {"type":"tool_result","tool_name":"touch_gesture","is_error":false,"screenshot_ref":"artifacts/step_001.jpg"}
-{"type":"verifier_decision","can_finish":false,"reason":"contact not open yet"}
+{"type":"tool_call","tool_name":"mouse_click","tool_input":"{\"x\":320,\"y\":100}"}
+{"type":"tool_result","tool_name":"mouse_click","is_error":false,"screenshot_ref":"artifacts/step_002.jpg"}
 ```
 
 Episodes should not long-term save large base64 blocks. Screenshots go to `artifacts/`, events only contain relative paths, dimensions, hash, necessary summary, and short evidence excerpts.
@@ -391,9 +380,9 @@ Verifier additional injection:
 
 Role constraints:
 
-- planner can use experience to modify plans, but must still be based on current screenshot and tool results.
-- verifier cannot approve this completion just because historical episode succeeded, must require current observation to prove completion conditions.
-- executor does not directly see experience, reducing probability of it bypassing planner or having blind spots based on old experience.
+- The Agent can use experience to inform its strategy, but must still be based on current screenshot and tool results.
+- The Agent cannot approve completion just because historical episode succeeded; must require current observation to prove completion conditions.
+- Retrieved experience helps guide execution but doesn't replace direct observation.
 
 ## Write Strategy
 
@@ -448,7 +437,7 @@ Conflict sources:
 Handling rules:
 
 1. More specific new evidence for same fact supersedes old memory first.
-2. When cannot determine who is correct, mark both as `conflicted`, don't enter planner's normal experience, only enter verifier's conflict reminder.
+2. When cannot determine who is correct, mark both as `conflicted`, don't enter the Agent's normal experience, only surface as conflict reminder.
 3. Expiration is not deletion. First mark `expired` or filter from index, then GC deletes according to retention.
 4. User explicit instructions have higher priority than automatic experience. When conflicting with user rules, automatic experience is downweighted or marked conflict.
 
@@ -458,7 +447,7 @@ Handling rules:
 | --- | --- | --- |
 | Device Profile | 90d | Re-verified by current screenshot/configuration |
 | App Profile | 30d | App opened, page structure or entry re-verified |
-| Interaction Procedure | 45d | Process succeeded and verifier approved |
+| Interaction Procedure | 45d | Process succeeded and task completed |
 | Calibration Memory | 30d | Coordinates, waits, screenshot dimensions re-verified |
 | Failure Memory | 60d | Same type of failure occurs again |
 | Task Episode | 30d full trace, 180d summary | Retain evidence excerpt if referenced by long-term memory |
@@ -497,10 +486,10 @@ go r.memoryPlane.CommitEpisode(context.Background(), episode)
 
 ### Role executor
 
-`roleLoopState` already has objective, criteria, plan, tool steps, verifier results, and world state. Need to supplement:
+`loopState` already has objective, criteria, tool steps, and world state. Need to supplement:
 
-- Parsed planner decision event.
-- Parsed verifier decision event.
+- Episode outcome data.
+- Parsed tool call/result events.
 - Initial/final world state summary.
 - Tool result screenshot artifact export hook.
 - Max iteration / parse error / tool error failure reason.
@@ -515,7 +504,7 @@ Suggest recording through `EpisodeRecorder` interface rather than inferring from
 func buildRoleProfiles(..., memory MemoryContext) RoleProfiles
 ```
 
-The planner prompt receives `memory.Planner` plus `memory.Common`. The verifier prompt receives only `memory.Verifier.FailureModes` and `memory.Verifier.Conflicts` as a caution block; `memory.Common` is not injected into verifier. The executor prompt receives no memory context.
+The Agent prompt receives retrieved memory context including device profiles, procedures, similar episodes, and failure cautions.
 
 ### Tools
 
@@ -533,9 +522,9 @@ These two tools are not MVP required; core path should be automatically retrieve
 Phase 1: Episode recording and retrieval injection
 
 - Add `TaskEpisodeStore` and `TaskEpisodeWriter`.
-- Record planner/tool/verifier trace.
+- Record tool call trace.
 - Add `MemoryPlane.Retrieve`, first do keyword recall from `long_term` and `episodes/index.yaml`.
-- Planner/verifier inject retrieved context by role.
+- Agent injects retrieved context.
 
 Phase 2: Device memory types
 

--- a/docs/04-agent/memory-plane.md
+++ b/docs/04-agent/memory-plane.md
@@ -146,7 +146,7 @@ type RoleMemoryContext struct {
 }
 ```
 
-The Agent receives Device Profile, App Profile, Interaction Procedures, Calibration Memory, similar successful Task Episodes, Failure Memory, and conflicting memories to inform its execution strategy.
+The Agent receives Device Profile, App Profile, Interaction Procedures, Calibration Memory, similar successful Task Episodes, and Failure Memory to inform its execution strategy. Conflicting memories are surfaced as cautions rather than normal execution context.
 
 ## Data Models
 
@@ -369,7 +369,7 @@ Replace current single `memoryContextForPrompt()`, generate role-specific contex
 - [cal_id] ...
 ```
 
-Verifier additional injection:
+Agent caution injection:
 
 ```text
 # Known Failure Modes And Conflicts
@@ -391,9 +391,9 @@ Role constraints:
 Success episode writes:
 
 - User goal, completion criteria, final state.
-- Planner decision sequence and plan revisions.
+- Agent decision sequence and execution flow.
 - Tool call sequence, tool results, post-action screenshot refs.
-- Verifier final approval reason.
+- Task completion reason.
 - Reusable experience candidates, e.g. more stable entry points, verified coordinate systems, wait times.
 
 Failed episode writes:
@@ -432,7 +432,7 @@ Conflict sources:
 - New observation clearly contradicts active memory.
 - Under same app/goal/procedure, success path and failure path negate each other.
 - Current device profile changes, e.g. language, resolution, input method changes.
-- Verifier fails multiple times due to same experience.
+- Task fails multiple times due to same experience.
 
 Handling rules:
 
@@ -564,8 +564,8 @@ Phase 4: Benchmark
 ✅ Complete episode recording implemented:
 - `TaskEpisodeStore` and `EpisodeRecorder` fully implemented
 - Record tool call trace, generate structured `events.jsonl`
-- `MemoryPlane.Retrieve` recalls from `long_term`, `device`, `episodes` and routes by role
-- Planner/verifier inject retrieved context by role
+- `MemoryPlane.Retrieve` recalls from `long_term`, `device`, `episodes` and routes by memory type
+- Agent injects retrieved context
 
 #### Device Memory Types (Phase 2 Core)
 
@@ -592,7 +592,7 @@ Phase 4: Benchmark
 **4. Navigation Memory (New)**
 - Extracts **page transition rules**: `Meituan/Home → Meituan/Cart`
 - Records tools, coordinates, tool-call content, decoupled from specific task goals
-- Routes to Planner at same level as procedure
+- Surfaced to Agent as execution guidance
 
 **5. Calibration Memory**
 - Records calibration info like normalized coordinate preference
@@ -600,7 +600,7 @@ Phase 4: Benchmark
 
 **6. Failure Memory**
 - Writes failure-type memories on failure
-- Routes to Verifier to indicate known failure modes
+- Surfaced to Agent as cautions to indicate known failure modes
 
 #### Data Extraction Capabilities
 
@@ -621,9 +621,9 @@ New `episode_extraction.go` provides complete episode event parsing:
 
 #### Retrieval and Rendering
 
-- ✅ `routeHit`: Route by memory type to different Planner/Verifier fields
+- ✅ `routeHit`: Route by memory type to different context fields
 - ✅ `renderMemoryHitLine`: Expand Steps rendering for procedure/navigation
-- ✅ `RenderForRole`: Generate different memory context by role
+- ✅ `RenderForRole`: Generate memory context for Agent
 
 #### Directory Structure
 
@@ -686,7 +686,7 @@ All existing tests pass.
 | Scenario | Design Goal | Current Implementation |
 |----------|-------------|------------------------|
 | Similar task reuse | After "order Mixue Ice City on Meituan", executing "order Starbucks on Meituan" can reuse navigation | ✅ Hits "Meituan/Home→Cart" navigation + "Cart" page procedure |
-| Planner sees procedure | Detailed steps, coordinates, page transitions | ✅ "step 1: launch_app(Meituan)→Home / step 2: touch_gesture(@x=500,y=850)→Cart" |
+| Agent sees procedure | Detailed steps, coordinates, page transitions | ✅ "step 1: launch_app(Meituan)→Home / step 2: touch_gesture(@x=500,y=850)→Cart" |
 | App prior knowledge | First time using an app can see commonly used pages and tools | ✅ app_profile accumulates pages_seen, tools_used |
 | Failure experience tracking | Failure modes surface as cautions | ✅ failure memory routes to Agent context |
 | Page-level indexing | Retrieve procedure by page_name | ✅ procedure ID includes page, page_name in entities/tags |

--- a/docs/04-agent/memory-plane.md
+++ b/docs/04-agent/memory-plane.md
@@ -484,7 +484,7 @@ episode := recorder.Finish(output, metrics, err, tags, entities)
 go r.memoryPlane.CommitEpisode(context.Background(), episode)
 ```
 
-### Role executor
+### Episode Recording
 
 `loopState` already has objective, criteria, tool steps, and world state. Need to supplement:
 
@@ -496,12 +496,12 @@ go r.memoryPlane.CommitEpisode(context.Background(), episode)
 
 Suggest recording through `EpisodeRecorder` interface rather than inferring from HTTP server's `history`. Server history is a UI artifact and should not be the sole source for memory writer.
 
-### Role profiles
+### Agent Profile
 
-`buildRoleProfiles` receives structured `MemoryContext` and returns `RoleProfiles`:
+`buildRoleProfile` receives structured `MemoryContext` and returns `RoleProfile`:
 
 ```go
-func buildRoleProfiles(..., memory MemoryContext) RoleProfiles
+func buildRoleProfile(..., memory MemoryContext) RoleProfile
 ```
 
 The Agent prompt receives retrieved memory context including device profiles, procedures, similar episodes, and failure cautions.
@@ -541,15 +541,15 @@ Phase 3: Conflict and lifecycle
 Phase 4: Benchmark
 
 - Add episode memory benchmark: does second execution of same task type reduce tool steps, does it avoid historical failure paths.
-- Add conflict benchmark: old experience should not continue to pollute planner after language/resolution changes.
-- Add failure experience benchmark: failure modes should enter verifier, preventing repeated approval of completions without evidence.
+- Add conflict benchmark: old experience should not continue to pollute the Agent after language/resolution changes.
+- Add failure experience benchmark: failure modes should surface as cautions, preventing repeated approval of completions without evidence.
 
 ## Acceptance Criteria
 
 - After clearing session conversation, similar tasks on same device can still obtain experience from episode/procedure.
-- Similar successful episodes will change planner's plan or next_step, and memory ref is visible in role_output.
-- Known failure modes enter verifier prompt; verifier will not pass current task based solely on historical success experience.
-- Expired, conflicted, or inapplicable memories do not enter planner's normal experience.
+- Similar successful episodes will influence the Agent's strategy, and memory ref is visible in output.
+- Known failure modes are surfaced as cautions; the Agent will not approve completion based solely on historical success experience.
+- Expired, conflicted, or inapplicable memories do not enter the Agent's normal experience.
 - Task failures also produce episodes and can extract searchable failure memory.
 - Memory write failures do not cause user task failure, but must have logs.
 
@@ -563,7 +563,7 @@ Phase 4: Benchmark
 
 ✅ Complete episode recording implemented:
 - `TaskEpisodeStore` and `EpisodeRecorder` fully implemented
-- Record planner/tool/verifier trace, generate structured `events.jsonl`
+- Record tool call trace, generate structured `events.jsonl`
 - `MemoryPlane.Retrieve` recalls from `long_term`, `device`, `episodes` and routes by role
 - Planner/verifier inject retrieved context by role
 
@@ -688,7 +688,7 @@ All existing tests pass.
 | Similar task reuse | After "order Mixue Ice City on Meituan", executing "order Starbucks on Meituan" can reuse navigation | ✅ Hits "Meituan/Home→Cart" navigation + "Cart" page procedure |
 | Planner sees procedure | Detailed steps, coordinates, page transitions | ✅ "step 1: launch_app(Meituan)→Home / step 2: touch_gesture(@x=500,y=850)→Cart" |
 | App prior knowledge | First time using an app can see commonly used pages and tools | ✅ app_profile accumulates pages_seen, tools_used |
-| Failure experience tracking | Failure modes enter verifier | ✅ failure memory routes to Verifier.FailureModes |
+| Failure experience tracking | Failure modes surface as cautions | ✅ failure memory routes to Agent context |
 | Page-level indexing | Retrieve procedure by page_name | ✅ procedure ID includes page, page_name in entities/tags |
 
 ### Differences from Design Doc

--- a/docs/04-agent/overview.md
+++ b/docs/04-agent/overview.md
@@ -28,7 +28,7 @@ In the firmware, it is installed by default to:
 - Built-in tool calling: HID, screenshots, audio volume, shell
 - HTTP Tool API for Web UI, external agents, or manual invocation
 - Auto-discovery and runtime activation of skills from `SKILL.md`
-- Three-stage role loop (`default` / `plan` / `execution`): simple tasks are directly executed by the planner, complex tasks go through `commit_plan` into executor-verifier collaboration; see [Agent Context Lifecycle](context-lifecycle.md)
+- Single-agent execution loop with streamlined tool calling and response handling
 - Conversation memory persistence, session memory compaction; see [Session Memory Compaction](session-memory.md)
 - Device / Task Episode memory design; see [Memory Plane Design](memory-plane.md)
 - Web UI: chat history, browser recording, attachments, Tool Lab, Skill Export

--- a/docs/04-agent/session-memory.md
+++ b/docs/04-agent/session-memory.md
@@ -1,6 +1,6 @@
 # Session Memory Compaction
 
-This document describes Aiden Agent's session-level conversation memory compaction. The mechanism turns a growing event stream into chunk summaries and keeps only the latest hot window available to the planner as native chat messages.
+This document describes Aiden Agent's session-level conversation memory compaction. The mechanism turns a growing event stream into chunk summaries and keeps only the latest hot window available to the Agent as native chat messages.
 
 This is separate from the [Memory Plane design](memory-plane.md). Memory Plane handles device and task-episode experience memory; session memory handles the dialogue history for one active session.
 
@@ -102,7 +102,7 @@ Maintenance may run asynchronously while the next turn is being appended. To avo
   - `prompt_tokens / context_window >= compress_at_percent%`.
 - Without prompt-token data, such as cold start, a provider response without usage metadata, or before the first LLM call, compaction triggers when `event_count > count_compress_after_events`.
 
-The prompt-token value is the largest single LLM prompt observed in the latest run. This avoids missing compaction when the planner prompt is large but a later verifier prompt is small.
+The prompt-token value is the largest single LLM prompt observed in the latest run. This avoids missing compaction when the main prompt is large but a later prompt in the same turn is small.
 
 `context_window` prefers the active model window from `ModelResolver`, so runtime model swaps take effect without restart. Unknown models fall back to `context_window` from `extraction.yaml`.
 
@@ -155,7 +155,7 @@ The prefix summary is intentionally written to both the chunk summary and the ho
 
 ## summary.md and Rolling Summary
 
-The active session's `summary.md` is injected into the planner prompt and has
+The active session's `summary.md` is injected into the Agent prompt and has
 two sections:
 
 ```markdown
@@ -179,14 +179,14 @@ The Rolling Summary currently has a 100-line cap (`maxRollingSummaryLines`). Whe
 
 Compressed session summaries are loaded into the role memory context, while the
 retained hot-window events are converted into native chat messages and inserted
-between the planner system prompt and the current planner task message. They are
+between the system prompt and the current task message. They are
 not rendered inside a `Conversation history:` text block. Compressed-history
 state is not exposed through a hot-window label, and no synthetic hot-window
 start/end markers are added. The session compaction thresholds and model context
 budget are the controls for prompt growth.
 
 **Note**: The `chat_history` store, while persisted, is NOT injected into the
-planner context. See `context-lifecycle.md` for rationale.
+Agent context. See `context-lifecycle.md` for rationale.
 
 Synthetic prompt text must not be persisted into `ChatMessageHistory`.
 `Snapshot()` reads history verbatim and `appendSessionEvents()` writes records

--- a/docs/04-agent/session-memory.md
+++ b/docs/04-agent/session-memory.md
@@ -151,7 +151,7 @@ When the cut lands inside a turn rather than on a `user_input` boundary, the hot
 3. The chunk summary stores `history + "\n\n---\n\nTurn Context (split turn):\n" + prefixSummary` for recall.
 4. The hot window receives a synthetic `system_event` containing the prefix summary for immediate prompt context.
 
-The prefix summary is intentionally written to both the chunk summary and the hot window: the former serves historical retrieval, while the latter serves the next planner prompt.
+The prefix summary is intentionally written to both the chunk summary and the hot window: the former serves historical retrieval, while the latter serves the next Agent prompt.
 
 ## summary.md and Rolling Summary
 

--- a/docs/04-agent/skills.md
+++ b/docs/04-agent/skills.md
@@ -1,6 +1,6 @@
 # Skills and RoleProfile Mechanism
 
-The Agent automatically discovers `SKILL.md` files from the config directory, displays an Available skills catalog in the system prompt, and loads the complete instructions of relevant skills on demand via `skill_read`. Activated skills enter the multi-role `RoleProfile`: `planner`, `executor`, `verifier`.
+The Agent automatically discovers `SKILL.md` files from the config directory, displays an Available skills catalog in the system prompt, and loads the complete instructions of relevant skills on demand via `skill_read`. Activated skills are injected into the Agent's `RoleProfile`, which contains the system prompt, skill instructions, and available tools.
 
 ## Directory Structure
 
@@ -35,7 +35,7 @@ Prefer describing what you see before clicking.
 
 - Automatically discover `SKILL.md`;
 - Display Available skills in the prompt and load complete `SKILL.md` at runtime via `skill_read`;
-- Inject skill instructions into the system prompt of the three roles' `RoleProfile`;
+- Inject skill instructions into the Agent's system prompt via `RoleProfile`;
 - Parse `allowed_tools` metadata for validation and future compatibility, but tool availability is currently controlled by the static Agent tool catalog rather than by active skills;
 - Provide `skill_list` / `skill_read` / `skill_manage` / `skill_mark_used` to the Agent; the HTTP Tool API exposes only the non-maintenance ones (`skill_list` / `skill_read`);
 - `skill_read` supports reading `SKILL.md` as well as UTF-8 supporting files under `references/`, `templates/`, `scripts/`, `assets/`;
@@ -44,19 +44,11 @@ Prefer describing what you see before clicking.
 - For skills with `source: agent` or `created_by: agent`, `skill_list` automatically executes lifecycle based on last use time: enter `stale` after 90 days of non-use, enter `archived` after 180 days; this automatic scan runs at most once every 24 hours;
 - `skill_mark_used` automatically restores `stale` / `archived` skills to `active`.
 
-## Role Permissions
+## Agent Execution
 
-The Agent loop uses a `default` / `plan` / `execution` three-phase state machine. See [Agent Context Lifecycle](context-lifecycle.md) for details.
+The Agent uses a streamlined execution loop that handles tool calls and generates responses in a single unified flow. All tools are available to the Agent throughout execution, and the Agent directly manages its own task breakdown and execution strategy.
 
-- `planner`:
-  - In `default` mode, only handles simple tasks (direct answer, single tool call, or at most two steps); when **3 or more steps** are expected, must first `enter_plan_mode`, and must not continue executing directly in default;
-  - In `plan` mode, can explore and maintain draft plan, and switch phases via `commit_plan` / `cancel_plan`;
-  - Is the only role allowed to create or modify plans;
-  - Additionally sees loop meta tools: `use_simple_mode`, `enter_plan_mode`, `commit_plan`, `cancel_plan`.
-- `executor`: Runs only in `execution` phase; can only execute the `next_step` already committed by planner, enters verifier review via `finish_step` / `abort_step`, cannot modify plan or decide to end.
-- `verifier`: runs only in `execution`; its system prompt contains the current date, `## Role rules`, and optional `## Verifier memory cautions`; each turn verifies only the current executor `step_text`; intermediate step success advances to the next step, and only final-step success may set `can_finish`; step failure sets `needs_replan`; it does not receive the tool catalog, skills, base instruction, runtime context, or global memory.
-
-Both `planner` and `executor` receive callable function tools. `verifier` does not call tools, only performs review based on executor evidence.
+Tool execution is integrated into the main loop with callback handlers for streaming responses and episode recording.
 
 ## Parsed but Not Fully Enforced Fields
 

--- a/docs/04-agent/telemetry-langfuse.md
+++ b/docs/04-agent/telemetry-langfuse.md
@@ -75,7 +75,7 @@ In addition to tokens, duration, and model info in `episode.Extra`, the exporter
 | Field | Description |
 | --- | --- |
 | `tool_call_count` | Total number of tool calls in the episode |
-| `iteration_count` | Number of agent iterations |
+| `iteration_count` | Number of agent iterations (from episode recorder counter or episode.Extra) |
 
 Additional trace `tags`:
 

--- a/docs/04-agent/telemetry-langfuse.md
+++ b/docs/04-agent/telemetry-langfuse.md
@@ -37,7 +37,7 @@ Credentials are written directly into the `[telemetry]` section of `agent.toml`.
 
 ```text
 Runtime.Run()
-  → Phased role loop (default / plan / execution)
+  → Agent execution loop
   → EpisodeRecorder records events
   → CommitEpisode persists to disk (episode.yaml + events.jsonl + artifacts/)
   → exportEpisodeBestEffort async reports to Langfuse
@@ -48,12 +48,8 @@ Runtime.Run()
 | Aiden Episode | Langfuse |
 | --- | --- |
 | `TaskEpisode` | Trace (`aiden-episode`) |
-| Run start | Span `phase/default` (created for all runs by default, covers default phase activity) |
-| `loop_phase` | Span `phase/{content}` (`default` / `plan` / `execution`), metadata contains `reason` (e.g., `enter_plan_mode`, `commit_plan`) |
-| `default_finish` | Span `planner/default_finish` (nested under current phase span) |
-| `planner_decision` | Span `iteration_N` + child Span `planner` (committed plan from `commit_plan`) |
-| `tool_call` / `tool_result` | Planner tools: `planner/tool/{name}` + `planner/tool_result/{name}`; Executor tools: `tool/{name}` + `tool_result/{name}` |
-| `verifier_decision` | Span `verifier` (nested under `iteration_N`, execution phase only) |
+| Run start | Span `run` (created for all runs, covers main execution activity) |
+| `tool_call` / `tool_result` | Span `tool/{name}` + `tool_result/{name}` |
 | `Outcome.Success` | Boolean Score `success=1/0` |
 | `artifacts/*.jpeg` | Media upload + observation reference |
 | `Extra` metrics | Trace metadata + generation model/cost/usage fields |
@@ -62,53 +58,33 @@ Typical trace structure:
 
 ```text
 aiden-episode (trace)
-├── phase/default
-│   ├── planner/tool/audio_volume
-│   │   └── planner/tool_result/audio_volume
-│   └── planner/default_finish
-└── phase/plan
-    └── loop_phase/enter_plan_mode (via phase/plan span metadata)
-
-aiden-episode (committed execution)
-├── phase/default
-├── phase/plan
-├── phase/execution
-├── iteration_1
-│   ├── planner
-│   ├── tool/mouse_click
-│   │   └── tool_result/mouse_click
-│   └── verifier
-└── generation (planner/executor/verifier LLM calls)
+├── run
+│   ├── tool/audio_volume
+│   │   └── tool_result/audio_volume
+│   ├── tool/screenshot
+│   │   └── tool_result/screenshot
+│   └── tool/mouse_click
+│       └── tool_result/mouse_click
+└── generation (LLM calls)
 ```
 
 ### Trace Metadata and Tags
 
-In addition to tokens, duration, and model info in `episode.Extra`, the exporter derives loop metrics from the event chain and writes them into trace `metadata`:
+In addition to tokens, duration, and model info in `episode.Extra`, the exporter derives execution metrics from the event chain and writes them into trace `metadata`:
 
 | Field | Description |
 | --- | --- |
-| `loop_mode` | `default` (direct finish) or `committed` (went through `commit_plan`) |
-| `final_phase` | Phase at completion |
-| `phase_transitions` | Phase transition sequence, e.g., `["plan:enter_plan_mode","execution:commit_plan"]` |
-| `loop_phase_count` | Number of phase transitions |
-| `enter_plan_mode_count` / `commit_plan_count` / `cancel_plan_count` / `plan_exhausted_count` | Trigger count for each meta tool |
-| `default_finish` | Whether finished directly in default phase |
-| `planner_tool_call_count` / `executor_tool_call_count` | Tool call count split by role |
-| `replan_count` | Number of replans triggered by verifier |
+| `tool_call_count` | Total number of tool calls in the episode |
+| `iteration_count` | Number of agent iterations |
 
 Additional trace `tags`:
 
 | Tag | Condition |
 | --- | --- |
-| `loop:default_finish` | `default_finish` event exists |
-| `loop:committed` | `planner_decision` (commit) exists |
-| `loop:plan` | Entered plan mode |
-| `loop:execution` | Entered execution after commit |
-| `loop:cancelled` | cancel_plan |
-| `loop:exhausted` | Plan steps exhausted |
-| `loop:replan` | verifier `needs_replan` |
+| `success` | Task completed successfully |
+| `failure` | Task failed |
 
-In Langfuse UI, you can quickly filter simple tasks vs. multi-step delegated tasks using `loop:default_finish` and `loop:committed`.
+In Langfuse UI, you can filter tasks by success/failure and tool usage patterns.
 
 Local episodes are still written to `/userdata/agent/memory/episodes/`; Langfuse serves as an additional copy for centralized analysis and dataset management.
 
@@ -134,12 +110,11 @@ Components: Langfuse Web + Worker, Postgres, ClickHouse, Redis, MinIO (screensho
 3. Execute a task (Web UI or benchmark)
 4. Confirm in Langfuse UI → Traces:
    - `aiden-episode` trace exists
-   - Contains `phase/default` (and `phase/plan`, `phase/execution` as needed)
-   - Simple tasks show `planner/tool/*` and `planner/default_finish`
-   - Delegated tasks show `iteration_N` + `tool/*` + `verifier`
+   - Contains `run` span with nested tool calls
+   - Tool calls show as `tool/*` and `tool_result/*` spans
    - Screenshots can be previewed in tool_result observations
-   - Metadata contains `loop_mode`, `phase_transitions`, `planner_tool_call_count`, `executor_tool_call_count`, token stats, tool/error/replan counts
-   - Tags contain `loop:default_finish` or `loop:committed`
+   - Metadata contains `tool_call_count`, `iteration_count`, token stats
+   - Tags contain `success` or `failure`
    - Trace contains `userId` (device ID) and `sessionId` (runtime session ID)
 
 ## Trace → Dataset → Benchmark Workflow


### PR DESCRIPTION
## Changes

This PR updates the agent documentation to reflect the current single-agent architecture, removing outdated references to the planner/executor/verifier multi-role system.

### Updated Documentation

- **overview.md**: Simplified to describe streamlined single-agent execution loop
- **skills.md**: Updated RoleProfile mechanism description and removed three-phase role permissions section
- **configuration.md**: Removed outdated known limitations about role splitting
- **session-memory.md**: Updated all references from 'planner' to 'Agent'
- **telemetry-langfuse.md**: Simplified trace structure documentation, removed phase/iteration spans
- **context-lifecycle.md**: Replaced phased role loop with simple agent execution loop description
- **memory-plane.md**: Updated memory context routing and retrieval descriptions

### Impact

- **-118 lines** of outdated multi-role architecture descriptions
- **+111 lines** of simplified single-agent documentation
- All agent documentation now consistently describes the current architecture
- No code changes, documentation only

### Testing

- Verified all planner/executor/verifier references in docs/04-agent/ have been updated
- Maintained technical accuracy while simplifying the conceptual model


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent documentation to describe a streamlined single-agent execution loop.
  * Clarified prompt composition, memory handling, session context, skill activation, and tool usage.
  * Revised memory-plane guidance, lifecycle diagrams, episode logging, and retrieval behavior.
  * Updated telemetry documentation to reflect simplified execution traces, tool spans, and reporting metrics.
  * Removed outdated limitations and role-specific execution details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->