### PR TITLE
fix: duplicate locale key

### DIFF
--- a/overlay/userdata/agent/agent.toml
+++ b/overlay/userdata/agent/agent.toml
@@ -1,12 +1,11 @@
 # Device UI and Agent response language: "zh-CN" or "en-US".
 # This is independent from [stt].language, which only controls speech recognition.
-locale = "zh-CN"
+locale = "zh-CN"  # "zh-CN" or "en-US"; also selects built-in voice notification text
 
 # Agent instruction and behavior
 # custom_instruction = ""
 # additional_prompt = ""
 # max_iterations = -1
-locale = "zh-CN"  # "zh-CN" or "en-US"; also selects built-in voice notification text
 
 # Screenshot context pruning:
 # keep the latest N screenshots and batch-prune older screenshots every interval


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and consolidated the locale setting documentation in the agent configuration.
  * Preserved the default locale as Simplified Chinese (zh-CN).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->