### PR TITLE
fix(ci): stop stale Buildroot stamp from suppressing cross-config clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,45 @@ jobs:
       - name: Verify self-hosted runner safety
         run: bash scripts/test_github_actions_self_hosted_safety.sh
 
+  # The reproducible rootfs policy asserts invariants about pico-sdk's
+  # sysdrv/Makefile. It also runs in build.yml, but that only fires on
+  # schedule/dispatch, so a regression there was invisible until an 80-minute
+  # build failed. Run it on pull requests too, against a sparse checkout of the
+  # pinned submodule commit rather than the ~1GB pico-sdk working tree.
+  buildroot-state-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Fetch pinned pico-sdk policy inputs
+        id: sdk
+        run: |
+          set -euo pipefail
+          sha="$(git ls-tree HEAD pico-sdk | awk '{print $3}')"
+          if [ -z "$sha" ]; then
+            echo "could not resolve the pinned pico-sdk submodule commit" >&2
+            exit 1
+          fi
+          echo "Pinned pico-sdk commit: $sha"
+          url="$(git config -f .gitmodules submodule.pico-sdk.url)"
+          dir="$RUNNER_TEMP/pico-sdk-policy"
+          git init -q "$dir"
+          git -C "$dir" remote add origin "$url"
+          # Restrict to the files the policy test reads. A blobless shallow
+          # sparse fetch of the pinned commit takes seconds and tens of MB.
+          git -C "$dir" sparse-checkout set --no-cone \
+            /sysdrv/Makefile \
+            /sysdrv/tools/board/buildroot/luckfox_pico_defconfig \
+            /sysdrv/tools/board/buildroot/luckfox_pico_w_defconfig
+          git -C "$dir" fetch -q --depth=1 --filter=blob:none origin "$sha"
+          git -C "$dir" checkout -q FETCH_HEAD
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+      - name: Verify reproducible rootfs policy
+        env:
+          PICO_SDK_DIR: ${{ steps.sdk.outputs.dir }}
+        run: bash scripts/test_reproducible_rootfs_policy.sh
+
   run-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,14 @@ jobs:
       # test_release_ci_scripts.sh checks ci.yml's job structure through a YAML
       # parser rather than by grepping, so PyYAML has to be present. It ships on
       # ubuntu-latest today; install it explicitly so a runner image change
-      # cannot turn the structural checks into a skip.
+      # cannot turn the structural checks into a skip. Pinned, and allowed to
+      # install into a PEP 668 managed interpreter -- a future runner image
+      # marking the system Python managed would otherwise fail this step.
       - name: Install workflow parsing dependency
-        run: python3 -m pip install --quiet --disable-pip-version-check pyyaml
+        run: |
+          python3 -m pip install --quiet --disable-pip-version-check \
+            --break-system-packages pyyaml==6.0.2 \
+            || python3 -m pip install --quiet --disable-pip-version-check pyyaml==6.0.2
       - name: Verify release scripts
         run: |
           sh scripts/test_release_ci_scripts.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,13 @@ jobs:
             /sysdrv/tools/board/buildroot/luckfox_pico_w_defconfig
           git -C "$dir" fetch -q --depth=1 --filter=blob:none origin "$sha"
           git -C "$dir" checkout -q FETCH_HEAD
+          # Assert what was actually checked out, so a wrong or partial fetch
+          # cannot leave the policy check verifying an unrelated revision.
+          got="$(git -C "$dir" rev-parse HEAD)"
+          if [ "$got" != "$sha" ]; then
+            echo "fetched pico-sdk $got but the submodule pins $sha" >&2
+            exit 1
+          fi
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
       - name: Verify reproducible rootfs policy
         env:
@@ -62,6 +69,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      # test_release_ci_scripts.sh checks ci.yml's job structure through a YAML
+      # parser rather than by grepping, so PyYAML has to be present. It ships on
+      # ubuntu-latest today; install it explicitly so a runner image change
+      # cannot turn the structural checks into a skip.
+      - name: Install workflow parsing dependency
+        run: python3 -m pip install --quiet --disable-pip-version-check pyyaml
       - name: Verify release scripts
         run: |
           sh scripts/test_release_ci_scripts.sh

