### PR TITLE
feat(config): restrict base_url override to openai and ollama only

### DIFF
--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -234,9 +234,9 @@ The three stall-score thresholds must satisfy
 
 | Field                     | Description                                                                                                                                                                                                                                          |
 | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `provider`                | `openai`, `openrouter`, `kimi`, `kimi-cn`, `volcengine`, `ollama`, `fake`. `kimi` targets the Moonshot global site (`https://api.moonshot.ai/v1`) and `kimi-cn` targets the mainland China site (`https://api.moonshot.cn/v1`); `volcengine` targets Volcengine Ark (`https://ark.cn-beijing.volces.com/api/v3`). All three accept a `base_url` override. |
+| `provider`                | `openai`, `openrouter`, `kimi`, `kimi-cn`, `volcengine`, `ollama`, `fake`. `kimi` targets the Moonshot global site (`https://api.moonshot.ai/v1`) and `kimi-cn` targets the mainland China site (`https://api.moonshot.cn/v1`); `volcengine` targets Volcengine Ark (`https://ark.cn-beijing.volces.com/api/v3`). |
 | `model`                   | Model name; usually required except for `fake`                                                                                                                                                                                                       |
-| `base_url`                | Custom OpenAI-compatible endpoint. Optional for `kimi`/`kimi-cn`/`volcengine` (each has a built-in default). Only `openai`, `openrouter`, `kimi`, `kimi-cn`, `volcengine`, and `ollama` accept it; other providers pin their endpoint and a stored value is dropped on load. |
+| `base_url`                | Custom OpenAI-compatible endpoint. Only `openai` and `ollama` accept a `base_url` override; other providers use their built-in endpoints and a stored value is dropped on load. |
 | `api_key`                 | API key written directly                                                                                                                                                                                                                             |
 | `token_env`               | Read the API key from the specified environment variable; only supported by `[model]`                                                                                                                                                                |
 | `temperature`             | Sampling temperature. When unset, the default is model-dependent (some models such as Kimi K3 require a fixed temperature), falling back to `0.2`. An explicit value always takes precedence.                                                        |
@@ -247,7 +247,7 @@ The three stall-score thresholds must satisfy
 
 ### Moonshot Kimi K3
 
-Use the dedicated `kimi` (global) or `kimi-cn` (mainland China) provider. Each has a built-in Moonshot OpenAI-compatible `base_url`, so only `model` and the API key are required. The `kimi-k3` context window and max output are in the built-in registry, so the metadata overrides can stay unset.
+Use the dedicated `kimi` (global) or `kimi-cn` (mainland China) provider. Each has a built-in Moonshot OpenAI-compatible endpoint, so only `model` and the API key are required. The `kimi-k3` context window and max output are in the built-in registry, so the metadata overrides can stay unset.
 
 ```toml
 # Global site (https://api.moonshot.ai/v1)
@@ -261,9 +261,6 @@ api_key = "MOONSHOT_API_KEY"
 # provider = "kimi-cn"
 # model = "kimi-k3"
 # api_key = "MOONSHOT_API_KEY"
-
-# base_url is optional for kimi/kimi-cn; set it only to override the default
-# (e.g. a proxy or self-hosted gateway).
 ```
 
 ### Volcengine Ark (Doubao)
@@ -280,10 +277,6 @@ api_key = "ARK_API_KEY"
 
 # Or read the key from the environment instead of writing it here:
 # token_env = "ARK_API_KEY"
-
-# base_url is optional; set it to route through a proxy, or to use the
-# subscription Agent Plan endpoint (https://ark.cn-beijing.volces.com/api/plan/v3),
-# which requires a plan-specific API key.
 ```
 
 Ark also exposes an Anthropic-protocol endpoint at `/api/compatible`. This agent

--- a/src/agent/internal/agent/config.go
+++ b/src/agent/internal/agent/config.go
@@ -856,7 +856,7 @@ func clearNonAllowedModelBaseURL(m *ModelConfig) {
 	}
 	provider := strings.ToLower(strings.TrimSpace(m.Provider))
 	switch provider {
-	case "openai", "openrouter", "kimi", "kimi-cn", "volcengine", "ollama":
+	case "openai", "ollama":
 	default:
 		m.BaseURL = ""
 	}

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -2838,14 +2838,11 @@ void set_json_string_vector(std::vector<std::string>* dst, cJSON* obj, const cha
 // model_base_url_allowed mirrors the agent runtime's whitelist
 // (clearNonAllowedModelBaseURL in src/agent/internal/agent/config.go). Providers
 // listed here accept a base_url override: openai for custom gateways, ollama for
-// a local server address, and openrouter/kimi/kimi-cn/volcengine for proxies in
-// front of their built-in endpoints. Anything else pins its endpoint, so a
-// stored base_url would be dead config. Keep both lists in sync.
+// a local server address. Anything else pins its endpoint, so a stored base_url
+// would be dead config. Keep both lists in sync.
 bool model_base_url_allowed(const std::string& provider) {
     const std::string normalized = lowercase_copy(trim_copy(provider));
-    return normalized == "openai" || normalized == "openrouter" ||
-           normalized == "kimi" || normalized == "kimi-cn" ||
-           normalized == "volcengine" || normalized == "ollama";
+    return normalized == "openai" || normalized == "ollama";
 }
 
 void update_model_from_json(cJSON* obj, aiden::ModelToml* m) {


### PR DESCRIPTION
## Changes

- Remove base_url support for openrouter, kimi, kimi-cn, and volcengine
- These providers now use their hardcoded built-in endpoints
- Only openai (custom gateways) and ollama (local server) support base_url override
- Update both Go runtime (config.go) and C++ config web (config_web.cpp) whitelists
- Update configuration.md to reflect the restriction

## Impact

**Supported base_url override:**
- ✅ openai - custom gateways
- ✅ ollama - local server address

**No longer supported:**
- ❌ openrouter - fixed to https://openrouter.ai/api/v1
- ❌ kimi - fixed to https://api.moonshot.ai/v1
- ❌ kimi-cn - fixed to https://api.moonshot.cn/v1
- ❌ volcengine - fixed to https://ark.cn-beijing.volces.com/api/v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Custom model base URLs are now supported only for OpenAI and Ollama providers.
  * Other providers use their built-in service endpoints, and related configuration examples have been updated.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->