### PR TITLE
fix(tts): isolate per-provider params to prevent cross-provider pollution

### DIFF
--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -351,8 +351,8 @@ TTS:
 | `provider`     | Required. One of `minimax`, `minimax-cn`, `fish-audio`, `alicloud`, `volcengine`                                           |
 | `api_key`      | Required. The authentication key for each provider; the examples below omit this field to avoid writing keys into the docs |
 | `model`        | Optional. Minimax model name, Fish Audio model header, Alibaba Cloud Realtime model name, Volcengine `X-Api-Resource-Id`   |
-| `voice_id`     | Optional. Minimax voice id, Alibaba Cloud voice, Volcengine speaker; Fish Audio can use it as a reference id               |
-| `reference_id` | Optional. Fish Audio reference id; takes priority over `voice_id` when set                                                 |
+| `voice_id`     | Optional. Minimax voice id, Alibaba Cloud voice, Volcengine speaker. Not used by Fish Audio (see `reference_id`)           |
+| `reference_id` | Required for Fish Audio; the reference id. Ignored by other providers                                                      |
 | `emotion`      | Optional. Minimax emotion; Volcengine passes it through as `audio_params.emotion`, requires voice support                  |
 | `speed`        | Optional. Speech rate, default `1.0`; the supported range varies by provider, refer to the official docs                   |
 
@@ -360,13 +360,13 @@ The config examples below only show non-key fields relevant to adapter behavior;
 
 Common TTS adapter configs:
 
-| Provider     | `model` example            | Voice/reference field                               | Description                                                                                                 |
-| ------------ | -------------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `minimax`    | `speech-2.8-hd`            | `voice_id = "male-qn-qingse"`                       | Minimax WebSocket via `api.minimax.io`; `emotion` is passed through to Minimax                              |
-| `minimax-cn` | `speech-2.8-hd`            | `voice_id = "male-qn-qingse"`                       | Minimax WebSocket via `api.minimaxi.com`; `emotion` is passed through to Minimax                            |
-| `fish-audio` | `s2-pro`                   | `reference_id = "98655a12fa944e26b274c535e5e03842"` | WebSocket live TTS; `model` is sent via the handshake header, `reference_id` takes priority over `voice_id` |
-| `alicloud`   | `qwen3-tts-flash-realtime` | `voice_id = "Cherry"`                               | DashScope Realtime; the adapter outputs 24 kHz PCM, automatically resampling when the sample rate differs   |
-| `volcengine` | `seed-tts-2.0`             | `voice_id = "zh_female_vv_uranus_bigtts"`           | `model` maps to `X-Api-Resource-Id`, `voice_id` maps to the speaker, and the two must match                 |
+| Provider     | `model` example            | Voice/reference field                               | Description                                                                                                         |
+| ------------ | -------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `minimax`    | `speech-2.8-hd`            | `voice_id = "male-qn-qingse"`                       | Minimax WebSocket via `api.minimax.io`; `emotion` is passed through to Minimax                                      |
+| `minimax-cn` | `speech-2.8-hd`            | `voice_id = "male-qn-qingse"`                       | Minimax WebSocket via `api.minimaxi.com`; `emotion` is passed through to Minimax                                    |
+| `fish-audio` | `s2-pro`                   | `reference_id = "98655a12fa944e26b274c535e5e03842"` | WebSocket live TTS; `model` is sent via the handshake header, `reference_id` is required and `voice_id` is not used |
+| `alicloud`   | `qwen3-tts-flash-realtime` | `voice_id = "Cherry"`                               | DashScope Realtime; the adapter outputs 24 kHz PCM, automatically resampling when the sample rate differs           |
+| `volcengine` | `seed-tts-2.0`             | `voice_id = "zh_female_vv_uranus_bigtts"`           | `model` maps to `X-Api-Resource-Id`, `voice_id` maps to the speaker, and the two must match                         |
 
 ### Provider examples
 
