### PR TITLE
fix(agent): restore bridge input and undo IME probe

### DIFF
--- a/src/agent/internal/agent/text_input_bridge.go
+++ b/src/agent/internal/agent/text_input_bridge.go
@@ -9,8 +9,6 @@ import (
 )
 
 const (
-	textViaBridgeConnectTimeout = 8 * time.Second
-	textViaBridgePollInterval   = 200 * time.Millisecond
 	textViaBridgePostWriteDelay = 2 * time.Second
 	textViaBridgePostPasteDelay = 350 * time.Millisecond
 	textViaBridgeMenuDelay      = 450 * time.Millisecond
@@ -54,9 +52,8 @@ type textInputBridge struct {
 	hw               *textInputHardwareDeps
 	vision           textInputVision
 	bridgeFn         func() *PhoneBridge
+	restorer         *PhoneBridgeRestorer
 	clipboardWriteFn func(context.Context, *PhoneBridge, string) error
-	findAppTapFn     func(context.Context, screenshotResult, string) (bridgeSearchResult, error)
-	confirmAppOpenFn func(context.Context, screenshotResult, string) (bridgeAppOpenResult, error)
 	findPrevAppFn    func(context.Context, screenshotResult) (previousAppCardResult, error)
 	findPasteMenuFn  func(context.Context, screenshotResult, string) (pasteMenuResult, error)
 	sleep            func(context.Context, time.Duration) error
@@ -195,7 +192,7 @@ func (t *textInputBridge) runLegacyBridgeFlow(ctx context.Context, platform stri
 		return textViaBridgeResult{Attempted: true, Err: fmt.Errorf("phone bridge is not configured")}
 	}
 	engine := newTextInputEngineWithSleep(*t.hw, t.vision, t.sleep)
-	if err := t.restoreBridgeAppIfNeeded(ctx, bridge, platform); err != nil {
+	if _, err := ensurePhoneBridgeReadyForCommand(ctx, bridge, t.restorer, "clipboard_write"); err != nil {
 		return textViaBridgeResult{Attempted: true, Err: err}
 	}
 	bridge = t.currentBridge()
@@ -414,38 +411,6 @@ func keyboardPasteKeys(platform string) []string {
 	}
 }
 
-func (t *textInputBridge) restoreBridgeAppIfNeeded(ctx context.Context, bridge *PhoneBridge, platform string) error {
-	if t == nil || t.hw == nil || t.hw.quickAction == nil || t.hw.keyboardText == nil || t.hw.touchGesture == nil {
-		return fmt.Errorf("bridge recovery tools are not fully configured")
-	}
-	searchTerm := textViaBridgeSearchTerm(platform, bridge.getStatus())
-	localEntry := &EnterTextTool{
-		engine:               newTextInputEngineWithSleep(*t.hw, t.vision, t.sleep),
-		iosKeyboardIsolation: iosKeyboardIsolationControllerFromContext(ctx),
-	}
-	openResult, err := runAppSearchOpenFlow(ctx, appSearchOpenFlowConfig{
-		hw:               t.hw,
-		vision:           t.vision,
-		platform:         platform,
-		searchTerm:       searchTerm,
-		findAppTapFn:     t.findAppTapFn,
-		confirmAppOpenFn: t.confirmAppOpenFn,
-		entryTool:        localEntry,
-		launchDelay:      appSearchOpenLaunchDelay,
-		sleep:            t.sleep,
-	})
-	if err != nil {
-		return err
-	}
-	if !openResult.Opened {
-		if reason := strings.TrimSpace(openResult.Reason); reason != "" {
-			return fmt.Errorf("bridge app did not open: %s", reason)
-		}
-		return fmt.Errorf("bridge app did not open")
-	}
-	return t.waitForBridgeConnection(ctx)
-}
-
 func (t *textInputBridge) tapTouchPoint(ctx context.Context, point focusPointArgs) error {
 	out, err := t.hw.touchGesture.Call(ctx, jsonString(map[string]any{
 		"type":        "tap",
@@ -530,26 +495,6 @@ Rules:
 	return result, nil
 }
 
-func (t *textInputBridge) waitForBridgeConnection(ctx context.Context) error {
-	deadline := time.NewTimer(textViaBridgeConnectTimeout)
-	defer deadline.Stop()
-	ticker := time.NewTicker(textViaBridgePollInterval)
-	defer ticker.Stop()
-	for {
-		bridge := t.currentBridge()
-		if bridge != nil && bridge.Connected() {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-deadline.C:
-			return fmt.Errorf("timed out waiting for phone bridge to connect")
-		case <-ticker.C:
-		}
-	}
-}
-
 func (t *textInputBridge) sleepAfterClipboardWrite(ctx context.Context) error {
 	sleep := sleepWithContext
 	if t != nil && t.sleep != nil {
@@ -608,15 +553,4 @@ func (t *textInputBridge) writeClipboard(ctx context.Context, bridge *PhoneBridg
 		return te
 	}
 	return interpretTextInputToolOutput(clipOut)
-}
-
-func textViaBridgeSearchTerm(platform string, status PhoneBridgeStatus) string {
-	if strings.EqualFold(strings.TrimSpace(platform), "android") && status.Environment != nil {
-		for _, app := range status.Environment.AvailableApps {
-			if strings.TrimSpace(app.AndroidPackage) == "com.qing.aidenbridgedaily" && strings.TrimSpace(app.Name) != "" {
-				return app.Name
-			}
-		}
-	}
-	return "Aiden"
 }

--- a/src/agent/internal/agent/text_input_bridge_test.go
+++ b/src/agent/internal/agent/text_input_bridge_test.go
@@ -401,17 +401,27 @@ type recordingBridgeQuickActionTool struct {
 	onCall func(string)
 }
 
-func TestTextInputBridgeRestoresReconnectsAndReturnsThroughRecents(t *testing.T) {
-	vision := &stubTextInputVision{analyses: []textInputScreenAnalysis{
-		{ObservedMode: textInputModeASCII},
-		{ObservedMode: textInputModeASCII, FieldText: "hello world", TargetMatched: true},
-	}}
+func TestTextInputBridgeRestoresViaSharedPhoneBridgeRestorerAndReturnsThroughRecents(t *testing.T) {
+	vision := &stubTextInputVision{analyses: []textInputScreenAnalysis{{
+		ObservedMode: textInputModeASCII, FieldText: "hello world", TargetMatched: true,
+	}}}
 	pb := newTestPhoneBridge(t)
 	pb.platform = "ios"
 	pb.appState = "background"
 	pb.returnEntry = "dynamic_island"
 	pb.returnEntrySeen = true
 	pb.returnEntryOK = true
+	restoreCalls := 0
+	restorer := NewPhoneBridgeRestorer(pb, nil)
+	restorer.waitTimeout = time.Second
+	restorer.tapReturnEntry = func(context.Context, PhoneBridgeStatus) error {
+		restoreCalls++
+		pb.mu.Lock()
+		pb.connected = true
+		pb.appState = "active"
+		pb.mu.Unlock()
+		return nil
+	}
 
 	keyboardText := &recordingTextInputTool{name: "keyboard_text", out: "ok"}
 	quickAction := &recordingTextInputTool{name: "quick_action", out: `{"ok":true}`}
@@ -429,18 +439,8 @@ func TestTextInputBridgeRestoresReconnectsAndReturnsThroughRecents(t *testing.T)
 		},
 		vision:   vision,
 		bridgeFn: func() *PhoneBridge { return pb },
+		restorer: restorer,
 		sleep:    testNoWaitSleep,
-		findAppTapFn: func(context.Context, screenshotResult, string) (bridgeSearchResult, error) {
-			return bridgeSearchResult{Found: true, TapPoint: focusPointArgs{X: 500, Y: 220, CoordSpace: "normalized"}, Label: "Aiden"}, nil
-		},
-		confirmAppOpenFn: func(context.Context, screenshotResult, string) (bridgeAppOpenResult, error) {
-			time.AfterFunc(10*time.Millisecond, func() {
-				pb.mu.Lock()
-				pb.connected = true
-				pb.mu.Unlock()
-			})
-			return bridgeAppOpenResult{Opened: true, Reason: "Aiden app visible"}, nil
-		},
 		findPrevAppFn: func(context.Context, screenshotResult) (previousAppCardResult, error) {
 			findPrevCalls++
 			if findPrevCalls == 1 {
@@ -478,23 +478,24 @@ func TestTextInputBridgeRestoresReconnectsAndReturnsThroughRecents(t *testing.T)
 	if !pb.connected {
 		t.Fatal("expected bridge to reconnect before clipboard write")
 	}
+	if restoreCalls != 1 {
+		t.Fatalf("shared bridge restore calls=%d, want 1", restoreCalls)
+	}
 	if findPrevCalls != 2 {
 		t.Fatalf("find previous app calls=%d, want 2", findPrevCalls)
 	}
-	if len(quickAction.calls) != 3 ||
-		!strings.Contains(quickAction.calls[0], `"action": "spotlight_search"`) ||
-		!strings.Contains(quickAction.calls[1], `"action": "app_switch"`) ||
-		!strings.Contains(quickAction.calls[2], `"action": "paste"`) {
+	if len(quickAction.calls) != 2 ||
+		!strings.Contains(quickAction.calls[0], `"action": "app_switch"`) ||
+		!strings.Contains(quickAction.calls[1], `"action": "paste"`) {
 		t.Fatalf("quick_action calls=%v", quickAction.calls)
 	}
-	if len(touch.calls) != 3 ||
-		!strings.Contains(touch.calls[0], `"type": "tap"`) ||
-		!strings.Contains(touch.calls[1], `"type": "swipe_right"`) ||
-		!strings.Contains(touch.calls[2], `"type": "tap"`) {
-		t.Fatalf("touch_gesture calls=%v", touch.calls)
+	if len(touch.calls) != 2 ||
+		!strings.Contains(touch.calls[0], `"type": "swipe_right"`) ||
+		!strings.Contains(touch.calls[1], `"type": "tap"`) {
+		t.Fatalf("touch_gesture calls=%v, want only return-to-target gestures", touch.calls)
 	}
-	if len(keyboardText.calls) < 2 {
-		t.Fatalf("keyboard_text calls=%v, want probe and Aiden search input", keyboardText.calls)
+	if len(keyboardText.calls) != 0 {
+		t.Fatalf("keyboard_text calls=%v, want no Aiden search input", keyboardText.calls)
 	}
 }
 

--- a/src/agent/internal/agent/text_input_common.go
+++ b/src/agent/internal/agent/text_input_common.go
@@ -317,6 +317,17 @@ func textInputKeyboardKeysForSelectAll(platform string) ([]string, error) {
 	}
 }
 
+func textInputKeyboardKeysForUndo(platform string) ([]string, error) {
+	switch strings.ToLower(strings.TrimSpace(platform)) {
+	case "android":
+		return []string{"ctrl", "z"}, nil
+	case "ios", "mac":
+		return []string{"meta", "z"}, nil
+	default:
+		return nil, fmt.Errorf("unsupported platform %q for undo", platform)
+	}
+}
+
 func interpretTextInputToolOutput(out string) error {
 	out = strings.TrimSpace(out)
 	if out == "" {

--- a/src/agent/internal/agent/text_input_engine.go
+++ b/src/agent/internal/agent/text_input_engine.go
@@ -288,15 +288,19 @@ func (e *textInputEngine) planCompositionSegmentsForChunks(ctx context.Context, 
 }
 
 func (e *textInputEngine) probeTextInputMode(ctx context.Context, platform string, focus focusPointArgs) (mode textInputMode, vlmCalls int, err error) {
+	undoKeys, err := textInputKeyboardKeysForUndo(platform)
+	if err != nil {
+		return textInputModeUnknown, vlmCalls, err
+	}
 	if err = e.typeASCIIChunk(ctx, "a"); err != nil {
 		return textInputModeUnknown, vlmCalls, fmt.Errorf("input mode probe: type a: %w", err)
 	}
 	defer func() {
-		deleteErr := e.tapKeys(ctx, []string{"backspace"})
-		if deleteErr == nil {
-			deleteErr = e.sleepFor(ctx, textInputKeystrokeGap)
+		undoErr := e.tapKeys(ctx, undoKeys)
+		if undoErr == nil {
+			undoErr = e.sleepFor(ctx, textInputKeystrokeGap)
 		}
-		err = errors.Join(err, deleteErr)
+		err = errors.Join(err, undoErr)
 	}()
 	if err = e.sleepFor(ctx, textInputProbeSettleDelay); err != nil {
 		return textInputModeUnknown, vlmCalls, err

--- a/src/agent/internal/agent/tools.go
+++ b/src/agent/internal/agent/tools.go
@@ -201,7 +201,12 @@ func (s *ToolSet) RegisterEnterTextTool(models model.Model, platformFn func() st
 		return
 	}
 	engine := newTextInputEngine(*s.textInputHW, newLLMTextInputVision(models))
-	bridgeTool := &textInputBridge{hw: s.textInputHW, vision: newLLMTextInputVision(models), bridgeFn: func() *PhoneBridge { return s.phoneBridge }}
+	bridgeTool := &textInputBridge{
+		hw:       s.textInputHW,
+		vision:   newLLMTextInputVision(models),
+		bridgeFn: func() *PhoneBridge { return s.phoneBridge },
+		restorer: s.phoneBridgeRestorer,
+	}
 	entryTool := &EnterTextTool{engine: engine, bridgeTool: bridgeTool, iosKeyboardIsolation: s.iosKeyboardIsolation}
 	searchOpenTool := &appSearchOpenTool{
 		hw:                   s.textInputHW,

--- a/src/agent/internal/agent/tools_enter_text_test.go
+++ b/src/agent/internal/agent/tools_enter_text_test.go
@@ -562,7 +562,7 @@ func TestTextInputEngineRunSegmentedUsesProbeStateInsteadOfASCIIVerification(t *
 		t.Fatalf("RunSegmented() = %+v, %v; want committed result", result, err)
 	}
 	if want := []string{
-		jsonString(map[string][]string{"keys": {"backspace"}}),
+		jsonString(map[string][]string{"keys": {"meta", "z"}}),
 		jsonString(map[string]any{"keys": []string{"capslock"}, "hold_ms": textInputIMESwitchHoldMs}),
 		jsonString(map[string]any{"keys": []string{"capslock"}, "hold_ms": textInputIMESwitchHoldMs}),
 	}; !reflect.DeepEqual(keyboardTap.calls, want) {
@@ -593,7 +593,7 @@ func TestTextInputEngineRunSegmentedDoesNotVerifyFinalASCIIPart(t *testing.T) {
 		t.Fatalf("RunSegmented() = %+v, %v; want committed result", result, err)
 	}
 	if want := []string{
-		jsonString(map[string][]string{"keys": {"backspace"}}),
+		jsonString(map[string][]string{"keys": {"meta", "z"}}),
 		jsonString(map[string]any{"keys": []string{"capslock"}, "hold_ms": textInputIMESwitchHoldMs}),
 	}; !reflect.DeepEqual(keyboardTap.calls, want) {
 		t.Fatalf("keyboard_tap calls = %#v, want %#v", keyboardTap.calls, want)
@@ -623,7 +623,7 @@ func TestTextInputEngineTypesFullWidthPunctuationInIMEMode(t *testing.T) {
 		t.Fatalf("keyboard_text calls = %#v, want %#v", keyboardText.calls, want)
 	}
 	if want := []string{
-		jsonString(map[string][]string{"keys": {"backspace"}}),
+		jsonString(map[string][]string{"keys": {"meta", "z"}}),
 		jsonString(map[string]any{"keys": []string{"capslock"}, "hold_ms": textInputIMESwitchHoldMs}),
 		jsonString(map[string]any{"keys": []string{"capslock"}, "hold_ms": textInputIMESwitchHoldMs}),
 	}; !reflect.DeepEqual(keyboardTap.calls, want) {

--- a/src/agent/internal/agent/tools_enter_text_test.go
+++ b/src/agent/internal/agent/tools_enter_text_test.go
@@ -253,7 +253,7 @@ func TestRunSegmentedTypesSpaceWithoutVisionVerification(t *testing.T) {
 	if err != nil || !result.Committed {
 		t.Fatalf("RunSegmented()=%+v err=%v", result, err)
 	}
-	if len(kbText.calls) != 3 || len(kbTap.calls) != 2 || !strings.Contains(kbTap.calls[0], "backspace") || !strings.Contains(kbTap.calls[1], "space") {
+	if len(kbText.calls) != 3 || len(kbTap.calls) != 2 || !strings.Contains(kbTap.calls[0], `"meta"`) || !strings.Contains(kbTap.calls[0], `"z"`) || !strings.Contains(kbTap.calls[1], "space") {
 		t.Fatalf("keyboard_text=%v keyboard_tap=%v", kbText.calls, kbTap.calls)
 	}
 	if len(mouse.calls) != 0 {
@@ -278,6 +278,22 @@ func TestTextInputProbeWaitsForConfiguredSettleDelayBeforeCapture(t *testing.T) 
 	}
 	if len(delays) == 0 || delays[0] != textInputProbeSettleDelay {
 		t.Fatalf("probe delays=%v, want first delay %s", delays, textInputProbeSettleDelay)
+	}
+}
+
+func TestTextInputKeyboardKeysForUndo(t *testing.T) {
+	for _, test := range []struct {
+		platform string
+		want     []string
+	}{
+		{platform: "ios", want: []string{"meta", "z"}},
+		{platform: "mac", want: []string{"meta", "z"}},
+		{platform: "android", want: []string{"ctrl", "z"}},
+	} {
+		got, err := textInputKeyboardKeysForUndo(test.platform)
+		if err != nil || strings.Join(got, ",") != strings.Join(test.want, ",") {
+			t.Errorf("undo keys for %s = %v, %v; want %v, nil", test.platform, got, err, test.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- reuse Phone Bridge foreground restoration for iOS text-entry clipboard flow
- replace IME probe cleanup backspace with platform-specific undo shortcuts

## Tests
- go test ./internal/agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-entry recovery when switching between apps, helping restore the connection and return to the intended screen more reliably.
  * Fixed undo behavior during segmented text entry on iOS, macOS, and Android by using the appropriate platform keyboard shortcut.
  * Reduced unnecessary keyboard-based app searching during text-input restoration, resulting in a smoother recovery experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->