### PR TITLE
feat(agent): add anthropic history pruning transforms

### DIFF
--- a/src/agent/internal/agent/agent_loop.go
+++ b/src/agent/internal/agent/agent_loop.go
@@ -11,6 +11,7 @@ import (
 
 	"aiden-agent/internal/agent/contextmanager"
 	"aiden-agent/internal/agent/executor"
+	"aiden-agent/internal/agent/model"
 	"aiden-agent/internal/util"
 
 	"github.com/tmc/langchaingo/agents"
@@ -33,7 +34,7 @@ const (
 )
 
 type AgentLoop struct {
-	Model                    llms.Model
+	Model                    model.Model
 	Profile                  RoleProfile
 	Memory                   schema.Memory
 	CallbacksHandler         callbacks.Handler
@@ -53,7 +54,7 @@ type AgentLoop struct {
 }
 
 func NewAgentLoop(
-	model llms.Model,
+	model model.Model,
 	profile RoleProfile,
 	memory schema.Memory,
 	maxIterations int,
@@ -77,8 +78,19 @@ func NewAgentLoop(
 	}
 }
 
+func (l *AgentLoop) outboundTransforms() []executor.OutboundMessageTransform {
+	modelName := l.Model.Spec().Name
+	modelProvider := l.Model.Spec().Provider
+	return []executor.OutboundMessageTransform{
+		AnthropicScreenshotPruner{
+			Enabled: IsAnthropicModel(modelProvider, modelName),
+			Config:  l.ScreenshotPruning,
+		},
+	}
+}
+
 func (l *AgentLoop) Run(ctx context.Context, input string, options ...chains.ChainCallOption) (string, error) {
-	llmExecutor := executor.NewLLMExecutor(l.Model, l.contextManager)
+	llmExecutor := executor.NewLLMExecutor(l.Model, l.contextManager, l.outboundTransforms()...)
 
 	agentTools := l.Profile.Tools
 	toolSpecs := NewToolSpecs(agentTools)

--- a/src/agent/internal/agent/agent_loop_prune_test.go
+++ b/src/agent/internal/agent/agent_loop_prune_test.go
@@ -1,0 +1,130 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"aiden-agent/internal/agent/contextmanager"
+	"aiden-agent/internal/agent/executor"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+type pruneRecordingModel struct {
+	last []llms.MessageContent
+}
+
+func (m *pruneRecordingModel) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	m.last = messages
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: "ok"}}}, nil
+}
+
+func (m *pruneRecordingModel) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	return "ok", nil
+}
+
+func newScreenshotObservationManager(t *testing.T, count int) *contextmanager.ContextManager {
+	t.Helper()
+	manager, err := contextmanager.NewContextManagerFromMessageList(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("NewContextManagerFromMessageList() error = %v", err)
+	}
+	for i := 0; i < count; i++ {
+		stored, err := manager.StoreAttachment("image/jpeg", []byte("img"))
+		if err != nil {
+			t.Fatalf("StoreAttachment() error = %v", err)
+		}
+		stored.Source = contextmanager.AttachmentSourceScreenshotObservation
+		if err := manager.AppendMessage(contextmanager.Message{
+			Role:        contextmanager.MessageRoleUser,
+			Content:     "shot",
+			Attachments: []contextmanager.Attachment{stored},
+		}); err != nil {
+			t.Fatalf("AppendMessage() error = %v", err)
+		}
+	}
+	return manager
+}
+
+func countBinaryAndOmitted(messages []llms.MessageContent) (binaryCount, omitted int) {
+	for _, msg := range messages {
+		for _, part := range msg.Parts {
+			switch p := part.(type) {
+			case llms.BinaryContent:
+				binaryCount++
+			case llms.TextContent:
+				if strings.Contains(p.Text, "[Image omitted]") {
+					omitted++
+				}
+			}
+		}
+	}
+	return binaryCount, omitted
+}
+
+func TestAgentLoopExecutorPrunesForAnthropicModel(t *testing.T) {
+	manager := newScreenshotObservationManager(t, 6)
+	model := &pruneRecordingModel{}
+	pruner := AnthropicScreenshotPruner{
+		Enabled: IsAnthropicModel("openrouter", "anthropic/claude-test"),
+		Config:  ScreenshotPruningConfig{}.WithDefaults(),
+	}
+	exec := executor.NewLLMExecutor(model, manager, pruner)
+	if _, err := exec.GenerateContent(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	binaryCount, omitted := countBinaryAndOmitted(model.last)
+	if binaryCount != 4 || omitted != 2 {
+		t.Fatalf("binary=%d omitted=%d messages=%#v", binaryCount, omitted, model.last)
+	}
+	if got := len(manager.MessageListDump().Messages); got != 6 {
+		t.Fatalf("persisted message count = %d", got)
+	}
+	for _, msg := range manager.MessageListDump().Messages {
+		if len(msg.Attachments) != 1 {
+			t.Fatalf("persisted attachments mutated: %#v", msg)
+		}
+	}
+}
+
+func TestAgentLoopExecutorSkipsPruneForNonAnthropic(t *testing.T) {
+	manager := newScreenshotObservationManager(t, 6)
+	model := &pruneRecordingModel{}
+	pruner := AnthropicScreenshotPruner{
+		Enabled: IsAnthropicModel("openrouter", "openai/gpt-4o"),
+		Config:  ScreenshotPruningConfig{}.WithDefaults(),
+	}
+	exec := executor.NewLLMExecutor(model, manager, pruner)
+	if _, err := exec.GenerateContent(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	binaryCount, omitted := countBinaryAndOmitted(model.last)
+	if binaryCount != 6 || omitted != 0 {
+		t.Fatalf("binary=%d omitted=%d messages=%#v", binaryCount, omitted, model.last)
+	}
+}
+
+func TestAgentLoopOutboundTransformsEnableForAnthropic(t *testing.T) {
+	loop := &AgentLoop{
+		Model:             &ModelManager{config: ModelConfig{Provider: "openrouter", Model: "anthropic/x"}},
+		ScreenshotPruning: ScreenshotPruningConfig{}.WithDefaults(),
+	}
+	transforms := loop.outboundTransforms()
+	pruner, ok := transforms[0].(AnthropicScreenshotPruner)
+	if !ok || !pruner.Enabled {
+		t.Fatalf("transforms = %#v", transforms)
+	}
+}
+
+func TestAgentLoopOutboundTransformsDisableForNonAnthropic(t *testing.T) {
+	loop := &AgentLoop{
+		Model:             &ModelManager{config: ModelConfig{Provider: "openrouter", Model: "openai/gpt-4o"}},
+		ScreenshotPruning: ScreenshotPruningConfig{}.WithDefaults(),
+	}
+	transforms := loop.outboundTransforms()
+	pruner, ok := transforms[0].(AnthropicScreenshotPruner)
+	if !ok || pruner.Enabled {
+		t.Fatalf("transforms = %#v", transforms)
+	}
+}

--- a/src/agent/internal/agent/anthropic_model.go
+++ b/src/agent/internal/agent/anthropic_model.go
@@ -1,0 +1,10 @@
+package agent
+
+import "strings"
+
+func IsAnthropicModel(provider, model string) bool {
+	if strings.EqualFold(strings.TrimSpace(provider), "anthropic") {
+		return true
+	}
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "anthropic/")
+}

--- a/src/agent/internal/agent/anthropic_model_test.go
+++ b/src/agent/internal/agent/anthropic_model_test.go
@@ -1,0 +1,25 @@
+package agent
+
+import "testing"
+
+func TestIsAnthropicModel(t *testing.T) {
+	cases := []struct {
+		provider, model string
+		want            bool
+	}{
+		{"anthropic", "claude-sonnet-4", true},
+		{"Anthropic", "anything", true},
+		{"openrouter", "anthropic/claude-sonnet-4", true},
+		{"openrouter", "openai/gpt-4o", false},
+		{"openai", "gpt-4o", false},
+		{"", "", false},
+		{"  anthropic  ", "", true},
+		{"openrouter", "  Anthropic/Claude  ", true},
+	}
+	for _, tc := range cases {
+		got := IsAnthropicModel(tc.provider, tc.model)
+		if got != tc.want {
+			t.Fatalf("IsAnthropicModel(%q, %q) = %v, want %v", tc.provider, tc.model, got, tc.want)
+		}
+	}
+}

--- a/src/agent/internal/agent/audio_dialog_test.go
+++ b/src/agent/internal/agent/audio_dialog_test.go
@@ -12,9 +12,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tmc/langchaingo/chains"
 	"github.com/tmc/langchaingo/llms"
 	langtools "github.com/tmc/langchaingo/tools"
 
+	"aiden-agent/internal/agent/model"
 	ttsmodule "aiden-agent/internal/agent/tts"
 )
 
@@ -1295,6 +1297,16 @@ func (m *blockingFirstCallModel) Call(ctx context.Context, prompt string, option
 	}
 	return resp.Choices[0].Content, nil
 }
