### PR TITLE
fix(config): restrict base_url to openai and ollama providers

### DIFF
--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -626,18 +626,21 @@ func applyRuntimeOptionalProviderDefaults(cfg *Config, metadata toml.MetaData) {
 		cfg.STT.Model = ""
 	}
 
-	// base_url is only honored for the openai provider; every other provider
-	// pins its own endpoint, so drop any stray override to keep runtime
+	// base_url is only honored for openai and ollama providers; every other
+	// provider pins its own endpoint, so drop any stray override to keep runtime
 	// behavior consistent with the config web UI (which hides the field).
-	clearNonOpenAIModelBaseURL(&cfg.Model)
-	clearNonOpenAIModelBaseURL(&cfg.ModelText)
+	clearNonAllowedModelBaseURL(&cfg.Model)
+	clearNonAllowedModelBaseURL(&cfg.ModelText)
 }
 
-func clearNonOpenAIModelBaseURL(m *ModelConfig) {
+func clearNonAllowedModelBaseURL(m *ModelConfig) {
 	if m == nil {
 		return
 	}
-	if strings.ToLower(strings.TrimSpace(m.Provider)) != "openai" {
+	provider := strings.ToLower(strings.TrimSpace(m.Provider))
+	// Only openai and ollama support base_url override.
+	// openai: custom gateway/proxy; ollama: local server address
+	if provider != "openai" && provider != "ollama" {
 		m.BaseURL = ""
 	}
 }

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -625,6 +625,21 @@ func applyRuntimeOptionalProviderDefaults(cfg *Config, metadata toml.MetaData) {
 	} else if !usesDefaultSTTModel(cfg.STT.Provider) && !metadata.IsDefined("stt", "model") {
 		cfg.STT.Model = ""
 	}
+
+	// base_url is only honored for the openai provider; every other provider
+	// pins its own endpoint, so drop any stray override to keep runtime
+	// behavior consistent with the config web UI (which hides the field).
+	clearNonOpenAIModelBaseURL(&cfg.Model)
+	clearNonOpenAIModelBaseURL(&cfg.ModelText)
+}
+
+func clearNonOpenAIModelBaseURL(m *ModelConfig) {
+	if m == nil {
+		return
+	}
+	if strings.ToLower(strings.TrimSpace(m.Provider)) != "openai" {
+		m.BaseURL = ""
+	}
 }
 
 func normalizeTTSProvider(provider string) string {

--- a/src/agent/internal/agent/config_meta.go
+++ b/src/agent/internal/agent/config_meta.go
@@ -114,7 +114,7 @@ func ConfigMeta() ConfigMetadata {
 					{Key: "model", Widget: WidgetText, Default: defaults.Model.Model},
 					{Key: "api_key", Widget: WidgetText, Secret: true},
 					{Key: "base_url", Widget: WidgetText,
-						VisibleWhen: all(ne("model.provider", "openrouter"))},
+						VisibleWhen: all(eq("model.provider", "openai"))},
 					{Key: "temperature", Widget: WidgetNumber, Default: defaults.Model.Temperature},
 					{Key: "max_response_tokens", Widget: WidgetNumber, Default: defaults.Model.MaxResponseTokens},
 					{Key: "log_raw_http", Widget: WidgetBoolean, Default: defaults.Model.LogRawHTTP},

--- a/src/agent/internal/agent/config_meta.go
+++ b/src/agent/internal/agent/config_meta.go
@@ -114,7 +114,7 @@ func ConfigMeta() ConfigMetadata {
 					{Key: "model", Widget: WidgetText, Default: defaults.Model.Model},
 					{Key: "api_key", Widget: WidgetText, Secret: true},
 					{Key: "base_url", Widget: WidgetText,
-						VisibleWhen: all(eq("model.provider", "openai"))},
+						VisibleWhen: all(in("model.provider", "openai", "ollama"))},
 					{Key: "temperature", Widget: WidgetNumber, Default: defaults.Model.Temperature},
 					{Key: "max_response_tokens", Widget: WidgetNumber, Default: defaults.Model.MaxResponseTokens},
 					{Key: "log_raw_http", Widget: WidgetBoolean, Default: defaults.Model.LogRawHTTP},

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -119,10 +119,11 @@ func TestLoadRuntimeConfigClearsBaseURLForNonOpenAIProvider(t *testing.T) {
 	}{
 		{"openai keeps base_url", "openai", "https://gateway.example.com/v1"},
 		{"OpenAI case insensitive keeps base_url", "OpenAI", "https://gateway.example.com/v1"},
+		{"ollama keeps base_url", "ollama", "https://gateway.example.com/v1"},
+		{"Ollama case insensitive keeps base_url", "Ollama", "https://gateway.example.com/v1"},
 		{"openrouter drops base_url", "openrouter", ""},
 		{"kimi drops base_url", "kimi", ""},
 		{"kimi-cn drops base_url", "kimi-cn", ""},
-		{"ollama drops base_url", "ollama", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -111,6 +111,51 @@ parse_failure_limit = 13
 	}
 }
 
+func TestLoadRuntimeConfigClearsBaseURLForNonOpenAIProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    string
+		wantBaseURL string
+	}{
+		{"openai keeps base_url", "openai", "https://gateway.example.com/v1"},
+		{"OpenAI case insensitive keeps base_url", "OpenAI", "https://gateway.example.com/v1"},
+		{"openrouter drops base_url", "openrouter", ""},
+		{"kimi drops base_url", "kimi", ""},
+		{"kimi-cn drops base_url", "kimi-cn", ""},
+		{"ollama drops base_url", "ollama", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "agent.toml")
+			contents := `
+[model]
+provider = "` + tt.provider + `"
+model = "some-model"
+base_url = "https://gateway.example.com/v1"
+
+[model_text]
+provider = "` + tt.provider + `"
+model = "some-model"
+base_url = "https://gateway.example.com/v1"
+`
+			if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			cfg, err := LoadRuntimeConfig(path)
+			if err != nil {
+				t.Fatalf("LoadRuntimeConfig() error = %v", err)
+			}
+			if cfg.Model.BaseURL != tt.wantBaseURL {
+				t.Errorf("model.base_url = %q, want %q", cfg.Model.BaseURL, tt.wantBaseURL)
+			}
+			if cfg.ModelText.BaseURL != tt.wantBaseURL {
+				t.Errorf("model_text.base_url = %q, want %q", cfg.ModelText.BaseURL, tt.wantBaseURL)
+			}
+		})
+	}
+}
+
 func TestConfigRejectsInvalidTerminationPolicyThresholdOrder(t *testing.T) {
 	cfg := Config{
 		Model: ModelConfig{Provider: "fake"},

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -2629,6 +2629,13 @@ void update_model_from_json(cJSON* obj, aiden::ModelToml* m) {
     set_json_int(&m->max_response_tokens, obj, "max_response_tokens");
     set_json_int(&m->context_window, obj, "context_window");
     set_json_int(&m->model_max_output_tokens, obj, "model_max_output_tokens");
+
+    // Clear base_url for non-whitelisted providers to keep config file clean.
+    // Only openai and ollama support base_url override.
+    std::string provider_lower = lowercase_copy(trim_copy(m->provider));
+    if (!m->base_url.empty() && provider_lower != "openai" && provider_lower != "ollama") {
+        m->base_url.clear();
+    }
 }
 
 void update_config_from_json(cJSON* root, aiden::AgentToml* config) {


### PR DESCRIPTION
## Changes

Restrict `base_url` configuration to OpenAI and Ollama providers only. For other providers (Kimi, OpenRouter, etc.), the `base_url` field is:
- Hidden in the Web UI
- Cleared at config load time (Go)
- Cleared at config save time (C++)

## Implementation

### UI Layer
- Modified `config_meta.go` to show `base_url` field only when `provider == "openai" || provider == "ollama"`

### Runtime Layer
- Added `clearInvalidBaseURL()` in `config.go` to clear `base_url` for non-whitelisted providers when loading config
- Applies to both `model` and `model_text` sections

### Save Layer
- Modified `update_model_from_json()` in `config_web.cpp` to clear `base_url` for non-whitelisted providers when saving config

## Testing

- ✅ Go tests pass (`TestLoadRuntimeConfigClearsBaseURLForNonOpenAIProvider`)
- ✅ C++ tests pass (2 new e2e tests covering save-time clearing and preservation)
- ✅ Verified for providers: openai, ollama, kimi, openrouter, kimi-cn

## Files Changed

- `src/agent/internal/agent/config.go` - Runtime clearing logic
- `src/agent/internal/agent/config_meta.go` - UI visibility rules
- `src/agent/internal/agent/config_test.go` - Go tests
- `src/config_web.cpp` - Save-time clearing logic
- `tests/config_web_e2e_test.cpp` - C++ e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
