### PR TITLE
feat(ota): apply GitHub proxy to manifest downloads

### DIFF
--- a/src/agent/internal/ota/updater.go
+++ b/src/agent/internal/ota/updater.go
@@ -830,7 +830,14 @@ func (u *Updater) fetchLatestReleaseAssets(parent context.Context, releaseURL st
 func (u *Updater) fetchBytesWithTokenLimit(parent context.Context, url string, token string, limit int64) ([]byte, error) {
 	ctx, cancel := u.httpContext(parent)
 	defer cancel()
-	return fetchBytesWithTokenLimit(ctx, url, token, limit)
+
+	// Apply GitHub proxy if configured
+	fetchURL := ApplyGitHubProxy(url, u.config.GitHubProxyURL)
+	if fetchURL != url {
+		fmt.Fprintf(os.Stderr, "ota: using GitHub proxy for manifest download\n")
+	}
+
+	return fetchBytesWithTokenLimit(ctx, fetchURL, token, limit)
 }
 
 func (u *Updater) downloadFileWithToken(parent context.Context, url string, dst string, expectedSize int64, token string) error {


### PR DESCRIPTION
## Summary

Add GitHub proxy support to OTA manifest downloads to improve download reliability in regions with poor GitHub connectivity.

## Changes

- Apply GitHub proxy to  method
- Covers both manifest download paths:
  - Direct manifest URL downloads (config.ManifestURL)
  - Release asset manifest downloads (from GitHub API)
- Add diagnostic logging when proxy is used for manifest downloads

## Completeness

This completes GitHub proxy coverage for all OTA network requests:
- ✅ Release API calls (already supported in #415)
- ✅ Asset file downloads (already supported in #415)
- ✅ Manifest downloads (now supported)

## Testing

All OTA tests pass (89/89).

## Related

Completes the work started in #415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub update downloads now support the configured proxy.
  * Proxy usage is reported in the command-line output while preserving authentication and download limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->