### PR TITLE
refactor(agent): remove impossible comparisons

### DIFF
--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -447,7 +447,7 @@ func NewRuntimeWithDeps(cfg Config, models model.ModelResolver, memories *Memory
 				}
 			})
 			longTermStore = memories.longTerm
-		} else if longTermStore == nil {
+		} else {
 			// No manager provided, create a standalone store
 			storeOpts := []LongTermMemoryOption{WithLifecycleDir(filepath.Join(memoryDir, "lifecycle"))}
 			longTermStore = NewLongTermMemoryStore(filepath.Join(memoryDir, "long_term"), storeOpts...)

--- a/src/agent/internal/agent/screen_mapping_prime.go
+++ b/src/agent/internal/agent/screen_mapping_prime.go
@@ -75,9 +75,6 @@ func (r *Runtime) PrimeScreenMappingOnStartup(ctx context.Context) error {
 		select {
 		case <-primeCtx.Done():
 			timer.Stop()
-			if lastErr == nil {
-				lastErr = primeCtx.Err()
-			}
 			if r.logger != nil {
 				r.logger.Warn("screen mapping prime failed: attempts=%d elapsed_ms=%d err=%v", attempts, time.Since(startedAt).Milliseconds(), lastErr)
 			}


### PR DESCRIPTION
## Summary
- always create a standalone long-term memory store when no manager is provided
- remove the unreachable `lastErr == nil` branch when screen mapping priming is cancelled

## Testing
- not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup memory-store initialization for configurations using a dedicated configuration directory.
  * Refined startup screen-mapping retry handling to provide more accurate failure reporting when initialization is interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->