### PR TITLE
fix(config_web): preserve original LLM log filename when exporting logs

### DIFF
--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -4738,9 +4738,15 @@ ApiResponse handle_export_support_logs(const Options& options) {
         std::string("Agent log path not available: ") + kAgentLogPath + "\n",
         kSupportLogAgentMaxBytes,
         &error);
+
+    // Keep the original LLM log filename instead of renaming to http.log
+    std::string llm_log_original_name = latest_llm_log_name(options);
+    if (llm_log_original_name.empty()) {
+        llm_log_original_name = kSupportLogHttpName;
+    }
     staged = staged && stage_file_or_placeholder(
         latest_llm_log_path(options),
-        stage_dir + "/" + kSupportLogHttpName,
+        stage_dir + "/" + llm_log_original_name,
         "HTTP log",
         "No llm-http-*.log files found under " + llm_log_dir(options) + ".\n",
         kSupportLogHttpMaxBytes,
@@ -4767,12 +4773,12 @@ ApiResponse handle_export_support_logs(const Options& options) {
         " -C " + shell_quote(stage_dir) + " " +
         shell_quote(kSupportLogLangfuseName) + " " +
         shell_quote(kSupportLogAgentName) + " " +
-        shell_quote(kSupportLogHttpName);
+        shell_quote(llm_log_original_name);
     std::string tar_stream_args =
         "-C " + shell_quote(stage_dir) + " " +
         shell_quote(kSupportLogLangfuseName) + " " +
         shell_quote(kSupportLogAgentName) + " " +
-        shell_quote(kSupportLogHttpName);
+        shell_quote(llm_log_original_name);
     std::string fallback_tar_path = archive_path + ".tar";
     std::string command = "tar -czf " + tar_args +
         " 2>/dev/null || (rm -f " + shell_quote(fallback_tar_path) +

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -4740,12 +4740,17 @@ ApiResponse handle_export_support_logs(const Options& options) {
         &error);
 
     // Keep the original LLM log filename instead of renaming to http.log
+    // Capture both name and path atomically to avoid race conditions during log rotation
     std::string llm_log_original_name = latest_llm_log_name(options);
+    std::string llm_log_source_path;
     if (llm_log_original_name.empty()) {
         llm_log_original_name = kSupportLogHttpName;
+        llm_log_source_path = "";  // Will trigger placeholder
+    } else {
+        llm_log_source_path = llm_log_path(options, llm_log_original_name);
     }
     staged = staged && stage_file_or_placeholder(
-        latest_llm_log_path(options),
+        llm_log_source_path,
         stage_dir + "/" + llm_log_original_name,
         "HTTP log",
         "No llm-http-*.log files found under " + llm_log_dir(options) + ".\n",

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -1791,9 +1791,10 @@ TEST_CASE("config_web: exports support log archive with langfuse agent and http 
     const std::string entries = run_command_capture("LC_ALL=C tar -tzf " + archive);
     CHECK(entries.find("langfuse.yaml\n") != std::string::npos);
     CHECK(entries.find("agent.log\n") != std::string::npos);
-    CHECK(entries.find("http.log\n") != std::string::npos);
+    // Expect the original LLM log filename, not the generic http.log
+    CHECK(entries.find("llm-http-20260701080000123.log\n") != std::string::npos);
 
-    const std::string http_log = run_command_capture("LC_ALL=C tar -xOzf " + archive + " http.log");
+    const std::string http_log = run_command_capture("LC_ALL=C tar -xOzf " + archive + " llm-http-20260701080000123.log");
     CHECK(http_log.find("new http log") != std::string::npos);
 
     const std::string langfuse = run_command_capture("LC_ALL=C tar -xOzf " + archive + " langfuse.yaml");
@@ -1818,11 +1819,37 @@ TEST_CASE("config_web: support log archive caps staged http log tail") {
     const std::string archive_path = handle->tmp_dir + "/support-logs-large.tar.gz";
     write_binary_file(archive_path, resp.body);
     const std::string archive = shell_quote(archive_path);
-    const std::string http_log = run_command_capture("LC_ALL=C tar -xOzf " + archive + " http.log");
+    const std::string http_log = run_command_capture("LC_ALL=C tar -xOzf " + archive + " llm-http-20260701090000123.log");
     CHECK(http_log.find("# truncated: copied latest ") != std::string::npos);
     CHECK(http_log.find("begin-marker") == std::string::npos);
     CHECK(http_log.find("end-marker") != std::string::npos);
     CHECK(http_log.size() < content.size());
+}
+
+TEST_CASE("config_web: support log archive falls back to http.log when no LLM log exists") {
+    StubEnv env;
+    auto handle = start_server(env);
+
+    const std::string log_dir = handle->tmp_dir + "/log";
+    REQUIRE(::mkdir(log_dir.c_str(), 0755) == 0);
+    // Do not create any llm-http-*.log files
+
+    const std::string memory_dir = handle->tmp_dir + "/memory";
+    REQUIRE(::mkdir(memory_dir.c_str(), 0755) == 0);
+
+    HttpResponse resp = http_request(handle->port, "GET", "/api/logs/export");
+    REQUIRE(resp.status == 200);
+
+    const std::string archive_path = handle->tmp_dir + "/support-logs-nohttp.tar.gz";
+    write_binary_file(archive_path, resp.body);
+    const std::string archive = shell_quote(archive_path);
+    const std::string entries = run_command_capture("LC_ALL=C tar -tzf " + archive);
+    // When no LLM log exists, should fall back to http.log
+    CHECK(entries.find("http.log\n") != std::string::npos);
+
+    const std::string http_log = run_command_capture("LC_ALL=C tar -xOzf " + archive + " http.log");
+    // Should contain placeholder text
+    CHECK(http_log.find("HTTP log unavailable") != std::string::npos);
 }
 
 TEST_CASE("config_web: legacy llm log JSON file endpoint is removed") {


### PR DESCRIPTION
## Summary
Previously, when exporting logs via the Aiden setup interface (port 80), the LLM HTTP log file was renamed to 'http.log' in the tar.gz archive, losing the original filename information (e.g., `llm-http-202606230828-session_*.log`).

This change preserves the original LLM log filename in the exported archive.

## Changes
- Modified `handle_export_support_logs()` to get the original LLM log filename using `latest_llm_log_name()`
- Updated tar command arguments to use the original filename instead of hardcoded `kSupportLogHttpName`
- Falls back to 'http.log' if no LLM log file is found

## Testing
- Compiled and deployed to board 192.168.50.135
- Service is running and listening on port 80
- Ready for testing via the Aiden setup interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Support log exports now preserve the original `llm-http-*.log` filename inside the packaged archive.
  * When the expected log is unavailable, exports still fall back to the standard `http.log` placeholder behavior.
* **Tests**
  * Updated end-to-end coverage to verify the preserved HTTP log name and its contents within the archive.
  * Strengthened truncation assertions and added a regression check for the “no matching LLM log exists” fallback case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->