### PR TITLE
refactor(agent): extract langfuse client package

### DIFF
--- a/src/agent/internal/agent/episode_exporter.go
+++ b/src/agent/internal/agent/episode_exporter.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"aiden-agent/internal/agent/langfuse"
 	"aiden-agent/internal/util"
 	"context"
 	"encoding/json"
@@ -17,9 +18,12 @@ import (
 )
 
 const (
-	langfuseBatchSize          = 40
+	langfuseBatchSize          = 10
 	langfuseTraceIngestReserve = 5 * time.Second
 )
+
+type langfuseClient = langfuse.Client
+type langfuseIngestionEvent = langfuse.IngestionEvent
 
 type langfuseIterationWindow struct {
 	Index int
@@ -47,8 +51,13 @@ type EpisodeExporter struct {
 
 func NewEpisodeExporter(cfg TelemetryConfig, logger *Logger) *EpisodeExporter {
 	return &EpisodeExporter{
-		cfg:    cfg,
-		client: newLangfuseClient(cfg),
+		cfg: cfg,
+		client: langfuse.NewClient(langfuse.Config{
+			BaseURL:       cfg.BaseURL,
+			PublicKey:     cfg.PublicKey,
+			SecretKey:     cfg.SecretKey,
+			UploadTimeout: cfg.UploadTimeoutOrDefault(),
+		}),
 		logger: logger,
 	}
 }
@@ -57,7 +66,7 @@ func (e *EpisodeExporter) ExportEpisodeDir(ctx context.Context, episodeDir strin
 	if e == nil || !e.cfg.EnabledOrDefault() {
 		return nil
 	}
-	if !e.client.configured() {
+	if !e.client.Configured() {
 		return fmt.Errorf("langfuse credentials or base_url missing")
 	}
 	metaPath := filepath.Join(episodeDir, "episode.yaml")
@@ -106,7 +115,7 @@ func (e *EpisodeExporter) ingestWithRetry(ctx context.Context, batch []langfuseI
 			if end > len(batch) {
 				end = len(batch)
 			}
-			if err := e.client.ingest(ctx, batch[i:end]); err != nil {
+			if err := e.client.Ingest(ctx, batch[i:end]); err != nil {
 				lastErr = err
 				break
 			}
@@ -985,14 +994,14 @@ func (e *EpisodeExporter) uploadPromptMedia(ctx context.Context, traceID string,
 		replacement := "[media omitted: upload unavailable]"
 		uploadCtx, cancel, ok := langfuseScreenshotUploadContext(ctx, e.cfg.UploadTimeoutOrDefault())
 		if ok {
-			mediaID, err := e.client.uploadMedia(uploadCtx, traceID, call.ID, media.ContentType, media.Data, "input")
+			mediaID, err := e.client.UploadMedia(uploadCtx, traceID, call.ID, media.ContentType, media.Data, "input")
 			cancel()
 			if err != nil {
 				if e.logger != nil {
 					e.logger.Warn("[telemetry] prompt media upload failed (%s, %d bytes): %v", media.ContentType, len(media.Data), err)
 				}
 			} else if mediaID != "" {
-				replacement = langfuseMediaToken(media.ContentType, mediaID)
+				replacement = langfuse.MediaToken(media.ContentType, mediaID)
 			}
 		}
 		replaceTelemetryMediaPlaceholder(call.Input, media.Placeholder, replacement)
@@ -1685,11 +1694,11 @@ func (e *EpisodeExporter) uploadScreenshot(ctx context.Context, traceID, observa
 		return "", err
 	}
 	contentType := screenshotContentType(path)
-	mediaID, err := e.client.uploadMedia(ctx, traceID, observationID, contentType, data, "output")
+	mediaID, err := e.client.UploadMedia(ctx, traceID, observationID, contentType, data, "output")
 	if err != nil {
 		return "", err
 	}
-	return langfuseMediaToken(contentType, mediaID), nil
+	return langfuse.MediaToken(contentType, mediaID), nil
 }
 
 func (e *EpisodeExporter) traceTags(episode TaskEpisode) []string {
@@ -2055,6 +2064,10 @@ func newLangfuseEvent(eventType string, ts time.Time, body map[string]interface{
 		Type:      eventType,
 		Body:      raw,
 	}, nil
+}
+
+func langfuseRFC3339(t time.Time) string {
+	return langfuse.RFC3339(t)
 }
 
 func parseEpisodeTime(raw string, fallback time.Time) time.Time {

--- a/src/agent/internal/agent/episode_exporter_test.go
+++ b/src/agent/internal/agent/episode_exporter_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"aiden-agent/internal/agent/langfuse"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -442,7 +443,7 @@ func langfuseSpanBodyByName(t *testing.T, batch []langfuseIngestionEvent, name s
 }
 
 func TestBuildLangfuseBatchUploadsCapturedPromptMedia(t *testing.T) {
-	var mediaRequest langfuseMediaCreateRequest
+	var mediaRequest langfuse.MediaCreateRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/api/public/media" {
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -622,7 +623,7 @@ func TestExportEpisodeDirUploadsToLangfuse(t *testing.T) {
 				t.Errorf("unexpected auth: ok=%v user=%q pass=%q", ok, user, pass)
 			}
 			body, _ := io.ReadAll(r.Body)
-			var req langfuseIngestionRequest
+			var req langfuse.IngestionRequest
 			if err := json.Unmarshal(body, &req); err != nil {
 				t.Fatalf("decode ingestion request: %v", err)
 			}
@@ -654,7 +655,7 @@ func TestExportEpisodeDirUploadsToLangfuse(t *testing.T) {
 			_, _ = w.Write([]byte(`{"successes":[{"id":"ok","status":201}],"errors":[]}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/api/public/media":
 			body, _ := io.ReadAll(r.Body)
-			var req langfuseMediaCreateRequest
+			var req langfuse.MediaCreateRequest
 			if err := json.Unmarshal(body, &req); err != nil {
 				t.Fatalf("decode media create request: %v", err)
 			}
@@ -904,7 +905,7 @@ func TestRuntimeStartupExportsInterruptedEpisodeToLangfuse(t *testing.T) {
 			t.Errorf("unexpected auth: ok=%v user=%q pass=%q", ok, user, pass)
 		}
 		body, _ := io.ReadAll(r.Body)
-		var req langfuseIngestionRequest
+		var req langfuse.IngestionRequest
 		if err := json.Unmarshal(body, &req); err != nil {
 			t.Errorf("decode ingestion request: %v", err)
 		}

--- a/src/agent/internal/agent/langfuse/client.go
+++ b/src/agent/internal/agent/langfuse/client.go
@@ -1,4 +1,4 @@
-package agent
+package langfuse
 
 import (
 	"bytes"
@@ -13,40 +13,47 @@ import (
 	"time"
 )
 
-type langfuseClient struct {
+type Config struct {
+	BaseURL       string
+	PublicKey     string
+	SecretKey     string
+	UploadTimeout time.Duration
+}
+
+type Client struct {
 	baseURL    string
 	publicKey  string
 	secretKey  string
 	httpClient *http.Client
 }
 
-func newLangfuseClient(cfg TelemetryConfig) *langfuseClient {
-	return &langfuseClient{
+func NewClient(cfg Config) *Client {
+	return &Client{
 		baseURL:   strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/"),
 		publicKey: strings.TrimSpace(cfg.PublicKey),
 		secretKey: strings.TrimSpace(cfg.SecretKey),
 		httpClient: &http.Client{
-			Timeout: cfg.UploadTimeoutOrDefault(),
+			Timeout: cfg.UploadTimeout,
 		},
 	}
 }
 
-func (c *langfuseClient) configured() bool {
+func (c *Client) Configured() bool {
 	return c != nil && c.baseURL != "" && c.publicKey != "" && c.secretKey != ""
 }
 
-type langfuseIngestionRequest struct {
-	Batch []langfuseIngestionEvent `json:"batch"`
+type IngestionRequest struct {
+	Batch []IngestionEvent `json:"batch"`
 }
 
-type langfuseIngestionEvent struct {
+type IngestionEvent struct {
 	ID        string          `json:"id"`
 	Timestamp string          `json:"timestamp"`
 	Type      string          `json:"type"`
 	Body      json.RawMessage `json:"body"`
 }
 
-type langfuseIngestionResponse struct {
+type IngestionResponse struct {
 	Successes []struct {
 		ID     string `json:"id"`
 		Status int    `json:"status"`
@@ -59,14 +66,14 @@ type langfuseIngestionResponse struct {
 	} `json:"errors"`
 }
 
-func (c *langfuseClient) ingest(ctx context.Context, batch []langfuseIngestionEvent) error {
+func (c *Client) Ingest(ctx context.Context, batch []IngestionEvent) error {
 	if len(batch) == 0 {
 		return nil
 	}
-	if !c.configured() {
+	if !c.Configured() {
 		return fmt.Errorf("langfuse client is not configured")
 	}
-	payload, err := json.Marshal(langfuseIngestionRequest{Batch: batch})
+	payload, err := json.Marshal(IngestionRequest{Batch: batch})
 	if err != nil {
 		return fmt.Errorf("marshal ingestion batch: %w", err)
 	}
@@ -86,7 +93,7 @@ func (c *langfuseClient) ingest(ctx context.Context, batch []langfuseIngestionEv
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("ingestion HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
-	var parsed langfuseIngestionResponse
+	var parsed IngestionResponse
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return fmt.Errorf("decode ingestion response: %w", err)
 	}
@@ -107,7 +114,7 @@ func (c *langfuseClient) ingest(ctx context.Context, batch []langfuseIngestionEv
 	return nil
 }
 
-type langfuseMediaCreateRequest struct {
+type MediaCreateRequest struct {
 	TraceID       string `json:"traceId"`
 	ObservationID string `json:"observationId,omitempty"`
 	ContentType   string `json:"contentType"`
@@ -116,23 +123,23 @@ type langfuseMediaCreateRequest struct {
 	Field         string `json:"field"`
 }
 
-type langfuseMediaCreateResponse struct {
+type MediaCreateResponse struct {
 	MediaID   string `json:"mediaId"`
 	UploadURL string `json:"uploadUrl"`
 }
 
-type langfuseMediaPatchRequest struct {
+type MediaPatchRequest struct {
 	UploadedAt       string  `json:"uploadedAt"`
 	UploadHTTPStatus int     `json:"uploadHttpStatus"`
 	UploadHTTPError  *string `json:"uploadHttpError,omitempty"`
 	UploadTimeMs     *int64  `json:"uploadTimeMs,omitempty"`
 }
 
-func (c *langfuseClient) uploadMedia(ctx context.Context, traceID, observationID, contentType string, data []byte, field string) (string, error) {
+func (c *Client) UploadMedia(ctx context.Context, traceID, observationID, contentType string, data []byte, field string) (string, error) {
 	if len(data) == 0 {
 		return "", nil
 	}
-	if !c.configured() {
+	if !c.Configured() {
 		return "", fmt.Errorf("langfuse client is not configured")
 	}
 	if field == "" {
@@ -141,7 +148,7 @@ func (c *langfuseClient) uploadMedia(ctx context.Context, traceID, observationID
 	hash := sha256.Sum256(data)
 	hashB64 := base64.StdEncoding.EncodeToString(hash[:])
 
-	createBody, err := json.Marshal(langfuseMediaCreateRequest{
+	createBody, err := json.Marshal(MediaCreateRequest{
 		TraceID:       traceID,
 		ObservationID: strings.TrimSpace(observationID),
 		ContentType:   contentType,
@@ -168,7 +175,7 @@ func (c *langfuseClient) uploadMedia(ctx context.Context, traceID, observationID
 	if createResp.StatusCode < 200 || createResp.StatusCode >= 300 {
 		return "", fmt.Errorf("media create HTTP %d: %s", createResp.StatusCode, strings.TrimSpace(string(createPayload)))
 	}
-	var created langfuseMediaCreateResponse
+	var created MediaCreateResponse
 	if err := json.Unmarshal(createPayload, &created); err != nil {
 		return "", fmt.Errorf("decode media create response: %w", err)
 	}
@@ -201,7 +208,7 @@ func (c *langfuseClient) uploadMedia(ctx context.Context, traceID, observationID
 	return created.MediaID, nil
 }
 
-func (c *langfuseClient) patchMediaUploadStatus(ctx context.Context, mediaID string, statusCode int, uploadBody string, uploadTimeMs int64) error {
+func (c *Client) patchMediaUploadStatus(ctx context.Context, mediaID string, statusCode int, uploadBody string, uploadTimeMs int64) error {
 	var uploadErr *string
 	if statusCode < 200 || statusCode >= 300 {
 		msg := strings.TrimSpace(uploadBody)
@@ -210,8 +217,8 @@ func (c *langfuseClient) patchMediaUploadStatus(ctx context.Context, mediaID str
 		}
 		uploadErr = &msg
 	}
-	payload, err := json.Marshal(langfuseMediaPatchRequest{
-		UploadedAt:       langfuseRFC3339(time.Now().UTC()),
+	payload, err := json.Marshal(MediaPatchRequest{
+		UploadedAt:       RFC3339(time.Now().UTC()),
 		UploadHTTPStatus: statusCode,
 		UploadHTTPError:  uploadErr,
 		UploadTimeMs:     &uploadTimeMs,
@@ -238,10 +245,10 @@ func (c *langfuseClient) patchMediaUploadStatus(ctx context.Context, mediaID str
 	return nil
 }
 
-func langfuseMediaToken(contentType, mediaID string) string {
+func MediaToken(contentType, mediaID string) string {
 	return fmt.Sprintf("@@@langfuseMedia:type=%s|id=%s|source=bytes@@@", contentType, mediaID)
 }
 
-func langfuseRFC3339(t time.Time) string {
+func RFC3339(t time.Time) string {
 	return t.UTC().Format(time.RFC3339Nano)
 }

--- a/src/agent/internal/agent/langfuse/client_test.go
+++ b/src/agent/internal/agent/langfuse/client_test.go
@@ -1,4 +1,4 @@
-package agent
+package langfuse
 
 import (
 	"context"
@@ -28,7 +28,7 @@ func TestUploadMediaCompletesWithPatch(t *testing.T) {
 		case r.Method == http.MethodPatch && r.URL.Path == "/api/public/media/media-abc":
 			patchCalled = true
 			body, _ := io.ReadAll(r.Body)
-			var patch langfuseMediaPatchRequest
+			var patch MediaPatchRequest
 			if err := json.Unmarshal(body, &patch); err != nil {
 				t.Fatalf("decode patch body: %v", err)
 			}
@@ -45,13 +45,13 @@ func TestUploadMediaCompletesWithPatch(t *testing.T) {
 	}))
 	defer langfuseServer.Close()
 
-	client := newLangfuseClient(TelemetryConfig{
+	client := NewClient(Config{
 		BaseURL:   langfuseServer.URL,
 		PublicKey: "pk-test",
 		SecretKey: "sk-test",
 	})
 
-	mediaID, err := client.uploadMedia(context.Background(), "trace-1", "observation-1", "image/jpeg", []byte("jpeg-bytes"), "output")
+	mediaID, err := client.UploadMedia(context.Background(), "trace-1", "observation-1", "image/jpeg", []byte("jpeg-bytes"), "output")
 	if err != nil {
 		t.Fatalf("uploadMedia() error = %v", err)
 	}

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"aiden-agent/internal/agent/langfuse"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -156,13 +157,13 @@ func TestRuntimeRunMarksMainAgentModelCallsForRawHTTPLog(t *testing.T) {
 }
 
 func TestRuntimeRunExportsFailedTraceWhenModelBuildFails(t *testing.T) {
-	ingestCh := make(chan langfuseIngestionRequest, 1)
+	ingestCh := make(chan langfuse.IngestionRequest, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/public/ingestion" {
 			http.NotFound(w, r)
 			return
 		}
-		var req langfuseIngestionRequest
+		var req langfuse.IngestionRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -200,7 +201,7 @@ func TestRuntimeRunExportsFailedTraceWhenModelBuildFails(t *testing.T) {
 		t.Fatalf("Run() error = %v, want %v", err, buildErr)
 	}
 
-	var ingest langfuseIngestionRequest
+	var ingest langfuse.IngestionRequest
 	select {
 	case ingest = <-ingestCh:
 	case <-time.After(2 * time.Second):

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -160,6 +160,7 @@ func TestServerHandleChatReturnsToolHistory(t *testing.T) {
 		}},
 		NewSkillIndex(),
 	)
+	defer runtime.Close()
 	server := newServerForTest(runtime)
 
 	body := bytes.NewBufferString(`{"message":"What is the current volume?"}`)
@@ -1447,15 +1448,10 @@ func TestServerHandleChatSkipsToolContentTTSWhenDisabled(t *testing.T) {
 	if requestID == "" {
 		t.Fatalf("missing request_id in response: %#v", startResp)
 	}
-	select {
-	case <-provider.started:
-		t.Fatal("tool content TTS started despite voice_tool_call_speech=false")
-	case <-time.After(50 * time.Millisecond):
-	}
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		resultReq := httptest.NewRequest(http.MethodGet, "/api/chat/result?request_id="+requestID+"&wait=true", nil)
+		resultReq := httptest.NewRequest(http.MethodGet, "/api/chat/result?request_id="+requestID, nil)
 		resultRec := httptest.NewRecorder()
 		server.handleChatResult(resultRec, resultReq)
 		if resultRec.Code != http.StatusOK {
@@ -1466,10 +1462,18 @@ func TestServerHandleChatSkipsToolContentTTSWhenDisabled(t *testing.T) {
 			t.Fatalf("decode result response: %v", err)
 		}
 		if resp.Status == "complete" {
+			select {
+			case <-provider.started:
+				t.Fatal("tool content TTS started despite voice_tool_call_speech=false")
+			default:
+			}
 			return
 		}
 		if resp.Status == "error" {
 			t.Fatalf("chat request failed: %s", resp.Error)
+		}
+		if resp.Status == "running" {
+			time.Sleep(10 * time.Millisecond)
 		}
 	}
 	t.Fatalf("chat request did not complete before deadline: request_id=%s", requestID)

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -1439,11 +1439,40 @@ func TestServerHandleChatSkipsToolContentTTSWhenDisabled(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
 	}
+	var startResp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&startResp); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+	requestID := startResp["request_id"]
+	if requestID == "" {
+		t.Fatalf("missing request_id in response: %#v", startResp)
+	}
 	select {
 	case <-provider.started:
 		t.Fatal("tool content TTS started despite voice_tool_call_speech=false")
 	case <-time.After(50 * time.Millisecond):
 	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resultReq := httptest.NewRequest(http.MethodGet, "/api/chat/result?request_id="+requestID+"&wait=true", nil)
+		resultRec := httptest.NewRecorder()
+		server.handleChatResult(resultRec, resultReq)
+		if resultRec.Code != http.StatusOK {
+			t.Fatalf("unexpected result status: %d body=%s", resultRec.Code, resultRec.Body.String())
+		}
+		var resp ChatResultResponse
+		if err := json.NewDecoder(resultRec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode result response: %v", err)
+		}
+		if resp.Status == "complete" {
+			return
+		}
+		if resp.Status == "error" {
+			t.Fatalf("chat request failed: %s", resp.Error)
+		}
+	}
+	t.Fatalf("chat request did not complete before deadline: request_id=%s", requestID)
 }
 
 func TestServerShouldSpeakToolCallRequiresTTSTag(t *testing.T) {


### PR DESCRIPTION
## Summary
- extract Langfuse client and protocol types into `internal/agent/langfuse`
- move the Langfuse client unit test into the new subpackage
- reduce Langfuse ingestion batch size from 40 to 10

## Testing
- `cd src/agent && go test ./internal/agent/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved episode telemetry export reliability by tuning ingestion batching and updating retry/validation behavior.
  * Corrected prompt media and screenshot uploads, ensuring the intended create→patch flow, proper upload status handling, and consistent RFC3339 timestamp formatting.
* **Tests**
  * Updated telemetry ingestion and media upload HTTP assertions to align with the latest request/response shapes.
  * Strengthened runtime and server tests to better verify failed-trace tracing and chat completion outcomes (including error and timeout handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->