### PR TITLE
feat(agent): support PC TTS playback

### DIFF
--- a/docs/03-services/agent.md
+++ b/docs/03-services/agent.md
@@ -21,7 +21,7 @@
 
 ## Modes
 
-- **Voice mode**: Continuous voice interaction using audio_service for recording/playback and STT/TTS providers
+- **Voice mode**: Continuous voice interaction using audio_service for recording, the configured TTS playback backend for speech, and STT/TTS providers
 - **Text mode**: HTTP-based text interaction for testing and debugging
 
 ## Configuration
@@ -34,6 +34,7 @@ provider = "anthropic"  # or "openai", "gemini"
 
 [audio]
 socket = "/run/audio_service/audio_service.sock"
+playback_backend = "auto"
 
 [hid]
 frame_socket = "/run/frame_service/frame_service.sock"

--- a/docs/04-agent/audio-features.md
+++ b/docs/04-agent/audio-features.md
@@ -27,7 +27,7 @@ The Go Agent supports device-side voice interaction, primarily consisting of `in
 | Audio client | `audio_client.go` | Connects to `audio_service`, starts recording/playback sessions, reads/writes PCM chunks |
 | VAD | `vad.go` + `/oem/usr/bin/rknn_vad` or `/oem/usr/bin/cpu_vad` | Silero VAD inference; input is fixed at 16 kHz, 512 samples/32 ms, with `state` maintained in helper |
 | STT | `stt.go`, `tencent_asr_stt.go` | OpenAI Whisper / OpenRouter / Tencent Cloud ASR (`tencent-asr`; legacy values `tencent` / `tencent_asr` are compatible) |
-| TTS | `tts/`, `tts_helpers.go` | Pluggable TTS provider, outputs PCM for playback via `audio_service`; automatically resamples to device playback sample rate when necessary |
+| TTS | `tts/`, `tts_helpers.go` | Pluggable TTS provider, outputs PCM for the configured playback backend; automatically resamples to the target playback sample rate when necessary |
 | Dialog manager | `audio_dialog.go` | Orchestrates recording, VAD, STT/LLM/TTS flow |
 | Voice notifications | `voice_notification.go`, `tts_fallback.go` | Adds a persistent response tail or final-turn failure replacement before TTS, with bundled local WAV fallback when final TTS is unavailable |
 
@@ -48,7 +48,7 @@ Device-side audio loop:
 2. VAD determines sentence boundaries;
 3. Sends WAV to STT;
 4. STT text goes to Agent runtime;
-5. TTS synthesizes reply and plays via `audio_service`.
+5. TTS synthesizes the reply and plays it through the configured playback backend.
 
 Before final non-streaming TTS, the runtime passes the spoken reply through the shared [Voice Notification manager](voice-notifications.md). A successful turn may receive one short persistent tail. A final LLM failure may use a fixed replacement. These changes affect spoken text only, not assistant history or UI response text.
 
@@ -87,6 +87,7 @@ socket = "/run/audio_service/audio_service.sock"
 sample_rate = 16000
 channels = 1
 bit_width = 16
+playback_backend = "auto"
 
 [stt]
 provider = "openai-whisper"
@@ -161,8 +162,8 @@ speed = 1.0
 
 ## Dependencies
 
-- `audio_service` must be running;
-- TTS adapter outputs PCM directly and writes to `audio_service`;
+- `audio_service` must be running for board-side recording/playback;
+- TTS adapter outputs PCM and writes to the configured playback backend. `audio.playback_backend = "auto"` uses `audio_service` on board and the local OS player in desktop/PC Agent mode through ADB input backend or environment bridge;
 - `rknn_vad` / `cpu_vad` helper must be executable; when `vad_backend="rknn"`, `vad_model_path` points to a converted encoder RKNN; when `vad_backend="cpu"`, helper defaults to `/oem/usr/bin/cpu_vad`;
 - STT/TTS require external API keys;
 - `wakeup` mode requires GPIO 33 or GPIO 32 hardware trigger condition.

--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -50,7 +50,7 @@ The page fields cover the following config sections (all detailed later on this 
 - `model`: provider, token_env, model, api_key, base_url, temperature, max_response_tokens, context_window, model_max_output_tokens. `context_window = 0` means auto-discover from OpenRouter/Ollama metadata when available.
 - `stt`: provider, api_key, model, base_url, Tencent ASR fields
 - `tts`: provider, api_key, model, voice_id, emotion, speed
-- `audio`: socket, sample_rate, channels, bit_width
+- `audio`: socket, sample_rate, channels, bit_width, playback_backend
 - `voice_notifications`: preserved by Config Web when other settings are saved; dedicated form controls are not currently rendered
 - `log`: LLM HTTP log retention
 - `hid`: keyboard_device, mouse_device, android_keyboard_device, frame_socket, pointer_mode
@@ -84,6 +84,7 @@ socket = "/run/audio_service/audio_service.sock"
 sample_rate = 16000
 channels = 1
 bit_width = 16
+playback_backend = "auto"
 
 [log]
 llm_http_retention_days = 7
@@ -142,6 +143,7 @@ socket = "/run/audio_service/audio_service.sock"
 sample_rate = 16000
 channels = 1
 bit_width = 16
+playback_backend = "auto"
 
 [hid]
 keyboard_device = "/dev/hidg0"
@@ -275,6 +277,7 @@ api_key = "MOONSHOT_API_KEY"
 | `sample_rate` | `16000` | Sample rate |
 | `channels` | `1` | Number of channels |
 | `bit_width` | `16` | Bit width |
+| `playback_backend` | `auto` | TTS playback backend. `auto` uses `audio_service` on board and the local OS player when the Agent is running in desktop/PC mode through ADB input backend or environment bridge. Use `audio_service` or `local` to force one. |
 
 ## `[voice_notifications]`
 

--- a/docs/04-agent/phone-bridge.md
+++ b/docs/04-agent/phone-bridge.md
@@ -60,6 +60,8 @@ adb reverse tcp:8080 tcp:8080
 
 The companion app keeps `192.168.42.1` as the first target, then falls back to the desktop ADB reverse target when the board API is unavailable. Android board-network binding is skipped for loopback URLs so the app can reach the ADB reverse socket.
 
+For TTS replies in this desktop/PC Agent mode, keep `audio.playback_backend = "auto"` or set it to `"local"`. The Agent will synthesize TTS normally, wrap the PCM as a temporary WAV, and play it through the host OS player instead of `audio_service`.
+
 ## App Opening Flow
 
 ```text

--- a/overlay/userdata/agent/agent.toml
+++ b/overlay/userdata/agent/agent.toml
@@ -82,6 +82,7 @@ api_key = "OPENAI_API_KEY"
 # sample_rate = 16000
 # channels = 1
 # bit_width = 16
+# playback_backend = "auto" # "auto" uses audio_service on board, local player in PC/ADB agent mode; "audio_service" and "local" force a backend
 
 # Audio archive configuration (optional)
 # When enabled, saves audio recordings to disk for playback in web UI.

