### PR TITLE
feat(agent): add bridge app switch back action

### DIFF
--- a/src/agent/config/skills/device-operator/SKILL.md
+++ b/src/agent/config/skills/device-operator/SKILL.md
@@ -52,7 +52,7 @@ For cross-app tasks that require extracting data from a source app and entering 
 
 Prefer the highest-level reliable tool for the job:
 
-- Use `quick_action` first when a catalog shortcut clearly matches the goal, such as back, home, app switch, search, copy/paste, or browser actions. Always pass both `action` and the observed `platform`. Common actions include back, home, hide_app, quit_app, app_switch, spotlight_search, copy, paste, cut, undo, redo, select_all, delete_backward, delete_forward, find, send, and browser_* actions; use `{"action":"list","platform":"..."}` to see the active catalog.
+- Use `quick_action` first when a catalog shortcut clearly matches the goal, such as back, home, app switch, search, copy/paste, or browser actions. Always pass both `action` and the observed `platform`. Common actions include back, home, hide_app, quit_app, app_switch, app_switch_back, spotlight_search, copy, paste, cut, undo, redo, select_all, delete_backward, delete_forward, find, send, and browser_* actions; use `{"action":"list","platform":"..."}` to see the active catalog.
   - If `status=reserved` in a list result, or `quick_action` returns `ok=false` or an error, skip it and use direct input tools instead.
   - If `ok=true` but the screenshot shows no expected change, treat it as ineffective: try `alternative=true` once when alternatives are listed, otherwise switch tools. Never loop on the same binding.
 - Use `touch_gesture` for mobile taps, swipes, drag, back, and home gestures.

--- a/src/agent/internal/agent/quick_actions.json
+++ b/src/agent/internal/agent/quick_actions.json
@@ -113,6 +113,43 @@
         }
       }
     },