--- a/scripts/check_ci_policy_job.py
+++ b/scripts/check_ci_policy_job.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Check how ci.yml runs the reproducible rootfs policy check.
+
+The policy check reads files from pico-sdk, but ci.yml deliberately does not
+check out that submodule: the worktree is several GB, and a18cae5e moved the
+check out of the release-script job for exactly that reason.
+
+Running it on pull requests is still worth doing -- it previously ran only in
+build.yml, which fires on schedule and workflow_dispatch, so a regression stayed
+invisible until an 80-minute build failed. The compromise is a dedicated job
+that sparse-fetches only the handful of files the check reads.
+
+These invariants are structural, so they are checked against the parsed
+workflow rather than by grepping the file. A grep sees a mention of
+"filter=blob:none" inside a comment as satisfying the requirement, and cannot
+tell which job a line belongs to.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+POLICY_SCRIPT = "scripts/test_reproducible_rootfs_policy.sh"
+
+# The release-script job has no SDK checkout of any kind, so the policy check
+# must never be folded back into it.
+RELEASE_SCRIPT_MARKER = "scripts/test_release_ci_scripts.sh"
+
+# Markers of a full checkout. Any of these in a policy job means the job is
+# paying the multi-GB cost the sparse fetch exists to avoid.
+FULL_CHECKOUT_MARKERS = (
+    "git submodule update",
+    "git clone",
+    "submodules: true",
+    "submodules: recursive",
+)
+
+REQUIRED_SPARSE_MARKERS = ("filter=blob:none", "sparse-checkout")
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def strip_comments(text: str) -> str:
+    """Drop whole-line comments so a mention in prose cannot satisfy a check.
+
+    Trailing comments are left alone: stripping them correctly needs quote
+    tracking, and a marker before a trailing '#' is real shell either way.
+    """
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def job_shell_text(job: dict) -> str:
+    """Concatenate everything in a job that can execute a command."""
+    parts: list[str] = []
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        return ""
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        run = step.get("run")
+        if isinstance(run, str):
+            parts.append(run)
+        uses = step.get("uses")
+        if isinstance(uses, str):
+            parts.append(uses)
+        # actions/checkout inputs decide whether submodules come along. YAML
+        # parses `true` as a bool, so normalise to the spelling used in the
+        # workflow rather than Python's `True`.
+        with_block = step.get("with")
+        if isinstance(with_block, dict):
+            for key, value in with_block.items():
+                if isinstance(value, bool):
+                    value = "true" if value else "false"
+                parts.append(f"{key}: {value}")
+    return "\n".join(parts)
+
+
+def main() -> None:
+    try:
+        import yaml
+    except ImportError:
+        fail(
+            "PyYAML is required to verify the CI policy job structure; "
+            "install python3-yaml"
+        )
+
+    root = Path(__file__).resolve().parent.parent
+    workflow_path = root / ".github/workflows/ci.yml"
+    if not workflow_path.is_file():
+        fail(f"missing CI workflow: {workflow_path}")
+
+    workflow = yaml.safe_load(workflow_path.read_text())
+    jobs = workflow.get("jobs") if isinstance(workflow, dict) else None
+    if not isinstance(jobs, dict) or not jobs:
+        fail("ci.yml declares no jobs")
+
+    policy_jobs = {}
+    release_jobs = set()
+    for name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        text = strip_comments(job_shell_text(job))
+        if POLICY_SCRIPT in text:
+            policy_jobs[name] = text
+        if RELEASE_SCRIPT_MARKER in text:
+            release_jobs.add(name)
+
+    if not policy_jobs:
+        # Not an error: the check still runs in build.yml. Say so, because a
+        # silent absence is how it stopped running on pull requests before.
+        print(
+            "note: ci.yml does not run the reproducible rootfs policy check; "
+            "it runs only in the scheduled build"
+        )
+        return
+
+    for name in sorted(policy_jobs):
+        text = policy_jobs[name]
+
+        if name in release_jobs:
+            fail(
+                f"job '{name}' runs both the release-script checks and the "
+                "submodule-dependent reproducible rootfs policy check; the "
+                "policy check needs a pico-sdk checkout and must stay in its "
+                "own job"
+            )
+
+        missing = [m for m in REQUIRED_SPARSE_MARKERS if m not in text]
+        if missing:
+            fail(
+                f"job '{name}' runs the reproducible rootfs policy check "
+                f"without a blobless sparse checkout (missing: "
+                f"{', '.join(missing)}); fetch only the files the check reads "
+                "instead of the multi-GB pico-sdk worktree"
+            )
+
+        for marker in FULL_CHECKOUT_MARKERS:
+            if marker in text:
+                fail(
+                    f"job '{name}' runs the reproducible rootfs policy check "
+                    f"but also performs a full checkout ('{marker}'); that "
+                    "defeats the sparse fetch and pulls the multi-GB pico-sdk "
+                    "worktree"
+                )
+
+    print(
+        "CI reproducible rootfs policy job structure verified "
+        f"({', '.join(sorted(policy_jobs))})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_ci_policy_job.py
+++ b/scripts/check_ci_policy_job.py
@@ -44,6 +44,26 @@ def fail(message: str) -> None:
     raise SystemExit(1)
 
 
+def workflow_triggers(workflow: dict) -> object:
+    """Return ci.yml's trigger block.
+
+    YAML 1.1 parses the bare key `on` as the boolean True, so a plain
+    workflow["on"] lookup silently misses it.
+    """
+    for key in ("on", True):
+        if key in workflow:
+            return workflow[key]
+    return None
+
+
+def triggers_on_pull_request(triggers: object) -> bool:
+    if isinstance(triggers, dict):
+        return "pull_request" in triggers
+    if isinstance(triggers, list):
+        return "pull_request" in triggers
+    return triggers == "pull_request"
+
+
 def strip_comments(text: str) -> str:
     """Drop whole-line comments so a mention in prose cannot satisfy a check.
 
@@ -101,6 +121,14 @@ def main() -> None:
     if not isinstance(jobs, dict) or not jobs:
         fail("ci.yml declares no jobs")
 
+    # The policy check has to reach pull requests. Asserting the trigger keeps
+    # the per-job checks below meaningful: a job that never fires proves nothing.
+    if not triggers_on_pull_request(workflow_triggers(workflow)):
+        fail(
+            "ci.yml must run on pull_request so the reproducible rootfs policy "
+            "check reaches pull requests"
+        )
+
     policy_jobs = {}
     release_jobs = set()
     for name, job in jobs.items():
@@ -112,14 +140,17 @@ def main() -> None:
         if RELEASE_SCRIPT_MARKER in text:
             release_jobs.add(name)
 
+    # An absent job is the regression this checker exists to catch, not a
+    # tolerable state. Running only in build.yml is what kept the stamp
+    # regression invisible until an 80-minute scheduled build failed, so a
+    # missing policy job has to fail rather than print a note and pass.
     if not policy_jobs:
-        # Not an error: the check still runs in build.yml. Say so, because a
-        # silent absence is how it stopped running on pull requests before.
-        print(
-            "note: ci.yml does not run the reproducible rootfs policy check; "
-            "it runs only in the scheduled build"
+        fail(
+            "ci.yml does not run the reproducible rootfs policy check; add a "
+            f"job that runs {POLICY_SCRIPT} against a blobless sparse checkout "
+            "of the pinned pico-sdk commit. Running it only in the scheduled "
+            "build hides regressions until an 80-minute build fails."
         )
-        return
 
     for name in sorted(policy_jobs):
         text = policy_jobs[name]

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -139,8 +139,22 @@ if grep -q 'scripts/test_build_scripts.sh' "$CI_WORKFLOW"; then
 fi
 
 if grep -q 'scripts/test_reproducible_rootfs_policy.sh' "$CI_WORKFLOW"; then
-    echo "CI release script checks must not run submodule-dependent reproducible rootfs policy checks" >&2
-    exit 1
+    # The policy check reads pico-sdk, so it must never share the release-script
+    # job, which has no SDK checkout. It may run in its own CI job provided that
+    # job sparse-fetches only the files the check reads: a blobless shallow fetch
+    # of the pinned commit costs seconds, while a full checkout is ~1GB. The
+    # submodule guard above still forbids the expensive path.
+    if ! grep -q 'filter=blob:none' "$CI_WORKFLOW" || \
+       ! grep -q 'sparse-checkout' "$CI_WORKFLOW"; then
+        echo "CI must fetch pico-sdk policy inputs with a blobless sparse checkout rather than a full submodule checkout" >&2
+        exit 1
+    fi
+
+    if sed -n '/^  run-tests:/,/^  [a-z]/p' "$CI_WORKFLOW" | \
+       grep -q 'scripts/test_reproducible_rootfs_policy.sh'; then
+        echo "CI release script checks must not run submodule-dependent reproducible rootfs policy checks" >&2
+        exit 1
+    fi
 fi
 
 if ! grep -q 'scripts/test_release_ci_scripts.sh' "$CI_WORKFLOW" || \

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -138,24 +138,12 @@ if grep -q 'scripts/test_build_scripts.sh' "$CI_WORKFLOW"; then
     exit 1
 fi
 
-if grep -q 'scripts/test_reproducible_rootfs_policy.sh' "$CI_WORKFLOW"; then
-    # The policy check reads pico-sdk, so it must never share the release-script
-    # job, which has no SDK checkout. It may run in its own CI job provided that
-    # job sparse-fetches only the files the check reads: a blobless shallow fetch
-    # of the pinned commit costs seconds, while a full checkout is ~1GB. The
-    # submodule guard above still forbids the expensive path.
-    if ! grep -q 'filter=blob:none' "$CI_WORKFLOW" || \
-       ! grep -q 'sparse-checkout' "$CI_WORKFLOW"; then
-        echo "CI must fetch pico-sdk policy inputs with a blobless sparse checkout rather than a full submodule checkout" >&2
-        exit 1
-    fi
-
-    if sed -n '/^  run-tests:/,/^  [a-z]/p' "$CI_WORKFLOW" | \
-       grep -q 'scripts/test_reproducible_rootfs_policy.sh'; then
-        echo "CI release script checks must not run submodule-dependent reproducible rootfs policy checks" >&2
-        exit 1
-    fi
-fi
+# The policy check reads pico-sdk, so it must not share the release-script job,
+# which has no SDK checkout, and any job running it must sparse-fetch rather
+# than check out the multi-GB worktree. Those are per-job structural facts, so
+# they are checked against the parsed workflow: grepping the whole file accepts
+# a marker that appears only in a comment, and cannot attribute a line to a job.
+python3 "$ROOT_DIR/scripts/check_ci_policy_job.py"
 
 if ! grep -q 'scripts/test_release_ci_scripts.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_clean_rootfs_overlay_staging.sh' "$CI_WORKFLOW" || \

--- a/scripts/test_release_ci_scripts.sh
+++ b/scripts/test_release_ci_scripts.sh
@@ -146,6 +146,7 @@ fi
 python3 "$ROOT_DIR/scripts/check_ci_policy_job.py"
 
 if ! grep -q 'scripts/test_release_ci_scripts.sh' "$CI_WORKFLOW" || \
+   ! grep -q 'scripts/test_reproducible_rootfs_policy.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_clean_rootfs_overlay_staging.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_github_release_upload.sh' "$CI_WORKFLOW" || \
    ! grep -q 'scripts/test_compress_release_images.sh' "$CI_WORKFLOW" || \

--- a/scripts/test_reproducible_rootfs_policy.sh
+++ b/scripts/test_reproducible_rootfs_policy.sh
@@ -4,7 +4,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_IMAGE_SH="$ROOT_DIR/build_image.sh"
 INNER_BUILD_IMAGE_SH="$ROOT_DIR/_build_image.sh"
-PICO_SDK="$ROOT_DIR/pico-sdk"
+# Only sysdrv/Makefile and the two Buildroot defconfigs are read below, so PR
+# CI can point this at a sparse checkout of the pinned submodule commit instead
+# of cloning the ~1GB pico-sdk working tree.
+PICO_SDK="${PICO_SDK_DIR:-$ROOT_DIR/pico-sdk}"
+
+if [ ! -f "$PICO_SDK/sysdrv/Makefile" ]; then
+  echo "missing pico-sdk sysdrv/Makefile under $PICO_SDK; set PICO_SDK_DIR or check out the pico-sdk submodule" >&2
+  exit 1
+fi
 
 for script in "$BUILD_IMAGE_SH" "$INNER_BUILD_IMAGE_SH"; do
   if ! grep -q 'AIDEN_REPRODUCIBLE_IMAGE_EPOCH' "$script"; then

--- a/scripts/test_reproducible_rootfs_policy.sh
+++ b/scripts/test_reproducible_rootfs_policy.sh
@@ -83,6 +83,24 @@ if ! printf '%s\n' "$refresh_buildroot_config_state" | grep -Fq '$(call buildroo
   exit 1
 fi
 
+# The stamp records which configuration produced the tree in output/, so it must
+# be written by the same define that decides whether to clean -- before packages
+# are built, not after a successful build. Writing it only on success leaves a
+# half-built tree labelled with the previous configuration's hash, so the next
+# build using that configuration sees a match, skips the clean and reuses
+# packages configured for a different one. A branch enabling opkg (which selects
+# BR2_PACKAGE_LIBARCHIVE) left mpv configured with --enable-libarchive in a tree
+# main reused, breaking every main build until the stamp was invalidated.
+if ! printf '%s\n' "$refresh_buildroot_config_state" | grep -Fq '> "$$stamp"'; then
+  echo "pico-sdk Buildroot state refresh must record the configuration that generated output/ in the same step that decides whether to clean, so an interrupted build cannot leave a stale stamp that suppresses the next clean" >&2
+  exit 1
+fi
+
+if grep -q 'write_buildroot_config_state_stamp' "$PICO_SDK/sysdrv/Makefile"; then
+  echo "pico-sdk sysdrv Makefile must not write the Buildroot state stamp in a separate post-build step; that is what let the stamp and the clean decision drift apart" >&2
+  exit 1
+fi
+
 buildroot_config_state_policy="$buildroot_config_state_value
 $refresh_buildroot_config_state"
 if ! printf '%s\n' "$buildroot_config_state_policy" | grep -q 'SOURCE_DATE_EPOCH'; then

--- a/scripts/test_reproducible_rootfs_policy.sh
+++ b/scripts/test_reproducible_rootfs_policy.sh
@@ -108,7 +108,10 @@ fi
 # the clean decision is made and nowhere else. Naming a new define, or inlining
 # the write straight into the buildroot recipe, reintroduces the same bug, so
 # check the recipe body rather than only the old define name.
-buildroot_target="$(sed -n '/^buildroot: prepare$/,/^buildroot_clean:/p' "$PICO_SDK/sysdrv/Makefile")"
+# Match the target on its name alone. Anchoring on the full "buildroot: prepare"
+# line made an unrelated edit -- adding a prerequisite -- collapse the range to
+# empty and fail this check for a reason that has nothing to do with the stamp.
+buildroot_target="$(sed -n '/^buildroot:[[:space:]]/,/^buildroot_clean:/p' "$PICO_SDK/sysdrv/Makefile")"
 if [ -z "$buildroot_target" ]; then
   echo "could not locate the buildroot target in pico-sdk sysdrv/Makefile" >&2
   exit 1
@@ -119,18 +122,44 @@ if printf '%s\n' "$buildroot_target" | grep -Fq '"$$stamp"'; then
   exit 1
 fi
 
-for stamp_writer in $(sed -n 's/^define \(.*stamp.*\)$/\1/p' "$PICO_SDK/sysdrv/Makefile"); do
-  case "$stamp_writer" in
-    refresh_buildroot_config_state|refresh_boardtools_config_state) continue ;;
-  esac
-  echo "pico-sdk sysdrv Makefile defines '$stamp_writer', a separate Buildroot state stamp step; writing the stamp anywhere other than beside the clean decision is what let the two drift apart" >&2
-  exit 1
-done
-
-if grep -q 'write_buildroot_config_state_stamp' "$PICO_SDK/sysdrv/Makefile"; then
-  echo "pico-sdk sysdrv Makefile must not write the Buildroot state stamp in a separate post-build step; that is what let the stamp and the clean decision drift apart" >&2
+# Find every write to the stamp path, wherever it lives and whatever it is
+# called. Scanning only defines whose name contains "stamp" missed a rename to
+# a name like persist_br_state, and matching only the '$$stamp' variable missed
+# a write that spells the path out in full. Both are the same bug, so key off
+# the stamp filename -- the one thing any such write has to mention -- and
+# require every mention to sit inside refresh_buildroot_config_state.
+stamp_basename='.aiden_buildroot_config_state'
+# One awk pass rather than grep|grep|cut: a grep that filters everything out
+# exits 1, and under `set -o pipefail` that aborts the script before the
+# explicit diagnostics below can run. Comment lines are skipped -- prose naming
+# the stamp is not a write.
+stamp_mentions="$(awk -v needle="$stamp_basename" '
+  { line = $0; sub(/^[[:space:]]+/, "", line) }
+  line ~ /^#/ { next }
+  index($0, needle) { print NR }
+' "$PICO_SDK/sysdrv/Makefile")"
+if [ -z "$stamp_mentions" ]; then
+  echo "pico-sdk sysdrv Makefile never mentions $stamp_basename; the Buildroot state stamp must exist to gate the cross-config clean" >&2
   exit 1
 fi
+
+refresh_start="$(awk '/^define refresh_buildroot_config_state$/ { print NR; exit }' "$PICO_SDK/sysdrv/Makefile")"
+if [ -z "$refresh_start" ]; then
+  echo "could not locate 'define refresh_buildroot_config_state' in pico-sdk sysdrv/Makefile" >&2
+  exit 1
+fi
+refresh_end="$(awk -v start="$refresh_start" 'NR > start && /^endef$/ { print NR; exit }' "$PICO_SDK/sysdrv/Makefile")"
+if [ -z "$refresh_end" ]; then
+  echo "'define refresh_buildroot_config_state' in pico-sdk sysdrv/Makefile is not terminated by endef" >&2
+  exit 1
+fi
+
+for line in $stamp_mentions; do
+  if [ "$line" -lt "$refresh_start" ] || [ "$line" -gt "$refresh_end" ]; then
+    echo "pico-sdk sysdrv Makefile touches $stamp_basename at line $line, outside refresh_buildroot_config_state (lines $refresh_start-$refresh_end); the stamp must be written only beside the clean decision it feeds, since splitting the two is what let them drift apart" >&2
+    exit 1
+  fi
+done
 
 buildroot_config_state_policy="$buildroot_config_state_value
 $refresh_buildroot_config_state"

--- a/scripts/test_reproducible_rootfs_policy.sh
+++ b/scripts/test_reproducible_rootfs_policy.sh
@@ -104,6 +104,29 @@ if ! printf '%s\n' "$refresh_buildroot_config_state" | grep -Fq '> "$$stamp"'; t
   exit 1
 fi
 
+# Assert the property, not one spelling of it: the stamp must be written where
+# the clean decision is made and nowhere else. Naming a new define, or inlining
+# the write straight into the buildroot recipe, reintroduces the same bug, so
+# check the recipe body rather than only the old define name.
+buildroot_target="$(sed -n '/^buildroot: prepare$/,/^buildroot_clean:/p' "$PICO_SDK/sysdrv/Makefile")"
+if [ -z "$buildroot_target" ]; then
+  echo "could not locate the buildroot target in pico-sdk sysdrv/Makefile" >&2
+  exit 1
+fi
+
+if printf '%s\n' "$buildroot_target" | grep -Fq '"$$stamp"'; then
+  echo "pico-sdk buildroot target must not write the Buildroot state stamp in its own recipe; the stamp belongs in refresh_buildroot_config_state, beside the clean decision it feeds" >&2
+  exit 1
+fi
+
+for stamp_writer in $(sed -n 's/^define \(.*stamp.*\)$/\1/p' "$PICO_SDK/sysdrv/Makefile"); do
+  case "$stamp_writer" in
+    refresh_buildroot_config_state|refresh_boardtools_config_state) continue ;;
+  esac
+  echo "pico-sdk sysdrv Makefile defines '$stamp_writer', a separate Buildroot state stamp step; writing the stamp anywhere other than beside the clean decision is what let the two drift apart" >&2
+  exit 1
+done
+
 if grep -q 'write_buildroot_config_state_stamp' "$PICO_SDK/sysdrv/Makefile"; then
   echo "pico-sdk sysdrv Makefile must not write the Buildroot state stamp in a separate post-build step; that is what let the stamp and the clean decision drift apart" >&2
   exit 1


### PR DESCRIPTION
## Summary

Every `main` build since 2026-07-30 10:02 failed compiling mpv 0.33.1 — **20 consecutive scheduled runs**, e.g. [30598921019](https://github.com/AidenAI-IO/aiden-firmware/actions/runs/30598921019):

    ../stream/stream_libarchive.h:12:5: error: unknown type name 'locale_t'
    ../stream/stream_libarchive.c:231:9: error: implicit declaration of function 'freelocale'

The failure was not in our code. The self-hosted runner was reusing an `output/` tree configured by a **different branch**.

Branch `Falcom/opkg` enabled `BR2_PACKAGE_LIBARCHIVE` (selected by `opkg`'s `Config.in`). Run [30523209899](https://github.com/AidenAI-IO/aiden-firmware/actions/runs/30523209899) (2026-07-30 08:59) cleaned, compiled libarchive 3.6.2 into staging, and configured mpv with `--enable-libarchive` (`HAVE_LIBARCHIVE=1` in `build/config.h`) — then failed, because the uClibc toolchain sets `#undef __UCLIBC_HAS_LOCALE__` and ships no `xlocale.h`.

The state stamp was only written *after* a successful build, so that failed run kept `main`'s hash. Later `main` builds recomputed that same hash, concluded the configuration had not changed, skipped the clean, and rebuilt only busybox and mpv on top of the poisoned mpv configuration. Confirmed on the runner: `output/build/opkg-0.7.0` and mpv's `.stamp_configured` dated Jul 30 08:06 were still present (later cleaned by this branch's own successful build).

## Change

Points `pico-sdk` at AidenAI-IO/aiden-sdk#25, which writes the stamp when the clean decision is made rather than after success — so it records which configuration produced the tree in `output/`, even when the build fails.

Because `buildroot_config_state_value` hashes `sysdrv/Makefile` itself, bumping the submodule also invalidates the stale stamp already sitting on every runner and dev machine, forcing the one clean that clears the leftover opkg/libarchive/mpv artifacts. No manual cleanup of shared CI machines required. Expect the first build after merge to be a full rebuild (~80 min).

## Guardrail

Commits 2-5 add and refine assertions in `scripts/test_reproducible_rootfs_policy.sh` and wire them into PR CI:

### What's asserted

- The stamp write must stay inside `refresh_buildroot_config_state` (beside the clean decision)
- No separate post-build stamp step may exist (under any name, as a define or inline)
- The `buildroot` target's recipe must not touch the stamp

Splitting the write from the decision is what let the two drift apart in the original regression. These assertions catch that split under any spelling: renamed defines, inlined recipes, literal paths, or a literal revert — see commit 5, which is what made that claim actually true.

Additionally (commit 5): `ci.yml` must run the policy check at all, and must still trigger on `pull_request`.

### Where it runs

That script previously ran only in `build.yml`, which fires on schedule and dispatch but **never on a pull request**. Regressions stayed invisible until an 80-minute build failed — exactly the feedback loop the assertions exist to replace.

Commit 2 adds a `buildroot-state-policy` job to `ci.yml` that runs on PRs. It sparse-fetches only the three SDK files the test reads (`sysdrv/Makefile` and the two Buildroot defconfigs) at the pinned submodule commit — blobless and shallow, ~20MB in about five seconds, rather than checking out the ~1GB pico-sdk tree. `PICO_SDK_DIR` points the test at that checkout.

Commit 3 narrowed a pre-existing guard (from a18cae5e, "keep rootfs policy check out of safety job") that had blanket-forbidden the policy script anywhere in `ci.yml`. The real constraint is "don't fetch the multi-GB submodule in fast CI"; the sparse approach satisfies that.

Commit 4 replaced the narrowed guard with `scripts/check_ci_policy_job.py`, which parses the workflow rather than grepping it. Review of commit 3 found the grep-based guard weaker than the blanket ban it replaced, in three ways:

1. **Comment bypass**: grepping the whole file for `filter=blob:none` and `sparse-checkout` accepted those markers inside a comment, so a `git clone --recursive` with a comment mentioning the old flags passed the guard.
2. **Job rename fragility**: `sed -n '/^  run-tests:/,/^  [a-z]/p'` to extract the release-script job depended on `run-tests` being the last job and on its exact name. Renaming it or appending any job after it put the policy check outside the scanned range.
3. **Assertion bypass via renaming**: the test forbade one define name (`write_buildroot_config_state_stamp`), so keeping the stamp write inside `refresh_buildroot_config_state` while also writing it from an inline post-build recipe line passed both assertions with the bug fully present.

The Python checker walks the parsed workflow: for every job running the policy check, it requires the sparse markers in that job's own steps, rejects the job if it also runs release-script checks, and rejects any full-checkout marker (`git submodule update`, `git clone`, `submodules: true/recursive`). Comments are stripped before matching.

Commit 4 also adds provenance verification: the workflow compares `git rev-parse HEAD` against the pinned SHA after checkout, so a wrong or partial fetch fails loudly rather than letting the policy check verify an unrelated revision.

### Commit 5: three gaps commit 4 left open

Reviewing commits 2-4 found each of these still exploitable, verified against a constructed case before and after:

1. **A missing job passed.** `check_ci_policy_job.py` returned 0 when *no* job ran the policy check, printing a note and passing. That absence is exactly the regression the checker exists to catch — running only in `build.yml` is what kept this bug invisible for 20 builds. It now fails. It also asserts `ci.yml` still triggers on `pull_request`, since a job that never fires proves nothing; YAML 1.1 parses the bare key `on` as boolean `True`, so the lookup has to try both spellings. `test_release_ci_scripts.sh` now lists the policy script among the checks `ci.yml` must run.

2. **Renaming the define still worked.** Commit 4 claimed to assert the property rather than a spelling, but the scan only looked at defines whose *name* contained `stamp` and at writes spelled `$$stamp`. A post-build define named `persist_br_state` writing the path in full passed cleanly, bug intact. The check now finds every non-comment mention of `.aiden_buildroot_config_state` and requires each to fall within `refresh_buildroot_config_state`'s line range — keyed on the one string any such write must contain.

3. **A harmless edit failed the build.** The recipe range anchored on the exact line `buildroot: prepare`, so adding a prerequisite collapsed the `sed` range to empty and failed with `could not locate the buildroot target` — a message pointing nowhere near the actual edit. It matches the target name alone now.

Two incidental fixes: line scans use `awk` instead of `grep | cut`, because a `grep` matching nothing exits 1 and under `set -o pipefail` aborts the script *before* the explicit diagnostics can print — silently converting a clear failure into a bare exit. And PyYAML is pinned to `6.0.2`, installed with `--break-system-packages` first, so a future PEP 668 runner image cannot break that step.

## Testing

- Each assertion confirmed to fail independently against the pre-fix SDK (`1c914823`) and to pass against the pinned commit.
- The CI job replayed locally end-to-end: fails on the stamp-provenance assertion at the pre-fix commit, passes at the pinned commit.
- Neighbouring `test_clean_rootfs_overlay_staging.sh` and `test_github_actions_self_hosted_safety.sh` still pass.

Every guardrail case was run against the code before and after commit 5:

| Case | Before c5 | After c5 |
|---|---|---|
| Policy job deleted from `ci.yml` | **exit 0** | caught |
| `pull_request` trigger removed | not checked | caught |
| Renamed define + literal stamp path | **missed** | caught |
| Literal revert to pre-fix SDK | caught | caught |
| Write inlined into `buildroot` recipe | caught | caught |
| Sparse markers in a comment + real full clone | caught | caught |
| Policy folded back into release-script job | caught | caught |
| Harmless extra prerequisite on `buildroot:` | **false positive** | passes |

CI on the pushed branch: `buildroot-state-policy` 9s, `github-actions-safety` 7s, `run-tests` 2m47s — all green ([run 30610777957](https://github.com/AidenAI-IO/aiden-firmware/actions/runs/30610777957)).
- Not exercised: the actual 80-minute rootfs build. The claim that the stale stamp suppressed the clean is inferred from the runner's on-disk state (leftover `opkg-0.7.0`, `libarchive.so.13.6.2`, mpv timestamps) and the run logs showing only busybox and mpv being rebuilt, not from a reproduced build.

## Context: why this reverses a prior decision

aiden-firmware `383cc77c` — "fix(ci): avoid persisting failed buildroot state (#349)" — encoded the opposite invariant in `scripts/test_build_scripts.sh`, asserting that `refresh_buildroot_config_state` must **not** contain the stamp write, that `write_buildroot_config_state_stamp` must exist, and that it must be the final command of the buildroot target.

There is no live contradiction: that script was deleted in `c6ec5f20` as dead code (never wired into CI, blocked by the release-script guard since inception). But the concern behind #349 was real, and worth stating plainly.

"Don't persist state from a failed build" is a sound instinct. The reason it loses here is that the stamp does not record success — it records *which configuration generated the tree in `output/`*. That fact is true the moment the clean decision is made, regardless of whether the build later succeeds, and it is the only thing the next build's comparison actually needs. Writing it after success makes the stamp answer a question nobody asks ("did this config once build cleanly?") while leaving the question that gets asked ("what config is this tree configured for?") answered wrongly.

The tradeoff #349 was protecting against does exist, and this PR accepts it knowingly: after a failed build, the stamp now matches, so retrying the *same* configuration resumes incrementally rather than cleaning first. That is safe because Buildroot's own per-package stamps track partial state, and it is faster. What is no longer possible is a *different* configuration silently inheriting the tree — which is the failure that broke 20 consecutive builds.

## Merge order

Unblocked. AidenAI-IO/aiden-sdk#25 was squash-merged as `b07c12ff`, so commit 6 re-pins the submodule from the now-unreachable branch commit (`30f3440d`) onto that SHA — otherwise the sparse fetch in `buildroot-state-policy` could not resolve it. The tree is byte-identical to the commit all the testing above was run against; only the SHA changed. Re-verified by replaying the CI fetch against `b07c12ff` (20MB, 11s, `rev-parse HEAD` matches the pin) and running the policy check against that checkout.

Note: `Falcom/opkg` will still hit the same `locale_t` wall on its own, since enabling opkg selects libarchive regardless. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CI validation for reproducible root filesystem policies and required workflow structure.
  * Added support for sparse SDK checkouts during policy verification.
  * Updated the pinned pico-sdk revision.

* **Bug Fixes**
  * Improved detection of invalid CI configurations, missing policy jobs, and incorrect checkout behavior.
  * Ensured required configuration state is written and validated during refresh and cleanup checks.

* **Tests**
  * Expanded release and reproducibility checks to validate CI workflow structure and policy enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->