--- a/src/agent/cmd/daemon/config_commands.go
+++ b/src/agent/cmd/daemon/config_commands.go
@@ -127,10 +127,11 @@ func (d sttDTO) transcriptionTestRequest(wavData []byte) agent.STTTranscriptionT
 }
 
 type audioDTO struct {
-	Socket     string `json:"socket"`
-	SampleRate int    `json:"sample_rate"`
-	Channels   int    `json:"channels"`
-	BitWidth   int    `json:"bit_width"`
+	Socket          string `json:"socket"`
+	SampleRate      int    `json:"sample_rate"`
+	Channels        int    `json:"channels"`
+	BitWidth        int    `json:"bit_width"`
+	PlaybackBackend string `json:"playback_backend"`
 }
 
 type audioArchiveDTO struct {
@@ -310,10 +311,11 @@ func (d webConfigDTO) toAgentConfig() agent.Config {
 			EngineModelType: d.STT.EngineModelType,
 		},
 		Audio: agent.AudioConfig{
-			Socket:     d.Audio.Socket,
-			SampleRate: d.Audio.SampleRate,
-			Channels:   d.Audio.Channels,
-			BitWidth:   d.Audio.BitWidth,
+			Socket:          d.Audio.Socket,
+			SampleRate:      d.Audio.SampleRate,
+			Channels:        d.Audio.Channels,
+			BitWidth:        d.Audio.BitWidth,
+			PlaybackBackend: d.Audio.PlaybackBackend,
 		},
 		AudioArchive: agent.AudioArchiveConfig{
 			Enabled:     d.AudioArchive.Enabled,
@@ -462,10 +464,11 @@ func webConfigDTOFromAgentConfig(cfg agent.Config) webConfigDTO {
 			EngineModelType: cfg.STT.EngineModelType,
 		},
 		Audio: audioDTO{
-			Socket:     cfg.Audio.SocketOrDefault(),
-			SampleRate: cfg.Audio.SampleRateOrDefault(),
-			Channels:   cfg.Audio.ChannelsOrDefault(),
-			BitWidth:   cfg.Audio.BitWidthOrDefault(),
+			Socket:          cfg.Audio.SocketOrDefault(),
+			SampleRate:      cfg.Audio.SampleRateOrDefault(),
+			Channels:        cfg.Audio.ChannelsOrDefault(),
+			BitWidth:        cfg.Audio.BitWidthOrDefault(),
+			PlaybackBackend: cfg.AudioPlaybackBackendOrDefault(),
 		},
 		AudioArchive: audioArchiveDTO{
 			Enabled:     audioArchive.Enabled,
@@ -933,6 +936,8 @@ func parseValidationErrors(err error) []ValidationError {
 		field = "audio.channels"
 	} else if strings.Contains(errMsg, "audio.bit_width") {
 		field = "audio.bit_width"
+	} else if strings.Contains(errMsg, "audio.playback_backend") {
+		field = "audio.playback_backend"
 	} else if strings.Contains(errMsg, "telemetry.base_url") {
 		field = "telemetry.base_url"
 	} else if strings.Contains(errMsg, "telemetry.public_key") {

--- a/src/agent/cmd/daemon/config_commands.go
+++ b/src/agent/cmd/daemon/config_commands.go
@@ -468,7 +468,7 @@ func webConfigDTOFromAgentConfig(cfg agent.Config) webConfigDTO {
 			SampleRate:      cfg.Audio.SampleRateOrDefault(),
 			Channels:        cfg.Audio.ChannelsOrDefault(),
 			BitWidth:        cfg.Audio.BitWidthOrDefault(),
-			PlaybackBackend: cfg.AudioPlaybackBackendOrDefault(),
+			PlaybackBackend: cfg.Audio.PlaybackBackendOrDefault(),
 		},
 		AudioArchive: audioArchiveDTO{
 			Enabled:     audioArchive.Enabled,

--- a/src/agent/cmd/daemon/config_commands_test.go
+++ b/src/agent/cmd/daemon/config_commands_test.go
@@ -201,8 +201,8 @@ llm_http_retention_days = 14
 		t.Fatalf("audio.socket = %q, want default %q",
 			dto.Audio.Socket, agent.DefaultConfig().Audio.Socket)
 	}
-	if dto.Audio.PlaybackBackend != agent.AudioPlaybackBackendAudioService {
-		t.Fatalf("audio.playback_backend = %q, want audio_service", dto.Audio.PlaybackBackend)
+	if dto.Audio.PlaybackBackend != agent.AudioPlaybackBackendAuto {
+		t.Fatalf("audio.playback_backend = %q, want auto", dto.Audio.PlaybackBackend)
 	}
 	if dto.Log.LLMHTTPRetentionDays != 14 {
 		t.Fatalf("log.llm_http_retention_days = %d, want 14", dto.Log.LLMHTTPRetentionDays)
@@ -308,6 +308,27 @@ func TestWebConfigDTOMapsAudioPlaybackBackend(t *testing.T) {
 	roundTrip := webConfigDTOFromAgentConfig(agent.Config{Audio: cfg.Audio})
 	if roundTrip.Audio.PlaybackBackend != agent.AudioPlaybackBackendLocal {
 		t.Fatalf("round-trip audio.playback_backend = %q, want local", roundTrip.Audio.PlaybackBackend)
+	}
+
+	autoDTO := webConfigDTO{
+		Audio: audioDTO{
+			Socket:          "/tmp/audio.sock",
+			SampleRate:      24000,
+			Channels:        1,
+			BitWidth:        16,
+			PlaybackBackend: agent.AudioPlaybackBackendAuto,
+		},
+	}
+	autoCfg := autoDTO.toAgentConfig()
+	if autoCfg.Audio.PlaybackBackend != agent.AudioPlaybackBackendAuto {
+		t.Fatalf("auto Audio.PlaybackBackend = %q, want auto", autoCfg.Audio.PlaybackBackend)
+	}
+	autoRoundTrip := webConfigDTOFromAgentConfig(agent.Config{
+		Audio: autoCfg.Audio,
+		HID:   agent.HIDConfig{InputBackend: "adb"},
+	})
+	if autoRoundTrip.Audio.PlaybackBackend != agent.AudioPlaybackBackendAuto {
+		t.Fatalf("auto round-trip audio.playback_backend = %q, want auto", autoRoundTrip.Audio.PlaybackBackend)
 	}
 }
 

--- a/src/agent/cmd/daemon/config_commands_test.go
+++ b/src/agent/cmd/daemon/config_commands_test.go
@@ -201,6 +201,9 @@ llm_http_retention_days = 14
 		t.Fatalf("audio.socket = %q, want default %q",
 			dto.Audio.Socket, agent.DefaultConfig().Audio.Socket)
 	}
+	if dto.Audio.PlaybackBackend != agent.AudioPlaybackBackendAudioService {
+		t.Fatalf("audio.playback_backend = %q, want audio_service", dto.Audio.PlaybackBackend)
+	}
 	if dto.Log.LLMHTTPRetentionDays != 14 {
 		t.Fatalf("log.llm_http_retention_days = %d, want 14", dto.Log.LLMHTTPRetentionDays)
 	}
@@ -215,7 +218,8 @@ func TestWebConfigDTOFromAgentConfig_UsesRuntimeDefaults(t *testing.T) {
 		t.Fatalf("search provider = %q, want duckduckgo", defaults.Search.Provider)
 	}
 	if defaults.Audio.Socket == "" || defaults.Audio.SampleRate == 0 ||
-		defaults.Audio.Channels == 0 || defaults.Audio.BitWidth == 0 {
+		defaults.Audio.Channels == 0 || defaults.Audio.BitWidth == 0 ||
+		defaults.Audio.PlaybackBackend == "" {
 		t.Fatalf("audio defaults were not populated: %+v", defaults.Audio)
 	}
 	if defaults.AudioArchive.Enabled || defaults.AudioArchive.StoragePath == "" ||
@@ -284,6 +288,26 @@ func TestWebConfigDTOMapsAudioArchive(t *testing.T) {
 	if roundTrip.AudioArchive.Enabled || roundTrip.AudioArchive.MaxFiles != 42 ||
 		roundTrip.AudioArchive.MaxSizeMB != 17 || roundTrip.AudioArchive.StoragePath != "/tmp/audio-archive" {
 		t.Fatalf("round-trip AudioArchive = %+v, want DTO values", roundTrip.AudioArchive)
+	}
+}
+
+func TestWebConfigDTOMapsAudioPlaybackBackend(t *testing.T) {
+	dto := webConfigDTO{
+		Audio: audioDTO{
+			Socket:          "/tmp/audio.sock",
+			SampleRate:      24000,
+			Channels:        1,
+			BitWidth:        16,
+			PlaybackBackend: agent.AudioPlaybackBackendLocal,
+		},
+	}
+	cfg := dto.toAgentConfig()
+	if cfg.Audio.PlaybackBackend != agent.AudioPlaybackBackendLocal {
+		t.Fatalf("Audio.PlaybackBackend = %q, want local", cfg.Audio.PlaybackBackend)
+	}
+	roundTrip := webConfigDTOFromAgentConfig(agent.Config{Audio: cfg.Audio})
+	if roundTrip.Audio.PlaybackBackend != agent.AudioPlaybackBackendLocal {
+		t.Fatalf("round-trip audio.playback_backend = %q, want local", roundTrip.Audio.PlaybackBackend)
 	}
 }
 

--- a/src/agent/cmd/daemon/config_wire_test.go
+++ b/src/agent/cmd/daemon/config_wire_test.go
@@ -98,6 +98,13 @@ func TestConfigCheck_WireFormatContract(t *testing.T) {
 				"search":{"provider":"google"},"agent":{}}`,
 			wantInField: "search.provider",
 		},
+		{
+			name: "invalid audio playback backend",
+			payload: `{"model":{"provider":"openai","model":"gpt-4"},
+				"search":{"provider":"duckduckgo"},
+				"audio":{"playback_backend":"speaker"},"agent":{}}`,
+			wantInField: "audio.playback_backend",
+		},
 	}
 
 	for _, tc := range invalidCases {

--- a/src/agent/internal/agent/audio_dialog.go
+++ b/src/agent/internal/agent/audio_dialog.go
@@ -30,6 +30,7 @@ type AudioDialog struct {
 	audioClient         *AudioServiceClient
 	sttClient           STTClient
 	ttsManager          *tts.ProviderManager
+	ttsPlaybackBackend  tts.AudioServiceBackend
 	vad                 *AudioVAD
 	recordMu            sync.Mutex
 	recordActive        bool
@@ -196,13 +197,14 @@ func NewAudioDialog(cfg Config) (*AudioDialog, error) {
 	}
 
 	return &AudioDialog{
-		config:       cfg,
-		audioClient:  audioClient,
-		sttClient:    sttClient,
-		ttsManager:   ttsManager,
-		vad:          vad,
-		audioArchive: NewAudioArchiveManager(cfg.AudioArchive),
-		connWarmer:   connWarmer,
+		config:             cfg,
+		audioClient:        audioClient,
+		sttClient:          sttClient,
+		ttsManager:         ttsManager,
+		ttsPlaybackBackend: newTTSPlaybackBackendFromConfig(cfg, audioClient, nil),
+		vad:                vad,
+		audioArchive:       NewAudioArchiveManager(cfg.AudioArchive),
+		connWarmer:         connWarmer,
 	}, nil
 }
 
@@ -587,7 +589,7 @@ func (d *AudioDialog) beginManagedTTSStreamForRun(ctx context.Context) (*streamS
 		ctx = context.Background()
 	}
 	streamCtx, streamCancel := context.WithCancel(ctx)
-	stream, err := beginManagedTTSStream(streamCtx, d.ttsManager, d.audioClient, d.config)
+	stream, err := beginManagedTTSStream(streamCtx, d.ttsManager, d.currentTTSPlaybackBackend(), d.config)
 	if err != nil {
 		streamCancel()
 		return nil, nil, nil, err
@@ -1161,7 +1163,23 @@ func (d *AudioDialog) SpeakFinal(ctx context.Context, text string, interrupt <-c
 }
 
 func (d *AudioDialog) CanSpeakFinalText() bool {
-	return d != nil && d.audioClient != nil && (d.ttsManager != nil || canPlayTTSUnavailableFallback(d.config))
+	return d != nil && d.currentTTSPlaybackBackend() != nil && (d.ttsManager != nil || canPlayTTSUnavailableFallback(d.config))
+}
+
+func (d *AudioDialog) currentTTSPlaybackBackend() tts.AudioServiceBackend {
+	if d == nil {
+		return nil
+	}
+	if d.ttsPlaybackBackend != nil {
+		if backend, ok := d.ttsPlaybackBackend.(*audioBackend); ok && d.audioClient != nil && backend.c != d.audioClient {
+			return newAudioBackend(d.audioClient)
+		}
+		return d.ttsPlaybackBackend
+	}
+	if d.audioClient == nil {
+		return nil
+	}
+	return newAudioBackend(d.audioClient)
 }
 
 func (d *AudioDialog) ConfigureRuntimeTools(ctx context.Context, runtime *Runtime) context.Context {
@@ -1206,9 +1224,9 @@ func (d *AudioDialog) speak(ctx context.Context, text string, interrupt <-chan s
 	if d.ttsManager == nil && !allowFallback {
 		return nil
 	}
-	if d.audioClient == nil {
+	if d.currentTTSPlaybackBackend() == nil {
 		if allowFallback {
-			return fmt.Errorf("audio service is not configured")
+			return fmt.Errorf("tts playback backend is not configured")
 		}
 		return nil
 	}
@@ -1241,7 +1259,7 @@ func (d *AudioDialog) speak(ctx context.Context, text string, interrupt <-chan s
 	ttsErr := errTTSNotConfigured
 	if d.ttsManager != nil {
 		log.Printf("[tts] Starting streaming playback...\n")
-		speechStarted, ttsErr = speakWithTTSManagerObserved(speakCtx, d.ttsManager, d.audioClient, d.config, text, func(stream *streamSessionWriter) func() {
+		speechStarted, ttsErr = speakWithTTSManagerObserved(speakCtx, d.ttsManager, d.currentTTSPlaybackBackend(), d.config, text, func(stream *streamSessionWriter) func() {
 			stream.setCancel(cancelOutput)
 			output.setStream(stream)
 			return func() {

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -401,10 +401,11 @@ type STTConfig struct {
 }
 
 type AudioConfig struct {
-	Socket     string `toml:"socket,omitempty"`
-	SampleRate int    `toml:"sample_rate,omitempty"`
-	Channels   int    `toml:"channels,omitempty"`
-	BitWidth   int    `toml:"bit_width,omitempty"`
+	Socket          string `toml:"socket,omitempty"`
+	SampleRate      int    `toml:"sample_rate,omitempty"`
+	Channels        int    `toml:"channels,omitempty"`
+	BitWidth        int    `toml:"bit_width,omitempty"`
+	PlaybackBackend string `toml:"playback_backend,omitempty"`
 }
 
 type ProxyConfig struct {
@@ -494,6 +495,39 @@ func (a AudioConfig) BitWidthOrDefault() int {
 		return a.BitWidth
 	}
 	return defaultAudioBitWidth
+}
+
+const (
+	AudioPlaybackBackendAuto         = "auto"
+	AudioPlaybackBackendAudioService = "audio_service"
+	AudioPlaybackBackendLocal        = "local"
+)
+
+func normalizeAudioPlaybackBackend(value string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", AudioPlaybackBackendAuto:
+		return AudioPlaybackBackendAuto, nil
+	case AudioPlaybackBackendAudioService, "audio-service", "audioservice":
+		return AudioPlaybackBackendAudioService, nil
+	case AudioPlaybackBackendLocal, "pc", "desktop":
+		return AudioPlaybackBackendLocal, nil
+	default:
+		return "", fmt.Errorf("invalid audio.playback_backend: %s (expected auto, audio_service, or local)", value)
+	}
+}
+
+func (c Config) AudioPlaybackBackendOrDefault() string {
+	backend, err := normalizeAudioPlaybackBackend(c.Audio.PlaybackBackend)
+	if err != nil {
+		return strings.ToLower(strings.TrimSpace(c.Audio.PlaybackBackend))
+	}
+	if backend != AudioPlaybackBackendAuto {
+		return backend
+	}
+	if c.HID.InputBackendADB() || c.EnvironmentBridge.Enabled {
+		return AudioPlaybackBackendLocal
+	}
+	return AudioPlaybackBackendAudioService
 }
 
 type HIDConfig struct {
@@ -1020,6 +1054,9 @@ func (c Config) Validate() error {
 	case "hdmi":
 	default:
 		return fmt.Errorf("invalid device.backend: %s (expected hdmi)", c.Device.Backend)
+	}
+	if _, err := normalizeAudioPlaybackBackend(c.Audio.PlaybackBackend); err != nil {
+		return err
 	}
 	if c.Model.MaxResponseTokens < 0 {
 		return fmt.Errorf("model.max_response_tokens must be >= 0, got %d", c.Model.MaxResponseTokens)

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -516,6 +516,14 @@ func normalizeAudioPlaybackBackend(value string) (string, error) {
 	}
 }
 
+func (a AudioConfig) PlaybackBackendOrDefault() string {
+	backend, err := normalizeAudioPlaybackBackend(a.PlaybackBackend)
+	if err != nil {
+		return strings.ToLower(strings.TrimSpace(a.PlaybackBackend))
+	}
+	return backend
+}
+
 func (c Config) AudioPlaybackBackendOrDefault() string {
 	backend, err := normalizeAudioPlaybackBackend(c.Audio.PlaybackBackend)
 	if err != nil {

--- a/src/agent/internal/agent/config_defaults.go
+++ b/src/agent/internal/agent/config_defaults.go
@@ -95,10 +95,11 @@ func DefaultConfig() Config {
 			Language: defaultSTTLanguage,
 		},
 		Audio: AudioConfig{
-			Socket:     defaultAudioSocket,
-			SampleRate: defaultAudioSampleRate,
-			Channels:   defaultAudioChannels,
-			BitWidth:   defaultAudioBitWidth,
+			Socket:          defaultAudioSocket,
+			SampleRate:      defaultAudioSampleRate,
+			Channels:        defaultAudioChannels,
+			BitWidth:        defaultAudioBitWidth,
+			PlaybackBackend: AudioPlaybackBackendAuto,
 		},
 		AudioArchive: AudioArchiveConfig{
 			Enabled:     true,

--- a/src/agent/internal/agent/config_meta.go
+++ b/src/agent/internal/agent/config_meta.go
@@ -202,6 +202,9 @@ func ConfigMeta() ConfigMetadata {
 					{Key: "sample_rate", Widget: WidgetNumber, Default: defaults.Audio.SampleRate},
 					{Key: "channels", Widget: WidgetNumber, Default: defaults.Audio.Channels},
 					{Key: "bit_width", Widget: WidgetNumber, Default: defaults.Audio.BitWidth},
+					{Key: "playback_backend", Widget: WidgetSelect,
+						Enum:    enumOptions(AudioPlaybackBackendAuto, AudioPlaybackBackendAudioService, AudioPlaybackBackendLocal),
+						Default: defaults.Audio.PlaybackBackend},
 				},
 			},
 			{

--- a/src/agent/internal/agent/config_meta_test.go
+++ b/src/agent/internal/agent/config_meta_test.go
@@ -176,6 +176,19 @@ func TestConfigMeta_EnumsMatchValidation(t *testing.T) {
 		}
 	}
 
+	audioPlaybackEnum := enumValues("audio.playback_backend")
+	for _, b := range []string{AudioPlaybackBackendAuto, AudioPlaybackBackendAudioService, AudioPlaybackBackendLocal} {
+		if !contains(audioPlaybackEnum, b) {
+			t.Errorf("audio.playback_backend enum missing %q", b)
+		}
+	}
+	for _, b := range audioPlaybackEnum {
+		c := Config{Audio: AudioConfig{PlaybackBackend: b}, Model: ModelConfig{Provider: "openai", Model: "x"}}
+		if err := c.Validate(); err != nil {
+			t.Errorf("audio.playback_backend enum value %q rejected by Validate: %v", b, err)
+		}
+	}
+
 	// vad_backend enum must match normalizeVADBackend's accepted set.
 	for _, b := range enumValues("agent.vad_backend") {
 		if _, err := normalizeVADBackend(b); err != nil {
@@ -222,6 +235,7 @@ func TestConfigMeta_RuntimeDefaultsMatch(t *testing.T) {
 		{"audio.sample_rate", defaults.Audio.SampleRate},
 		{"audio.channels", defaults.Audio.Channels},
 		{"audio.bit_width", defaults.Audio.BitWidth},
+		{"audio.playback_backend", defaults.Audio.PlaybackBackend},
 		{"audio_archive.enabled", defaults.AudioArchive.Enabled},
 		{"audio_archive.max_files", defaults.AudioArchive.MaxFilesOrDefault()},
 		{"audio_archive.max_size_mb", defaults.AudioArchive.MaxSizeMBOrDefault()},

--- a/src/agent/internal/agent/config_test.go
+++ b/src/agent/internal/agent/config_test.go
@@ -1148,6 +1148,32 @@ func TestDeviceConfigBackendDefaultsToHDMI(t *testing.T) {
 	}
 }
 
+func TestAudioPlaybackBackendDefaultsByAgentMode(t *testing.T) {
+	if got := (Config{Model: ModelConfig{Provider: "fake"}}).AudioPlaybackBackendOrDefault(); got != AudioPlaybackBackendAudioService {
+		t.Fatalf("default playback backend = %q, want audio_service", got)
+	}
+	if got := (Config{Model: ModelConfig{Provider: "fake"}, HID: HIDConfig{InputBackend: "adb"}}).AudioPlaybackBackendOrDefault(); got != AudioPlaybackBackendLocal {
+		t.Fatalf("adb playback backend = %q, want local", got)
+	}
+	if got := (Config{Model: ModelConfig{Provider: "fake"}, EnvironmentBridge: EnvironmentBridgeConfig{Enabled: true}}).AudioPlaybackBackendOrDefault(); got != AudioPlaybackBackendLocal {
+		t.Fatalf("environment bridge playback backend = %q, want local", got)
+	}
+	if got := (Config{Model: ModelConfig{Provider: "fake"}, Audio: AudioConfig{PlaybackBackend: "audio-service"}, HID: HIDConfig{InputBackend: "adb"}}).AudioPlaybackBackendOrDefault(); got != AudioPlaybackBackendAudioService {
+		t.Fatalf("explicit audio-service backend = %q, want audio_service", got)
+	}
+}
+
+func TestConfigValidateRejectsUnknownAudioPlaybackBackend(t *testing.T) {
+	cfg := Config{
+		Model: ModelConfig{Provider: "fake"},
+		Audio: AudioConfig{PlaybackBackend: "bogus"},
+	}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "invalid audio.playback_backend") {
+		t.Fatalf("Validate() error = %v, want invalid audio.playback_backend", err)
+	}
+}
+
 func TestLoadConfigRejectsUnknownDeviceBackend(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agent.toml")

--- a/src/agent/internal/agent/local_audio_playback.go
+++ b/src/agent/internal/agent/local_audio_playback.go
@@ -24,12 +24,13 @@ const (
 )
 
 type localAudioPlaybackBackend struct {
-	mu              sync.Mutex
-	playerAdmission sync.Mutex
-	nextID          uint64
-	sessions        map[uint64]*localAudioPlaybackSession
-	player          *localAudioPlayer
-	logger          *Logger
+	mu                       sync.Mutex
+	playerAdmission          sync.Mutex
+	playerAdmissionBlockedFn func()
+	nextID                   uint64
+	sessions                 map[uint64]*localAudioPlaybackSession
+	player                   *localAudioPlayer
+	logger                   *Logger
 }
 
 type localAudioPlaybackSession struct {
@@ -187,7 +188,7 @@ func (b *localAudioPlaybackBackend) finalizeLocalPlaybackSessionLocked(sessionID
 	if player == nil {
 		return b.failLocalPlaybackSessionLocked(sessionID, session, fmt.Errorf("local audio player is unavailable"))
 	}
-	b.playerAdmission.Lock()
+	b.acquirePlayerAdmission()
 	ctx, cancel := context.WithCancel(context.Background())
 	session.cancel = cancel
 	cmd := localAudioCommandContext(ctx, player.name, player.args(session.path)...)
@@ -209,6 +210,16 @@ func (b *localAudioPlaybackBackend) finalizeLocalPlaybackSessionLocked(sessionID
 		done <- err
 	}(session.path, sessionID, session.done)
 	return nil
+}
+
+func (b *localAudioPlaybackBackend) acquirePlayerAdmission() {
+	if b.playerAdmission.TryLock() {
+		return
+	}
+	if b.playerAdmissionBlockedFn != nil {
+		b.playerAdmissionBlockedFn()
+	}
+	b.playerAdmission.Lock()
 }
 
 func (b *localAudioPlaybackBackend) failLocalPlaybackSessionLocked(sessionID uint64, session *localAudioPlaybackSession, err error) error {

--- a/src/agent/internal/agent/local_audio_playback.go
+++ b/src/agent/internal/agent/local_audio_playback.go
@@ -1,0 +1,263 @@
+package agent
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+
+	"aiden-agent/internal/agent/tts"
+)
+
+var (
+	localAudioLookPath       = exec.LookPath
+	localAudioCommandContext = exec.CommandContext
+)
+
+type localAudioPlaybackBackend struct {
+	mu       sync.Mutex
+	nextID   uint64
+	sessions map[uint64]*localAudioPlaybackSession
+	player   *localAudioPlayer
+	logger   *Logger
+}
+
+type localAudioPlaybackSession struct {
+	format    tts.AudioFormat
+	file      *os.File
+	path      string
+	dataBytes uint32
+	final     bool
+	cancel    context.CancelFunc
+	done      chan error
+}
+
+type localAudioPlayer struct {
+	name string
+	args func(path string) []string
+}
+
+func newLocalAudioPlaybackBackend(logger *Logger) *localAudioPlaybackBackend {
+	return &localAudioPlaybackBackend{
+		sessions: make(map[uint64]*localAudioPlaybackSession),
+		logger:   logger,
+	}
+}
+
+func (b *localAudioPlaybackBackend) StartPlayback(format tts.AudioFormat) (uint64, error) {
+	if err := validateLocalPlaybackFormat(format); err != nil {
+		return 0, err
+	}
+	player, err := b.localPlayer()
+	if err != nil {
+		return 0, err
+	}
+	file, err := os.CreateTemp("", "aiden-tts-*.wav")
+	if err != nil {
+		return 0, fmt.Errorf("create local playback wav: %w", err)
+	}
+	if err := writeWAVHeader(file, format, 0); err != nil {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return 0, fmt.Errorf("write local playback wav header: %w", err)
+	}
+
+	b.mu.Lock()
+	b.nextID++
+	id := b.nextID
+	b.sessions[id] = &localAudioPlaybackSession{
+		format: format,
+		file:   file,
+		path:   file.Name(),
+	}
+	b.player = player
+	b.mu.Unlock()
+	return id, nil
+}
+
+func (b *localAudioPlaybackBackend) WritePlayChunk(sessionID uint64, data []byte, isFinal bool) error {
+	b.mu.Lock()
+	session := b.sessions[sessionID]
+	player := b.player
+	b.mu.Unlock()
+	if session == nil {
+		return fmt.Errorf("local playback session not found: %d", sessionID)
+	}
+
+	if len(data) > 0 {
+		if session.final {
+			return fmt.Errorf("local playback session already finalized")
+		}
+		n, err := session.file.Write(data)
+		if err != nil {
+			return fmt.Errorf("write local playback pcm: %w", err)
+		}
+		session.dataBytes += uint32(n)
+	}
+	if !isFinal {
+		return nil
+	}
+	if session.final {
+		return nil
+	}
+	session.final = true
+	if err := patchWAVHeader(session.file, session.format, session.dataBytes); err != nil {
+		return fmt.Errorf("finalize local playback wav header: %w", err)
+	}
+	if err := session.file.Close(); err != nil {
+		return fmt.Errorf("close local playback wav: %w", err)
+	}
+	session.file = nil
+	if player == nil {
+		return fmt.Errorf("local audio player is unavailable")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := localAudioCommandContext(ctx, player.name, player.args(session.path)...)
+	if err := cmd.Start(); err != nil {
+		cancel()
+		_ = os.Remove(session.path)
+		return fmt.Errorf("start local audio player %q: %w", player.name, err)
+	}
+	session.cancel = cancel
+	session.done = make(chan error, 1)
+	go func(path string, id uint64) {
+		err := cmd.Wait()
+		cancel()
+		_ = os.Remove(path)
+		b.mu.Lock()
+		delete(b.sessions, id)
+		b.mu.Unlock()
+		session.done <- err
+	}(session.path, sessionID)
+	return nil
+}
+
+func (b *localAudioPlaybackBackend) StopPlayback(sessionID uint64) error {
+	b.mu.Lock()
+	session := b.sessions[sessionID]
+	delete(b.sessions, sessionID)
+	b.mu.Unlock()
+	if session == nil {
+		return nil
+	}
+	if session.cancel != nil {
+		session.cancel()
+	}
+	if session.file != nil {
+		_ = session.file.Close()
+	}
+	if session.done != nil {
+		<-session.done
+	}
+	if session.path != "" {
+		_ = os.Remove(session.path)
+	}
+	return nil
+}
+
+func (b *localAudioPlaybackBackend) localPlayer() (*localAudioPlayer, error) {
+	b.mu.Lock()
+	player := b.player
+	b.mu.Unlock()
+	if player != nil {
+		return player, nil
+	}
+	player, err := detectLocalAudioPlayer()
+	if err != nil {
+		return nil, err
+	}
+	b.mu.Lock()
+	if b.player == nil {
+		b.player = player
+	}
+	player = b.player
+	b.mu.Unlock()
+	if b.logger != nil {
+		b.logger.Info("Local TTS playback enabled: player=%s", player.name)
+	}
+	return player, nil
+}
+
+func detectLocalAudioPlayer() (*localAudioPlayer, error) {
+	for _, candidate := range localAudioPlayerCandidates(runtime.GOOS) {
+		if _, err := localAudioLookPath(candidate.name); err == nil {
+			return &candidate, nil
+		}
+	}
+	return nil, fmt.Errorf("no local audio player found (tried afplay, pw-play, paplay, aplay, ffplay, powershell)")
+}
+
+func localAudioPlayerCandidates(goos string) []localAudioPlayer {
+	switch goos {
+	case "darwin":
+		return []localAudioPlayer{
+			{name: "afplay", args: func(path string) []string { return []string{path} }},
+			{name: "ffplay", args: func(path string) []string { return []string{"-nodisp", "-autoexit", "-loglevel", "error", path} }},
+		}
+	case "windows":
+		return []localAudioPlayer{
+			{name: "powershell", args: func(path string) []string {
+				return []string{"-NoProfile", "-Command", "(New-Object Media.SoundPlayer $args[0]).PlaySync()", path}
+			}},
+			{name: "powershell.exe", args: func(path string) []string {
+				return []string{"-NoProfile", "-Command", "(New-Object Media.SoundPlayer $args[0]).PlaySync()", path}
+			}},
+		}
+	default:
+		return []localAudioPlayer{
+			{name: "pw-play", args: func(path string) []string { return []string{path} }},
+			{name: "paplay", args: func(path string) []string { return []string{path} }},
+			{name: "aplay", args: func(path string) []string { return []string{"-q", path} }},
+			{name: "ffplay", args: func(path string) []string { return []string{"-nodisp", "-autoexit", "-loglevel", "error", path} }},
+		}
+	}
+}
+
+func validateLocalPlaybackFormat(format tts.AudioFormat) error {
+	if format.SampleRate <= 0 {
+		return fmt.Errorf("local playback requires sample_rate > 0")
+	}
+	if format.Channels <= 0 {
+		return fmt.Errorf("local playback requires channels > 0")
+	}
+	if format.BitWidth <= 0 || format.BitWidth%8 != 0 {
+		return fmt.Errorf("local playback requires byte-aligned bit_width, got %d", format.BitWidth)
+	}
+	return nil
+}
+
+func writeWAVHeader(file *os.File, format tts.AudioFormat, dataBytes uint32) error {
+	header := make([]byte, 44)
+	copy(header[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(header[4:8], 36+dataBytes)
+	copy(header[8:12], "WAVE")
+	copy(header[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(header[16:20], 16)
+	binary.LittleEndian.PutUint16(header[20:22], 1)
+	binary.LittleEndian.PutUint16(header[22:24], uint16(format.Channels))
+	binary.LittleEndian.PutUint32(header[24:28], uint32(format.SampleRate))
+	blockAlign := uint16(format.Channels * (format.BitWidth / 8))
+	binary.LittleEndian.PutUint32(header[28:32], uint32(format.SampleRate)*uint32(blockAlign))
+	binary.LittleEndian.PutUint16(header[32:34], blockAlign)
+	binary.LittleEndian.PutUint16(header[34:36], uint16(format.BitWidth))
+	copy(header[36:40], "data")
+	binary.LittleEndian.PutUint32(header[40:44], dataBytes)
+	if _, err := file.Write(header); err != nil {
+		return err
+	}
+	return nil
+}
+
+func patchWAVHeader(file *os.File, format tts.AudioFormat, dataBytes uint32) error {
+	if _, err := file.Seek(0, 0); err != nil {
+		return err
+	}
+	if err := writeWAVHeader(file, format, dataBytes); err != nil {
+		return err
+	}
+	_, err := file.Seek(0, 2)
+	return err
+}

--- a/src/agent/internal/agent/local_audio_playback.go
+++ b/src/agent/internal/agent/local_audio_playback.go
@@ -24,11 +24,12 @@ const (
 )
 
 type localAudioPlaybackBackend struct {
-	mu       sync.Mutex
-	nextID   uint64
-	sessions map[uint64]*localAudioPlaybackSession
-	player   *localAudioPlayer
-	logger   *Logger
+	mu              sync.Mutex
+	playerAdmission sync.Mutex
+	nextID          uint64
+	sessions        map[uint64]*localAudioPlaybackSession
+	player          *localAudioPlayer
+	logger          *Logger
 }
 
 type localAudioPlaybackSession struct {
@@ -113,11 +114,12 @@ func (b *localAudioPlaybackBackend) WritePlayChunk(sessionID uint64, data []byte
 		}
 		n, err := session.file.Write(data)
 		if err != nil {
-			return fmt.Errorf("write local playback pcm: %w", err)
+			session.dataBytes += uint64(n)
+			return b.failLocalPlaybackSessionLocked(sessionID, session, fmt.Errorf("write local playback pcm: %w", err))
 		}
 		session.dataBytes += uint64(n)
 		if n != len(data) {
-			return fmt.Errorf("write local playback pcm: wrote %d of %d bytes", n, len(data))
+			return b.failLocalPlaybackSessionLocked(sessionID, session, fmt.Errorf("write local playback pcm: wrote %d of %d bytes", n, len(data)))
 		}
 	}
 	if !isFinal {
@@ -185,15 +187,19 @@ func (b *localAudioPlaybackBackend) finalizeLocalPlaybackSessionLocked(sessionID
 	if player == nil {
 		return b.failLocalPlaybackSessionLocked(sessionID, session, fmt.Errorf("local audio player is unavailable"))
 	}
+	b.playerAdmission.Lock()
 	ctx, cancel := context.WithCancel(context.Background())
 	session.cancel = cancel
 	cmd := localAudioCommandContext(ctx, player.name, player.args(session.path)...)
 	if err := cmd.Start(); err != nil {
+		cancel()
+		b.playerAdmission.Unlock()
 		return b.failLocalPlaybackSessionLocked(sessionID, session, fmt.Errorf("start local audio player %q: %w", player.name, err))
 	}
 	session.done = make(chan error, 1)
 	session.final = true
 	go func(path string, id uint64, done chan<- error) {
+		defer b.playerAdmission.Unlock()
 		err := cmd.Wait()
 		cancel()
 		_ = os.Remove(path)

--- a/src/agent/internal/agent/local_audio_playback.go
+++ b/src/agent/internal/agent/local_audio_playback.go
@@ -17,6 +17,12 @@ var (
 	localAudioCommandContext = exec.CommandContext
 )
 
+const (
+	wavMaxUint16    = uint64(65535)
+	wavMaxUint32    = uint64(4294967295)
+	wavMaxDataBytes = wavMaxUint32 - 36
+)
+
 type localAudioPlaybackBackend struct {
 	mu       sync.Mutex
 	nextID   uint64
@@ -29,7 +35,7 @@ type localAudioPlaybackSession struct {
 	format    tts.AudioFormat
 	file      *os.File
 	path      string
-	dataBytes uint32
+	dataBytes uint64
 	final     bool
 	cancel    context.CancelFunc
 	done      chan error
@@ -91,17 +97,26 @@ func (b *localAudioPlaybackBackend) WritePlayChunk(sessionID uint64, data []byte
 		if session.final {
 			return fmt.Errorf("local playback session already finalized")
 		}
+		if err := validateLocalPlaybackAppendSize(session.dataBytes, uint64(len(data))); err != nil {
+			return err
+		}
 		n, err := session.file.Write(data)
 		if err != nil {
 			return fmt.Errorf("write local playback pcm: %w", err)
 		}
-		session.dataBytes += uint32(n)
+		session.dataBytes += uint64(n)
+		if n != len(data) {
+			return fmt.Errorf("write local playback pcm: wrote %d of %d bytes", n, len(data))
+		}
 	}
 	if !isFinal {
 		return nil
 	}
 	if session.final {
 		return nil
+	}
+	if err := validateLocalPlaybackDataSize(session.dataBytes); err != nil {
+		return err
 	}
 	session.final = true
 	if err := patchWAVHeader(session.file, session.format, session.dataBytes); err != nil {
@@ -220,19 +235,59 @@ func validateLocalPlaybackFormat(format tts.AudioFormat) error {
 	if format.SampleRate <= 0 {
 		return fmt.Errorf("local playback requires sample_rate > 0")
 	}
+	if uint64(format.SampleRate) > wavMaxUint32 {
+		return fmt.Errorf("local playback sample_rate %d exceeds WAV uint32 limit", format.SampleRate)
+	}
 	if format.Channels <= 0 {
 		return fmt.Errorf("local playback requires channels > 0")
+	}
+	if uint64(format.Channels) > wavMaxUint16 {
+		return fmt.Errorf("local playback channels %d exceeds WAV uint16 limit", format.Channels)
 	}
 	if format.BitWidth <= 0 || format.BitWidth%8 != 0 {
 		return fmt.Errorf("local playback requires byte-aligned bit_width, got %d", format.BitWidth)
 	}
+	if uint64(format.BitWidth) > wavMaxUint16 {
+		return fmt.Errorf("local playback bit_width %d exceeds WAV uint16 limit", format.BitWidth)
+	}
+	blockAlign := uint64(format.Channels) * uint64(format.BitWidth/8)
+	if blockAlign > wavMaxUint16 {
+		return fmt.Errorf("local playback block_align %d exceeds WAV uint16 limit", blockAlign)
+	}
+	byteRate := uint64(format.SampleRate) * blockAlign
+	if byteRate > wavMaxUint32 {
+		return fmt.Errorf("local playback byte_rate %d exceeds WAV uint32 limit", byteRate)
+	}
 	return nil
 }
 
-func writeWAVHeader(file *os.File, format tts.AudioFormat, dataBytes uint32) error {
+func validateLocalPlaybackDataSize(dataBytes uint64) error {
+	if dataBytes > wavMaxDataBytes {
+		return fmt.Errorf("local playback wav data size %d exceeds RIFF limit %d", dataBytes, wavMaxDataBytes)
+	}
+	return nil
+}
+
+func validateLocalPlaybackAppendSize(currentBytes, chunkBytes uint64) error {
+	if err := validateLocalPlaybackDataSize(currentBytes); err != nil {
+		return err
+	}
+	if chunkBytes > wavMaxDataBytes-currentBytes {
+		return fmt.Errorf("local playback wav data size %d exceeds RIFF limit %d", currentBytes+chunkBytes, wavMaxDataBytes)
+	}
+	return nil
+}
+
+func writeWAVHeader(file *os.File, format tts.AudioFormat, dataBytes uint64) error {
+	if err := validateLocalPlaybackFormat(format); err != nil {
+		return err
+	}
+	if err := validateLocalPlaybackDataSize(dataBytes); err != nil {
+		return err
+	}
 	header := make([]byte, 44)
 	copy(header[0:4], "RIFF")
-	binary.LittleEndian.PutUint32(header[4:8], 36+dataBytes)
+	binary.LittleEndian.PutUint32(header[4:8], uint32(36+dataBytes))
 	copy(header[8:12], "WAVE")
 	copy(header[12:16], "fmt ")
 	binary.LittleEndian.PutUint32(header[16:20], 16)
@@ -244,14 +299,14 @@ func writeWAVHeader(file *os.File, format tts.AudioFormat, dataBytes uint32) err
 	binary.LittleEndian.PutUint16(header[32:34], blockAlign)
 	binary.LittleEndian.PutUint16(header[34:36], uint16(format.BitWidth))
 	copy(header[36:40], "data")
-	binary.LittleEndian.PutUint32(header[40:44], dataBytes)
+	binary.LittleEndian.PutUint32(header[40:44], uint32(dataBytes))
 	if _, err := file.Write(header); err != nil {
 		return err
 	}
 	return nil
 }
 
-func patchWAVHeader(file *os.File, format tts.AudioFormat, dataBytes uint32) error {
+func patchWAVHeader(file *os.File, format tts.AudioFormat, dataBytes uint64) error {
 	if _, err := file.Seek(0, 0); err != nil {
 		return err
 	}

--- a/src/agent/internal/agent/local_audio_playback.go
+++ b/src/agent/internal/agent/local_audio_playback.go
@@ -32,11 +32,14 @@ type localAudioPlaybackBackend struct {
 }
 
 type localAudioPlaybackSession struct {
+	mu        sync.Mutex
 	format    tts.AudioFormat
 	file      *os.File
 	path      string
 	dataBytes uint64
 	final     bool
+	stopped   bool
+	failedErr error
 	cancel    context.CancelFunc
 	done      chan error
 }
@@ -93,9 +96,17 @@ func (b *localAudioPlaybackBackend) WritePlayChunk(sessionID uint64, data []byte
 		return fmt.Errorf("local playback session not found: %d", sessionID)
 	}
 
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	if err := session.stateError(sessionID); err != nil {
+		return err
+	}
 	if len(data) > 0 {
 		if session.final {
 			return fmt.Errorf("local playback session already finalized")
+		}
+		if session.file == nil {
+			return fmt.Errorf("local playback session file is unavailable")
 		}
 		if err := validateLocalPlaybackAppendSize(session.dataBytes, uint64(len(data))); err != nil {
 			return err
@@ -115,39 +126,7 @@ func (b *localAudioPlaybackBackend) WritePlayChunk(sessionID uint64, data []byte
 	if session.final {
 		return nil
 	}
-	if err := validateLocalPlaybackDataSize(session.dataBytes); err != nil {
-		return err
-	}
-	session.final = true
-	if err := patchWAVHeader(session.file, session.format, session.dataBytes); err != nil {
-		return fmt.Errorf("finalize local playback wav header: %w", err)
-	}
-	if err := session.file.Close(); err != nil {
-		return fmt.Errorf("close local playback wav: %w", err)
-	}
-	session.file = nil
-	if player == nil {
-		return fmt.Errorf("local audio player is unavailable")
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	cmd := localAudioCommandContext(ctx, player.name, player.args(session.path)...)
-	if err := cmd.Start(); err != nil {
-		cancel()
-		_ = os.Remove(session.path)
-		return fmt.Errorf("start local audio player %q: %w", player.name, err)
-	}
-	session.cancel = cancel
-	session.done = make(chan error, 1)
-	go func(path string, id uint64) {
-		err := cmd.Wait()
-		cancel()
-		_ = os.Remove(path)
-		b.mu.Lock()
-		delete(b.sessions, id)
-		b.mu.Unlock()
-		session.done <- err
-	}(session.path, sessionID)
-	return nil
+	return b.finalizeLocalPlaybackSessionLocked(sessionID, session, player)
 }
 
 func (b *localAudioPlaybackBackend) StopPlayback(sessionID uint64) error {
@@ -158,19 +137,96 @@ func (b *localAudioPlaybackBackend) StopPlayback(sessionID uint64) error {
 	if session == nil {
 		return nil
 	}
+	session.mu.Lock()
+	session.stopped = true
 	if session.cancel != nil {
 		session.cancel()
 	}
 	if session.file != nil {
 		_ = session.file.Close()
+		session.file = nil
 	}
-	if session.done != nil {
-		<-session.done
+	done := session.done
+	path := session.path
+	session.mu.Unlock()
+	if done != nil {
+		<-done
+	}
+	if path != "" {
+		_ = os.Remove(path)
+	}
+	return nil
+}
+
+func (s *localAudioPlaybackSession) stateError(sessionID uint64) error {
+	if s.failedErr != nil {
+		return fmt.Errorf("local playback session failed: %w", s.failedErr)
+	}
+	if s.stopped {
+		return fmt.Errorf("local playback session stopped: %d", sessionID)
+	}
+	return nil
+}
+
+func (b *localAudioPlaybackBackend) finalizeLocalPlaybackSessionLocked(sessionID uint64, session *localAudioPlaybackSession, player *localAudioPlayer) error {
+	if err := validateLocalPlaybackDataSize(session.dataBytes); err != nil {
+		return b.failLocalPlaybackSessionLocked(sessionID, session, err)
+	}
+	if session.file == nil {
+		return b.failLocalPlaybackSessionLocked(sessionID, session, fmt.Errorf("local playback session file is unavailable"))
+	}
+	if err := patchWAVHeader(session.file, session.format, session.dataBytes); err != nil {
+		return b.failLocalPlaybackSessionLocked(sessionID, session, fmt.Errorf("finalize local playback wav header: %w", err))
+	}
+	if err := session.file.Close(); err != nil {
+		return b.failLocalPlaybackSessionLocked(sessionID, session, fmt.Errorf("close local playback wav: %w", err))
+	}
+	session.file = nil
+	if player == nil {
+		return b.failLocalPlaybackSessionLocked(sessionID, session, fmt.Errorf("local audio player is unavailable"))
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	session.cancel = cancel
+	cmd := localAudioCommandContext(ctx, player.name, player.args(session.path)...)
+	if err := cmd.Start(); err != nil {
+		return b.failLocalPlaybackSessionLocked(sessionID, session, fmt.Errorf("start local audio player %q: %w", player.name, err))
+	}
+	session.done = make(chan error, 1)
+	session.final = true
+	go func(path string, id uint64, done chan<- error) {
+		err := cmd.Wait()
+		cancel()
+		_ = os.Remove(path)
+		b.mu.Lock()
+		delete(b.sessions, id)
+		b.mu.Unlock()
+		done <- err
+	}(session.path, sessionID, session.done)
+	return nil
+}
+
+func (b *localAudioPlaybackBackend) failLocalPlaybackSessionLocked(sessionID uint64, session *localAudioPlaybackSession, err error) error {
+	session.failedErr = err
+	b.cleanupLocalPlaybackSessionLocked(sessionID, session)
+	return err
+}
+
+func (b *localAudioPlaybackBackend) cleanupLocalPlaybackSessionLocked(sessionID uint64, session *localAudioPlaybackSession) {
+	if session.cancel != nil {
+		session.cancel()
+		session.cancel = nil
+	}
+	if session.file != nil {
+		_ = session.file.Close()
+		session.file = nil
 	}
 	if session.path != "" {
 		_ = os.Remove(session.path)
+		session.path = ""
 	}
-	return nil
+	b.mu.Lock()
+	delete(b.sessions, sessionID)
+	b.mu.Unlock()
 }
 
 func (b *localAudioPlaybackBackend) localPlayer() (*localAudioPlayer, error) {

--- a/src/agent/internal/agent/local_audio_playback_test.go
+++ b/src/agent/internal/agent/local_audio_playback_test.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"aiden-agent/internal/agent/tts"
+)
+
+func TestLocalAudioPlaybackBackendWritesWAVAndCleansUp(t *testing.T) {
+	oldLookPath := localAudioLookPath
+	oldCommandContext := localAudioCommandContext
+	defer func() {
+		localAudioLookPath = oldLookPath
+		localAudioCommandContext = oldCommandContext
+	}()
+
+	localAudioLookPath = func(name string) (string, error) {
+		return name, nil
+	}
+	var playedPath string
+	localAudioCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if len(args) == 0 {
+			t.Fatalf("local player %q received no wav path", name)
+		}
+		playedPath = args[len(args)-1]
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestLocalAudioPlaybackHelper")
+		cmd.Env = append(os.Environ(), "AIDEN_LOCAL_AUDIO_HELPER=1")
+		return cmd
+	}
+
+	backend := newLocalAudioPlaybackBackend(nil)
+	format := tts.AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16}
+	sessionID, err := backend.StartPlayback(format)
+	if err != nil {
+		t.Fatalf("StartPlayback() error = %v", err)
+	}
+	pcm := []byte{1, 2, 3, 4}
+	if err := backend.WritePlayChunk(sessionID, pcm, false); err != nil {
+		t.Fatalf("WritePlayChunk(pcm) error = %v", err)
+	}
+	if err := backend.WritePlayChunk(sessionID, nil, true); err != nil {
+		t.Fatalf("WritePlayChunk(final) error = %v", err)
+	}
+	if playedPath == "" {
+		t.Fatal("local player was not invoked")
+	}
+	wav, err := os.ReadFile(playedPath)
+	if err != nil {
+		t.Fatalf("read generated wav: %v", err)
+	}
+	if string(wav[0:4]) != "RIFF" || string(wav[8:12]) != "WAVE" || string(wav[36:40]) != "data" {
+		t.Fatalf("invalid wav header: %q %q %q", wav[0:4], wav[8:12], wav[36:40])
+	}
+	if got := binary.LittleEndian.Uint32(wav[40:44]); got != uint32(len(pcm)) {
+		t.Fatalf("data size = %d, want %d", got, len(pcm))
+	}
+	if got := wav[44:]; string(got) != string(pcm) {
+		t.Fatalf("pcm payload = %#v, want %#v", got, pcm)
+	}
+
+	if err := backend.StopPlayback(sessionID); err != nil {
+		t.Fatalf("StopPlayback() error = %v", err)
+	}
+	if _, err := os.Stat(playedPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("generated wav still exists or stat failed differently: %v", err)
+	}
+}
+
+func TestLocalAudioPlaybackBackendReportsMissingPlayer(t *testing.T) {
+	oldLookPath := localAudioLookPath
+	defer func() { localAudioLookPath = oldLookPath }()
+	localAudioLookPath = func(name string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+
+	backend := newLocalAudioPlaybackBackend(nil)
+	_, err := backend.StartPlayback(tts.AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16})
+	if err == nil {
+		t.Fatal("StartPlayback() error = nil, want missing local player")
+	}
+}
+
+func TestLocalAudioPlaybackHelper(t *testing.T) {
+	if os.Getenv("AIDEN_LOCAL_AUDIO_HELPER") != "1" {
+		return
+	}
+	time.Sleep(5 * time.Second)
+	os.Exit(0)
+}

--- a/src/agent/internal/agent/local_audio_playback_test.go
+++ b/src/agent/internal/agent/local_audio_playback_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -83,6 +85,107 @@ func TestLocalAudioPlaybackBackendReportsMissingPlayer(t *testing.T) {
 	_, err := backend.StartPlayback(tts.AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16})
 	if err == nil {
 		t.Fatal("StartPlayback() error = nil, want missing local player")
+	}
+}
+
+func TestValidateLocalPlaybackFormatRejectsWAVHeaderOverflow(t *testing.T) {
+	cases := []struct {
+		name   string
+		format tts.AudioFormat
+		want   string
+	}{
+		{
+			name:   "channels",
+			format: tts.AudioFormat{SampleRate: 16000, Channels: 65536, BitWidth: 16},
+			want:   "channels",
+		},
+		{
+			name:   "bit width",
+			format: tts.AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 65536},
+			want:   "bit_width",
+		},
+		{
+			name:   "block align",
+			format: tts.AudioFormat{SampleRate: 16000, Channels: 65535, BitWidth: 16},
+			want:   "block_align",
+		},
+		{
+			name:   "byte rate",
+			format: tts.AudioFormat{SampleRate: 1000000, Channels: 1, BitWidth: 65528},
+			want:   "byte_rate",
+		},
+	}
+	if strconv.IntSize > 32 {
+		tooLargeSampleRate := wavMaxUint32 + 1
+		cases = append(cases, struct {
+			name   string
+			format tts.AudioFormat
+			want   string
+		}{
+			name:   "sample rate",
+			format: tts.AudioFormat{SampleRate: int(tooLargeSampleRate), Channels: 1, BitWidth: 16},
+			want:   "sample_rate",
+		})
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateLocalPlaybackFormat(tc.format)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validateLocalPlaybackFormat() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLocalAudioPlaybackBackendRejectsRIFFDataOverflow(t *testing.T) {
+	oldLookPath := localAudioLookPath
+	defer func() { localAudioLookPath = oldLookPath }()
+	localAudioLookPath = func(name string) (string, error) {
+		return name, nil
+	}
+
+	backend := newLocalAudioPlaybackBackend(nil)
+	sessionID, err := backend.StartPlayback(tts.AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16})
+	if err != nil {
+		t.Fatalf("StartPlayback() error = %v", err)
+	}
+	defer func() {
+		if err := backend.StopPlayback(sessionID); err != nil {
+			t.Fatalf("StopPlayback() error = %v", err)
+		}
+	}()
+
+	backend.mu.Lock()
+	backend.sessions[sessionID].dataBytes = wavMaxDataBytes
+	backend.mu.Unlock()
+	err = backend.WritePlayChunk(sessionID, []byte{1}, false)
+	if err == nil || !strings.Contains(err.Error(), "RIFF limit") {
+		t.Fatalf("WritePlayChunk(overflow) error = %v, want RIFF limit", err)
+	}
+
+	backend.mu.Lock()
+	backend.sessions[sessionID].dataBytes = wavMaxDataBytes + 1
+	backend.mu.Unlock()
+	err = backend.WritePlayChunk(sessionID, nil, true)
+	if err == nil || !strings.Contains(err.Error(), "RIFF limit") {
+		t.Fatalf("WritePlayChunk(final overflow) error = %v, want RIFF limit", err)
+	}
+}
+
+func TestWriteWAVHeaderRejectsOversizeData(t *testing.T) {
+	file, err := os.CreateTemp("", "aiden-tts-header-*.wav")
+	if err != nil {
+		t.Fatalf("CreateTemp() error = %v", err)
+	}
+	defer func() {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+	}()
+
+	err = writeWAVHeader(file, tts.AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16}, wavMaxDataBytes+1)
+	if err == nil || !strings.Contains(err.Error(), "RIFF limit") {
+		t.Fatalf("writeWAVHeader() error = %v, want RIFF limit", err)
 	}
 }
 

--- a/src/agent/internal/agent/local_audio_playback_test.go
+++ b/src/agent/internal/agent/local_audio_playback_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -156,20 +157,70 @@ func TestLocalAudioPlaybackBackendRejectsRIFFDataOverflow(t *testing.T) {
 		}
 	}()
 
-	backend.mu.Lock()
-	backend.sessions[sessionID].dataBytes = wavMaxDataBytes
-	backend.mu.Unlock()
+	session := localAudioPlaybackTestSession(t, backend, sessionID)
+	session.mu.Lock()
+	session.dataBytes = wavMaxDataBytes
+	session.mu.Unlock()
 	err = backend.WritePlayChunk(sessionID, []byte{1}, false)
 	if err == nil || !strings.Contains(err.Error(), "RIFF limit") {
 		t.Fatalf("WritePlayChunk(overflow) error = %v, want RIFF limit", err)
 	}
 
-	backend.mu.Lock()
-	backend.sessions[sessionID].dataBytes = wavMaxDataBytes + 1
-	backend.mu.Unlock()
+	session.mu.Lock()
+	session.dataBytes = wavMaxDataBytes + 1
+	session.mu.Unlock()
 	err = backend.WritePlayChunk(sessionID, nil, true)
 	if err == nil || !strings.Contains(err.Error(), "RIFF limit") {
 		t.Fatalf("WritePlayChunk(final overflow) error = %v, want RIFF limit", err)
+	}
+}
+
+func TestLocalAudioPlaybackBackendFinalizationFailureCleansUp(t *testing.T) {
+	oldLookPath := localAudioLookPath
+	oldCommandContext := localAudioCommandContext
+	defer func() {
+		localAudioLookPath = oldLookPath
+		localAudioCommandContext = oldCommandContext
+	}()
+	localAudioLookPath = func(name string) (string, error) {
+		return name, nil
+	}
+	missingPlayer := filepath.Join(t.TempDir(), "missing-player")
+	localAudioCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, missingPlayer)
+	}
+
+	backend := newLocalAudioPlaybackBackend(nil)
+	sessionID, err := backend.StartPlayback(tts.AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16})
+	if err != nil {
+		t.Fatalf("StartPlayback() error = %v", err)
+	}
+	session := localAudioPlaybackTestSession(t, backend, sessionID)
+	path := session.path
+
+	err = backend.WritePlayChunk(sessionID, []byte{1, 2}, true)
+	if err == nil || !strings.Contains(err.Error(), "start local audio player") {
+		t.Fatalf("WritePlayChunk(final start failure) error = %v, want start local audio player", err)
+	}
+	session.mu.Lock()
+	final := session.final
+	failedErr := session.failedErr
+	session.mu.Unlock()
+	if final {
+		t.Fatal("session.final = true after failed finalization, want false")
+	}
+	if failedErr == nil {
+		t.Fatal("session.failedErr = nil after failed finalization")
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary wav still exists or stat failed differently: %v", err)
+	}
+	if localAudioPlaybackSessionExists(backend, sessionID) {
+		t.Fatal("failed session still present in backend session map")
+	}
+	err = backend.WritePlayChunk(sessionID, nil, true)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("WritePlayChunk(second final) error = %v, want session not found", err)
 	}
 }
 
@@ -187,6 +238,23 @@ func TestWriteWAVHeaderRejectsOversizeData(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "RIFF limit") {
 		t.Fatalf("writeWAVHeader() error = %v, want RIFF limit", err)
 	}
+}
+
+func localAudioPlaybackTestSession(t *testing.T, backend *localAudioPlaybackBackend, sessionID uint64) *localAudioPlaybackSession {
+	t.Helper()
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	session := backend.sessions[sessionID]
+	if session == nil {
+		t.Fatalf("local playback session %d not found", sessionID)
+	}
+	return session
+}
+
+func localAudioPlaybackSessionExists(backend *localAudioPlaybackBackend, sessionID uint64) bool {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	return backend.sessions[sessionID] != nil
 }
 
 func TestLocalAudioPlaybackHelper(t *testing.T) {

--- a/src/agent/internal/agent/local_audio_playback_test.go
+++ b/src/agent/internal/agent/local_audio_playback_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -224,6 +225,119 @@ func TestLocalAudioPlaybackBackendFinalizationFailureCleansUp(t *testing.T) {
 	}
 }
 
+func TestLocalAudioPlaybackBackendWriteFailureCleansUp(t *testing.T) {
+	oldLookPath := localAudioLookPath
+	defer func() { localAudioLookPath = oldLookPath }()
+	localAudioLookPath = func(name string) (string, error) {
+		return name, nil
+	}
+
+	backend := newLocalAudioPlaybackBackend(nil)
+	sessionID, err := backend.StartPlayback(tts.AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16})
+	if err != nil {
+		t.Fatalf("StartPlayback() error = %v", err)
+	}
+	session := localAudioPlaybackTestSession(t, backend, sessionID)
+	path := session.path
+	session.mu.Lock()
+	if err := session.file.Close(); err != nil {
+		t.Fatalf("close test wav: %v", err)
+	}
+	session.mu.Unlock()
+
+	err = backend.WritePlayChunk(sessionID, []byte{1, 2}, false)
+	if err == nil || !strings.Contains(err.Error(), "write local playback pcm") {
+		t.Fatalf("WritePlayChunk(write failure) error = %v, want write local playback pcm", err)
+	}
+	session.mu.Lock()
+	failedErr := session.failedErr
+	dataBytes := session.dataBytes
+	session.mu.Unlock()
+	if failedErr == nil {
+		t.Fatal("session.failedErr = nil after write failure")
+	}
+	if dataBytes != 0 {
+		t.Fatalf("session.dataBytes = %d, want 0 for failed zero-byte write", dataBytes)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary wav still exists or stat failed differently: %v", err)
+	}
+	if localAudioPlaybackSessionExists(backend, sessionID) {
+		t.Fatal("failed session still present in backend session map")
+	}
+}
+
+func TestLocalAudioPlaybackBackendSerializesPlayerAdmission(t *testing.T) {
+	oldLookPath := localAudioLookPath
+	oldCommandContext := localAudioCommandContext
+	defer func() {
+		localAudioLookPath = oldLookPath
+		localAudioCommandContext = oldCommandContext
+	}()
+	localAudioLookPath = func(name string) (string, error) {
+		return name, nil
+	}
+
+	releaseFirst := filepath.Join(t.TempDir(), "release-first")
+	starts := make(chan int, 2)
+	var startCount int32
+	localAudioCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		idx := int(atomic.AddInt32(&startCount, 1))
+		starts <- idx
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestLocalAudioPlaybackHelper")
+		cmd.Env = append(os.Environ(), "AIDEN_LOCAL_AUDIO_HELPER=1")
+		if idx == 1 {
+			cmd.Env = append(cmd.Env, "AIDEN_LOCAL_AUDIO_WAIT_FILE="+releaseFirst)
+		} else {
+			cmd.Env = append(cmd.Env, "AIDEN_LOCAL_AUDIO_EXIT=1")
+		}
+		return cmd
+	}
+
+	backend := newLocalAudioPlaybackBackend(nil)
+	firstID, err := backend.StartPlayback(tts.AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16})
+	if err != nil {
+		t.Fatalf("first StartPlayback() error = %v", err)
+	}
+	defer func() { _ = backend.StopPlayback(firstID) }()
+	secondID, err := backend.StartPlayback(tts.AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16})
+	if err != nil {
+		t.Fatalf("second StartPlayback() error = %v", err)
+	}
+	defer func() { _ = backend.StopPlayback(secondID) }()
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- backend.WritePlayChunk(firstID, []byte{1}, true)
+	}()
+	if got := waitLocalAudioStart(t, starts); got != 1 {
+		t.Fatalf("first player start index = %d, want 1", got)
+	}
+	if err := waitLocalAudioDone(t, firstDone); err != nil {
+		t.Fatalf("first WritePlayChunk(final) error = %v", err)
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- backend.WritePlayChunk(secondID, []byte{2}, true)
+	}()
+	select {
+	case got := <-starts:
+		t.Fatalf("second player started before first admission released: start index %d", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if err := os.WriteFile(releaseFirst, []byte("done"), 0600); err != nil {
+		t.Fatalf("release first player: %v", err)
+	}
+	if got := waitLocalAudioStart(t, starts); got != 2 {
+		t.Fatalf("second player start index = %d, want 2", got)
+	}
+	if err := waitLocalAudioDone(t, secondDone); err != nil {
+		t.Fatalf("second WritePlayChunk(final) error = %v", err)
+	}
+}
+
 func TestWriteWAVHeaderRejectsOversizeData(t *testing.T) {
 	file, err := os.CreateTemp("", "aiden-tts-header-*.wav")
 	if err != nil {
@@ -257,9 +371,44 @@ func localAudioPlaybackSessionExists(backend *localAudioPlaybackBackend, session
 	return backend.sessions[sessionID] != nil
 }
 
+func waitLocalAudioStart(t *testing.T, starts <-chan int) int {
+	t.Helper()
+	select {
+	case got := <-starts:
+		return got
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for local audio player start")
+		return 0
+	}
+}
+
+func waitLocalAudioDone(t *testing.T, done <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for local playback finalization")
+		return nil
+	}
+}
+
 func TestLocalAudioPlaybackHelper(t *testing.T) {
 	if os.Getenv("AIDEN_LOCAL_AUDIO_HELPER") != "1" {
 		return
+	}
+	if os.Getenv("AIDEN_LOCAL_AUDIO_EXIT") == "1" {
+		return
+	}
+	if waitFile := os.Getenv("AIDEN_LOCAL_AUDIO_WAIT_FILE"); waitFile != "" {
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(waitFile); err == nil {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		os.Exit(2)
 	}
 	time.Sleep(5 * time.Second)
 	os.Exit(0)

--- a/src/agent/internal/agent/local_audio_playback_test.go
+++ b/src/agent/internal/agent/local_audio_playback_test.go
@@ -280,6 +280,7 @@ func TestLocalAudioPlaybackBackendSerializesPlayerAdmission(t *testing.T) {
 
 	releaseFirst := filepath.Join(t.TempDir(), "release-first")
 	starts := make(chan int, 2)
+	admissionBlocked := make(chan struct{}, 1)
 	var startCount int32
 	localAudioCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		idx := int(atomic.AddInt32(&startCount, 1))
@@ -295,6 +296,9 @@ func TestLocalAudioPlaybackBackendSerializesPlayerAdmission(t *testing.T) {
 	}
 
 	backend := newLocalAudioPlaybackBackend(nil)
+	backend.playerAdmissionBlockedFn = func() {
+		admissionBlocked <- struct{}{}
+	}
 	firstID, err := backend.StartPlayback(tts.AudioFormat{SampleRate: 16000, Channels: 1, BitWidth: 16})
 	if err != nil {
 		t.Fatalf("first StartPlayback() error = %v", err)
@@ -321,10 +325,11 @@ func TestLocalAudioPlaybackBackendSerializesPlayerAdmission(t *testing.T) {
 	go func() {
 		secondDone <- backend.WritePlayChunk(secondID, []byte{2}, true)
 	}()
+	waitLocalAudioAdmissionBlocked(t, admissionBlocked)
 	select {
 	case got := <-starts:
 		t.Fatalf("second player started before first admission released: start index %d", got)
-	case <-time.After(100 * time.Millisecond):
+	default:
 	}
 
 	if err := os.WriteFile(releaseFirst, []byte("done"), 0600); err != nil {
@@ -369,6 +374,15 @@ func localAudioPlaybackSessionExists(backend *localAudioPlaybackBackend, session
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
 	return backend.sessions[sessionID] != nil
+}
+
+func waitLocalAudioAdmissionBlocked(t *testing.T, blocked <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for local audio admission block")
+	}
 }
 
 func waitLocalAudioStart(t *testing.T, starts <-chan int) int {

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	ttsManager           *tts.ProviderManager
 	ttsMu                sync.RWMutex
 	audioClient          *AudioServiceClient
+	ttsPlaybackBackend   tts.AudioServiceBackend
 	screenCaptureMu      sync.Mutex
 	screenCaptureClient  *ScreenCaptureClient
 	recordMu             sync.Mutex
@@ -390,6 +391,7 @@ func NewServer(runtime *Runtime, addr string) *Server {
 	// Initialize speech clients if configured.
 	cfg := runtime.config
 	s.audioClient = NewAudioServiceClient(cfg.Audio.SocketOrDefault())
+	s.ttsPlaybackBackend = newTTSPlaybackBackendFromConfig(cfg, s.audioClient, s.logger)
 
 	sttClient, err := NewSTTClientFromConfig(cfg)
 	if err != nil {
@@ -416,7 +418,7 @@ func NewServer(runtime *Runtime, addr string) *Server {
 		if manager == nil {
 			return fmt.Errorf("tts is not configured")
 		}
-		_, err := speakWithTTSManager(ctx, manager, s.audioClient, s.runtime.config, text)
+		_, err := speakWithTTSManager(ctx, manager, s.currentTTSPlaybackBackend(), s.runtime.config, text)
 		return err
 	})
 
@@ -1182,9 +1184,9 @@ func (s *Server) handleChatAsync(
 		unregisterStreamOutput := func() {}
 		ttsManager := s.currentTTSManager()
 
-		if s.runtime.config.VoiceStreamingTTSEnabledOrDefault() && s.audioClient != nil {
+		if s.runtime.config.VoiceStreamingTTSEnabledOrDefault() && s.currentTTSPlaybackBackend() != nil {
 			if ttsManager != nil {
-				stream, err := beginManagedTTSStream(runCtx, ttsManager, s.audioClient, s.runtime.config)
+				stream, err := beginManagedTTSStream(runCtx, ttsManager, s.currentTTSPlaybackBackend(), s.runtime.config)
 				if err != nil {
 					if s.logger != nil {
 						s.logger.Warn("TTS BeginStream failed: %v", err)
@@ -1564,10 +1566,10 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 	streamWriters := []io.Writer{
 		newChatAssistantStreamWriter(stream, episodeID, req.RequestID),
 	}
-	if s.runtime.config.VoiceStreamingTTSEnabledOrDefault() && s.audioClient != nil {
+	if s.runtime.config.VoiceStreamingTTSEnabledOrDefault() && s.currentTTSPlaybackBackend() != nil {
 		s.logger.Info("Starting TTS stream")
 		if ttsManager != nil {
-			streamSession, err := beginManagedTTSStream(ctx, ttsManager, s.audioClient, s.runtime.config)
+			streamSession, err := beginManagedTTSStream(ctx, ttsManager, s.currentTTSPlaybackBackend(), s.runtime.config)
 			if err != nil {
 				if s.logger != nil {
 					s.logger.Warn("TTS BeginStream failed: %v", err)
@@ -1905,7 +1907,7 @@ func (w *streamFanoutWriter) StreamEmitted() bool {
 
 func (s *Server) speakToolContent(ctx context.Context, content string) {
 	content = strings.TrimSpace(content)
-	if content == "" || s.audioClient == nil {
+	if content == "" || s.currentTTSPlaybackBackend() == nil {
 		return
 	}
 	if ctx == nil {
@@ -1943,8 +1945,24 @@ func (s *Server) currentTTSManager() *tts.ProviderManager {
 	return s.ttsManager
 }
 
+func (s *Server) currentTTSPlaybackBackend() tts.AudioServiceBackend {
+	if s == nil {
+		return nil
+	}
+	if s.ttsPlaybackBackend != nil {
+		if backend, ok := s.ttsPlaybackBackend.(*audioBackend); ok && s.audioClient != nil && backend.c != s.audioClient {
+			return newAudioBackend(s.audioClient)
+		}
+		return s.ttsPlaybackBackend
+	}
+	if s.audioClient == nil {
+		return nil
+	}
+	return newAudioBackend(s.audioClient)
+}
+
 func (s *Server) canSpeakFinalText() bool {
-	if s == nil || s.audioClient == nil {
+	if s == nil || s.currentTTSPlaybackBackend() == nil {
 		return false
 	}
 	if s.currentTTSManager() != nil {
@@ -2024,7 +2042,7 @@ func (s *Server) speakTextObservedMode(ctx context.Context, requestID, text stri
 	speechStarted := false
 	ttsErr := errTTSNotConfigured
 	if manager != nil {
-		speechStarted, ttsErr = speakWithTTSManagerObserved(speakCtx, manager, s.audioClient, cfg, text, func(stream *streamSessionWriter) func() {
+		speechStarted, ttsErr = speakWithTTSManagerObserved(speakCtx, manager, s.currentTTSPlaybackBackend(), cfg, text, func(stream *streamSessionWriter) func() {
 			stream.setCancel(cancelOutput)
 			output.setStream(stream)
 			return func() {

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -1990,7 +1990,7 @@ func TestServerHandleChatCancelStopsRequestScopedStreamingTTSPlayback(t *testing
 	defer cancel()
 	server.registerActiveRun(requestID, cancel)
 
-	stream, err := beginManagedTTSStream(ctx, server.ttsManager, server.audioClient, Config{})
+	stream, err := beginManagedTTSStream(ctx, server.ttsManager, server.currentTTSPlaybackBackend(), Config{})
 	if err != nil {
 		t.Fatalf("beginManagedTTSStream() error = %v", err)
 	}

--- a/src/agent/internal/agent/tts_config_test_runner.go
+++ b/src/agent/internal/agent/tts_config_test_runner.go
@@ -47,7 +47,8 @@ func RunTTSPlaybackTest(ctx context.Context, cfg Config, req TTSPlaybackTestRequ
 	defer manager.Close()
 
 	audio := NewAudioServiceClient(cfg.Audio.SocketOrDefault())
-	spoke, err := speakWithTTSManager(ctx, manager, audio, cfg, text)
+	playback := newTTSPlaybackBackendFromConfig(cfg, audio, nil)
+	spoke, err := speakWithTTSManager(ctx, manager, playback, cfg, text)
 	result := TTSPlaybackTestResult{
 		Provider: manager.Current(),
 		Text:     text,

--- a/src/agent/internal/agent/tts_helpers.go
+++ b/src/agent/internal/agent/tts_helpers.go
@@ -114,6 +114,18 @@ func ttsPlaybackTargetFormat(cfg Config, source tts.AudioFormat) tts.AudioFormat
 	return target
 }
 
+func newTTSPlaybackBackendFromConfig(cfg Config, audio *AudioServiceClient, logger *Logger) tts.AudioServiceBackend {
+	switch cfg.AudioPlaybackBackendOrDefault() {
+	case AudioPlaybackBackendLocal:
+		return newLocalAudioPlaybackBackend(logger)
+	default:
+		if audio == nil {
+			return nil
+		}
+		return newAudioBackend(audio)
+	}
+}
+
 func containsInt(values []int, target int) bool {
 	for _, value := range values {
 		if value == target {
@@ -123,13 +135,16 @@ func containsInt(values []int, target int) bool {
 	return false
 }
 
-func beginManagedTTSStream(ctx context.Context, manager *tts.ProviderManager, audio *AudioServiceClient, cfg Config) (*streamSessionWriter, error) {
+func beginManagedTTSStream(ctx context.Context, manager *tts.ProviderManager, playback tts.AudioServiceBackend, cfg Config) (*streamSessionWriter, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if playback == nil {
+		return nil, errors.New("tts playback backend is not configured")
+	}
 	holder := manager.Holder()
 	sourceFormat := ttsPlaybackFormat(cfg, holder.Capabilities())
-	targetSink := tts.NewAudioServiceSink(newAudioBackend(audio), ttsPlaybackTargetFormat(cfg, sourceFormat))
+	targetSink := tts.NewAudioServiceSink(playback, ttsPlaybackTargetFormat(cfg, sourceFormat))
 	providerSink := tts.NewResamplingSink(sourceFormat, targetSink)
 	session, err := holder.BeginStream(ctx, providerSink)
 	if err != nil {
@@ -140,13 +155,13 @@ func beginManagedTTSStream(ctx context.Context, manager *tts.ProviderManager, au
 
 type ttsStreamObserver func(*streamSessionWriter) func()
 
-func speakWithTTSManager(ctx context.Context, manager *tts.ProviderManager, audio *AudioServiceClient, cfg Config, text string) (bool, error) {
-	return speakWithTTSManagerObserved(ctx, manager, audio, cfg, text, nil)
+func speakWithTTSManager(ctx context.Context, manager *tts.ProviderManager, playback tts.AudioServiceBackend, cfg Config, text string) (bool, error) {
+	return speakWithTTSManagerObserved(ctx, manager, playback, cfg, text, nil)
 }
 
-func speakWithTTSManagerObserved(ctx context.Context, manager *tts.ProviderManager, audio *AudioServiceClient, cfg Config, text string, observe ttsStreamObserver) (bool, error) {
+func speakWithTTSManagerObserved(ctx context.Context, manager *tts.ProviderManager, playback tts.AudioServiceBackend, cfg Config, text string, observe ttsStreamObserver) (bool, error) {
 	text = strings.TrimSpace(text)
-	if text == "" || manager == nil || audio == nil {
+	if text == "" || manager == nil || playback == nil {
 		return false, nil
 	}
 
@@ -163,7 +178,7 @@ func speakWithTTSManagerObserved(ctx context.Context, manager *tts.ProviderManag
 			}
 		}
 
-		stream, err := beginManagedTTSStream(ctx, manager, audio, cfg)
+		stream, err := beginManagedTTSStream(ctx, manager, playback, cfg)
 		if err != nil {
 			lastErr = err
 			if isTransientTTSError(err) && attempt < maxRetries {

--- a/src/agent_toml.cpp
+++ b/src/agent_toml.cpp
@@ -377,6 +377,7 @@ void apply_kv(AgentToml& cfg,
         else if (key == "sample_rate") assign_int(&cfg.audio.sample_rate, raw, &sub_err);
         else if (key == "channels") assign_int(&cfg.audio.channels, raw, &sub_err);
         else if (key == "bit_width") assign_int(&cfg.audio.bit_width, raw, &sub_err);
+        else if (key == "playback_backend") assign_string(&cfg.audio.playback_backend, raw, &sub_err);
         if (!sub_err.empty()) fail(sub_err);
     } else if (section == "audio_archive") {
         if (key == "enabled") assign_bool(&cfg.audio_archive.enabled, raw, &sub_err);
@@ -750,6 +751,7 @@ bool save_agent_toml(const char* path, const AgentToml& cfg, std::string* error)
     if (cfg.audio.sample_rate != 0) emit_int(out, "sample_rate", cfg.audio.sample_rate);
     if (cfg.audio.channels != 0) emit_int(out, "channels", cfg.audio.channels);
     if (cfg.audio.bit_width != 0) emit_int(out, "bit_width", cfg.audio.bit_width);
+    if (!cfg.audio.playback_backend.empty()) emit_string(out, "playback_backend", cfg.audio.playback_backend);
     out << "\n";
 
     out << "[audio_archive]\n";

--- a/src/agent_toml.h
+++ b/src/agent_toml.h
@@ -47,6 +47,7 @@ struct AudioToml {
     int sample_rate = 0;
     int channels = 0;
     int bit_width = 0;
+    std::string playback_backend;
 };
 
 struct AudioArchiveToml {

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -708,6 +708,7 @@ bool validate_known_config_field_types(cJSON* root, std::string* error) {
         {"audio", "sample_rate", CONFIG_FIELD_NUMBER},
         {"audio", "channels", CONFIG_FIELD_NUMBER},
         {"audio", "bit_width", CONFIG_FIELD_NUMBER},
+        {"audio", "playback_backend", CONFIG_FIELD_STRING},
         {"audio_archive", "enabled", CONFIG_FIELD_BOOL},
         {"audio_archive", "storage_path", CONFIG_FIELD_STRING},
         {"audio_archive", "max_files", CONFIG_FIELD_NUMBER},
@@ -2495,6 +2496,7 @@ cJSON* config_to_json(const aiden::AgentToml& config, bool include_secrets = fal
     cJSON_AddNumberToObject(audio, "sample_rate", config.audio.sample_rate);
     cJSON_AddNumberToObject(audio, "channels", config.audio.channels);
     cJSON_AddNumberToObject(audio, "bit_width", config.audio.bit_width);
+    cJSON_AddStringToObject(audio, "playback_backend", config.audio.playback_backend.c_str());
 
     cJSON* audio_archive = add_object(root, "audio_archive");
     cJSON_AddBoolToObject(audio_archive, "enabled", config.audio_archive.enabled ? 1 : 0);
@@ -2820,6 +2822,7 @@ void update_config_from_json(cJSON* root, aiden::AgentToml* config) {
         set_json_int(&config->audio.sample_rate, audio, "sample_rate");
         set_json_int(&config->audio.channels, audio, "channels");
         set_json_int(&config->audio.bit_width, audio, "bit_width");
+        set_json_str(&config->audio.playback_backend, audio, "playback_backend");
     }
 
     cJSON* audio_archive = cJSON_GetObjectItem(root, "audio_archive");

--- a/src/config_web_html.h
+++ b/src/config_web_html.h
@@ -247,6 +247,7 @@ static const char* CONFIG_WEB_HTML =
     "            <div class=\"field\"><label>sample_rate</label><input id=\"audio_sample_rate\" type=\"number\" data-section=\"audio\"></div>\n"
     "            <div class=\"field\"><label>channels</label><input id=\"audio_channels\" type=\"number\" data-section=\"audio\"></div>\n"
     "            <div class=\"field\"><label>bit_width</label><input id=\"audio_bit_width\" type=\"number\" data-section=\"audio\"></div>\n"
+    "            <div class=\"field\"><label>playback_backend</label><select id=\"audio_playback_backend\" data-section=\"audio\"></select></div>\n"
     "          </div>\n"
     "        </div>\n"
     "        <div class=\"section-card\" id=\"section-audio_archive\">\n"

--- a/tests/agent_toml_test.cpp
+++ b/tests/agent_toml_test.cpp
@@ -85,6 +85,7 @@ TEST_CASE("agent_toml round-trip preserves Go-agent schema fields") {
     cfg.audio.sample_rate = 16000;
     cfg.audio.channels = 1;
     cfg.audio.bit_width = 16;
+    cfg.audio.playback_backend = "local";
 
     cfg.audio_archive.enabled = false;
     cfg.audio_archive.max_files = 42;
@@ -203,6 +204,7 @@ TEST_CASE("agent_toml round-trip preserves Go-agent schema fields") {
     CHECK(loaded.audio.sample_rate == 16000);
     CHECK(loaded.audio.channels == 1);
     CHECK(loaded.audio.bit_width == 16);
+    CHECK(loaded.audio.playback_backend == "local");
 
     CHECK(loaded.audio_archive.enabled == false);
     CHECK(loaded.audio_archive.max_files == 42);

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -226,7 +226,7 @@ std::string resolved_config_json(const std::string& search_provider, bool search
         "\"stt\":{\"provider\":\"openai-whisper\",\"api_key\":\"\",\"model\":\"whisper-1\",\"base_url\":\"\","
         "\"app_id\":\"\",\"secret_id\":\"\",\"secret_key\":\"\",\"region\":\"\",\"engine_model_type\":\"\"},"
         "\"audio\":{\"socket\":\"/run/audio_service/audio_service.sock\",\"sample_rate\":16000,"
-        "\"channels\":1,\"bit_width\":16},"
+        "\"channels\":1,\"bit_width\":16,\"playback_backend\":\"audio_service\"},"
         "\"audio_archive\":{\"enabled\":true,\"max_files\":500,\"max_size_mb\":100,"
         "\"storage_path\":\"/userdata/audio\"},"
         "\"voice_notifications\":{\"enabled\":false,\"max_pending\":6,"
@@ -1640,7 +1640,8 @@ TEST_CASE("config_web: stt live test proxies start and stop to agent") {
         "\"socket\":\"/tmp/audio.sock\","
         "\"sample_rate\":16000,"
         "\"channels\":1,"
-        "\"bit_width\":16"
+        "\"bit_width\":16,"
+        "\"playback_backend\":\"audio_service\""
         "}}";
 
     HttpResponse start_resp = http_request(handle->port, "POST", "/api/config/test/stt/start", start_body);


### PR DESCRIPTION
## Summary
- add a configurable TTS playback backend for board vs PC Agent modes
- play synthesized TTS locally on desktop/ADB mode via temporary WAV and host player
- expose and validate audio.playback_backend in config, config web, docs, and tests

## Verification
- git diff --check
- env GOCACHE=/private/tmp/aiden-go-cache go test ./internal/agent ./cmd/daemon -count=1
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `audio.playback_backend` to control TTS playback (`auto`, `audio_service`, `local`), with mode-dependent `auto` behavior.
  * Enabled local TTS playback by rendering PCM to a temporary WAV and playing it through the host OS player.
  * Extended config web, config JSON, and TOML handling to fully support the new setting end-to-end.
* **Documentation**
  * Updated voice/audio/phone-bridge docs to describe how `playback_backend` affects TTS routing.
* **Tests**
  * Added/expanded coverage for UI metadata, defaults, JSON/TOML round-trip, validation, and local playback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->