+    "app_switch_back": {
+      "label": "Switch to Previous App",
+      "aliases": ["切回上一个应用", "previous_app", "switch_previous_app"],
+      "category": "navigation",
+      "platforms": {
+        "ios": {
+          "status": "active",
+          "tool": "touch_gesture",
+          "input": {
+            "type": "swipe",
+            "start": { "x": 500, "y": 1000 },
+            "end": { "x": 1000, "y": 1000 },
+            "duration_ms": 400,
+            "hold_before_ms": 80,
+            "steps": 14
+          },
+          "note": "verified: swipe right from bottom center to switch to the previous app"
+        },
+        "android": {
+          "status": "active",
+          "tool": "touch_gesture",
+          "input": {
+            "type": "swipe",
+            "start": { "x": 500, "y": 1000 },
+            "end": { "x": 1000, "y": 1000 },
+            "duration_ms": 400,
+            "hold_before_ms": 80,
+            "steps": 14
+          },
+          "note": "swipe right from bottom center to switch to the previous app"
+        },
+        "mac": {
+          "status": "reserved",
+          "note": "unreliable via HID: Cmd+Shift+Tab needs key hold"
+        }
+      }
+    },
     "quick_app_switch_left": {
       "label": "Quick App Switch Left",
       "aliases": ["快速切换上一个", "无缝切换左", "quick_switch_left", "switch_prev_app"],

--- a/src/agent/internal/agent/text_input_bridge.go
+++ b/src/agent/internal/agent/text_input_bridge.go
@@ -13,7 +13,6 @@ const (
 	textViaBridgePostPasteDelay = 350 * time.Millisecond
 	textViaBridgeMenuDelay      = 450 * time.Millisecond
 	textViaBridgePasteAttempts  = 2
-	textViaBridgeRecentsSwipes  = 3
 	preparedClipboardMaxAge     = 5 * time.Minute
 	textViaBridgeLongPressMS    = 900
 )
@@ -27,12 +26,6 @@ type bridgeSearchResult struct {
 type bridgeAppOpenResult struct {
 	Opened bool   `json:"opened"`
 	Reason string `json:"reason,omitempty"`
-}
-
-type previousAppCardResult struct {
-	Found    bool           `json:"found"`
-	TapPoint focusPointArgs `json:"tap_point"`
-	Label    string         `json:"label,omitempty"`
 }
 
 type pasteMenuResult struct {
@@ -54,7 +47,6 @@ type textInputBridge struct {
 	bridgeFn         func() *PhoneBridge
 	restorer         *PhoneBridgeRestorer
 	clipboardWriteFn func(context.Context, *PhoneBridge, string) error
-	findPrevAppFn    func(context.Context, screenshotResult) (previousAppCardResult, error)
 	findPasteMenuFn  func(context.Context, screenshotResult, string) (pasteMenuResult, error)
 	sleep            func(context.Context, time.Duration) error
 }
@@ -205,10 +197,7 @@ func (t *textInputBridge) runLegacyBridgeFlow(ctx context.Context, platform stri
 	if err := t.sleepAfterClipboardWrite(ctx); err != nil {
 		return textViaBridgeResult{Attempted: true, Err: err}
 	}
-	if _, err := t.callQuickAction(ctx, "app_switch", platform); err != nil {
-		return textViaBridgeResult{Attempted: true, Err: err}
-	}
-	if err := t.returnToPreviousApp(ctx, engine); err != nil {
+	if _, err := t.callQuickAction(ctx, "app_switch_back", platform); err != nil {
 		return textViaBridgeResult{Attempted: true, Err: err}
 	}
 	result := t.focusPasteVerify(ctx, engine, platform, args)
@@ -409,90 +398,6 @@ func keyboardPasteKeys(platform string) []string {
 	default:
 		return []string{"meta", "v"}
 	}
-}
-
-func (t *textInputBridge) tapTouchPoint(ctx context.Context, point focusPointArgs) error {
-	out, err := t.hw.touchGesture.Call(ctx, jsonString(map[string]any{
-		"type":        "tap",
-		"point":       map[string]any{"x": point.X, "y": point.Y},
-		"coord_space": firstNonEmptyString([]string{strings.TrimSpace(point.CoordSpace), "normalized"}),
-	}))
-	if err != nil {
-		return err
-	}
-	return interpretTextInputToolOutput(out)
-}
-
-func (t *textInputBridge) returnToPreviousApp(ctx context.Context, engine *textInputEngine) error {
-	for attempt := 1; attempt <= textViaBridgeRecentsSwipes+1; attempt++ {
-		result, err := t.findPreviousAppCard(ctx, engine)
-		if err != nil {
-			return err
-		}
-		if result.Found {
-			return t.tapTouchPoint(ctx, result.TapPoint)
-		}
-		if attempt > textViaBridgeRecentsSwipes {
-			break
-		}
-		if err := t.swipeRecentsToFindPreviousApp(ctx); err != nil {
-			return err
-		}
-	}
-	return fmt.Errorf("previous app card not found in app switcher")
-}
-
-func (t *textInputBridge) swipeRecentsToFindPreviousApp(ctx context.Context) error {
-	out, err := t.hw.touchGesture.Call(ctx, jsonString(map[string]any{
-		"type":        "swipe_right",
-		"coord_space": "normalized",
-		"strength":    "medium",
-	}))
-	if err != nil {
-		return err
-	}
-	return interpretTextInputToolOutput(out)
-}
-
-func (t *textInputBridge) findPreviousAppCard(ctx context.Context, engine *textInputEngine) (previousAppCardResult, error) {
-	shot, err := engine.captureScreenshot(ctx)
-	if err != nil {
-		return previousAppCardResult{}, err
-	}
-	if t != nil && t.findPrevAppFn != nil {
-		result, err := t.findPrevAppFn(ctx, shot)
-		return result, err
-	}
-	modelVision, ok := t.vision.(*llmTextInputVision)
-	if !ok || modelVision == nil {
-		return previousAppCardResult{}, fmt.Errorf("previous app selection vision is not configured")
-	}
-	prompt := strings.TrimSpace(`Analyze this device screenshot of the app switcher / recent apps view.
-Find the previous app card that should be tapped to return from the Aiden companion app back to the user's prior task.
-Return JSON only:
-{
-  "found": true,
-  "tap_point": {"x": 180, "y": 290, "coord_space": "normalized"},
-  "label": "Settings"
-}
-
-Rules:
-- Return found=true only when a non-Aiden previous app card is clearly visible and tappable.
-- Prefer the app card that represents the task immediately before Aiden, not the Aiden card itself.
-- tap_point must be inside the visible app card body using normalized 0-1000 coordinates.
-- If not visible, return {"found": false, "tap_point": {"x": 0, "y": 0, "coord_space": "normalized"}}.`)
-	raw, err := modelVision.visionJSON(ctx, "previous_app", prompt, shot)
-	if err != nil {
-		return previousAppCardResult{}, err
-	}
-	var result previousAppCardResult
-	if err := json.Unmarshal([]byte(raw), &result); err != nil {
-		return previousAppCardResult{}, fmt.Errorf("parse previous app card: %w", err)
-	}
-	if strings.TrimSpace(result.TapPoint.CoordSpace) == "" {
-		result.TapPoint.CoordSpace = "normalized"
-	}
-	return result, nil
 }
 
 func (t *textInputBridge) sleepAfterClipboardWrite(ctx context.Context) error {

--- a/src/agent/internal/agent/text_input_bridge_test.go
+++ b/src/agent/internal/agent/text_input_bridge_test.go
@@ -401,7 +401,7 @@ type recordingBridgeQuickActionTool struct {
 	onCall func(string)
 }
 
-func TestTextInputBridgeRestoresViaSharedPhoneBridgeRestorerAndReturnsThroughRecents(t *testing.T) {
+func TestTextInputBridgeRestoresViaSharedPhoneBridgeRestorerAndSwitchesBack(t *testing.T) {
 	vision := &stubTextInputVision{analyses: []textInputScreenAnalysis{{
 		ObservedMode: textInputModeASCII, FieldText: "hello world", TargetMatched: true,
 	}}}
@@ -425,13 +425,11 @@ func TestTextInputBridgeRestoresViaSharedPhoneBridgeRestorerAndReturnsThroughRec
 
 	keyboardText := &recordingTextInputTool{name: "keyboard_text", out: "ok"}
 	quickAction := &recordingTextInputTool{name: "quick_action", out: `{"ok":true}`}
-	touch := &recordingTextInputTool{name: "touch_gesture", out: "ok"}
-	findPrevCalls := 0
 	bridgePath := &textInputBridge{
 		hw: &textInputHardwareDeps{
 			pointerMode:  "absolute",
 			mouseClick:   &recordingTextInputTool{name: "mouse_click", out: "ok"},
-			touchGesture: touch,
+			touchGesture: &recordingTextInputTool{name: "touch_gesture", out: "ok"},
 			keyboardTap:  &recordingTextInputTool{name: "keyboard_tap", out: "ok"},
 			keyboardText: keyboardText,
 			quickAction:  quickAction,
@@ -441,13 +439,6 @@ func TestTextInputBridgeRestoresViaSharedPhoneBridgeRestorerAndReturnsThroughRec
 		bridgeFn: func() *PhoneBridge { return pb },
 		restorer: restorer,
 		sleep:    testNoWaitSleep,
-		findPrevAppFn: func(context.Context, screenshotResult) (previousAppCardResult, error) {
-			findPrevCalls++
-			if findPrevCalls == 1 {
-				return previousAppCardResult{Found: false, TapPoint: focusPointArgs{CoordSpace: "normalized"}}, nil
-			}
-			return previousAppCardResult{Found: true, TapPoint: focusPointArgs{X: 180, Y: 290, CoordSpace: "normalized"}, Label: "Settings"}, nil
-		},
 		clipboardWriteFn: func(_ context.Context, _ *PhoneBridge, text string) error {
 			if text != "hello world" {
 				t.Fatalf("clipboard text = %q", text)
@@ -481,18 +472,10 @@ func TestTextInputBridgeRestoresViaSharedPhoneBridgeRestorerAndReturnsThroughRec
 	if restoreCalls != 1 {
 		t.Fatalf("shared bridge restore calls=%d, want 1", restoreCalls)
 	}
-	if findPrevCalls != 2 {
-		t.Fatalf("find previous app calls=%d, want 2", findPrevCalls)
-	}
 	if len(quickAction.calls) != 2 ||
-		!strings.Contains(quickAction.calls[0], `"action": "app_switch"`) ||
+		!strings.Contains(quickAction.calls[0], `"action": "app_switch_back"`) ||
 		!strings.Contains(quickAction.calls[1], `"action": "paste"`) {
 		t.Fatalf("quick_action calls=%v", quickAction.calls)
-	}
-	if len(touch.calls) != 2 ||
-		!strings.Contains(touch.calls[0], `"type": "swipe_right"`) ||
-		!strings.Contains(touch.calls[1], `"type": "tap"`) {
-		t.Fatalf("touch_gesture calls=%v, want only return-to-target gestures", touch.calls)
 	}
 	if len(keyboardText.calls) != 0 {
 		t.Fatalf("keyboard_text calls=%v, want no Aiden search input", keyboardText.calls)

--- a/src/agent/internal/agent/tools_quick_actions.go
+++ b/src/agent/internal/agent/tools_quick_actions.go
@@ -756,7 +756,7 @@ func platformNote(actionID, platform string, binding quickActionBinding) string 
 
 func quickActionBehaviorSummary() string {
 	return strings.Join([]string{
-		"Common actions: back, home, hide_app, quit_app, app_switch, spotlight_search, copy, paste, cut, undo, redo, select_all, delete_backward, delete_forward, find, send, browser_new_tab, browser_close_tab, browser_refresh, browser_address_bar.",
+		"Common actions: back, home, hide_app, quit_app, app_switch, app_switch_back, spotlight_search, copy, paste, cut, undo, redo, select_all, delete_backward, delete_forward, find, send, browser_new_tab, browser_close_tab, browser_refresh, browser_address_bar.",
 		"- Infer platform from screenshot/context and pass platform=ios/android/mac.",
 		"- Prefer quick_action before ad-hoc keyboard_tap or touch_gesture when an active catalog entry exists.",
 		"- If status=reserved in a list result or quick_action returns ok=false or an error message: skip quick_action and use direct input tools instead.",

--- a/src/agent/internal/agent/tools_quick_actions_test.go
+++ b/src/agent/internal/agent/tools_quick_actions_test.go
@@ -40,6 +40,13 @@ func TestQuickActionsResolveAliasAndPlatform(t *testing.T) {
 	if id, ok := table.resolveActionID("quick-switch-left"); !ok || id != "quick_app_switch_left" {
 		t.Fatalf("expected hyphenated alias to resolve to quick_app_switch_left, got %q ok=%v", id, ok)
 	}
+	if id, ok := table.resolveActionID("switch_previous_app"); !ok || id != "app_switch_back" {
+		t.Fatalf("expected previous-app alias to resolve to app_switch_back, got %q ok=%v", id, ok)
+	}
+	_, binding, ok := table.lookup("app_switch_back", "android")
+	if !ok || binding.Status != quickActionStatusActive || binding.Tool != "touch_gesture" {
+		t.Fatalf("Android app_switch_back binding = %#v, found=%v; want active touch_gesture", binding, ok)
+	}
 	if id, ok := table.resolveActionID("退格"); !ok || id != "delete_backward" {
 		t.Fatalf("expected delete-backward alias to resolve to delete_backward, got %q ok=%v", id, ok)
 	}


### PR DESCRIPTION
## Summary
- add the app_switch_back quick action for iOS and Android
- use it to return from the companion app in the Bridge legacy text-entry flow
- remove recent-app-card vision selection from that flow
## Testing
- GOCACHE=/private/tmp/aiden-hardware-demo-go-cache go test ./internal/agent -run 'Test(TextInputBridgeRestoresViaSharedPhoneBridgeRestorerAndSwitchesBack|QuickActionsResolveAliasAndPlatform)$' -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `app_switch_back` quick action for returning to the previously used app.
  * Supports swipe-based switching on iOS and Android.
  * Added support for the `switch_previous_app` action alias.

* **Improvements**
  * App restoration now uses the shared switch-back action for a simpler, more consistent return flow.
  * The action remains unavailable on macOS, where the required keyboard shortcut is unreliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->