@@ -391,7 +391,7 @@ reference_id = "98655a12fa944e26b274c535e5e03842"
 speed = 1.0
 ```
 
-Fish Audio `model` defaults to `s2-pro` and is sent as a WebSocket handshake header. `voice_id` is also accepted as the reference id. If both `reference_id` and `voice_id` are set, `reference_id` wins. In some networks, the public Fish Audio endpoint may require `ALL_PROXY` or `HTTPS_PROXY` in `/userdata/system/env`.
+Fish Audio `model` defaults to `s2-pro` and is sent as a WebSocket handshake header. `reference_id` is required and must be configured under `[tts]` or `[tts.credentials.fish-audio]`; `voice_id` is not used by Fish Audio and is ignored (this avoids inheriting a `voice_id` meant for another provider). In some networks, the public Fish Audio endpoint may require `ALL_PROXY` or `HTTPS_PROXY` in `/userdata/system/env`.
 
 Alibaba Cloud Qwen-TTS Realtime:
 

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -368,7 +368,7 @@ type TTSConfig struct {
 	//
 	//   [tts.credentials.fish-audio]
 	//   api_key = "<fish-key>"
-	//   voice_id = "<fish-reference-id>"
+	//   reference_id = "<fish-reference-id>"
 	//
 	//   [tts.credentials.cartesia]
 	//   api_key = "<cartesia-key>"

--- a/src/agent/internal/agent/tts/adapters/fishaudio/adapter.go
+++ b/src/agent/internal/agent/tts/adapters/fishaudio/adapter.go
@@ -57,9 +57,14 @@ func New(cfg tts.ProviderConfig) (tts.TTSProvider, error) {
 	if endpoint == "" {
 		endpoint = defaultEndpoint
 	}
-	referenceID := cfg.Voice
+	// Fish Audio uses reference_id exclusively. Do not read cfg.Voice to avoid
+	// parameter pollution from other providers (e.g., Minimax voice_id).
+	referenceID := ""
 	if extra, ok := cfg.Extra["reference_id"].(string); ok && extra != "" {
 		referenceID = extra
+	}
+	if referenceID == "" {
+		return nil, fmt.Errorf("fish-audio: reference_id is required (configure it in [tts] or [tts.credentials.fish-audio])")
 	}
 	model := defaultModel
 	if extra, ok := cfg.Extra["model"].(string); ok && extra != "" {

--- a/src/agent/internal/agent/tts/adapters/fishaudio/adapter_test.go
+++ b/src/agent/internal/agent/tts/adapters/fishaudio/adapter_test.go
@@ -44,7 +44,11 @@ func TestFishAudioOmitsEmptyReferenceIDForDefaultVoice(t *testing.T) {
 	}))
 	defer server.Close()
 
-	provider, err := New(tts.ProviderConfig{APIKey: "test-key", Endpoint: "ws" + strings.TrimPrefix(server.URL, "http")})
+	provider, err := New(tts.ProviderConfig{
+		APIKey:   "test-key",
+		Endpoint: "ws" + strings.TrimPrefix(server.URL, "http"),
+		Extra:    map[string]any{"reference_id": "test-ref-id"},
+	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -61,8 +65,8 @@ func TestFishAudioOmitsEmptyReferenceIDForDefaultVoice(t *testing.T) {
 	if !ok {
 		t.Fatalf("request = %#v, want map", msg["request"])
 	}
-	if _, ok := request["reference_id"]; ok {
-		t.Fatalf("reference_id was sent for default voice: %#v", request)
+	if refID, ok := request["reference_id"].(string); !ok || refID != "test-ref-id" {
+		t.Fatalf("reference_id = %#v, want test-ref-id", request["reference_id"])
 	}
 	if request["text"] != "" {
 		t.Fatalf("text = %#v, want empty string", request["text"])
@@ -96,7 +100,11 @@ func TestFishAudioCloseReturnsWhenServerNeverFinishes(t *testing.T) {
 	defer server.Close()
 	defer server.CloseClientConnections()
 
-	provider, err := New(tts.ProviderConfig{APIKey: "test-key", Endpoint: "ws" + strings.TrimPrefix(server.URL, "http")})
+	provider, err := New(tts.ProviderConfig{
+		APIKey:   "test-key",
+		Endpoint: "ws" + strings.TrimPrefix(server.URL, "http"),
+		Extra:    map[string]any{"reference_id": "test-ref-id"},
+	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -148,7 +156,11 @@ func TestFishAudioCloseDoesNotUseConnectTimeoutForPlaybackDrain(t *testing.T) {
 	}))
 	defer server.Close()
 
-	provider, err := New(tts.ProviderConfig{APIKey: "test-key", Endpoint: "ws" + strings.TrimPrefix(server.URL, "http")})
+	provider, err := New(tts.ProviderConfig{
+		APIKey:   "test-key",
+		Endpoint: "ws" + strings.TrimPrefix(server.URL, "http"),
+		Extra:    map[string]any{"reference_id": "test-ref-id"},
+	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -170,6 +182,68 @@ func TestFishAudioCloseDoesNotUseConnectTimeoutForPlaybackDrain(t *testing.T) {
 func TestFishAudioSynthesisTimeoutExceedsConnectTimeout(t *testing.T) {
 	if synthesisTimeout <= connectTimeout {
 		t.Fatalf("synthesisTimeout = %s, want greater than connectTimeout %s", synthesisTimeout, connectTimeout)
+	}
+}
+
+// TestFishAudioRequiresReferenceID verifies that Fish Audio adapter
+// requires reference_id and does not fall back to Voice (voice_id).
+// This prevents parameter pollution from other providers.
+func TestFishAudioRequiresReferenceID(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       tts.ProviderConfig
+		wantError string
+	}{
+		{
+			name: "missing reference_id",
+			cfg: tts.ProviderConfig{
+				APIKey: "test-key",
+			},
+			wantError: "reference_id is required",
+		},
+		{
+			name: "voice_id without reference_id should fail",
+			cfg: tts.ProviderConfig{
+				APIKey: "test-key",
+				Voice:  "some-voice-id", // This should NOT be used
+			},
+			wantError: "reference_id is required",
+		},
+		{
+			name: "reference_id in Extra should work",
+			cfg: tts.ProviderConfig{
+				APIKey: "test-key",
+				Extra:  map[string]any{"reference_id": "valid-ref-id"},
+			},
+			wantError: "",
+		},
+		{
+			name: "reference_id takes precedence over Voice",
+			cfg: tts.ProviderConfig{
+				APIKey: "test-key",
+				Voice:  "ignored-voice-id",
+				Extra:  map[string]any{"reference_id": "valid-ref-id"},
+			},
+			wantError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.cfg)
+			if tt.wantError != "" {
+				if err == nil {
+					t.Fatalf("New() expected error containing %q, got nil", tt.wantError)
+				}
+				if !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("New() error = %v, want error containing %q", err, tt.wantError)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("New() unexpected error = %v", err)
+				}
+			}
+		})
 	}
 }
 

--- a/src/agent/internal/agent/tts_helpers.go
+++ b/src/agent/internal/agent/tts_helpers.go
@@ -75,6 +75,40 @@ func buildTTSProviderConfigFor(cfg Config, provider string) tts.ProviderConfig {
 		extra["reference_id"] = referenceID
 	}
 
+	// Provider-specific parameter cleanup to avoid cross-provider pollution.
+	// Each provider should only receive parameters it actually uses.
+	switch provider {
+	case "fish-audio":
+		// Fish Audio uses reference_id exclusively; clear voice to prevent
+		// inheriting voice_id from other providers (e.g., Minimax, OpenRouter).
+		voice = ""
+		// Fish Audio doesn't use emotion
+		delete(extra, "emotion")
+
+	case "minimax", "minimax-cn":
+		// Minimax uses voice_id and emotion; clear Fish Audio's reference_id
+		delete(extra, "reference_id")
+
+	case "volcengine":
+		// Volcengine uses voice_id (as speaker) and emotion; clear Fish Audio's reference_id
+		delete(extra, "reference_id")
+
+	case "openrouter":
+		// OpenRouter uses voice_id; clear Fish Audio's reference_id and provider-specific emotion
+		delete(extra, "reference_id")
+		delete(extra, "emotion")
+
+	case "alicloud":
+		// Alicloud uses voice_id; clear Fish Audio's reference_id and Minimax's emotion
+		delete(extra, "reference_id")
+		delete(extra, "emotion")
+
+	case "google-cloud":
+		// Google Cloud uses voice_id; clear Fish Audio's reference_id and Minimax's emotion
+		delete(extra, "reference_id")
+		delete(extra, "emotion")
+	}
+
 	proxy := ProxyConfigFromEnvironment()
 	return tts.ProviderConfig{
 		Provider:   provider,


### PR DESCRIPTION
## Background

When configuring Fish Audio as the TTS provider, the interface returns an error if `voice_id` is configured. The root cause is parameter pollution during multi-provider switching:

- All providers share a unified `ProviderConfig`, and top-level `[tts]` fields (`voice_id`, `emotion`, etc.) are inherited by every provider.
- Fish Audio reads `cfg.Voice` as `reference_id`, causing a `voice_id` meant for Minimax/OpenRouter to leak in and break the API call unless `voice_id` is manually cleared.

## Changes

Isolate parameters by ensuring each provider only receives parameters it actually uses:

- **fish-audio**: Read `reference_id` exclusively (ignore `voice_id`); return a clear error when missing.
- **buildTTSProviderConfigFor**: Clear unused fields per provider via a switch statement:
  - fish-audio clears `voice_id` / `emotion`
  - minimax / volcengine / openrouter / alicloud / google-cloud clear `reference_id` (and `emotion` for providers that don't support it)
- Update tests and configuration docs to reflect that Fish Audio requires `reference_id` and no longer accepts `voice_id` as an alias.

## Testing

- `go build ./...` passes
- `go test ./internal/agent/tts/... ./internal/agent/` (TTS/FishAudio/Minimax/Volcengine related) all pass
- New test `TestFishAudioRequiresReferenceID` covers parameter validation

## Breaking Change

⚠️ Fish Audio configurations that only set `voice_id` must switch to `reference_id`:

```toml
[tts]
provider = "fish-audio"
reference_id = "98655a12fa944e26b274c535e5e03842"  # Required
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)