+
+func (m *blockingFirstCallModel) Spec() model.ModelSpec {
+	return model.ModelSpec{
+		Provider:      "fake",
+		Name:          "scripted",
+		ContextWindow: 100,
+	}
+}
+
+func (m *blockingFirstCallModel) CallOptions() []chains.ChainCallOption { return nil }
 
 func TestAudioDialogRunScriptUsesConfiguredTTS(t *testing.T) {
 	configDir := ensureTestConfigDir(t, t.TempDir())

--- a/src/agent/internal/agent/compactor/compactor.go
+++ b/src/agent/internal/agent/compactor/compactor.go
@@ -24,14 +24,14 @@ var DefaultProtectRule = ProtectRule{
 
 type Compactor struct {
 	ProtectRule ProtectRule
-	Models      model.ModelResolver
+	Model       model.Model
 }
 
-func NewCompactor(protectRule ProtectRule, models model.ModelResolver) *Compactor {
+func NewCompactor(protectRule ProtectRule, model model.Model) *Compactor {
 	validateProtectRule(protectRule)
 	return &Compactor{
 		ProtectRule: protectRule,
-		Models:      models,
+		Model:       model,
 	}
 }
 
@@ -123,10 +123,6 @@ func (c *Compactor) generateSummary(ctx context.Context, messageList []contextma
 		return ""
 	}
 
-	model, err := c.Models.Get()
-	if err != nil {
-		return ""
-	}
 	prompt := `
 Please summarize the conversation in a concised summary. Template:
 ## Goal
@@ -153,7 +149,7 @@ And here are the conversation details:
 
 ` + transcript.String()
 	// TODO: dynamic token budget for summary
-	result, err := llms.GenerateFromSinglePrompt(ctx, model, prompt, llms.WithMaxTokens(800))
+	result, err := llms.GenerateFromSinglePrompt(ctx, c.Model, prompt, llms.WithMaxTokens(800))
 	if err != nil {
 		return ""
 	}

--- a/src/agent/internal/agent/compactor/compactor_test.go
+++ b/src/agent/internal/agent/compactor/compactor_test.go
@@ -13,16 +13,14 @@ import (
 	"github.com/tmc/langchaingo/llms"
 )
 
-type testModelResolver struct {
-	model llms.Model
-	spec  model.ModelSpec
+type testModel struct {
+	llms.Model
+	model.ModelSpec
 }
 
-func (r *testModelResolver) Get() (llms.Model, error) { return r.model, nil }
+func (m *testModel) CallOptions() []chains.ChainCallOption { return nil }
 
-func (r *testModelResolver) CallOptions() []chains.ChainCallOption { return nil }
-
-func (r *testModelResolver) Spec() model.ModelSpec { return r.spec }
+func (m *testModel) Spec() model.ModelSpec { return m.ModelSpec }
 
 type promptCapturingModel struct {
 	prompts []string
@@ -76,7 +74,7 @@ func TestEstimateTokenUsageCountsToolPayloads(t *testing.T) {
 		t.Fatalf("NewContextManagerFromMessageList() error = %v", err)
 	}
 
-	compactor := NewCompactor(DefaultProtectRule, &testModelResolver{})
+	compactor := NewCompactor(DefaultProtectRule, &testModel{})
 	want := tokencounter.EstimateTextTokens(`{"input":"hello world"}`) + tokencounter.EstimateTextTokens(`{"output":"done"}`)
 	if got := compactor.EstimateTokenUsage(manager); got != want {
 		t.Fatalf("EstimateTokenUsage() = %d, want %d", got, want)
@@ -85,7 +83,7 @@ func TestEstimateTokenUsageCountsToolPayloads(t *testing.T) {
 
 func TestGenerateSummaryIncludesToolPayloads(t *testing.T) {
 	model := &promptCapturingModel{reply: "summary"}
-	compactor := NewCompactor(DefaultProtectRule, &testModelResolver{model: model})
+	compactor := NewCompactor(DefaultProtectRule, &testModel{Model: model})
 
 	got := compactor.generateSummary(context.Background(), []contextmanager.Message{
 		{

--- a/src/agent/internal/agent/context_manager_bridge.go
+++ b/src/agent/internal/agent/context_manager_bridge.go
@@ -112,6 +112,7 @@ func visualFollowupMessageFromLLMContent(manager *contextmanager.ContextManager,
 			if ok && strings.HasPrefix(strings.ToLower(mimeType), "image/") && len(data) > 0 && manager != nil {
 				stored, err := manager.StoreAttachment(mimeType, data)
 				if err == nil {
+					stored.Source = contextmanager.AttachmentSourceScreenshotObservation
 					message.Attachments = append(message.Attachments, stored)
 					continue
 				}
@@ -130,6 +131,7 @@ func visualFollowupMessageFromLLMContent(manager *contextmanager.ContextManager,
 				message.Content = mergePromptText(message.Content, attachmentStorageFailureText(typed.MIMEType, err))
 				continue
 			}
+			stored.Source = contextmanager.AttachmentSourceScreenshotObservation
 			message.Attachments = append(message.Attachments, stored)
 		default:
 			fallback := messageFromLLMContent(manager, llms.MessageContent{

--- a/src/agent/internal/agent/context_manager_bridge_test.go
+++ b/src/agent/internal/agent/context_manager_bridge_test.go
@@ -16,7 +16,8 @@ func TestFreshNewContextManagerSeedsSystemPromptOnlyForFreshSession(t *testing.T
 	if err != nil {
 		t.Fatalf("freshNewContextManager() error = %v", err)
 	}
-	messages := manager.ConvertToStandardMessageList()
+	rawMessages := manager.CloneMessageList()
+	messages := contextmanager.ConvertMessageList(rawMessages)
 	if len(messages) != 1 {
 		t.Fatalf("messages = %d, want 1", len(messages))
 	}
@@ -31,7 +32,7 @@ func TestFreshNewContextManagerSeedsSystemPromptOnlyForFreshSession(t *testing.T
 	if err != nil {
 		t.Fatalf("reload freshNewContextManager() error = %v", err)
 	}
-	reloadedMessages := reloaded.ConvertToStandardMessageList()
+	reloadedMessages := contextmanager.ConvertMessageList(reloaded.CloneMessageList())
 	if len(reloadedMessages) != 2 {
 		t.Fatalf("messages = %d, want 2", len(reloadedMessages))
 	}
@@ -57,7 +58,7 @@ func TestUserMessageFromInputPreservesAttachments(t *testing.T) {
 		t.Fatalf("AppendMessage() error = %v", err)
 	}
 
-	messages := manager.ConvertToStandardMessageList()
+	messages := contextmanager.ConvertMessageList(manager.CloneMessageList())
 	if len(messages) != 2 {
 		t.Fatalf("messages = %#v", messages)
 	}
@@ -67,5 +68,43 @@ func TestUserMessageFromInputPreservesAttachments(t *testing.T) {
 	}
 	if len(userMessage.Parts) != 2 {
 		t.Fatalf("parts = %#v, want text + binary attachment", userMessage.Parts)
+	}
+}
+
+func TestVisualFollowupMarksScreenshotObservationSource(t *testing.T) {
+	manager, err := InitializeContextManager("system", t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("InitializeContextManager() error = %v", err)
+	}
+	msg := visualFollowupMessageFromLLMContent(manager, llms.MessageContent{
+		Role: llms.ChatMessageTypeHuman,
+		Parts: []llms.ContentPart{
+			llms.TextPart("This image is the screenshot observation returned by the screenshot tool."),
+			llms.BinaryPart("image/jpeg", []byte("jpeg-bytes")),
+		},
+	})
+	if len(msg.Attachments) != 1 {
+		t.Fatalf("attachments = %#v", msg.Attachments)
+	}
+	if msg.Attachments[0].Source != contextmanager.AttachmentSourceScreenshotObservation {
+		t.Fatalf("Source = %q", msg.Attachments[0].Source)
+	}
+}
+
+func TestUserMessageAttachmentsRemainUnmarked(t *testing.T) {
+	manager, err := InitializeContextManager("system", t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("InitializeContextManager() error = %v", err)
+	}
+	msg := userMessageFromInput(manager, "hello", []InputAttachment{{
+		Kind:     AttachmentKindImage,
+		MIMEType: "image/png",
+		Data:     []byte("png"),
+	}})
+	if len(msg.Attachments) != 1 {
+		t.Fatalf("attachments = %#v", msg.Attachments)
+	}
+	if msg.Attachments[0].Source != "" {
+		t.Fatalf("user upload Source = %q, want empty", msg.Attachments[0].Source)
 	}
 }

--- a/src/agent/internal/agent/contextmanager/context_manager.go
+++ b/src/agent/internal/agent/contextmanager/context_manager.go
@@ -1,10 +1,8 @@
 package contextmanager
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
-	"os"
 	"strings"
 	"sync"
 
@@ -79,7 +77,10 @@ type Attachment struct {
 	MIMEType string `json:"mime_type"`
 	FileSize int64  `json:"file_size"`
 	FilePath string `json:"file_path"`
+	Source   string `json:"source,omitempty"`
 }
+
+const AttachmentSourceScreenshotObservation = "screenshot_observation"
 
 // ContextManager is a manager for the context of the agent, it is used to manage the context of the agent, it is used to append messages to the context and to fork the context.
 // It is thread safe and can be used concurrently by multiple goroutines.
@@ -329,72 +330,6 @@ func cloneMessage(msg Message) Message {
 	return cloned
 }
 
-func (c *ContextManager) ConvertToStandardMessageList() []llms.MessageContent {
-	c.mu.RLock()
-	messages := cloneMessages(c.messageList)
-	c.mu.RUnlock()
-	return convertToStandardMessageList(messages)
-}
-
-func convertToStandardMessageList(messages []Message) []llms.MessageContent {
-	standardMessageList := make([]llms.MessageContent, len(messages))
-	for i, message := range messages {
-		newMessage := llms.MessageContent{
-			Role:  message.Role.ToStandardRole(),
-			Parts: []llms.ContentPart{},
-		}
-		if message.Role == MessageRoleToolResult {
-			for resultIndex, result := range message.ToolResults {
-				toolCallID := strings.TrimSpace(result.ToolCallID)
-				if toolCallID == "" {
-					toolCallID = toolCallIDOrFallback("", i, resultIndex)
-				}
-				newMessage.Parts = append(newMessage.Parts, llms.ToolCallResponse{
-					ToolCallID: toolCallID,
-					Name:       strings.TrimSpace(result.Name),
-					Content:    result.Content,
-				})
-			}
-			standardMessageList[i] = newMessage
-			continue
-		}
-		if content := strings.TrimSpace(message.Content); content != "" {
-			newMessage.Parts = append(newMessage.Parts, llms.TextPart(content))
-		}
-		for toolIndex, call := range message.ToolCalls {
-			name := strings.TrimSpace(call.Name)
-			if name == "" {
-				continue
-			}
-			newMessage.Parts = append(newMessage.Parts, llms.ToolCall{
-				ID:   toolCallIDOrFallback(call.ID, i, toolIndex),
-				Type: "function",
-				FunctionCall: &llms.FunctionCall{
-					Name:      name,
-					Arguments: normalizeToolCallArguments(call.Arguments),
-				},
-			})
-		}
-		for _, attachment := range message.Attachments {
-			filePath := strings.TrimSpace(attachment.FilePath)
-			if filePath == "" {
-				continue
-			}
-			data, err := os.ReadFile(filePath)
-			if err != nil {
-				newMessage.Parts = append(newMessage.Parts, llms.TextPart(attachmentOmittedMessage(attachment.MIMEType, err)))
-				continue
-			}
-			if len(data) == 0 {
-				continue
-			}
-			newMessage.Parts = append(newMessage.Parts, llms.BinaryPart(attachment.MIMEType, data))
-		}
-		standardMessageList[i] = newMessage
-	}
-	return standardMessageList
-}
-
 func attachmentOmittedMessage(mimeType string, err error) string {
 	label := strings.TrimSpace(mimeType)
 	if label == "" {
@@ -404,83 +339,4 @@ func attachmentOmittedMessage(mimeType string, err error) string {
 		return fmt.Sprintf("[Attachment omitted: %s could not be loaded.]", label)
 	}
 	return fmt.Sprintf("[Attachment omitted: %s could not be loaded: %v]", label, err)
-}
-
-// ConvertChoiceToContextManagerMessage converts a content choice to a context manager message
-func ConvertChoiceToContextManagerMessage(choice llms.ContentChoice) Message {
-	role := MessageRoleAssistant
-	if contentChoiceHasToolCalls(choice) {
-		role = MessageRoleToolCall
-	}
-	return Message{
-		Role:      role,
-		Content:   contentChoiceText(choice),
-		ToolCalls: toolCallsFromContentChoice(choice),
-	}
-}
-
-func contentChoiceHasToolCalls(choice llms.ContentChoice) bool {
-	if len(choice.ToolCalls) > 0 {
-		return true
-	}
-	return choice.FuncCall != nil
-}
-
-func contentChoiceText(choice llms.ContentChoice) string {
-	parts := make([]string, 0, 2)
-	if reasoning := strings.TrimSpace(choice.ReasoningContent); reasoning != "" {
-		parts = append(parts, reasoning)
-	}
-	if content := strings.TrimSpace(choice.Content); content != "" {
-		parts = append(parts, content)
-	}
-	return strings.Join(parts, "\n")
-}
-
-func toolCallsFromContentChoice(choice llms.ContentChoice) []ToolCall {
-	toolCalls := choice.ToolCalls
-	if len(toolCalls) == 0 && choice.FuncCall != nil {
-		toolCalls = []llms.ToolCall{{
-			Type:         "function",
-			FunctionCall: choice.FuncCall,
-		}}
-	}
-	result := make([]ToolCall, 0, len(toolCalls))
-	for _, call := range toolCalls {
-		if call.FunctionCall == nil {
-			continue
-		}
-		name := strings.TrimSpace(call.FunctionCall.Name)
-		if name == "" {
-			continue
-		}
-		result = append(result, ToolCall{
-			ID:        strings.TrimSpace(call.ID),
-			Name:      name,
-			Arguments: normalizeToolCallArguments(call.FunctionCall.Arguments),
-		})
-	}
-	return result
-}
-
-func normalizeToolCallArguments(arguments string) string {
-	trimmed := strings.TrimSpace(arguments)
-	if trimmed == "" {
-		return "{}"
-	}
-	if json.Valid([]byte(trimmed)) {
-		return trimmed
-	}
-	encoded, err := json.Marshal(map[string]string{"input": arguments})
-	if err != nil {
-		return "{}"
-	}
-	return string(encoded)
-}
-
-func toolCallIDOrFallback(id string, messageIndex, toolIndex int) string {
-	if id = strings.TrimSpace(id); id != "" {
-		return id
-	}
-	return fmt.Sprintf("ctx_tool_call_%d_%d", messageIndex, toolIndex)
 }

--- a/src/agent/internal/agent/contextmanager/context_manager_test.go
+++ b/src/agent/internal/agent/contextmanager/context_manager_test.go
@@ -140,7 +140,7 @@ func TestConvertToStandardMessageList_ToolCalls(t *testing.T) {
 		}},
 	})
 
-	messages := manager.ConvertToStandardMessageList()
+	messages := ConvertMessageList(manager.CloneMessageList())
 	if len(messages) != 1 {
 		t.Fatalf("messages = %#v", messages)
 	}
@@ -172,7 +172,7 @@ func TestConvertToStandardMessageList_NormalizesInvalidToolCallArguments(t *test
 		}},
 	})
 
-	messages := manager.ConvertToStandardMessageList()
+	messages := ConvertMessageList(manager.CloneMessageList())
 	if len(messages) != 1 || len(messages[0].Parts) != 1 {
 		t.Fatalf("messages = %#v, want one tool call message", messages)
 	}
@@ -214,7 +214,7 @@ func TestConvertToStandardMessageList_ToolResults(t *testing.T) {
 		}},
 	})
 
-	messages := manager.ConvertToStandardMessageList()
+	messages := ConvertMessageList(manager.CloneMessageList())
 	if len(messages) != 2 {
 		t.Fatalf("messages = %#v", messages)
 	}
@@ -312,7 +312,7 @@ func TestAppendMessageRepairsPersistedOrphanToolCallBeforeNextUser(t *testing.T)
 		t.Fatalf("last message = %#v, want user", dump.Messages[2])
 	}
 
-	messages := reloaded.ConvertToStandardMessageList()
+	messages := ConvertMessageList(reloaded.CloneMessageList())
 	if len(messages) != 3 || messages[0].Role != llms.ChatMessageTypeAI || messages[1].Role != llms.ChatMessageTypeTool || messages[2].Role != llms.ChatMessageTypeHuman {
 		t.Fatalf("provider messages = %#v, want assistant/tool/user", messages)
 	}
@@ -377,7 +377,7 @@ func TestAppendMessagePairsLegacyMissingToolCallIDByName(t *testing.T) {
 		t.Fatalf("AppendMessage(tool result) error = %v", err)
 	}
 
-	messages := manager.ConvertToStandardMessageList()
+	messages := ConvertMessageList(manager.CloneMessageList())
 	if len(messages) != 2 {
 		t.Fatalf("messages = %#v, want paired call and result", messages)
 	}
@@ -475,14 +475,12 @@ func TestContextManagerConcurrentAppendWithStatefulHook(t *testing.T) {
 
 	const appends = 32
 	var wg sync.WaitGroup
-	for i := 0; i < appends; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range appends {
+		wg.Go(func() {
 			if err := manager.AppendMessage(Message{Role: MessageRoleUser, Content: "hello"}); err != nil {
 				t.Errorf("AppendMessage() error = %v", err)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -523,7 +521,7 @@ func TestStoreAttachmentPersistsMetadataOnly(t *testing.T) {
 		Attachments: []Attachment{stored},
 	})
 
-	messages := manager.ConvertToStandardMessageList()
+	messages := ConvertMessageList(manager.CloneMessageList())
 	if len(messages) != 1 || len(messages[0].Parts) != 2 {
 		t.Fatalf("messages = %#v, want text + binary parts", messages)
 	}
@@ -585,13 +583,54 @@ func TestConvertToStandardMessageListLoadsAttachmentFromFilePath(t *testing.T) {
 		}},
 	})
 
-	messages := manager.ConvertToStandardMessageList()
+	messages := ConvertMessageList(manager.CloneMessageList())
 	if len(messages) != 1 || len(messages[0].Parts) != 2 {
 		t.Fatalf("messages = %#v, want text + binary parts", messages)
 	}
 	binaryPart, ok := messages[0].Parts[1].(llms.BinaryContent)
 	if !ok || string(binaryPart.Data) != "manual-bytes" {
 		t.Fatalf("binary part = %#v", messages[0].Parts[1])
+	}
+}
+
+func TestConvertMessageListUsesProvidedSlice(t *testing.T) {
+	manager := newTestContextManager(t)
+	stored, err := manager.StoreAttachment("image/png", []byte("png-bytes"))
+	if err != nil {
+		t.Fatalf("StoreAttachment() error = %v", err)
+	}
+	stored.Source = AttachmentSourceScreenshotObservation
+	if err := manager.AppendMessage(Message{
+		Role:        MessageRoleUser,
+		Content:     "caption",
+		Attachments: []Attachment{stored},
+	}); err != nil {
+		t.Fatalf("AppendMessage() error = %v", err)
+	}
+
+	cloned := manager.CloneMessageList()
+	if len(cloned) != 1 || len(cloned[0].Attachments) != 1 {
+		t.Fatalf("clone = %#v", cloned)
+	}
+	if cloned[0].Attachments[0].Source != AttachmentSourceScreenshotObservation {
+		t.Fatalf("Source = %q", cloned[0].Attachments[0].Source)
+	}
+
+	// Ephemeral prune: drop attachment, keep text — ConvertMessageList must not read the file.
+	cloned[0].Attachments = nil
+	cloned[0].Content = "caption\n[Image omitted]"
+	converted := ConvertMessageList(cloned)
+	if len(converted) != 1 {
+		t.Fatalf("converted len = %d", len(converted))
+	}
+	for _, part := range converted[0].Parts {
+		if _, ok := part.(llms.BinaryContent); ok {
+			t.Fatalf("expected no binary parts after ephemeral prune, got %#v", converted[0].Parts)
+		}
+	}
+	dump := manager.MessageListDump()
+	if len(dump.Messages) != 1 || len(dump.Messages[0].Attachments) != 1 {
+		t.Fatalf("persisted dump mutated: %#v", dump)
 	}
 }
 
@@ -607,7 +646,7 @@ func TestConvertToStandardMessageListReportsMissingAttachment(t *testing.T) {
 		}},
 	})
 
-	messages := manager.ConvertToStandardMessageList()
+	messages := ConvertMessageList(manager.CloneMessageList())
 	if len(messages) != 1 || len(messages[0].Parts) != 2 {
 		t.Fatalf("messages = %#v, want text + omitted attachment notice", messages)
 	}

--- a/src/agent/internal/agent/contextmanager/convert.go
+++ b/src/agent/internal/agent/contextmanager/convert.go
@@ -1,0 +1,148 @@
+package contextmanager
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+func ConvertMessageList(messages []Message) []llms.MessageContent {
+	standardMessageList := make([]llms.MessageContent, len(messages))
+	for i, message := range messages {
+		newMessage := llms.MessageContent{
+			Role:  message.Role.ToStandardRole(),
+			Parts: []llms.ContentPart{},
+		}
+		if message.Role == MessageRoleToolResult {
+			for resultIndex, result := range message.ToolResults {
+				toolCallID := strings.TrimSpace(result.ToolCallID)
+				if toolCallID == "" {
+					toolCallID = toolCallIDOrFallback("", i, resultIndex)
+				}
+				newMessage.Parts = append(newMessage.Parts, llms.ToolCallResponse{
+					ToolCallID: toolCallID,
+					Name:       strings.TrimSpace(result.Name),
+					Content:    result.Content,
+				})
+			}
+			standardMessageList[i] = newMessage
+			continue
+		}
+		if content := strings.TrimSpace(message.Content); content != "" {
+			newMessage.Parts = append(newMessage.Parts, llms.TextPart(content))
+		}
+		for toolIndex, call := range message.ToolCalls {
+			name := strings.TrimSpace(call.Name)
+			if name == "" {
+				continue
+			}
+			newMessage.Parts = append(newMessage.Parts, llms.ToolCall{
+				ID:   toolCallIDOrFallback(call.ID, i, toolIndex),
+				Type: "function",
+				FunctionCall: &llms.FunctionCall{
+					Name:      name,
+					Arguments: normalizeToolCallArguments(call.Arguments),
+				},
+			})
+		}
+		for _, attachment := range message.Attachments {
+			filePath := strings.TrimSpace(attachment.FilePath)
+			if filePath == "" {
+				continue
+			}
+			data, err := os.ReadFile(filePath)
+			if err != nil {
+				newMessage.Parts = append(newMessage.Parts, llms.TextPart(attachmentOmittedMessage(attachment.MIMEType, err)))
+				continue
+			}
+			if len(data) == 0 {
+				continue
+			}
+			newMessage.Parts = append(newMessage.Parts, llms.BinaryPart(attachment.MIMEType, data))
+		}
+		standardMessageList[i] = newMessage
+	}
+	return standardMessageList
+}
+
+// ConvertChoiceToContextManagerMessage converts a content choice to a context manager message
+func ConvertChoiceToContextManagerMessage(choice llms.ContentChoice) Message {
+	role := MessageRoleAssistant
+	if contentChoiceHasToolCalls(choice) {
+		role = MessageRoleToolCall
+	}
+	return Message{
+		Role:      role,
+		Content:   contentChoiceText(choice),
+		ToolCalls: toolCallsFromContentChoice(choice),
+	}
+}
+
+func contentChoiceHasToolCalls(choice llms.ContentChoice) bool {
+	if len(choice.ToolCalls) > 0 {
+		return true
+	}
+	return choice.FuncCall != nil
+}
+
+func contentChoiceText(choice llms.ContentChoice) string {
+	parts := make([]string, 0, 2)
+	if reasoning := strings.TrimSpace(choice.ReasoningContent); reasoning != "" {
+		parts = append(parts, reasoning)
+	}
+	if content := strings.TrimSpace(choice.Content); content != "" {
+		parts = append(parts, content)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func toolCallsFromContentChoice(choice llms.ContentChoice) []ToolCall {
+	toolCalls := choice.ToolCalls
+	if len(toolCalls) == 0 && choice.FuncCall != nil {
+		toolCalls = []llms.ToolCall{{
+			Type:         "function",
+			FunctionCall: choice.FuncCall,
+		}}
+	}
+	result := make([]ToolCall, 0, len(toolCalls))
+	for _, call := range toolCalls {
+		if call.FunctionCall == nil {
+			continue
+		}
+		name := strings.TrimSpace(call.FunctionCall.Name)
+		if name == "" {
+			continue
+		}
+		result = append(result, ToolCall{
+			ID:        strings.TrimSpace(call.ID),
+			Name:      name,
+			Arguments: normalizeToolCallArguments(call.FunctionCall.Arguments),
+		})
+	}
+	return result
+}
+
+func normalizeToolCallArguments(arguments string) string {
+	trimmed := strings.TrimSpace(arguments)
+	if trimmed == "" {
+		return "{}"
+	}
+	if json.Valid([]byte(trimmed)) {
+		return trimmed
+	}
+	encoded, err := json.Marshal(map[string]string{"input": arguments})
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
+}
+
+func toolCallIDOrFallback(id string, messageIndex, toolIndex int) string {
+	if id = strings.TrimSpace(id); id != "" {
+		return id
+	}
+	return fmt.Sprintf("ctx_tool_call_%d_%d", messageIndex, toolIndex)
+}

--- a/src/agent/internal/agent/executor/executor.go
+++ b/src/agent/internal/agent/executor/executor.go
@@ -11,12 +11,14 @@ import (
 type LLMExecutor struct {
 	model          llms.Model
 	contextManager *contextmanager.ContextManager
+	transforms     []OutboundMessageTransform
 }
 
-func NewLLMExecutor(model llms.Model, contextManager *contextmanager.ContextManager) *LLMExecutor {
+func NewLLMExecutor(model llms.Model, contextManager *contextmanager.ContextManager, transforms ...OutboundMessageTransform) *LLMExecutor {
 	return &LLMExecutor{
 		model:          model,
 		contextManager: contextManager,
+		transforms:     transforms,
 	}
 }
 
@@ -29,8 +31,15 @@ func (e *LLMExecutor) AppendMessage(message contextmanager.Message) error {
 }
 
 func (e *LLMExecutor) GenerateContent(ctx context.Context, options ...llms.CallOption) (*llms.ContentResponse, error) {
-	messages := e.contextManager.ConvertToStandardMessageList()
-	contentResponse, err := e.model.GenerateContent(ctx, messages, options...)
+	messages := e.contextManager.CloneMessageList()
+	for _, transform := range e.transforms {
+		if transform == nil {
+			continue
+		}
+		messages = transform.Transform(messages)
+	}
+	standard := contextmanager.ConvertMessageList(messages)
+	contentResponse, err := e.model.GenerateContent(ctx, standard, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/src/agent/internal/agent/executor/executor_test.go
+++ b/src/agent/internal/agent/executor/executor_test.go
@@ -1,0 +1,63 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"aiden-agent/internal/agent/contextmanager"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+type recordingModel struct {
+	last []llms.MessageContent
+}
+
+func (m *recordingModel) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	m.last = messages
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: "ok"}}}, nil
+}
+
+func (m *recordingModel) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	return "ok", nil
+}
+
+type dropUserTransform struct{}
+
+func (dropUserTransform) Transform(messages []contextmanager.Message) []contextmanager.Message {
+	out := make([]contextmanager.Message, 0, len(messages))
+	for _, msg := range messages {
+		if msg.Role == contextmanager.MessageRoleUser {
+			continue
+		}
+		out = append(out, msg)
+	}
+	return out
+}
+
+func TestGenerateContentAppliesOutboundTransformsWithoutMutatingStore(t *testing.T) {
+	sessionFolder := t.TempDir()
+	manager, err := contextmanager.NewContextManagerFromMessageList(sessionFolder, nil)
+	if err != nil {
+		t.Fatalf("NewContextManagerFromMessageList() error = %v", err)
+	}
+	if err := manager.AppendMessage(contextmanager.Message{Role: contextmanager.MessageRoleSystem, Content: "sys"}); err != nil {
+		t.Fatalf("append system: %v", err)
+	}
+	if err := manager.AppendMessage(contextmanager.Message{Role: contextmanager.MessageRoleUser, Content: "user"}); err != nil {
+		t.Fatalf("append user: %v", err)
+	}
+
+	model := &recordingModel{}
+	exec := NewLLMExecutor(model, manager, dropUserTransform{})
+	if _, err := exec.GenerateContent(context.Background()); err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+	if len(model.last) != 1 || model.last[0].Role != llms.ChatMessageTypeSystem {
+		t.Fatalf("model messages = %#v, want only system", model.last)
+	}
+	dump := manager.MessageListDump()
+	if len(dump.Messages) != 2 {
+		t.Fatalf("persisted messages = %d, want 2", len(dump.Messages))
+	}
+}

--- a/src/agent/internal/agent/executor/transform.go
+++ b/src/agent/internal/agent/executor/transform.go
@@ -1,0 +1,7 @@
+package executor
+
+import "aiden-agent/internal/agent/contextmanager"
+
+type OutboundMessageTransform interface {
+	Transform(messages []contextmanager.Message) []contextmanager.Message
+}

--- a/src/agent/internal/agent/long_term_memory_bench_test.go
+++ b/src/agent/internal/agent/long_term_memory_bench_test.go
@@ -15,8 +15,7 @@ func BenchmarkLongTermMemorySearchCacheHit(b *testing.B) {
 		b.Fatalf("warm Search error: %v", err)
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := store.Search(ctx, MemoryQuery{Limit: 10}); err != nil {
 			b.Fatalf("Search error: %v", err)
 		}
@@ -31,8 +30,7 @@ func BenchmarkLongTermMemorySearchOverCapacity(b *testing.B) {
 		b.Fatalf("warm Search error: %v", err)
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := store.Search(ctx, MemoryQuery{Limit: 10}); err != nil {
 			b.Fatalf("Search error: %v", err)
 		}
@@ -43,7 +41,7 @@ func benchmarkLongTermMemoryStore(b *testing.B, count int, capacity int) *LongTe
 	b.Helper()
 	ctx := context.Background()
 	store := NewLongTermMemoryStore(filepath.Join(b.TempDir(), "long_term"), withParsedCacheCapacity(capacity))
-	for i := 0; i < count; i++ {
+	for i := range count {
 		if _, err := store.AddMemory(ctx, MemoryItem{
 			ID:               fmt.Sprintf("mem_bench_%03d", i),
 			Type:             "fact",

--- a/src/agent/internal/agent/model/model_resolver.go
+++ b/src/agent/internal/agent/model/model_resolver.go
@@ -5,11 +5,8 @@ import (
 	"github.com/tmc/langchaingo/llms"
 )
 
-type ModelResolver interface {
-	Get() (llms.Model, error)
+type Model interface {
+	llms.Model
 	CallOptions() []chains.ChainCallOption
-	// Spec returns capabilities (context window, max output) for the configured
-	// model. Implementations return a zero-value ModelSpec for unknown models;
-	// callers must fall back to a configured default.
 	Spec() ModelSpec
 }

--- a/src/agent/internal/agent/model/model_spec.go
+++ b/src/agent/internal/agent/model/model_spec.go
@@ -20,6 +20,8 @@ package model
 // auto mode (field omitted from the request). It is only a default: an explicit
 // model.reasoning_effort always wins.
 type ModelSpec struct {
+	Provider               string
+	Name                   string
 	ContextWindow          int
 	MaxOutput              int
 	DefaultTemperature     *float64

--- a/src/agent/internal/agent/models.go
+++ b/src/agent/internal/agent/models.go
@@ -28,6 +28,7 @@ const (
 	moonshotGlobalBaseURL = "https://api.moonshot.ai/v1"
 	moonshotCNBaseURL     = "https://api.moonshot.cn/v1"
 )
+
 type ModelManager struct {
 	config ModelConfig
 	proxy  ProxyConfig
@@ -84,7 +85,7 @@ func (m *ModelManager) activeSessionID() string {
 	return m.rawHTTPLogSessionID()
 }
 
-func (m *ModelManager) Get() (llms.Model, error) {
+func (m *ModelManager) get() (llms.Model, error) {
 	if m.model != nil {
 		return m.model, nil
 	}
@@ -95,6 +96,22 @@ func (m *ModelManager) Get() (llms.Model, error) {
 	}
 	m.model = built
 	return built, nil
+}
+
+func (m *ModelManager) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	model, err := m.get()
+	if err != nil {
+		return nil, err
+	}
+	return model.GenerateContent(ctx, messages, options...)
+}
+
+func (m *ModelManager) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	model, err := m.get()
+	if err != nil {
+		return "", err
+	}
+	return model.Call(ctx, prompt, options...)
 }
 
 func (m *ModelManager) CallOptions() []chains.ChainCallOption {
@@ -129,6 +146,10 @@ func (m *ModelManager) Spec() model.ModelSpec {
 			spec.MaxOutput = providerSpec.MaxOutput
 		}
 	}
+
+	spec.Provider = m.config.Provider
+	spec.Name = m.config.Model
+
 	return spec
 }
 

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -619,7 +619,7 @@ func TestRuntimeConfiguresRawHTTPLogWithActiveMemorySessionID(t *testing.T) {
 	memories := NewMemoryManager(memoryDir)
 	NewRuntimeWithDeps(Config{}, manager, memories, nil, nil)
 
-	model, err := manager.Get()
+	model, err := manager.get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
@@ -689,7 +689,7 @@ func TestRuntimeRawHTTPLogUsesSessionIDForFileName(t *testing.T) {
 	memories := NewMemoryManager(memoryDir)
 	NewRuntimeWithDeps(Config{}, manager, memories, nil, nil)
 
-	model, err := manager.Get()
+	model, err := manager.get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
@@ -752,7 +752,7 @@ func TestRuntimeRawHTTPLogSwitchesSessionFileAfterRotation(t *testing.T) {
 	memories := NewMemoryManager(memoryDir)
 	NewRuntimeWithDeps(Config{}, manager, memories, nil, nil)
 
-	model, err := manager.Get()
+	model, err := manager.get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
@@ -969,7 +969,7 @@ func TestModelManagerEnablesRawHTTPLoggingFromModelConfig(t *testing.T) {
 		BaseURL:    server.URL,
 		LogRawHTTP: true,
 	}, ProxyConfig{}, WithLLMRawHTTPLogDir(logDir))
-	model, err := manager.Get()
+	model, err := manager.get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
@@ -1017,7 +1017,7 @@ func TestModelManagerEnablesRawHTTPLoggingFromDefaultConfig(t *testing.T) {
 	cfg.Model = "test-model"
 	cfg.BaseURL = server.URL
 	manager := NewModelManager(cfg, ProxyConfig{}, WithLLMRawHTTPLogDir(logDir))
-	model, err := manager.Get()
+	model, err := manager.get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
@@ -1064,7 +1064,7 @@ func TestModelManagerDoesNotLogRawHTTPWhenDisabled(t *testing.T) {
 		Model:    "test-model",
 		BaseURL:  server.URL,
 	}, ProxyConfig{}, WithLLMRawHTTPLogDir(logDir))
-	model, err := manager.Get()
+	model, err := manager.get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
@@ -1549,7 +1549,7 @@ func TestModelManagerSendsSessionHeaderOnlyForOpenRouter(t *testing.T) {
 
 			mgr := NewModelManager(ModelConfig{Provider: tc.provider, Model: "m", APIKey: "k", BaseURL: server.URL}, ProxyConfig{})
 			mgr.SetRawHTTPLogSessionIDProvider(func() string { return "sess-123" })
-			model, err := mgr.Get()
+			model, err := mgr.get()
 			if err != nil {
 				t.Fatalf("Get() error = %v", err)
 			}
@@ -1594,7 +1594,7 @@ func TestOpenRouterSupportedModelAddsPromptCacheControlToSystemPrefix(t *testing
 	defer server.Close()
 
 	manager := NewModelManager(ModelConfig{Provider: "openrouter", Model: "vendor/cache-control-model", APIKey: "k", BaseURL: server.URL}, ProxyConfig{})
-	model, err := manager.Get()
+	model, err := manager.get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
@@ -1645,7 +1645,7 @@ func TestOpenRouterSupportedModelAddsPromptCacheControlToSingleSystemPart(t *tes
 	defer server.Close()
 
 	manager := NewModelManager(ModelConfig{Provider: "openrouter", Model: "vendor/cache-control-model", APIKey: "k", BaseURL: server.URL}, ProxyConfig{})
-	model, err := manager.Get()
+	model, err := manager.get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
@@ -1693,7 +1693,7 @@ func TestOpenRouterUnsupportedModelDoesNotSendPromptCacheControl(t *testing.T) {
 	defer server.Close()
 
 	manager := NewModelManager(ModelConfig{Provider: "openrouter", Model: "openai/gpt-4o", APIKey: "k", BaseURL: server.URL}, ProxyConfig{})
-	model, err := manager.Get()
+	model, err := manager.get()
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
@@ -1973,7 +1973,7 @@ func TestModelManagerOpenRouterRetriesEOFInModelCall(t *testing.T) {
 		APIKey:   "token",
 		BaseURL:  server.URL,
 	}, ProxyConfig{})
-	model, err := manager.Get()
+	model, err := manager.get()
 	if err != nil {
 		t.Fatalf("Get model: %v", err)
 	}

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -46,7 +46,7 @@ const (
 
 type Runtime struct {
 	config             Config
-	models             model.ModelResolver
+	models             model.Model
 	memories           *MemoryManager
 	tools              *ToolSet
 	skills             *SkillManager
@@ -236,10 +236,16 @@ type RunEvent struct {
 }
 
 type usageTrackingModel struct {
-	inner           llms.Model
+	inner           model.Model
 	metrics         *RunMetrics
 	promptCapture   *telemetryPromptCapture
 	contextWindowFn ContextWindowFn
+}
+
+func (m *usageTrackingModel) CallOptions() []chains.ChainCallOption { return m.inner.CallOptions() }
+
+func (m *usageTrackingModel) Spec() model.ModelSpec {
+	return m.inner.Spec()
 }
 
 func (m *usageTrackingModel) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
@@ -409,7 +415,7 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 	return rt, nil
 }
 
-func NewRuntimeWithDeps(cfg Config, models model.ModelResolver, memories *MemoryManager, tools *ToolSet, skillIndex *SkillIndex) *Runtime {
+func NewRuntimeWithDeps(cfg Config, models model.Model, memories *MemoryManager, tools *ToolSet, skillIndex *SkillIndex) *Runtime {
 	waitForWakeupController := NewWaitForWakeupController()
 	if tools != nil {
 		if tool, ok := tools.Get(toolWaitForWakeup); ok {
@@ -739,10 +745,6 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (result RunResult, ru
 		return RunResult{}, err
 	}
 
-	m, err := r.models.Get()
-	if err != nil {
-		return RunResult{}, err
-	}
 	contextWindow := r.effectiveContextWindow()
 	if contextWindow > 0 {
 		metrics.ContextWindow = contextWindow
@@ -750,7 +752,7 @@ func (r *Runtime) Run(ctx context.Context, req RunRequest) (result RunResult, ru
 			r.logger.Info("Resolved model context window: context_window=%d", contextWindow)
 		}
 	}
-	m = &usageTrackingModel{inner: m, metrics: metrics, promptCapture: promptCapture, contextWindowFn: func() model.ModelSpec {
+	m := &usageTrackingModel{inner: r.models, metrics: metrics, promptCapture: promptCapture, contextWindowFn: func() model.ModelSpec {
 		if r.models != nil {
 			return r.models.Spec()
 		}
@@ -2084,12 +2086,8 @@ func truncateForLog(text string, max int) string {
 	return string(runes[:max]) + "..."
 }
 
-func buildLLMSummarizeFn(models model.ModelResolver) SummarizeFn {
+func buildLLMSummarizeFn(models model.Model) SummarizeFn {
 	return func(ctx context.Context, events []SessionEvent) string {
-		model, err := models.Get()
-		if err != nil {
-			return ""
-		}
 		var transcript strings.Builder
 		for _, evt := range events {
 			if evt.Content == "" {
@@ -2101,7 +2099,7 @@ func buildLLMSummarizeFn(models model.ModelResolver) SummarizeFn {
 			return ""
 		}
 		prompt := "Summarize this conversation in 2-3 concise sentences. Focus on what was discussed, decided, or requested. Write in the same language as the conversation.\n\n" + transcript.String()
-		result, err := llms.GenerateFromSinglePrompt(ctx, model, prompt, llms.WithMaxTokens(200))
+		result, err := llms.GenerateFromSinglePrompt(ctx, models, prompt, llms.WithMaxTokens(200))
 		if err != nil {
 			return ""
 		}
@@ -2138,15 +2136,8 @@ const (
 	structuredSummaryMaxSummaryRune = 480
 )
 
-func buildLLMStructuredSummarizeFn(models model.ModelResolver, logger *Logger) StructuredSummarizeFn {
+func buildLLMStructuredSummarizeFn(models model.Model, logger *Logger) StructuredSummarizeFn {
 	return func(ctx context.Context, events []SessionEvent) ChunkStructuredSummary {
-		model, err := models.Get()
-		if err != nil {
-			if logger != nil {
-				logger.Warn("[memory] structured summary: failed to get model: %v", err)
-			}
-			return ChunkStructuredSummary{}
-		}
 		var transcript strings.Builder
 		for _, evt := range events {
 			content := strings.TrimSpace(evt.Content)
@@ -2158,7 +2149,7 @@ func buildLLMStructuredSummarizeFn(models model.ModelResolver, logger *Logger) S
 		if transcript.Len() == 0 {
 			return ChunkStructuredSummary{}
 		}
-		result, err := llms.GenerateFromSinglePrompt(ctx, model, structuredSummarizerPrompt+transcript.String(), llms.WithMaxTokens(800))
+		result, err := llms.GenerateFromSinglePrompt(ctx, models, structuredSummarizerPrompt+transcript.String(), llms.WithMaxTokens(800))
 		if err != nil {
 			if logger != nil {
 				logger.Warn("[memory] structured summary: LLM generation failed: %v", err)
@@ -2224,12 +2215,8 @@ func capRunes(text string, max int) string {
 	return string(runes[:max])
 }
 
-func buildLLMProfileFn(models model.ModelResolver) ProfileFn {
+func buildLLMProfileFn(models model.Model) ProfileFn {
 	return func(ctx context.Context, entries []ProfileEntry) string {
-		model, err := models.Get()
-		if err != nil {
-			return ""
-		}
 		var input strings.Builder
 		for _, e := range entries {
 			input.WriteString(fmt.Sprintf("[%s] %s\n", e.Type, e.Content))
@@ -2248,7 +2235,7 @@ Rules:
 
 Memory entries:
 ` + input.String()
-		result, err := llms.GenerateFromSinglePrompt(ctx, model, prompt, llms.WithMaxTokens(400))
+		result, err := llms.GenerateFromSinglePrompt(ctx, models, prompt, llms.WithMaxTokens(400))
 		if err != nil {
 			return ""
 		}

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -82,12 +82,20 @@ type testModelResolver struct {
 	spec  model.ModelSpec
 }
 
-func (r *testModelResolver) Get() (llms.Model, error) {
+func (r *testModelResolver) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
 	r.calls++
 	if r.err != nil {
 		return nil, r.err
 	}
-	return r.model, nil
+	return r.model.GenerateContent(ctx, messages, options...)
+}
+
+func (r *testModelResolver) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	r.calls++
+	if r.err != nil {
+		return "", r.err
+	}
+	return r.model.Call(ctx, prompt, options...)
 }
 
 func (r *testModelResolver) CallOptions() []chains.ChainCallOption {
@@ -2094,6 +2102,16 @@ func (m *scriptedModel) GenerateContent(ctx context.Context, messages []llms.Mes
 func (m *scriptedModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
 	panic("unexpected Call invocation")
 }
+
+func (m *scriptedModel) Spec() model.ModelSpec {
+	return model.ModelSpec{
+		Provider:      "fake",
+		Name:          "scripted",
+		ContextWindow: 100,
+	}
+}
+
+func (m *scriptedModel) CallOptions() []chains.ChainCallOption { return nil }
 
 func contentResponse(content string) *llms.ContentResponse {
 	return contentResponseWithInfo(content, nil)

--- a/src/agent/internal/agent/screenshot_pruner.go
+++ b/src/agent/internal/agent/screenshot_pruner.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"strings"
+
+	"aiden-agent/internal/agent/contextmanager"
+	"aiden-agent/internal/agent/executor"
+)
+
+var _ executor.OutboundMessageTransform = AnthropicScreenshotPruner{}
+
+const (
+	screenshotAttachedText    = "The image is attached in the next message."
+	screenshotPlaceholderText = "The image is replaced with a placeholder in the next message."
+)
+
+type AnthropicScreenshotPruner struct {
+	Enabled bool
+	Config  ScreenshotPruningConfig
+}
+
+func (p AnthropicScreenshotPruner) Transform(messages []contextmanager.Message) []contextmanager.Message {
+	if !p.Enabled || len(messages) == 0 {
+		return messages
+	}
+	cfg := p.Config.WithDefaults()
+
+	total := 0
+	for _, msg := range messages {
+		for _, a := range msg.Attachments {
+			if a.Source == contextmanager.AttachmentSourceScreenshotObservation {
+				total++
+			}
+		}
+	}
+	pruned := cfg.PrunedCount(total)
+	if pruned <= 0 {
+		return messages
+	}
+
+	out := make([]contextmanager.Message, len(messages))
+	seen := 0
+	for i, msg := range messages {
+		cloned := msg
+		if len(msg.Attachments) > 0 {
+			cloned.Attachments = append([]contextmanager.Attachment(nil), msg.Attachments...)
+		}
+		if len(msg.ToolCalls) > 0 {
+			cloned.ToolCalls = append([]contextmanager.ToolCall(nil), msg.ToolCalls...)
+		}
+		if len(msg.ToolResults) > 0 {
+			cloned.ToolResults = append([]contextmanager.ToolResult(nil), msg.ToolResults...)
+		}
+
+		kept := cloned.Attachments[:0]
+		for _, a := range cloned.Attachments {
+			if a.Source != contextmanager.AttachmentSourceScreenshotObservation {
+				kept = append(kept, a)
+				continue
+			}
+			seen++
+			if seen <= pruned {
+				if i > 0 {
+					out[i-1] = rewritePrunedScreenshotToolResult(out[i-1])
+				}
+				if !strings.Contains(cloned.Content, "[Image omitted]") {
+					if strings.TrimSpace(cloned.Content) == "" {
+						cloned.Content = "[Image omitted]"
+					} else {
+						cloned.Content = cloned.Content + "\n[Image omitted]"
+					}
+				}
+				continue
+			}
+			kept = append(kept, a)
+		}
+		cloned.Attachments = kept
+		out[i] = cloned
+	}
+	return out
+}
+
+func rewritePrunedScreenshotToolResult(msg contextmanager.Message) contextmanager.Message {
+	if msg.Role != contextmanager.MessageRoleToolResult || len(msg.ToolResults) == 0 {
+		return msg
+	}
+
+	cloned := msg
+	cloned.ToolResults = append([]contextmanager.ToolResult(nil), msg.ToolResults...)
+	for i, result := range cloned.ToolResults {
+		if !strings.Contains(result.Content, screenshotAttachedText) {
+			continue
+		}
+		result.Content = strings.ReplaceAll(result.Content, screenshotAttachedText, screenshotPlaceholderText)
+		cloned.ToolResults[i] = result
+	}
+	return cloned
+}

--- a/src/agent/internal/agent/screenshot_pruner_test.go
+++ b/src/agent/internal/agent/screenshot_pruner_test.go
@@ -1,0 +1,261 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"aiden-agent/internal/agent/contextmanager"
+)
+
+func TestAnthropicScreenshotPrunerDisabledIsNoop(t *testing.T) {
+	msgs := screenshotObservationMessages(4)
+	out := AnthropicScreenshotPruner{Enabled: false, Config: ScreenshotPruningConfig{}.WithDefaults()}.Transform(msgs)
+	if countScreenshotSources(out) != 4 {
+		t.Fatalf("disabled pruner changed messages: %#v", out)
+	}
+	if len(out) == 0 || &out[0] != &msgs[0] {
+		t.Fatal("disabled pruner must return the same slice (pointer identity)")
+	}
+}
+
+func TestAnthropicScreenshotPrunerBatchesLikePrunedCount(t *testing.T) {
+	// Defaults KeepN=3 Interval=2: total 6 → pruned 2 (same as scratchpad batch tests).
+	pruner := AnthropicScreenshotPruner{Enabled: true, Config: ScreenshotPruningConfig{}.WithDefaults()}
+	msgs := screenshotObservationMessages(6)
+	snapshot := cloneMessagesForAssert(msgs)
+	out := pruner.Transform(msgs)
+	assertMessagesUnchanged(t, msgs, snapshot)
+	if got := countScreenshotSources(out); got != 4 {
+		t.Fatalf("remaining screenshot attachments = %d, want 4", got)
+	}
+	if got := countImageOmitted(out); got != 2 {
+		t.Fatalf("[Image omitted] count = %d, want 2", got)
+	}
+	assertRemainingScreenshotPaths(t, out, []string{
+		"/tmp/fake-2.jpg", "/tmp/fake-3.jpg", "/tmp/fake-4.jpg", "/tmp/fake-5.jpg",
+	})
+}
+
+func TestAnthropicScreenshotPrunerConfiguredKeepNInterval(t *testing.T) {
+	// KeepN=2 Interval=4: total 7 → pruned 4, remaining marked attachments 3
+	// (mirrors TestFunctionAgentScratchpadUsesConfiguredScreenshotPruning).
+	pruner := AnthropicScreenshotPruner{Enabled: true, Config: ScreenshotPruningConfig{KeepN: 2, Interval: 4}}
+	msgs := screenshotObservationMessages(7)
+	snapshot := cloneMessagesForAssert(msgs)
+	out := pruner.Transform(msgs)
+	assertMessagesUnchanged(t, msgs, snapshot)
+	if got := countScreenshotSources(out); got != 3 {
+		t.Fatalf("remaining screenshot attachments = %d, want 3", got)
+	}
+	if got := countImageOmitted(out); got != 4 {
+		t.Fatalf("[Image omitted] count = %d, want 4", got)
+	}
+	assertRemainingScreenshotPaths(t, out, []string{
+		"/tmp/fake-4.jpg", "/tmp/fake-5.jpg", "/tmp/fake-6.jpg",
+	})
+}
+
+func TestAnthropicScreenshotPrunerIgnoresUnmarkedAttachments(t *testing.T) {
+	msgs := []contextmanager.Message{
+		{Role: contextmanager.MessageRoleUser, Content: "upload", Attachments: []contextmanager.Attachment{{
+			MIMEType: "image/png", FilePath: "/tmp/user.png",
+		}}},
+		{Role: contextmanager.MessageRoleUser, Content: "shot", Attachments: []contextmanager.Attachment{{
+			MIMEType: "image/png", FilePath: "/tmp/s.png",
+			Source: contextmanager.AttachmentSourceScreenshotObservation,
+		}}},
+	}
+	snapshot := cloneMessagesForAssert(msgs)
+	// With KeepN=3, a single marked shot should never prune; unmarked must remain.
+	out := AnthropicScreenshotPruner{Enabled: true, Config: ScreenshotPruningConfig{KeepN: 3, Interval: 2}}.Transform(msgs)
+	assertMessagesUnchanged(t, msgs, snapshot)
+	if len(out[0].Attachments) != 1 || out[0].Attachments[0].Source != "" {
+		t.Fatalf("user upload mutated: %#v", out[0])
+	}
+	if len(out[1].Attachments) != 1 {
+		t.Fatalf("single screenshot should remain: %#v", out[1])
+	}
+}
+
+func TestAnthropicScreenshotPrunerRewritesPairedToolResultWhenPruning(t *testing.T) {
+	msgs := []contextmanager.Message{
+		{
+			Role: contextmanager.MessageRoleToolResult,
+			ToolResults: []contextmanager.ToolResult{{
+				ToolCallID: "call_1",
+				Name:       "screenshot",
+				Content:    "screenshot returned a screenshot observation: format=jpeg width=100 height=50 size=123 bytes. The image is attached in the next message.",
+			}},
+		},
+		{
+			Role:    contextmanager.MessageRoleUser,
+			Content: "This image is the screenshot observation returned by the screenshot tool.",
+			Attachments: []contextmanager.Attachment{{
+				MIMEType: "image/jpeg",
+				FilePath: "/tmp/fake-0.jpg",
+				Source:   contextmanager.AttachmentSourceScreenshotObservation,
+			}},
+		},
+		{
+			Role: contextmanager.MessageRoleToolResult,
+			ToolResults: []contextmanager.ToolResult{{
+				ToolCallID: "call_2",
+				Name:       "screenshot",
+				Content:    "screenshot returned a screenshot observation: format=jpeg width=100 height=50 size=456 bytes. The image is attached in the next message.",
+			}},
+		},
+		{
+			Role:    contextmanager.MessageRoleUser,
+			Content: "This image is the screenshot observation returned by the screenshot tool.",
+			Attachments: []contextmanager.Attachment{{
+				MIMEType: "image/jpeg",
+				FilePath: "/tmp/fake-1.jpg",
+				Source:   contextmanager.AttachmentSourceScreenshotObservation,
+			}},
+		},
+		{
+			Role: contextmanager.MessageRoleToolResult,
+			ToolResults: []contextmanager.ToolResult{{
+				ToolCallID: "call_3",
+				Name:       "screenshot",
+				Content:    "screenshot returned a screenshot observation: format=jpeg width=100 height=50 size=789 bytes. The image is attached in the next message.",
+			}},
+		},
+		{
+			Role:    contextmanager.MessageRoleUser,
+			Content: "This image is the screenshot observation returned by the screenshot tool.",
+			Attachments: []contextmanager.Attachment{{
+				MIMEType: "image/jpeg",
+				FilePath: "/tmp/fake-2.jpg",
+				Source:   contextmanager.AttachmentSourceScreenshotObservation,
+			}},
+		},
+		{
+			Role: contextmanager.MessageRoleToolResult,
+			ToolResults: []contextmanager.ToolResult{{
+				ToolCallID: "call_4",
+				Name:       "screenshot",
+				Content:    "screenshot returned a screenshot observation: format=jpeg width=100 height=50 size=999 bytes. The image is attached in the next message.",
+			}},
+		},
+		{
+			Role:    contextmanager.MessageRoleUser,
+			Content: "This image is the screenshot observation returned by the screenshot tool.",
+			Attachments: []contextmanager.Attachment{{
+				MIMEType: "image/jpeg",
+				FilePath: "/tmp/fake-3.jpg",
+				Source:   contextmanager.AttachmentSourceScreenshotObservation,
+			}},
+		},
+	}
+
+	out := AnthropicScreenshotPruner{Enabled: true, Config: ScreenshotPruningConfig{}.WithDefaults()}.Transform(msgs)
+
+	if got := out[0].ToolResults[0].Content; !strings.Contains(got, "replaced with a placeholder") {
+		t.Fatalf("first tool result content = %q, want placeholder notice", got)
+	}
+	if got := out[2].ToolResults[0].Content; !strings.Contains(got, "The image is attached in the next message.") {
+		t.Fatalf("second tool result content = %q, want attached notice for retained screenshot", got)
+	}
+	if got := countImageOmitted(out); got != 1 {
+		t.Fatalf("[Image omitted] count = %d, want 1", got)
+	}
+	if got := countScreenshotSources(out); got != 3 {
+		t.Fatalf("remaining screenshot attachments = %d, want 3", got)
+	}
+}
+
+func screenshotObservationMessages(n int) []contextmanager.Message {
+	out := make([]contextmanager.Message, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, contextmanager.Message{
+			Role:    contextmanager.MessageRoleUser,
+			Content: "This image is the screenshot observation returned by the screenshot tool.",
+			Attachments: []contextmanager.Attachment{{
+				MIMEType: "image/jpeg",
+				FilePath: fmt.Sprintf("/tmp/fake-%d.jpg", i),
+				Source:   contextmanager.AttachmentSourceScreenshotObservation,
+			}},
+		})
+	}
+	return out
+}
+
+func cloneMessagesForAssert(messages []contextmanager.Message) []contextmanager.Message {
+	out := make([]contextmanager.Message, len(messages))
+	for i, msg := range messages {
+		cloned := msg
+		if len(msg.Attachments) > 0 {
+			cloned.Attachments = append([]contextmanager.Attachment(nil), msg.Attachments...)
+		}
+		if len(msg.ToolCalls) > 0 {
+			cloned.ToolCalls = append([]contextmanager.ToolCall(nil), msg.ToolCalls...)
+		}
+		if len(msg.ToolResults) > 0 {
+			cloned.ToolResults = append([]contextmanager.ToolResult(nil), msg.ToolResults...)
+		}
+		out[i] = cloned
+	}
+	return out
+}
+
+func assertMessagesUnchanged(t *testing.T, got, want []contextmanager.Message) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("input slice length mutated: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Content != want[i].Content {
+			t.Fatalf("input[%d].Content mutated: got %q want %q", i, got[i].Content, want[i].Content)
+		}
+		if len(got[i].Attachments) != len(want[i].Attachments) {
+			t.Fatalf("input[%d].Attachments length mutated: got %d want %d", i, len(got[i].Attachments), len(want[i].Attachments))
+		}
+		for j := range want[i].Attachments {
+			if got[i].Attachments[j] != want[i].Attachments[j] {
+				t.Fatalf("input[%d].Attachments[%d] mutated: got %#v want %#v", i, j, got[i].Attachments[j], want[i].Attachments[j])
+			}
+		}
+	}
+}
+
+func assertRemainingScreenshotPaths(t *testing.T, messages []contextmanager.Message, wantPaths []string) {
+	t.Helper()
+	var got []string
+	for _, msg := range messages {
+		for _, a := range msg.Attachments {
+			if a.Source == contextmanager.AttachmentSourceScreenshotObservation {
+				got = append(got, a.FilePath)
+			}
+		}
+	}
+	if len(got) != len(wantPaths) {
+		t.Fatalf("remaining screenshot paths = %v, want %v", got, wantPaths)
+	}
+	for i := range wantPaths {
+		if got[i] != wantPaths[i] {
+			t.Fatalf("remaining screenshot paths = %v, want %v", got, wantPaths)
+		}
+	}
+}
+
+func countScreenshotSources(messages []contextmanager.Message) int {
+	n := 0
+	for _, msg := range messages {
+		for _, a := range msg.Attachments {
+			if a.Source == contextmanager.AttachmentSourceScreenshotObservation {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+func countImageOmitted(messages []contextmanager.Message) int {
+	n := 0
+	for _, msg := range messages {
+		n += strings.Count(msg.Content, "[Image omitted]")
+	}
+	return n
+}

--- a/src/agent/internal/agent/screenshot_pruner_test.go
+++ b/src/agent/internal/agent/screenshot_pruner_test.go
@@ -150,7 +150,10 @@ func TestAnthropicScreenshotPrunerRewritesPairedToolResultWhenPruning(t *testing
 		},
 	}
 
-	out := AnthropicScreenshotPruner{Enabled: true, Config: ScreenshotPruningConfig{}.WithDefaults()}.Transform(msgs)
+	out := AnthropicScreenshotPruner{
+		Enabled: true,
+		Config:  ScreenshotPruningConfig{KeepN: 2, Interval: 1},
+	}.Transform(msgs)
 
 	if got := out[0].ToolResults[0].Content; !strings.Contains(got, "replaced with a placeholder") {
 		t.Fatalf("first tool result content = %q, want placeholder notice", got)

--- a/src/agent/internal/agent/skill_merge_llm.go
+++ b/src/agent/internal/agent/skill_merge_llm.go
@@ -11,21 +11,16 @@ import (
 )
 
 type LLMSkillMergeModel struct {
-	models model.ModelResolver
+	model model.Model
 }
 
-func NewLLMSkillMergeModel(models model.ModelResolver) *LLMSkillMergeModel {
-	return &LLMSkillMergeModel{models: models}
+func NewLLMSkillMergeModel(models model.Model) *LLMSkillMergeModel {
+	return &LLMSkillMergeModel{model: models}
 }
 
 func (m *LLMSkillMergeModel) MergeSkill(ctx context.Context, input SkillMergeInput) (*SkillMergeResult, error) {
-	model, err := m.models.Get()
-	if err != nil {
-		return nil, fmt.Errorf("get model: %w", err)
-	}
-
 	prompt := buildMergePrompt(input)
-	raw, err := llms.GenerateFromSinglePrompt(ctx, model, prompt, llms.WithMaxTokens(4096))
+	raw, err := llms.GenerateFromSinglePrompt(ctx, m.model, prompt, llms.WithMaxTokens(4096))
 	if err != nil {
 		return nil, fmt.Errorf("LLM call: %w", err)
 	}

--- a/src/agent/internal/agent/text_input_vision.go
+++ b/src/agent/internal/agent/text_input_vision.go
@@ -48,10 +48,10 @@ type textInputVision interface {
 }
 
 type llmTextInputVision struct {
-	models model.ModelResolver
+	models model.Model
 }
 
-func newLLMTextInputVision(models model.ModelResolver) textInputVision {
+func newLLMTextInputVision(models model.Model) textInputVision {
 	if models == nil {
 		return nil
 	}
@@ -129,10 +129,6 @@ Rules:
 }
 
 func (v *llmTextInputVision) visionJSON(ctx context.Context, prompt string, screenshot screenshotResult) (string, error) {
-	model, err := v.models.Get()
-	if err != nil {
-		return "", err
-	}
 	if strings.TrimSpace(screenshot.Data) == "" {
 		return "", fmt.Errorf("screenshot data missing")
 	}
@@ -149,7 +145,7 @@ func (v *llmTextInputVision) visionJSON(ctx context.Context, prompt string, scre
 	// Use the model's configured temperature for vision analysis. Previously
 	// hardcoded to 0 for determinism, but that breaks kimi-k3 (requires temp=1)
 	// and the temperature difference has minimal impact on vision text extraction.
-	resp, err := model.GenerateContent(ctx, msgs, llms.WithJSONMode())
+	resp, err := v.models.GenerateContent(ctx, msgs, llms.WithJSONMode())
 	if err != nil {
 		return "", err
 	}

--- a/src/agent/internal/agent/tools.go
+++ b/src/agent/internal/agent/tools.go
@@ -170,7 +170,7 @@ func newHardwareToolSet(hidCfg HIDConfig, audioCfg AudioConfig, searchCfg Search
 	return toolSet
 }
 
-func (s *ToolSet) RegisterEnterTextInFieldTool(models model.ModelResolver, platformFn func() string) {
+func (s *ToolSet) RegisterEnterTextInFieldTool(models model.Model, platformFn func() string) {
 	if s == nil || s.textInputHW == nil || models == nil {
 		return
 	}


### PR DESCRIPTION
## Summary
- add outbound message transform support in the executor/runtime path
- add Anthropic-specific persisted-history screenshot pruning and message conversion updates
- cover the pruning, model routing, and context conversion behavior with tests

## Testing
- not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added screenshot-aware message processing for Anthropic models, including configurable image pruning and “[Image omitted]” omission markers.
  * Added screenshot-observation attachment source tagging for visual follow-ups.
  * Exposed model provider/name metadata for identification.
* **Bug Fixes**
  * Prevented outbound message transforms (including pruning) from mutating persisted conversation history.
  * Improved attachment and tool-result handling, including safe behavior when image data is missing.
* **Refactor**
  * Updated agent runtime to use a direct model interface and added outbound message transform support in the executor.
* **Tests**
  * Expanded coverage for pruning and attachment-source behaviors across agent components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->