### PR TITLE
fix(hid): address PR 440 review gaps

### DIFF
--- a/src/agent/internal/agent/ios_keyboard_isolation.go
+++ b/src/agent/internal/agent/ios_keyboard_isolation.go
@@ -36,7 +36,8 @@ type iosKeyboardIsolationController struct {
 	pointerDev         *HIDDevice
 	extraKeysDev       *HIDDevice
 	run                iosKeyboardIsolationCommand
-	mu                 sync.Mutex
+	gateOnce           sync.Once
+	gate               chan struct{}
 	needsRestore       bool
 	lastRestoreErr     error
 	lastRestoreFailure time.Time
@@ -74,6 +75,33 @@ func (c *iosKeyboardIsolationController) closeHIDDevices() {
 	if c.extraKeysDev != nil {
 		c.extraKeysDev.Close()
 	}
+}
+
+func (c *iosKeyboardIsolationController) acquire(ctx context.Context) error {
+	if c == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c.gateOnce.Do(func() {
+		c.gate = make(chan struct{}, 1)
+		c.gate <- struct{}{}
+	})
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.gate:
+	}
+	if err := ctx.Err(); err != nil {
+		c.release()
+		return err
+	}
+	return nil
+}
+
+func (c *iosKeyboardIsolationController) release() {
+	c.gate <- struct{}{}
 }
 
 func (c *iosKeyboardIsolationController) switchProfile(command string) error {
@@ -171,8 +199,10 @@ func (c *iosKeyboardIsolationController) withBatch(ctx context.Context, action f
 		return err
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	if err := c.acquire(ctx); err != nil {
+		return err
+	}
+	defer c.release()
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -224,8 +254,10 @@ func (c *iosKeyboardIsolationController) withKeyboard(ctx context.Context, isola
 		return action()
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	if err := c.acquire(ctx); err != nil {
+		return err
+	}
+	defer c.release()
 	if ctx != nil {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -269,8 +301,10 @@ func (c *iosKeyboardIsolationController) withPointerCall(ctx context.Context, ac
 		}
 		return action(ctx)
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	if err := c.acquire(ctx); err != nil {
+		return "", err
+	}
+	defer c.release()
 	if err := c.ensureNormalProfileLocked(); err != nil {
 		return "", err
 	}
@@ -289,8 +323,10 @@ func (c *iosKeyboardIsolationController) withExtraKeys(ctx context.Context, acti
 		}
 		return action()
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	if err := c.acquire(ctx); err != nil {
+		return err
+	}
+	defer c.release()
 	if err := c.ensureNormalProfileLocked(); err != nil {
 		return err
 	}

--- a/src/agent/internal/agent/ios_keyboard_isolation_test.go
+++ b/src/agent/internal/agent/ios_keyboard_isolation_test.go
@@ -103,6 +103,67 @@ func TestIOSKeyboardIsolationNestedBatchReusesOuterProfile(t *testing.T) {
 	}
 }
 
+func TestIOSKeyboardIsolationBatchWaitCanBeCanceled(t *testing.T) {
+	controller := newTestIOSKeyboardIsolationController(&[]string{})
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- controller.withBatch(context.Background(), func(context.Context) error {
+			close(firstStarted)
+			<-releaseFirst
+			return nil
+		})
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first batch did not acquire isolation controller")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	secondActionErr := errors.New("second batch action unexpectedly ran")
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- controller.withBatch(ctx, func(context.Context) error {
+			return secondActionErr
+		})
+	}()
+
+	select {
+	case err := <-secondDone:
+		close(releaseFirst)
+		<-firstDone
+		t.Fatalf("second batch returned before cancellation: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-secondDone:
+		if !errors.Is(err, context.Canceled) {
+			close(releaseFirst)
+			<-firstDone
+			t.Fatalf("second batch error = %v, want context canceled", err)
+		}
+		if errors.Is(err, secondActionErr) {
+			close(releaseFirst)
+			<-firstDone
+			t.Fatalf("second batch action ran after cancellation: %v", err)
+		}
+	case <-time.After(time.Second):
+		close(releaseFirst)
+		<-firstDone
+		t.Fatal("canceled batch remained blocked waiting for isolation controller")
+	}
+
+	close(releaseFirst)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first batch error = %v", err)
+	}
+}
+
 func TestIOSKeyboardIsolationBatchRestoresBeforePointerAndCanReisolate(t *testing.T) {
 	events := []string{}
 	controller := newTestIOSKeyboardIsolationController(&events)

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1000,10 +1000,7 @@ func (r *Runtime) run(ctx context.Context, req RunRequest) (result RunResult, ru
 		}
 	}
 
-	// Set platformFn for text entry tools (bridge > config > LLM).
-	type platformConfigurable interface {
-		SetPlatformFn(func() string)
-	}
+	// Set platformFn for platform-aware tools (bridge > config > LLM).
 	platformFn := func() string {
 		if deviceEnv != nil {
 			if p := strings.TrimSpace(deviceEnv.Platform); p != "" {
@@ -1012,13 +1009,7 @@ func (r *Runtime) run(ctx context.Context, req RunRequest) (result RunResult, ru
 		}
 		return defaultPlatform
 	}
-	for _, name := range []string{"enter_text_in_field", "enter_text_via_bridge"} {
-		if textInputTool, ok := r.tools.Get(name); ok {
-			if tool, ok := textInputTool.(platformConfigurable); ok {
-				tool.SetPlatformFn(platformFn)
-			}
-		}
-	}
+	r.tools.SetRuntimePlatformFn(platformFn)
 
 	// setup context manager if not initialized
 	if r.contextManager == nil {

--- a/src/agent/internal/agent/tools.go
+++ b/src/agent/internal/agent/tools.go
@@ -19,6 +19,10 @@ type ToolSet struct {
 	iosKeyboardIsolation *iosKeyboardIsolationController
 }
 
+type runtimePlatformConfigurable interface {
+	SetPlatformFn(func() string)
+}
+
 // NewBuiltinToolSet returns all built-in tools. Tools are not configurable;
 // everything is registered here with its runtime dependencies already wired up.
 type BuiltinToolSetOption func(*builtinToolSetOptions)
@@ -156,6 +160,7 @@ func newHardwareToolSet(hidCfg HIDConfig, audioCfg AudioConfig, searchCfg Search
 		tool, ok := tools[name]
 		return tool, ok
 	})
+	runScript.iosKeyboardIsolation = iosKeyboardIsolation
 	tools["run_script"] = runScript
 	tools["list_scripts"] = NewListScriptsTool(toolOptions.scriptsDir)
 	tools["read_script"] = NewReadScriptTool(toolOptions.scriptsDir)
@@ -205,6 +210,21 @@ func (s *ToolSet) SetRunScriptSpeaker(speaker runScriptSpeaker) {
 	}
 	if runScript, ok := tool.(*RunScriptTool); ok {
 		runScript.SetSpeaker(speaker)
+	}
+}
+
+func (s *ToolSet) SetRuntimePlatformFn(fn func() string) {
+	if s == nil {
+		return
+	}
+	for _, name := range []string{"enter_text_in_field", "enter_text_via_bridge", "search_launch_app"} {
+		tool, ok := s.tools[name]
+		if !ok {
+			continue
+		}
+		if configurable, ok := tool.(runtimePlatformConfigurable); ok {
+			configurable.SetPlatformFn(fn)
+		}
 	}
 }
 

--- a/src/agent/internal/agent/tools_app_search_open.go
+++ b/src/agent/internal/agent/tools_app_search_open.go
@@ -46,6 +46,12 @@ type appSearchOpenArgs struct {
 	Platform string `json:"platform,omitempty"`
 }
 
+func (t *appSearchOpenTool) SetPlatformFn(fn func() string) {
+	if t != nil {
+		t.platformFn = fn
+	}
+}
+
 func (t *appSearchOpenTool) Name() string { return "search_launch_app" }
 
 func (t *appSearchOpenTool) Description() string {

--- a/src/agent/internal/agent/tools_phone_bridge_test.go
+++ b/src/agent/internal/agent/tools_phone_bridge_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	langtools "github.com/tmc/langchaingo/tools"
 	"nhooyr.io/websocket"
 )
 
@@ -194,6 +195,60 @@ func TestAppSearchOpenFlowCanBeReused(t *testing.T) {
 	}
 	if len(quick.calls) != 1 || len(keyboardText.calls) != 1 || len(touch.calls) != 1 {
 		t.Fatalf("unexpected tool calls: quick=%v keyboard=%v touch=%v", quick.calls, keyboardText.calls, touch.calls)
+	}
+}
+
+func TestSearchLaunchAppUsesRuntimeAndroidPlatformBeforeIOSFallback(t *testing.T) {
+	vision := &stubTextInputVision{}
+	quick := &recordingTextInputTool{name: "quick_action", out: "ok"}
+	touch := &recordingTextInputTool{name: "touch_gesture", out: "ok"}
+	keyboardText := &recordingTextInputTool{name: "keyboard_text", out: "ok"}
+	hw := &textInputHardwareDeps{
+		mouseClick:   textInputStubTool{name: "mouse_click", out: "ok"},
+		quickAction:  quick,
+		touchGesture: touch,
+		keyboardText: keyboardText,
+		keyboardTap:  textInputStubTool{name: "keyboard_tap", out: "ok"},
+		screenshot:   textInputStubTool{name: "screenshot", out: `{"format":"jpeg","width":100,"height":100,"data":"abc"}`},
+	}
+	tool := &appSearchOpenTool{
+		hw:                   hw,
+		vision:               vision,
+		entryTool:            &EnterTextInFieldTool{engine: newFastTextInputEngine(*hw, vision)},
+		sleep:                testNoWaitSleep,
+		iosKeyboardIsolation: newTestIOSKeyboardIsolationController(&[]string{}),
+		findAppTapFn: func(context.Context, screenshotResult, string) (bridgeSearchResult, error) {
+			return bridgeSearchResult{Found: true, TapPoint: focusPointArgs{X: 500, Y: 200, CoordSpace: "normalized"}, Label: "WeChat"}, nil
+		},
+		confirmAppOpenFn: func(context.Context, screenshotResult, string) (bridgeAppOpenResult, error) {
+			return bridgeAppOpenResult{Opened: true, Reason: "WeChat visible"}, nil
+		},
+	}
+	toolSet := &ToolSet{tools: map[string]langtools.Tool{"search_launch_app": tool}}
+	toolSet.SetRuntimePlatformFn(func() string { return "android" })
+
+	out, err := tool.Call(context.Background(), `{"app":"WeChat"}`)
+	if err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+	var result struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode Call() output: %v: %s", err, out)
+	}
+	if !result.OK {
+		t.Fatalf("Call() output = %s, want ok", out)
+	}
+	if len(quick.calls) != 1 {
+		t.Fatalf("quick_action calls = %v, want one", quick.calls)
+	}
+	var quickArgs quickActionArgs
+	if err := json.Unmarshal([]byte(quick.calls[0]), &quickArgs); err != nil {
+		t.Fatalf("decode quick_action input: %v", err)
+	}
+	if quickArgs.Platform != "android" {
+		t.Fatalf("quick_action platform = %q, want android", quickArgs.Platform)
 	}
 }
 

--- a/src/agent/internal/agent/tools_run_script.go
+++ b/src/agent/internal/agent/tools_run_script.go
@@ -48,12 +48,13 @@ func runScriptSpeakerFromContext(ctx context.Context) runScriptSpeaker {
 // RunScriptTool executes local JSONL demo scripts without involving the LLM
 // between scripted steps.
 type RunScriptTool struct {
-	lookup     runScriptToolLookup
-	speaker    runScriptSpeaker
-	sleeper    runScriptSleeper
-	readFile   func(string) ([]byte, error)
-	scriptsDir string
-	mu         sync.RWMutex
+	lookup               runScriptToolLookup
+	speaker              runScriptSpeaker
+	sleeper              runScriptSleeper
+	readFile             func(string) ([]byte, error)
+	scriptsDir           string
+	iosKeyboardIsolation *iosKeyboardIsolationController
+	mu                   sync.RWMutex
 }
 
 func NewRunScriptTool(scriptsDir string, lookup runScriptToolLookup) *RunScriptTool {
@@ -94,6 +95,16 @@ func (t *RunScriptTool) speakerFn(ctx context.Context) runScriptSpeaker {
 }
 
 func (t *RunScriptTool) Call(ctx context.Context, input string) (string, error) {
+	var controller *iosKeyboardIsolationController
+	if t != nil {
+		controller = t.iosKeyboardIsolation
+	}
+	return withIOSKeyboardIsolationBatchCall(ctx, controller, func(batchCtx context.Context) (string, error) {
+		return t.call(batchCtx, input)
+	})
+}
+
+func (t *RunScriptTool) call(ctx context.Context, input string) (string, error) {
 	var args struct {
 		File string `json:"file"`
 	}

--- a/src/agent/internal/agent/tools_run_script_test.go
+++ b/src/agent/internal/agent/tools_run_script_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -67,6 +68,45 @@ func TestRunScriptExecutesJSONLStepsWithoutLLM(t *testing.T) {
 	}
 	if result.Steps[1].Text != "正在打开设置" || result.Steps[1].Output != "queued" {
 		t.Fatalf("tts result = %#v, want text and queued output", result.Steps[1])
+	}
+}
+
+func TestRunScriptBatchesIOSModifierIsolationAcrossSteps(t *testing.T) {
+	skipHIDSleeps(t)
+
+	scriptsDir := t.TempDir()
+	dev, _ := newTestHIDDevice(t)
+	events := []string{}
+	controller := newTestIOSKeyboardIsolationController(&events)
+	controller.keyboardDev = dev
+	keyboard := &KeyboardTapTool{dev: dev, iosKeyboardIsolation: controller}
+	tool := NewRunScriptTool(scriptsDir, func(name string) (langtools.Tool, bool) {
+		if name == "keyboard_tap" {
+			return keyboard, true
+		}
+		return nil, false
+	})
+	tool.iosKeyboardIsolation = controller
+
+	file := "modifier-batch.jsonl"
+	writeRunScriptTestFile(t, scriptsDir, file, strings.Join([]string{
+		`{"type":"call","tool":"keyboard_tap","input":{"keys":["meta","a"],"hold_ms":1}}`,
+		`{"type":"call","tool":"keyboard_tap","input":{"keys":["meta","c"],"hold_ms":1}}`,
+	}, "\n"))
+
+	out, err := tool.Call(context.Background(), `{"file":`+quoteJSON(file)+`}`)
+	if err != nil {
+		t.Fatalf("Call error: %v", err)
+	}
+	var result runScriptResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid result JSON: %v\n%s", err, out)
+	}
+	if !result.OK || result.StepsRun != 2 {
+		t.Fatalf("result = %#v, output=%s", result, out)
+	}
+	if want := []string{"isolate", "restore"}; !reflect.DeepEqual(events, want) {
+		t.Fatalf("profile events = %v, want %v", events, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make iOS HID isolation ownership context-cancelable so preempted runs do not remain blocked behind detached HTTP tools
- batch direct HTTP run_script modifier operations across the whole script
- prefer runtime Phone Bridge/config platform information before the iOS controller fallback in search_launch_app
- add focused regression tests for all three cases

## Verification

- go test ./...
- go test ./internal/agent -count=1
- focused go test -race coverage
- go vet ./...
- sh scripts/test_dynamic_keyboard.sh
- sh scripts/test_usb_gadget_watchdog.sh
- git diff --check

Stacked on #440.