### PR TITLE
feat(opkg): integrate opkg package manager for on-device Entware support

### DIFF
--- a/docs/07-operations/troubleshooting.md
+++ b/docs/07-operations/troubleshooting.md
@@ -153,18 +153,32 @@ Solution:
   from `POST /api/tools/{tool_name}`;
 - Separate transport failure from tool failure judgement.
 
-## `opkg` reports `Failed to open /etc/opkg/90-userfeeds.conf`
+## `opkg update` prints nothing, and no package can be found
 
-The message names a config file, but the first thing to check is the `/opt`
-mount. `90-userfeeds.conf` is a symlink to `/opt/etc/opkg/userfeeds.conf`; when
-`/opt` is not bound from `/userdata/opt` the symlink dangles, and opkg 0.7.0
-aborts if any `/etc/opkg/*.conf` fragment cannot be opened. That refusal is a
-deliberate guard, not a corrupt config — it keeps packages from being installed
-into the current A/B rootfs, where they would not survive an OTA.
+```
+# opkg update
+# opkg install htop
+error: opkg_prepare_url_for_install: Couldn't find anything to satisfy 'htop'.
+```
+
+`opkg update` prints one `Downloading` line per configured source, so silence
+means no source is configured. Two different causes produce it:
 
 ```bash
-/etc/init.d/S22opt status
+cat /etc/opkg/*.conf | grep -E '^\s*(src|dist)'   # any sources at all?
+/etc/init.d/S22opt status                          # is /opt actually bound?
 ```
+
+Every `src` line lives in `/opt/etc/opkg/userfeeds.conf`, so an unbound `/opt`
+looks exactly like "no source was ever configured". Check both before writing a
+source into a file that cannot be read.
+
+Note this is *not* opkg refusing to start. `/etc/opkg/90-userfeeds.conf` is a
+symlink into `/opt`, and when it dangles uClibc-ng's `glob()` silently drops it —
+opkg never tries to open it and runs normally. The protection against installing
+into the A/B rootfs comes from the read-only seal `S22opt` applies to `/opt`,
+plus the fact that no source is reachable. See
+[opkg Package Management](opkg-package-management.md) §6.2.1.
 
 `opt=bound` is healthy. For `sealed`, `wrong-source` or `unbound`, and for the
 rest of the opkg runbook (enabling a feed, recovering a truncated package

--- a/docs/07-operations/troubleshooting.md
+++ b/docs/07-operations/troubleshooting.md
@@ -153,6 +153,24 @@ Solution:
   from `POST /api/tools/{tool_name}`;
 - Separate transport failure from tool failure judgement.
 
+## `opkg` reports `Failed to open /etc/opkg/90-userfeeds.conf`
+
+The message names a config file, but the first thing to check is the `/opt`
+mount. `90-userfeeds.conf` is a symlink to `/opt/etc/opkg/userfeeds.conf`; when
+`/opt` is not bound from `/userdata/opt` the symlink dangles, and opkg 0.7.0
+aborts if any `/etc/opkg/*.conf` fragment cannot be opened. That refusal is a
+deliberate guard, not a corrupt config — it keeps packages from being installed
+into the current A/B rootfs, where they would not survive an OTA.
+
+```bash
+/etc/init.d/S22opt status
+```
+
+`opt=bound` is healthy. For `sealed`, `wrong-source` or `unbound`, and for the
+rest of the opkg runbook (enabling a feed, recovering a truncated package
+database, cleaning up before a restore), see
+[opkg Package Management](opkg-package-management.md) §13.
+
 ## Docker build fails
 
 Check:

--- a/docs/07-operations/troubleshooting.md
+++ b/docs/07-operations/troubleshooting.md
@@ -155,7 +155,7 @@ Solution:
 
 ## `opkg update` prints nothing, and no package can be found
 
-```
+```text
 # opkg update
 # opkg install htop
 error: opkg_prepare_url_for_install: Couldn't find anything to satisfy 'htop'.

--- a/overlay/etc/init.d/S22opt
+++ b/overlay/etc/init.d/S22opt
@@ -188,10 +188,18 @@ start() {
 	fi
 
 	# Confirm through mountinfo rather than trusting the exit status: the mount
-	# can succeed and still land somewhere else, e.g. when $PERSISTENT_OPT is a
-	# symlink. Leaving $USERFEEDS_FILE uncreated keeps opkg disabled.
+	# can succeed and still land somewhere else -- if $PERSISTENT_OPT is a
+	# symlink, mount follows it, so /opt can end up bound to a rootfs directory.
+	# Such a mount is writable, so it has to be torn down and replaced by the
+	# seal; leaving it in place would drop the design's second layer of defence
+	# and let anything writing under /opt fill the system partition.
 	if ! opt_is_bound; then
 		echo "S22opt: $OPT_DIR is mounted but not bound from $PERSISTENT_OPT" >&2
+		if ! "$UMOUNT_BIN" "$OPT_DIR"; then
+			echo "S22opt: cannot release the unexpected mount on $OPT_DIR; do not use opkg" >&2
+			return 1
+		fi
+		seal_opt
 		return 1
 	fi
 

--- a/overlay/etc/init.d/S22opt
+++ b/overlay/etc/init.d/S22opt
@@ -24,6 +24,11 @@ OPT_DIR=${OPT_DIR:-/opt}
 USERDATA_DIR=${USERDATA_DIR:-/userdata}
 PERSISTENT_OPT=${PERSISTENT_OPT:-$USERDATA_DIR/opt}
 USERFEEDS_FILE=${USERFEEDS_FILE:-$OPT_DIR/etc/opkg/userfeeds.conf}
+# Source seeded into a freshly created userfeeds.conf. Expanded with "-" rather
+# than ":-" on purpose: DEFAULT_FEED= (explicitly empty) must produce a source
+# less image, which is what the tests use and what an image that does not want
+# to endorse a third-party feed would set.
+DEFAULT_FEED=${DEFAULT_FEED-src/gz entware https://bin.entware.net/armv7sf-k3.2}
 LOCK_DIR=${LOCK_DIR:-/run/lock}
 MOUNT_BIN=${MOUNT_BIN:-mount}
 UMOUNT_BIN=${UMOUNT_BIN:-umount}
@@ -125,6 +130,41 @@ seal_opt() {
 	return 1
 }
 
+# Write a fresh userfeeds.conf. Only ever called when the file does not exist.
+#
+# Written via a temporary file and mv so a failure part way through (a full
+# /userdata is the realistic one) cannot leave a half-written source line that
+# opkg would then try to parse. mv within the same directory is atomic.
+write_default_userfeeds() {
+	_uf_dir=${USERFEEDS_FILE%/*}
+	_uf_tmp=$_uf_dir/.userfeeds.conf.$$
+
+	if [ -n "$DEFAULT_FEED" ]; then
+		{
+			echo "# opkg package sources, one 'src/gz <name> <url>' per line."
+			echo "#"
+			echo "# This file lives on /userdata and survives reboots and OTA."
+			echo "# A full flash erases /userdata; the default below is then"
+			echo "# written again on the next boot."
+			echo "#"
+			echo "# Edit or delete these lines freely -- an existing file is"
+			echo "# never rewritten, so your choice is kept."
+			echo "$DEFAULT_FEED"
+		} > "$_uf_tmp" 2>/dev/null || { rm -f "$_uf_tmp"; unset _uf_dir _uf_tmp; return 1; }
+	else
+		: > "$_uf_tmp" 2>/dev/null || { rm -f "$_uf_tmp"; unset _uf_dir _uf_tmp; return 1; }
+	fi
+
+	if ! mv "$_uf_tmp" "$USERFEEDS_FILE"; then
+		rm -f "$_uf_tmp"
+		unset _uf_dir _uf_tmp
+		return 1
+	fi
+
+	unset _uf_dir _uf_tmp
+	return 0
+}
+
 ensure_opt_layout() {
 	# opkg's lock_file lives under /run, which is a tmpfs and starts empty.
 	mkdir -p "$LOCK_DIR" 2>/dev/null || true
@@ -142,10 +182,24 @@ ensure_opt_layout() {
 	fi
 
 	# Create when absent, never truncate: this file holds the user's feed
-	# selection and is expected to survive reboots and OTA (§6.4).
-	if [ ! -e "$USERFEEDS_FILE" ] && ! touch "$USERFEEDS_FILE"; then
-		echo "S22opt: cannot create $USERFEEDS_FILE" >&2
-		return 1
+	# selection and is expected to survive reboots and OTA (§6.4). A full flash
+	# does erase /userdata, and this is where the default source comes back.
+	#
+	# Seeding here rather than shipping the source as a rootfs fragment is the
+	# whole point (§6.5.1). When /opt fails to mount, the only thing standing
+	# between that and packages landing in the A/B rootfs is that no source is
+	# reachable -- opkg does NOT refuse to run on a dangling config symlink the
+	# way §6.2.1 first assumed, because uClibc-ng's glob() silently drops it.
+	# Keeping every src line inside /opt is what preserves that property; a
+	# rootfs fragment would destroy it.
+	#
+	# Only the absent case is touched, so a user who deletes the seeded line
+	# keeps their choice: the file still exists and is left alone.
+	if [ ! -e "$USERFEEDS_FILE" ]; then
+		if ! write_default_userfeeds; then
+			echo "S22opt: cannot create $USERFEEDS_FILE" >&2
+			return 1
+		fi
 	fi
 
 	return 0

--- a/overlay/etc/init.d/S22opt
+++ b/overlay/etc/init.d/S22opt
@@ -15,10 +15,17 @@
 #
 # What happens when the bind fails: /opt is sealed with a read-only tmpfs so
 # writes fail with EROFS instead of silently landing in the current A/B rootfs,
-# where they would neither persist nor be accounted for (§6.2.1). That is only
-# the first guard -- /etc/opkg/90-userfeeds.conf is a symlink into /opt, and
-# opkg 0.7.0 aborts when any /etc/opkg/*.conf fragment cannot be opened, so a
-# failed mount also stops opkg from running at all.
+# where they would neither persist nor be accounted for (§6.2.1). That seal is
+# the only thing actually enforced.
+#
+# A second, weaker effect backs it up: every "src" line lives in
+# /opt/etc/opkg/userfeeds.conf, so a failed mount leaves opkg with no package
+# source and nothing to install. Note this is NOT because opkg refuses to run --
+# /etc/opkg/90-userfeeds.conf is then a dangling symlink, and uClibc-ng's glob()
+# silently drops those, so opkg never even tries to open it and starts normally.
+# The protection comes purely from keeping every source inside /opt, which is
+# also why the default feed is seeded there rather than shipped as a rootfs
+# fragment (§6.5.1).
 
 OPT_DIR=${OPT_DIR:-/opt}
 USERDATA_DIR=${USERDATA_DIR:-/userdata}
@@ -114,8 +121,20 @@ opt_is_sealed() {
 }
 
 seal_opt() {
-	if path_is_mounted "$OPT_DIR"; then
+	# Already sealed by an earlier attempt: nothing to do.
+	if opt_is_sealed; then
 		return 0
+	fi
+
+	# Mounted, but not by us and not read-only. Reporting success here would be
+	# a lie: the caller would believe /opt is protected while it is in fact
+	# writable, so an opkg install would land in whatever that mount is. Do not
+	# stack a tmpfs on top either -- start() deliberately refuses to touch a
+	# foreign mount, and unmounting something this script did not create could
+	# pull the rug from under whoever did.
+	if path_is_mounted "$OPT_DIR"; then
+		echo "S22opt: $OPT_DIR carries an unexpected writable mount and cannot be sealed; do not use opkg" >&2
+		return 1
 	fi
 
 	mkdir -p "$OPT_DIR" 2>/dev/null || true

--- a/overlay/etc/init.d/S22opt
+++ b/overlay/etc/init.d/S22opt
@@ -1,0 +1,241 @@
+#!/bin/sh
+# Bind the persistent opkg install root into /opt.
+#
+# See docs/07-operations/opkg-package-management.md.
+#
+# Why /userdata/opt: rootfs and oem are A/B partitions that are overwritten
+# wholesale by OTA, so /userdata is the only writable space a package can
+# survive an upgrade in (§6.1).
+#
+# Why a bind mount and not a symlink: overlay/ only syncs etc/ into the rootfs,
+# so a /opt symlink cannot be baked into the image; and the Buildroot skeleton
+# may already ship an empty /opt, which "ln -s" will not overwrite. A bind
+# mount works either way (§6.2). /opt itself has to be a real path because
+# Entware binaries carry it in PT_INTERP and DT_RUNPATH.
+#
+# What happens when the bind fails: /opt is sealed with a read-only tmpfs so
+# writes fail with EROFS instead of silently landing in the current A/B rootfs,
+# where they would neither persist nor be accounted for (§6.2.1). That is only
+# the first guard -- /etc/opkg/90-userfeeds.conf is a symlink into /opt, and
+# opkg 0.7.0 aborts when any /etc/opkg/*.conf fragment cannot be opened, so a
+# failed mount also stops opkg from running at all.
+
+OPT_DIR=${OPT_DIR:-/opt}
+USERDATA_DIR=${USERDATA_DIR:-/userdata}
+PERSISTENT_OPT=${PERSISTENT_OPT:-$USERDATA_DIR/opt}
+USERFEEDS_FILE=${USERFEEDS_FILE:-$OPT_DIR/etc/opkg/userfeeds.conf}
+LOCK_DIR=${LOCK_DIR:-/run/lock}
+MOUNT_BIN=${MOUNT_BIN:-mount}
+UMOUNT_BIN=${UMOUNT_BIN:-umount}
+AWK_BIN=${AWK_BIN:-awk}
+MOUNTINFO_PATH=${MOUNTINFO_PATH:-/proc/self/mountinfo}
+
+# Print one property of the last /proc/self/mountinfo entry mounted at $1.
+#
+# /proc/mounts is not enough here: it reports a bind mount's *device*, never the
+# directory it was bound from, so it cannot tell /opt bound from /userdata/opt
+# apart from /opt bound from anywhere else on the same filesystem. mountinfo
+# also carries the path within the filesystem, which is what makes the source
+# check in opt_is_bound possible.
+#
+# mountinfo fields 1-6 are fixed (id, parent, major:minor, root, mount point,
+# options). A variable number of optional fields then precedes a "-" separator,
+# after which comes the filesystem type -- so fstype is found by walking to the
+# separator, not by column number.
+mount_field() {
+	[ -r "$MOUNTINFO_PATH" ] || return 1
+	"$AWK_BIN" -v target="$1" -v want="$2" '
+		$5 == target {
+			found = 1
+			dev = $3
+			root = $4
+			opts = $6
+			fstype = ""
+			for (i = 7; i <= NF; i++) {
+				if ($i == "-") {
+					fstype = $(i + 1)
+					break
+				}
+			}
+		}
+		END {
+			if (!found) exit 1
+			if (want == "dev") print dev
+			else if (want == "root") print root
+			else if (want == "opts") print opts
+			else if (want == "fstype") print fstype
+			else exit 1
+		}
+	' "$MOUNTINFO_PATH"
+}
+
+path_is_mounted() {
+	mount_field "$1" dev >/dev/null 2>&1
+}
+
+# The in-filesystem path that $PERSISTENT_OPT occupies, i.e. what mountinfo
+# reports as the "root" of a correct bind mount at $OPT_DIR.
+persistent_opt_fs_root() {
+	case "$PERSISTENT_OPT" in
+		"$USERDATA_DIR"/?*) ;;
+		*)
+			echo "S22opt: $PERSISTENT_OPT is not below $USERDATA_DIR" >&2
+			return 1
+			;;
+	esac
+
+	userdata_root=$(mount_field "$USERDATA_DIR" root) || return 1
+	printf '%s\n' "${userdata_root%/}${PERSISTENT_OPT#"$USERDATA_DIR"}"
+}
+
+# True only when $OPT_DIR is a bind of $PERSISTENT_OPT: same filesystem as
+# $USERDATA_DIR, and the same path inside it. Merely being mounted is not
+# enough -- a wrong source has to be reported as an error.
+opt_is_bound() {
+	opt_dev=$(mount_field "$OPT_DIR" dev) || return 1
+	opt_root=$(mount_field "$OPT_DIR" root) || return 1
+	userdata_dev=$(mount_field "$USERDATA_DIR" dev) || return 1
+	expected_root=$(persistent_opt_fs_root) || return 1
+
+	[ "$opt_dev" = "$userdata_dev" ] && [ "$opt_root" = "$expected_root" ]
+}
+
+opt_is_sealed() {
+	[ "$(mount_field "$OPT_DIR" fstype)" = "tmpfs" ] || return 1
+	case ",$(mount_field "$OPT_DIR" opts)," in
+		*,ro,*) return 0 ;;
+	esac
+	return 1
+}
+
+seal_opt() {
+	if path_is_mounted "$OPT_DIR"; then
+		return 0
+	fi
+
+	mkdir -p "$OPT_DIR" 2>/dev/null || true
+
+	# "ro" is what enforces the seal; size=0 does not cap a tmpfs.
+	if "$MOUNT_BIN" -t tmpfs -o ro,size=0 tmpfs "$OPT_DIR"; then
+		echo "S22opt: bind mount failed, $OPT_DIR sealed read-only" >&2
+		return 0
+	fi
+
+	echo "S22opt: bind mount failed and $OPT_DIR could not be sealed; do not use opkg" >&2
+	return 1
+}
+
+ensure_opt_layout() {
+	# opkg's lock_file lives under /run, which is a tmpfs and starts empty.
+	mkdir -p "$LOCK_DIR" 2>/dev/null || true
+
+	if ! mkdir -p \
+		"$OPT_DIR/bin" \
+		"$OPT_DIR/sbin" \
+		"$OPT_DIR/tmp" \
+		"$OPT_DIR/etc/opkg" \
+		"$OPT_DIR/var/cache/opkg" \
+		"$OPT_DIR/var/lib/opkg/info" \
+		"$OPT_DIR/var/lib/opkg/lists"; then
+		echo "S22opt: cannot create the opkg layout under $OPT_DIR" >&2
+		return 1
+	fi
+
+	# Create when absent, never truncate: this file holds the user's feed
+	# selection and is expected to survive reboots and OTA (§6.4).
+	if [ ! -e "$USERFEEDS_FILE" ] && ! touch "$USERFEEDS_FILE"; then
+		echo "S22opt: cannot create $USERFEEDS_FILE" >&2
+		return 1
+	fi
+
+	return 0
+}
+
+start() {
+	if opt_is_bound; then
+		ensure_opt_layout
+		return
+	fi
+
+	if ! path_is_mounted "$USERDATA_DIR"; then
+		echo "S22opt: $USERDATA_DIR is not mounted" >&2
+		seal_opt
+		return 1
+	fi
+
+	# A read-only seal left by an earlier failed boot holds nothing, so drop it
+	# and retry. That makes "S22opt restart" the recovery path once whatever
+	# broke the bind has been fixed.
+	if opt_is_sealed && ! "$UMOUNT_BIN" "$OPT_DIR"; then
+		echo "S22opt: cannot release the read-only seal on $OPT_DIR" >&2
+		return 1
+	fi
+
+	if path_is_mounted "$OPT_DIR"; then
+		echo "S22opt: $OPT_DIR is already mounted from an unexpected source" >&2
+		return 1
+	fi
+
+	if ! mkdir -p "$PERSISTENT_OPT" "$OPT_DIR"; then
+		echo "S22opt: cannot create $PERSISTENT_OPT" >&2
+		seal_opt
+		return 1
+	fi
+
+	if ! "$MOUNT_BIN" -o bind "$PERSISTENT_OPT" "$OPT_DIR"; then
+		seal_opt
+		return 1
+	fi
+
+	# Confirm through mountinfo rather than trusting the exit status: the mount
+	# can succeed and still land somewhere else, e.g. when $PERSISTENT_OPT is a
+	# symlink. Leaving $USERFEEDS_FILE uncreated keeps opkg disabled.
+	if ! opt_is_bound; then
+		echo "S22opt: $OPT_DIR is mounted but not bound from $PERSISTENT_OPT" >&2
+		return 1
+	fi
+
+	ensure_opt_layout
+}
+
+stop() {
+	# Deliberately not unmounted: processes started from /opt may still be
+	# running, and the kernel releases the mount on reboot anyway.
+	echo "opt bind is managed at boot"
+}
+
+status() {
+	if opt_is_bound; then
+		echo "opt=bound source=$PERSISTENT_OPT"
+		return 0
+	fi
+	if opt_is_sealed; then
+		echo "opt=sealed source=none (bind of $PERSISTENT_OPT failed; opkg is disabled)"
+		return 1
+	fi
+	if path_is_mounted "$OPT_DIR"; then
+		echo "opt=wrong-source (mounted, but not bound from $PERSISTENT_OPT)"
+		return 1
+	fi
+	echo "opt=unbound"
+	return 1
+}
+
+case "${1:-start}" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	restart|reload)
+		start
+		;;
+	status)
+		status
+		;;
+	*)
+		echo "Usage: $0 {start|stop|restart|reload|status}" >&2
+		exit 1
+		;;
+esac

--- a/overlay/etc/opkg/00-aiden.conf
+++ b/overlay/etc/opkg/00-aiden.conf
@@ -1,0 +1,37 @@
+# Fixed opkg configuration. Ships with the rootfs, so OTA updates it.
+#
+# Loaded because opkg 0.7.0 reads /etc/opkg/*.conf. That only happens when no
+# -f is given: "opkg -f <file>" takes a different path and skips these
+# fragments entirely, so run plain "opkg update" / "opkg install".
+#
+# Feeds are NOT configured here -- see 90-userfeeds.conf.
+
+# Single destination. Entware payloads already carry an opt/ prefix
+# (./opt/bin/strace), so installing with / as the root lands them in /opt.
+# "dest opt /opt" would produce /opt/opt/bin/strace instead. opkg's default
+# destination is the first dest, and there is no "option default_dest".
+dest root /
+
+# Package database and caches all live under /opt, which is bind mounted from
+# /userdata/opt, so the database stays consistent with the installed files
+# across an OTA. Without this they would land in the A/B rootfs and be lost on
+# the next upgrade while the files themselves survived.
+# These are "option <name>" -- the only top-level keywords opkg 0.7.0 accepts
+# are option / dist / dist/gz / src / src/gz / dest / arch. Entware's
+# "lists_dir ext ..." is opkg-lede syntax and is not understood here; invalid
+# lines are only warned about, not rejected.
+option lists_dir   /opt/var/lib/opkg/lists
+option cache_dir   /opt/var/cache/opkg
+option status_file /opt/var/lib/opkg/status
+option info_dir    /opt/var/lib/opkg/info
+option lock_file   /run/lock/opkg.lock
+option tmp_dir     /opt/tmp
+
+# Download everything before installing anything, so a dropped connection is
+# less likely to leave a half-installed package. Requires libsolv; the internal
+# solver ignores it. This is not transactional and gives no power-fail
+# atomicity -- opkg 0.7.0 rewrites its status file in place.
+option download_first 1
+
+arch all        100
+arch armv7-3.2  160

--- a/overlay/etc/opkg/90-userfeeds.conf
+++ b/overlay/etc/opkg/90-userfeeds.conf
@@ -1,0 +1,1 @@
+/opt/etc/opkg/userfeeds.conf

--- a/overlay/etc/profile.d/aiden-opt.sh
+++ b/overlay/etc/profile.d/aiden-opt.sh
@@ -17,21 +17,47 @@
 # Core services are not touched at all: they start from absolute paths and do
 # not inherit a login shell's environment.
 
-# Each directory is probed on its own: something else may already have put
-# /opt/bin on PATH (a user's own profile, or /userdata/system/env, which
-# aiden-env.sh sources), and a single probe would then skip /opt/sbin forever --
-# or append a duplicate when only /opt/sbin was present.
-
+# Existing /opt entries are removed first, then both are appended, so the result
+# does not depend on what ran before this file.
+#
+# Merely probing "is it already there?" is not enough. profile.d is sourced in
+# alphabetical order, so aiden-env.sh -- which sources /userdata/system/env with
+# "set -a" -- has already run by the time we get here. A PATH=/opt/bin:$PATH in
+# that file would leave /opt/bin ahead of /usr/bin, and a probe would see it
+# present and leave it there, quietly breaking the ordering guarantee above.
+#
+# Scope, stated honestly: this only fixes login shells. Core services are
+# started through aiden-env-run, which sources the same /userdata/system/env and
+# is not affected by this file at all -- so this is not a security boundary, it
+# is a predictable default. A user who really wants /opt first can still do it
+# in ~/.profile, which runs after /etc/profile.d.
+#
+# Done with string surgery rather than IFS splitting because splitting silently
+# drops a trailing empty PATH component, and an empty component means "the
+# current directory" -- changing that behind the user's back is its own bug.
+aiden_opt_path=":$PATH:"
 for aiden_opt_dir in /opt/bin /opt/sbin; do
-	case ":$PATH:" in
-		*":$aiden_opt_dir:"*) ;;
-		*) PATH="$PATH:$aiden_opt_dir" ;;
-	esac
+	while :; do
+		case $aiden_opt_path in
+			*":$aiden_opt_dir:"*)
+				aiden_opt_path="${aiden_opt_path%%":$aiden_opt_dir:"*}:${aiden_opt_path#*":$aiden_opt_dir:"}"
+				;;
+			*)
+				break
+				;;
+		esac
+	done
 done
+aiden_opt_path=${aiden_opt_path#:}
+aiden_opt_path=${aiden_opt_path%:}
+
+# The :+ guard matters: without it an emptied PATH would yield a leading ":",
+# which is an empty component, i.e. the current directory on PATH.
+PATH="${aiden_opt_path:+$aiden_opt_path:}/opt/bin:/opt/sbin"
 
 export PATH
 
-unset aiden_opt_dir
+unset aiden_opt_dir aiden_opt_path
 
 # Let ncurses programs find Entware's terminfo database.
 #

--- a/overlay/etc/profile.d/aiden-opt.sh
+++ b/overlay/etc/profile.d/aiden-opt.sh
@@ -32,3 +32,44 @@ done
 export PATH
 
 unset aiden_opt_dir
+
+# Let ncurses programs find Entware's terminfo database.
+#
+# The rootfs ships ~18 terminfo entries (ansi, dumb, linux, putty*, screen,
+# vt100/vt220, xterm*). Anything else -- tmux-256color is the one people hit
+# first -- is simply absent, and every ncurses program then exits with
+# "Error opening terminal: $TERM". Entware's terminfo package carries a full
+# database, but installs it under /opt/share/terminfo where nothing looks.
+#
+# Entware's own answer is a postinst that appends "export TERMINFO=..." to
+# /opt/etc/profile. That file is an Entware convention this system does not
+# follow: nothing sources it, so the export never runs. We deliberately do NOT
+# source it either -- it is writable by any package's postinst, and sourcing it
+# into every login shell would let a package silently redefine the environment,
+# including undoing the PATH ordering above. Handling the one setting that
+# actually matters is the smaller blast radius.
+#
+# TERMINFO_DIRS, not TERMINFO: TERMINFO names a *single* directory and would
+# hide the rootfs database outright. TERMINFO_DIRS is a search list, so both
+# survive. The rootfs comes first for the same reason /opt is appended to PATH
+# and not prepended -- an installed package fills gaps, it does not redefine
+# terminals that already work.
+#
+# The two directories are read from the environment purely so this file stays
+# testable on a host that has no /opt (same approach as S22opt); nothing sets
+# them in production. They grant no capability a user does not already have by
+# setting TERMINFO_DIRS directly.
+aiden_opt_terminfo=${AIDEN_OPT_TERMINFO:-/opt/share/terminfo}
+aiden_sys_terminfo=${AIDEN_SYS_TERMINFO:-/usr/share/terminfo}
+
+if [ -d "$aiden_opt_terminfo" ]; then
+	case ":${TERMINFO_DIRS-}:" in
+		*":$aiden_opt_terminfo:"*) ;;
+		*)
+			TERMINFO_DIRS="${TERMINFO_DIRS:-$aiden_sys_terminfo}:$aiden_opt_terminfo"
+			export TERMINFO_DIRS
+			;;
+	esac
+fi
+
+unset aiden_opt_terminfo aiden_sys_terminfo

--- a/overlay/etc/profile.d/aiden-opt.sh
+++ b/overlay/etc/profile.d/aiden-opt.sh
@@ -17,13 +17,18 @@
 # Core services are not touched at all: they start from absolute paths and do
 # not inherit a login shell's environment.
 
-OPT_HOME=/opt
+# Each directory is probed on its own: something else may already have put
+# /opt/bin on PATH (a user's own profile, or /userdata/system/env, which
+# aiden-env.sh sources), and a single probe would then skip /opt/sbin forever --
+# or append a duplicate when only /opt/sbin was present.
 
-case ":$PATH:" in
-	*":$OPT_HOME/bin:"*) ;;
-	*) PATH="$PATH:$OPT_HOME/bin:$OPT_HOME/sbin" ;;
-esac
+for aiden_opt_dir in /opt/bin /opt/sbin; do
+	case ":$PATH:" in
+		*":$aiden_opt_dir:"*) ;;
+		*) PATH="$PATH:$aiden_opt_dir" ;;
+	esac
+done
 
 export PATH
 
-unset OPT_HOME
+unset aiden_opt_dir

--- a/overlay/etc/profile.d/aiden-opt.sh
+++ b/overlay/etc/profile.d/aiden-opt.sh
@@ -55,6 +55,23 @@ unset aiden_opt_dir
 # and not prepended -- an installed package fills gaps, it does not redefine
 # terminals that already work.
 #
+# Set unconditionally -- deliberately NOT guarded on the directory existing.
+#
+# An earlier version only acted when /opt/share/terminfo was already there. That
+# is wrong for the flow everybody actually uses:
+#
+#     ssh in            <- nothing installed yet, so the guard did nothing
+#     opkg install htop <- terminfo arrives now
+#     htop              <- same shell: TERMINFO_DIRS still unset -> still fails
+#
+# The variable is read by ncurses at program start, so it has to be right for
+# shells that logged in before the package existed. Only the next login would
+# have picked it up, which makes the fix useless exactly when it is needed.
+#
+# Naming a directory that does not exist costs nothing: ncurses skips missing
+# entries in the search list (verified on the board with both orderings), and
+# $HOME/.terminfo is still searched independently of this variable.
+#
 # The two directories are read from the environment purely so this file stays
 # testable on a host that has no /opt (same approach as S22opt); nothing sets
 # them in production. They grant no capability a user does not already have by
@@ -62,14 +79,12 @@ unset aiden_opt_dir
 aiden_opt_terminfo=${AIDEN_OPT_TERMINFO:-/opt/share/terminfo}
 aiden_sys_terminfo=${AIDEN_SYS_TERMINFO:-/usr/share/terminfo}
 
-if [ -d "$aiden_opt_terminfo" ]; then
-	case ":${TERMINFO_DIRS-}:" in
-		*":$aiden_opt_terminfo:"*) ;;
-		*)
-			TERMINFO_DIRS="${TERMINFO_DIRS:-$aiden_sys_terminfo}:$aiden_opt_terminfo"
-			export TERMINFO_DIRS
-			;;
-	esac
-fi
+case ":${TERMINFO_DIRS-}:" in
+	*":$aiden_opt_terminfo:"*) ;;
+	*)
+		TERMINFO_DIRS="${TERMINFO_DIRS:-$aiden_sys_terminfo}:$aiden_opt_terminfo"
+		export TERMINFO_DIRS
+		;;
+esac
 
 unset aiden_opt_terminfo aiden_sys_terminfo

--- a/overlay/etc/profile.d/aiden-opt.sh
+++ b/overlay/etc/profile.d/aiden-opt.sh
@@ -1,0 +1,29 @@
+# Put opkg-installed tools on the path for interactive login shells.
+#
+# See docs/07-operations/opkg-package-management.md §6.7. Two deliberate
+# asymmetries:
+#
+#   Appended, never prepended. storage_manager.go invokes mount, umount, fsck,
+#   sync and mkfs.* by bare name, so a package that happens to ship one of those
+#   names must not be able to shadow the system tool -- doing so breaks SD card
+#   handling, and because /userdata survives OTA and rollback, a bad package
+#   would survive them too. System tools stay first; packages only fill gaps.
+#
+#   No /opt/lib in LD_LIBRARY_PATH. Entware binaries carry
+#   PT_INTERP=/opt/lib/ld-linux.so.3 and DT_RUNPATH=/opt/lib, so they resolve
+#   their own runtime. Adding it gains exactly nothing and risks shadowing a
+#   system library that shares a SONAME.
+#
+# Core services are not touched at all: they start from absolute paths and do
+# not inherit a login shell's environment.
+
+OPT_HOME=/opt
+
+case ":$PATH:" in
+	*":$OPT_HOME/bin:"*) ;;
+	*) PATH="$PATH:$OPT_HOME/bin:$OPT_HOME/sbin" ;;
+esac
+
+export PATH
+
+unset OPT_HOME

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -193,3 +193,8 @@ add_test(
     NAME s22opt_tests
     COMMAND /bin/sh ${CMAKE_CURRENT_SOURCE_DIR}/test_s22opt.sh
 )
+
+add_test(
+    NAME aiden_opt_profile_tests
+    COMMAND /bin/sh ${CMAKE_CURRENT_SOURCE_DIR}/test_aiden_opt_profile.sh
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -185,3 +185,11 @@ add_test(NAME aiden_tests COMMAND $<TARGET_FILE:aiden_tests>)
 add_test(NAME logger_shell_format
     COMMAND sh ${CMAKE_SOURCE_DIR}/scripts/test_logger_format.sh
 )
+
+# Shell-level test for the /opt bind mount that opkg installs into. Needs no
+# build artifacts and no board: S22opt reads its paths and its mount/umount
+# binaries from the environment, so the test stubs them out.
+add_test(
+    NAME s22opt_tests
+    COMMAND /bin/sh ${CMAKE_CURRENT_SOURCE_DIR}/test_s22opt.sh
+)

--- a/tests/test_aiden_opt_profile.sh
+++ b/tests/test_aiden_opt_profile.sh
@@ -66,8 +66,45 @@ check_path \
 
 check_path \
 	"/usr/bin:/opt/sbin" \
-	"/usr/bin:/opt/sbin:/opt/bin" \
-	"adds /opt/bin without duplicating /opt/sbin"
+	"/usr/bin:/opt/bin:/opt/sbin" \
+	"an existing /opt/sbin is relocated into canonical order, not duplicated"
+
+# The reachable violation this guards: profile.d is sourced alphabetically, so
+# aiden-env.sh (which sources /userdata/system/env with "set -a") has already
+# run. A PATH=/opt/bin:$PATH there would otherwise survive, leaving package
+# binaries ahead of the system tools.
+check_path \
+	"/opt/bin:/usr/bin:/bin" \
+	"/usr/bin:/bin:/opt/bin:/opt/sbin" \
+	"an /opt entry placed ahead of the system directories is moved behind them"
+
+check_path \
+	"/opt/sbin:/opt/bin:/usr/bin" \
+	"/usr/bin:/opt/bin:/opt/sbin" \
+	"both /opt entries are relocated when they lead the PATH"
+
+check_path \
+	"/opt/bin:/usr/bin:/opt/bin" \
+	"/usr/bin:/opt/bin:/opt/sbin" \
+	"repeated /opt entries collapse to one"
+
+check_path \
+	"/opt/bin" \
+	"/opt/bin:/opt/sbin" \
+	"a PATH containing nothing else does not gain an empty component"
+
+# An empty PATH component means "the current directory". Whatever one thinks of
+# that, rewriting it behind the user's back would be a separate bug -- and it is
+# exactly what IFS-based splitting does to a trailing one.
+check_path \
+	"/usr/bin::/bin" \
+	"/usr/bin::/bin:/opt/bin:/opt/sbin" \
+	"an interior empty component is preserved"
+
+check_path \
+	"/usr/bin:" \
+	"/usr/bin::/opt/bin:/opt/sbin" \
+	"a trailing empty component is preserved"
 
 # Substring traps: neither of these is /opt/bin, so both must still be added.
 check_path \

--- a/tests/test_aiden_opt_profile.sh
+++ b/tests/test_aiden_opt_profile.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+# Host tests for overlay/etc/profile.d/aiden-opt.sh.
+#
+# The script is sourced into every interactive login shell, so the properties
+# that matter are ordering and idempotency: /opt must never come before the
+# system directories (a package shipping "mount" or "mkfs.ext4" would otherwise
+# shadow the tools storage_manager.go calls by bare name), and re-sourcing must
+# not grow PATH without bound. See
+# docs/07-operations/opkg-package-management.md §6.7.
+#
+# Set SH to re-run under a closer stand-in for the board's busybox ash, e.g.
+# "SH=dash sh tests/test_aiden_opt_profile.sh".
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+PROFILE="$SCRIPT_DIR/../overlay/etc/profile.d/aiden-opt.sh"
+SH=${SH:-sh}
+
+failures=0
+
+fail() {
+	echo "  FAIL: $*" >&2
+	failures=$((failures + 1))
+}
+
+pass() {
+	echo "  ok: $*"
+}
+
+# Source the profile script with $1 as the starting PATH and echo the result.
+resulting_path() {
+	PATH_IN=$1 "$SH" -c 'PATH=$PATH_IN; . "$1"; printf "%s\n" "$PATH"' sh "$PROFILE"
+}
+
+check_path() {
+	# check_path <input PATH> <expected PATH> <description>
+	actual=$(resulting_path "$1")
+	if [ "$actual" = "$2" ]; then
+		pass "$3"
+	else
+		fail "$3"
+		echo "        in:       $1" >&2
+		echo "        expected: $2" >&2
+		echo "        actual:   $actual" >&2
+	fi
+}
+
+echo "=== aiden-opt.sh tests ==="
+
+check_path \
+	"/usr/bin:/bin" \
+	"/usr/bin:/bin:/opt/bin:/opt/sbin" \
+	"appends both directories to a clean PATH"
+
+check_path \
+	"/usr/bin:/bin:/opt/bin:/opt/sbin" \
+	"/usr/bin:/bin:/opt/bin:/opt/sbin" \
+	"re-sourcing is a no-op"
+
+# The bug this guards: a single probe on /opt/bin skipped /opt/sbin entirely.
+check_path \
+	"/usr/bin:/opt/bin" \
+	"/usr/bin:/opt/bin:/opt/sbin" \
+	"adds /opt/sbin when only /opt/bin was already present"
+
+check_path \
+	"/usr/bin:/opt/sbin" \
+	"/usr/bin:/opt/sbin:/opt/bin" \
+	"adds /opt/bin without duplicating /opt/sbin"
+
+# Substring traps: neither of these is /opt/bin, so both must still be added.
+check_path \
+	"/usr/bin:/opt/binaries" \
+	"/usr/bin:/opt/binaries:/opt/bin:/opt/sbin" \
+	"a directory merely starting with /opt/bin does not count as a match"
+
+check_path \
+	"/usr/bin:/usr/local/opt/bin" \
+	"/usr/bin:/usr/local/opt/bin:/opt/bin:/opt/sbin" \
+	"a directory merely ending in /opt/bin does not count as a match"
+
+echo "Ordering: /opt must stay behind the system directories"
+actual=$(resulting_path "/usr/sbin:/usr/bin:/sbin:/bin")
+case $actual in
+	/usr/sbin:/usr/bin:/sbin:/bin:*)
+		pass "system directories keep their leading position"
+		;;
+	*)
+		fail "system directories were displaced: $actual"
+		;;
+esac
+case $actual in
+	*/opt/bin*/usr/bin*)
+		fail "/opt/bin was placed ahead of /usr/bin: $actual"
+		;;
+	*)
+		pass "/opt/bin never precedes /usr/bin"
+		;;
+esac
+
+echo "Hygiene: no loop variable leaks into the login shell"
+leaked=$(PATH_IN=/bin "$SH" -c \
+	'PATH=$PATH_IN; . "$1"; printf "%s\n" "${aiden_opt_dir-unset}"' sh "$PROFILE")
+if [ "$leaked" = "unset" ]; then
+	pass "aiden_opt_dir is unset afterwards"
+else
+	fail "aiden_opt_dir leaked as '$leaked'"
+fi
+
+echo "LD_LIBRARY_PATH is deliberately left alone (§6.7)"
+ld=$(PATH_IN=/bin "$SH" -c \
+	'PATH=$PATH_IN; . "$1"; printf "%s\n" "${LD_LIBRARY_PATH-unset}"' sh "$PROFILE")
+if [ "$ld" = "unset" ]; then
+	pass "no LD_LIBRARY_PATH is introduced"
+else
+	fail "LD_LIBRARY_PATH was set to '$ld'"
+fi
+
+echo ""
+if [ "$failures" -eq 0 ]; then
+	echo "=== all aiden-opt.sh tests passed ==="
+	exit 0
+fi
+echo "=== $failures aiden-opt.sh check(s) failed ==="
+exit 1

--- a/tests/test_aiden_opt_profile.sh
+++ b/tests/test_aiden_opt_profile.sh
@@ -150,13 +150,16 @@ else
 	fail "existing TERMINFO_DIRS mishandled: $actual"
 fi
 
-# No /opt database installed -> the variable must be left completely alone,
-# otherwise every shell would carry a search path pointing at nothing.
-actual=$(terminfo_dirs unset "$TI_TMP/does-not-exist")
-if [ "$actual" = "unset" ]; then
-	pass "leaves TERMINFO_DIRS unset when no /opt database is installed"
+# The regression that motivated dropping the directory-exists guard: a shell
+# that logs in BEFORE any package is installed must still export the path, or
+# "ssh in; opkg install htop; htop" fails in that same session and only a
+# re-login fixes it. ncurses skips search entries that do not exist.
+missing="$TI_TMP/does-not-exist"
+actual=$(terminfo_dirs unset "$missing")
+if [ "$actual" = "$SYS_TI:$missing" ]; then
+	pass "sets the path even before the /opt database exists"
 else
-	fail "TERMINFO_DIRS was set to '$actual' with no /opt database"
+	fail "expected '$SYS_TI:$missing', got '$actual'"
 fi
 
 # TERMINFO names a single directory and would hide the rootfs database.

--- a/tests/test_aiden_opt_profile.sh
+++ b/tests/test_aiden_opt_profile.sh
@@ -108,6 +108,75 @@ else
 	fail "aiden_opt_dir leaked as '$leaked'"
 fi
 
+echo "TERMINFO_DIRS: Entware's terminfo database must be findable (§6.7)"
+
+# The script reads both terminfo directories from the environment so this runs
+# on a host with no /opt at all. OPT_TI is created; SYS_TI merely has to be a
+# distinguishable string.
+TI_TMP=$(mktemp -d "${TMPDIR:-/tmp}/aiden-terminfo.XXXXXX")
+trap 'rm -rf "$TI_TMP"' EXIT
+OPT_TI="$TI_TMP/opt-terminfo"
+SYS_TI="$TI_TMP/sys-terminfo"
+mkdir -p "$OPT_TI" "$SYS_TI"
+
+terminfo_dirs() {
+	# terminfo_dirs <incoming TERMINFO_DIRS, or the literal "unset"> [opt dir]
+	AIDEN_OPT_TERMINFO=${2-$OPT_TI} AIDEN_SYS_TERMINFO=$SYS_TI TD=$1 \
+		"$SH" -c '
+			if [ "$TD" = unset ]; then unset TERMINFO_DIRS; else TERMINFO_DIRS=$TD; fi
+			. "$1"
+			printf "%s\n" "${TERMINFO_DIRS-unset}"
+		' sh "$PROFILE"
+}
+
+actual=$(terminfo_dirs unset)
+if [ "$actual" = "$SYS_TI:$OPT_TI" ]; then
+	pass "sets a search list with the rootfs database first"
+else
+	fail "unexpected TERMINFO_DIRS: got '$actual', want '$SYS_TI:$OPT_TI'"
+fi
+
+actual=$(terminfo_dirs "$SYS_TI:$OPT_TI")
+if [ "$actual" = "$SYS_TI:$OPT_TI" ]; then
+	pass "re-sourcing does not duplicate the /opt database"
+else
+	fail "re-sourcing changed TERMINFO_DIRS: $actual"
+fi
+
+actual=$(terminfo_dirs "/home/me/.terminfo")
+if [ "$actual" = "/home/me/.terminfo:$OPT_TI" ]; then
+	pass "an existing TERMINFO_DIRS is preserved and appended to"
+else
+	fail "existing TERMINFO_DIRS mishandled: $actual"
+fi
+
+# No /opt database installed -> the variable must be left completely alone,
+# otherwise every shell would carry a search path pointing at nothing.
+actual=$(terminfo_dirs unset "$TI_TMP/does-not-exist")
+if [ "$actual" = "unset" ]; then
+	pass "leaves TERMINFO_DIRS unset when no /opt database is installed"
+else
+	fail "TERMINFO_DIRS was set to '$actual' with no /opt database"
+fi
+
+# TERMINFO names a single directory and would hide the rootfs database.
+ti=$(AIDEN_OPT_TERMINFO=$OPT_TI AIDEN_SYS_TERMINFO=$SYS_TI "$SH" -c \
+	'. "$1"; printf "%s\n" "${TERMINFO-unset}"' sh "$PROFILE")
+if [ "$ti" = "unset" ]; then
+	pass "TERMINFO itself is never set"
+else
+	fail "TERMINFO was set to '$ti', which would hide the rootfs database"
+fi
+
+leaked=$(AIDEN_OPT_TERMINFO=$OPT_TI AIDEN_SYS_TERMINFO=$SYS_TI "$SH" -c \
+	'. "$1"; printf "%s|%s\n" "${aiden_opt_terminfo-unset}" "${aiden_sys_terminfo-unset}"' \
+	sh "$PROFILE")
+if [ "$leaked" = "unset|unset" ]; then
+	pass "terminfo helper variables do not leak"
+else
+	fail "terminfo helper variables leaked: $leaked"
+fi
+
 echo "LD_LIBRARY_PATH is deliberately left alone (§6.7)"
 ld=$(PATH_IN=/bin "$SH" -c \
 	'PATH=$PATH_IN; . "$1"; printf "%s\n" "${LD_LIBRARY_PATH-unset}"' sh "$PROFILE")

--- a/tests/test_s22opt.sh
+++ b/tests/test_s22opt.sh
@@ -280,6 +280,40 @@ check_status 1 $? "start fails"
 check_contains "$OUTPUT" "is not mounted" "names the missing /userdata"
 check_contains "$MOUNTLOG" "mount -t tmpfs" "seals /opt anyway"
 
+echo "Test 8b: a writable foreign mount on /opt is never mistaken for a seal"
+new_case no-userdata-foreign-opt
+# /userdata is gone AND something else already holds /opt, writable. Treating
+# "already mounted" as "already sealed" would report protection that does not
+# exist, and an opkg install would land in that foreign mount.
+: > "$MOUNTINFO"
+preset_opt_mount 0:99 / ext4 rw,relatime
+run_s22opt start
+check_status 1 $? "start fails"
+check_contains "$OUTPUT" "cannot be sealed" "says the seal could not be applied"
+if grep -q "mount -t tmpfs" "$MOUNTLOG"; then
+	fail "stacked a tmpfs on top of a foreign mount"
+else
+	pass "does not stack a seal on a foreign mount"
+fi
+if grep -q "^umount" "$MOUNTLOG"; then
+	fail "unmounted a mount it did not create"
+else
+	pass "does not unmount a foreign mount"
+fi
+
+echo "Test 8c: an already-sealed /opt is still recognised as sealed"
+new_case no-userdata-already-sealed
+: > "$MOUNTINFO"
+preset_opt_mount 0:42 / tmpfs ro,relatime
+run_s22opt start
+check_status 1 $? "start still fails (no /userdata)"
+if grep -q "mount -t tmpfs" "$MOUNTLOG"; then
+	fail "re-sealed an already sealed /opt"
+else
+	pass "does not re-seal"
+fi
+check_absent "$case_dir/opt/etc/opkg/userfeeds.conf" "creates no feed file"
+
 echo "Test 9: restart recovers from a seal once the bind can succeed"
 new_case recover
 preset_opt_mount 0:42 / tmpfs ro,relatime

--- a/tests/test_s22opt.sh
+++ b/tests/test_s22opt.sh
@@ -247,13 +247,25 @@ run_s22opt status
 check_status 1 $? "status fails"
 check_contains "$OUTPUT" "opt=wrong-source" "a same-path mount on another device is rejected"
 
-echo "Test 7: a bind that succeeds but lands elsewhere is caught"
+echo "Test 7: a bind that succeeds but lands elsewhere is torn down and sealed"
 new_case bind-lands-wrong
 echo /elsewhere > "$case_dir/bind-root"
 run_s22opt start
 check_status 1 $? "start fails"
 check_contains "$OUTPUT" "not bound from" "the post-mount check catches it"
+check_contains "$MOUNTLOG" "umount $case_dir/opt" "releases the wrong mount"
+check_contains "$MOUNTLOG" "mount -t tmpfs -o ro,size=0 tmpfs $case_dir/opt" \
+	"seals /opt instead of leaving a writable foreign mount"
 check_absent "$case_dir/opt/etc/opkg/userfeeds.conf" "no feed file, so opkg stays disabled"
+
+echo "Test 7b: a wrong landing that cannot be released is reported, not ignored"
+new_case bind-lands-wrong-stuck
+echo /elsewhere > "$case_dir/bind-root"
+: > "$case_dir/fail-umount"
+run_s22opt start
+check_status 1 $? "start fails"
+check_contains "$OUTPUT" "cannot release the unexpected mount" "warns that /opt is unprotected"
+check_absent "$case_dir/opt/etc/opkg/userfeeds.conf" "still creates no feed file"
 
 echo "Test 8: /userdata not mounted seals /opt instead of writing to the rootfs"
 new_case no-userdata

--- a/tests/test_s22opt.sh
+++ b/tests/test_s22opt.sh
@@ -1,0 +1,315 @@
+#!/bin/sh
+# Host tests for overlay/etc/init.d/S22opt (the /opt bind mount for opkg).
+#
+# The script takes every path and every external binary from the environment,
+# so the whole thing runs on a dev host with no board and no root: mount and
+# umount are replaced by stubs that edit a fake /proc/self/mountinfo, which is
+# the only thing S22opt reads to decide what is mounted where.
+#
+# The cases that matter are the failure ones. V7 (a failed bind must never let
+# a package land in the rootfs) and V9 (a mount from the wrong source must be
+# an error, not a success) are the two guards the whole design rests on; see
+# docs/07-operations/opkg-package-management.md §6.2 and §8.
+#
+# The board runs busybox ash, which is stricter than the host /bin/sh. Set SH to
+# re-run the same cases under a closer stand-in, e.g. "SH=dash sh
+# tests/test_s22opt.sh".
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+S22OPT="$SCRIPT_DIR/../overlay/etc/init.d/S22opt"
+SH=${SH:-sh}
+
+# A bind of /userdata/opt shows up in mountinfo as the /userdata *device* with
+# an in-filesystem root of /opt -- never as the string "/userdata/opt". Getting
+# that wrong is exactly the mistake the source check has to survive.
+USERDATA_DEV=8:6
+OTHER_DEV=8:7
+
+failures=0
+tmproot=$(mktemp -d "${TMPDIR:-/tmp}/s22opt-test.XXXXXX") || exit 1
+trap 'rm -rf "$tmproot"' EXIT INT TERM
+
+fail() {
+	echo "  FAIL: $*" >&2
+	failures=$((failures + 1))
+}
+
+pass() {
+	echo "  ok: $*"
+}
+
+check_status() {
+	# check_status <expected> <actual> <description>
+	if [ "$1" = "$2" ]; then
+		pass "$3"
+	else
+		fail "$3 (expected exit $1, got $2)"
+	fi
+}
+
+check_contains() {
+	# check_contains <file> <pattern> <description>
+	if grep -q "$2" "$1" 2>/dev/null; then
+		pass "$3"
+	else
+		fail "$3 (no match for '$2' in $1)"
+		sed 's/^/        /' "$1" >&2 2>/dev/null || true
+	fi
+}
+
+check_absent() {
+	# check_absent <path> <description>
+	if [ -e "$1" ]; then
+		fail "$2 ($1 exists)"
+	else
+		pass "$2"
+	fi
+}
+
+check_present() {
+	# check_present <path> <description>
+	if [ -e "$1" ]; then
+		pass "$2"
+	else
+		fail "$2 ($1 is missing)"
+	fi
+}
+
+# Build a fresh sandbox: fake mountinfo, mount/umount stubs, empty dirs.
+#
+# Stub knobs, set by each case before running S22opt:
+#   $case_dir/fail-bind    exists -> "mount -o bind" fails
+#   $case_dir/fail-tmpfs   exists -> "mount -t tmpfs" fails
+#   $case_dir/fail-umount  exists -> umount fails
+#   $case_dir/bind-dev     bind mount lands on this device  (default $USERDATA_DEV)
+#   $case_dir/bind-root    bind mount lands on this fs root (default /opt)
+new_case() {
+	case_name=$1
+	case_dir=$tmproot/$case_name
+	mkdir -p "$case_dir/bin" "$case_dir/opt" "$case_dir/userdata/opt" "$case_dir/run"
+
+	MOUNTINFO=$case_dir/mountinfo
+	MOUNTLOG=$case_dir/mount.log
+	OUTPUT=$case_dir/output
+	: > "$MOUNTLOG"
+
+	# /userdata is mounted from fstab before any S script runs.
+	printf '25 1 %s / %s rw,relatime - ext4 /dev/mmcblk0p6 rw\n' \
+		"$USERDATA_DEV" "$case_dir/userdata" > "$MOUNTINFO"
+
+	cat > "$case_dir/bin/mount" <<'STUB'
+#!/bin/sh
+printf '%s\n' "mount $*" >> "$MOUNTLOG"
+target=
+fstype=
+bind=0
+while [ "$#" -gt 0 ]; do
+	case $1 in
+		-t) fstype=$2; shift 2 ;;
+		-o) case ,$2, in *,bind,*) bind=1 ;; esac; shift 2 ;;
+		*) target=$1; shift ;;
+	esac
+done
+if [ "$bind" = 1 ]; then
+	[ -e "$CASE_DIR/fail-bind" ] && exit 1
+	dev=$(cat "$CASE_DIR/bind-dev" 2>/dev/null || echo "$STUB_USERDATA_DEV")
+	root=$(cat "$CASE_DIR/bind-root" 2>/dev/null || echo /opt)
+	printf '90 25 %s %s %s rw,relatime - ext4 /dev/mmcblk0p6 rw\n' \
+		"$dev" "$root" "$target" >> "$MOUNTINFO"
+	exit 0
+fi
+if [ "$fstype" = tmpfs ]; then
+	[ -e "$CASE_DIR/fail-tmpfs" ] && exit 1
+	printf '91 25 0:42 / %s ro,relatime - tmpfs tmpfs ro\n' "$target" >> "$MOUNTINFO"
+	exit 0
+fi
+exit 1
+STUB
+
+	cat > "$case_dir/bin/umount" <<'STUB'
+#!/bin/sh
+printf '%s\n' "umount $*" >> "$MOUNTLOG"
+[ -e "$CASE_DIR/fail-umount" ] && exit 1
+awk -v target="$1" '$5 != target' "$MOUNTINFO" > "$MOUNTINFO.new" &&
+	mv "$MOUNTINFO.new" "$MOUNTINFO"
+STUB
+
+	chmod +x "$case_dir/bin/mount" "$case_dir/bin/umount"
+}
+
+run_s22opt() {
+	CASE_DIR=$case_dir \
+	MOUNTINFO=$MOUNTINFO \
+	MOUNTLOG=$MOUNTLOG \
+	STUB_USERDATA_DEV=$USERDATA_DEV \
+	MOUNTINFO_PATH=$MOUNTINFO \
+	OPT_DIR=$case_dir/opt \
+	USERDATA_DIR=$case_dir/userdata \
+	PERSISTENT_OPT=$case_dir/userdata/opt \
+	USERFEEDS_FILE=$case_dir/opt/etc/opkg/userfeeds.conf \
+	LOCK_DIR=$case_dir/run/lock \
+	MOUNT_BIN=$case_dir/bin/mount \
+	UMOUNT_BIN=$case_dir/bin/umount \
+		"$SH" "$S22OPT" "$@" > "$OUTPUT" 2>&1
+}
+
+# Append a mountinfo entry for $case_dir/opt directly, bypassing the stub, to
+# set up a pre-existing mount state.
+preset_opt_mount() {
+	# preset_opt_mount <dev> <fs-root> [fstype] [options]
+	printf '90 25 %s %s %s %s - %s /dev/mmcblk0p6 rw\n' \
+		"$1" "$2" "$case_dir/opt" "${4:-rw,relatime}" "${3:-ext4}" >> "$MOUNTINFO"
+}
+
+echo "=== S22opt tests ==="
+
+echo "Test 1: a clean boot binds /userdata/opt and lays out the opkg tree"
+new_case clean-boot
+run_s22opt start
+check_status 0 $? "start succeeds"
+check_contains "$MOUNTLOG" "mount -o bind $case_dir/userdata/opt $case_dir/opt" \
+	"binds the persistent root onto /opt"
+check_present "$case_dir/opt/etc/opkg/userfeeds.conf" "creates the user feed file"
+check_present "$case_dir/opt/var/lib/opkg/lists" "creates lists_dir"
+check_present "$case_dir/opt/var/lib/opkg/info" "creates info_dir"
+check_present "$case_dir/opt/var/cache/opkg" "creates cache_dir"
+check_present "$case_dir/opt/tmp" "creates tmp_dir"
+check_present "$case_dir/run/lock" "creates the lock directory"
+run_s22opt status
+check_status 0 $? "status reports bound"
+check_contains "$OUTPUT" "opt=bound" "status names the source"
+
+echo "Test 2: an existing user feed file is never truncated (§6.4)"
+new_case keep-feeds
+mkdir -p "$case_dir/opt/etc/opkg"
+echo 'src/gz entware https://bin.entware.net/armv7sf-k3.2' \
+	> "$case_dir/opt/etc/opkg/userfeeds.conf"
+preset_opt_mount "$USERDATA_DEV" /opt
+run_s22opt start
+check_status 0 $? "start succeeds when already bound"
+check_contains "$case_dir/opt/etc/opkg/userfeeds.conf" "bin.entware.net" \
+	"the configured feed survives"
+if [ "$(wc -l < "$case_dir/opt/etc/opkg/userfeeds.conf")" -eq 1 ]; then
+	pass "the feed file is left exactly as it was"
+else
+	fail "the feed file was rewritten"
+fi
+if grep -q "mount -o bind" "$MOUNTLOG"; then
+	fail "re-bound an already correct mount"
+else
+	pass "does not re-mount when already bound"
+fi
+
+echo "Test 3: a failed bind seals /opt read-only and leaves opkg unusable (V7)"
+new_case seal
+: > "$case_dir/fail-bind"
+run_s22opt start
+check_status 1 $? "start fails"
+check_contains "$MOUNTLOG" "mount -t tmpfs -o ro,size=0 tmpfs $case_dir/opt" \
+	"seals /opt with a read-only tmpfs"
+check_contains "$OUTPUT" "sealed read-only" "says /opt was sealed"
+check_absent "$case_dir/opt/etc/opkg/userfeeds.conf" \
+	"leaves the feed symlink target missing, so opkg refuses to run"
+run_s22opt status
+check_status 1 $? "status fails while sealed"
+check_contains "$OUTPUT" "opt=sealed" "status reports the seal"
+
+echo "Test 4: when even the seal cannot be applied, that is reported"
+new_case seal-fails
+: > "$case_dir/fail-bind"
+: > "$case_dir/fail-tmpfs"
+run_s22opt start
+check_status 1 $? "start fails"
+check_contains "$OUTPUT" "could not be sealed" "warns that /opt is unprotected"
+check_absent "$case_dir/opt/etc/opkg/userfeeds.conf" "still creates no feed file"
+
+echo "Test 5: /opt mounted from the wrong path on the right device is an error (V9)"
+new_case wrong-root
+preset_opt_mount "$USERDATA_DEV" /somewhere-else
+run_s22opt status
+check_status 1 $? "status fails"
+check_contains "$OUTPUT" "opt=wrong-source" "status calls out the wrong source"
+run_s22opt start
+check_status 1 $? "start refuses"
+check_contains "$OUTPUT" "unexpected source" "start explains why"
+if grep -q "mount -o bind" "$MOUNTLOG"; then
+	fail "stacked a second mount on /opt"
+else
+	pass "does not stack a mount on the foreign one"
+fi
+
+echo "Test 6: /opt mounted from the right path on the wrong device is an error (V9)"
+new_case wrong-dev
+preset_opt_mount "$OTHER_DEV" /opt
+run_s22opt status
+check_status 1 $? "status fails"
+check_contains "$OUTPUT" "opt=wrong-source" "a same-path mount on another device is rejected"
+
+echo "Test 7: a bind that succeeds but lands elsewhere is caught"
+new_case bind-lands-wrong
+echo /elsewhere > "$case_dir/bind-root"
+run_s22opt start
+check_status 1 $? "start fails"
+check_contains "$OUTPUT" "not bound from" "the post-mount check catches it"
+check_absent "$case_dir/opt/etc/opkg/userfeeds.conf" "no feed file, so opkg stays disabled"
+
+echo "Test 8: /userdata not mounted seals /opt instead of writing to the rootfs"
+new_case no-userdata
+: > "$MOUNTINFO"
+run_s22opt start
+check_status 1 $? "start fails"
+check_contains "$OUTPUT" "is not mounted" "names the missing /userdata"
+check_contains "$MOUNTLOG" "mount -t tmpfs" "seals /opt anyway"
+
+echo "Test 9: restart recovers from a seal once the bind can succeed"
+new_case recover
+preset_opt_mount 0:42 / tmpfs ro,relatime
+run_s22opt restart
+check_status 0 $? "restart succeeds"
+check_contains "$MOUNTLOG" "umount $case_dir/opt" "releases the seal first"
+check_contains "$MOUNTLOG" "mount -o bind" "then binds the persistent root"
+check_present "$case_dir/opt/etc/opkg/userfeeds.conf" "the opkg tree is laid out"
+
+echo "Test 10: a seal that cannot be released is not silently worked around"
+new_case stuck-seal
+preset_opt_mount 0:42 / tmpfs ro,relatime
+: > "$case_dir/fail-umount"
+run_s22opt restart
+check_status 1 $? "restart fails"
+check_contains "$OUTPUT" "cannot release" "explains the stuck seal"
+if grep -q "mount -o bind" "$MOUNTLOG"; then
+	fail "bound on top of the seal"
+else
+	pass "does not bind on top of the seal"
+fi
+
+echo "Test 11: a persistent root outside /userdata is rejected, not assumed good"
+new_case outside-userdata
+PERSISTENT_OPT_OVERRIDE=$case_dir/elsewhere
+preset_opt_mount "$USERDATA_DEV" /opt
+CASE_DIR=$case_dir MOUNTINFO=$MOUNTINFO MOUNTLOG=$MOUNTLOG \
+STUB_USERDATA_DEV=$USERDATA_DEV MOUNTINFO_PATH=$MOUNTINFO \
+OPT_DIR=$case_dir/opt USERDATA_DIR=$case_dir/userdata \
+PERSISTENT_OPT=$PERSISTENT_OPT_OVERRIDE \
+USERFEEDS_FILE=$case_dir/opt/etc/opkg/userfeeds.conf \
+LOCK_DIR=$case_dir/run/lock MOUNT_BIN=$case_dir/bin/mount \
+UMOUNT_BIN=$case_dir/bin/umount \
+	"$SH" "$S22OPT" status > "$OUTPUT" 2>&1
+check_status 1 $? "status fails"
+check_contains "$OUTPUT" "is not below" "explains the misconfiguration"
+
+echo "Test 12: usage errors are rejected"
+new_case usage
+run_s22opt bogus
+check_status 1 $? "an unknown subcommand fails"
+check_contains "$OUTPUT" "Usage:" "prints usage"
+
+echo ""
+if [ "$failures" -eq 0 ]; then
+	echo "=== all S22opt tests passed ==="
+	exit 0
+fi
+echo "=== $failures S22opt check(s) failed ==="
+exit 1

--- a/tests/test_s22opt.sh
+++ b/tests/test_s22opt.sh
@@ -312,6 +312,17 @@ if grep -q "mount -t tmpfs" "$MOUNTLOG"; then
 else
 	pass "does not re-seal"
 fi
+# "no second tmpfs" on its own would also pass if the seal had been torn down
+# and never replaced, which is the outcome that actually matters. Assert both
+# that nothing was unmounted and that /opt is still sealed afterwards.
+if grep -q "^umount" "$MOUNTLOG"; then
+	fail "unmounted the existing seal"
+else
+	pass "does not unmount the existing seal"
+fi
+run_s22opt status
+check_status 1 $? "status still fails"
+check_contains "$OUTPUT" "opt=sealed" "the original seal is still in place"
 check_absent "$case_dir/opt/etc/opkg/userfeeds.conf" "creates no feed file"
 
 echo "Test 9: restart recovers from a seal once the bind can succeed"

--- a/tests/test_s22opt.sh
+++ b/tests/test_s22opt.sh
@@ -210,8 +210,13 @@ check_status 1 $? "start fails"
 check_contains "$MOUNTLOG" "mount -t tmpfs -o ro,size=0 tmpfs $case_dir/opt" \
 	"seals /opt with a read-only tmpfs"
 check_contains "$OUTPUT" "sealed read-only" "says /opt was sealed"
+# No feed file means no src line anywhere, so opkg cannot resolve any package.
+# Note this is NOT because opkg refuses to start on a dangling config symlink --
+# uClibc-ng's glob() silently drops it. Keeping the only src line inside /opt is
+# what makes a failed mount safe, which is why the default source is seeded here
+# and not shipped as a rootfs fragment (§6.5.1).
 check_absent "$case_dir/opt/etc/opkg/userfeeds.conf" \
-	"leaves the feed symlink target missing, so opkg refuses to run"
+	"creates no feed file, so no source is reachable"
 run_s22opt status
 check_status 1 $? "status fails while sealed"
 check_contains "$OUTPUT" "opt=sealed" "status reports the seal"
@@ -317,6 +322,69 @@ new_case usage
 run_s22opt bogus
 check_status 1 $? "an unknown subcommand fails"
 check_contains "$OUTPUT" "Usage:" "prints usage"
+
+echo "Test 13: a freshly created feed file is seeded with the default source (§6.5.1)"
+new_case seed-default
+run_s22opt start
+check_status 0 $? "start succeeds"
+UF=$case_dir/opt/etc/opkg/userfeeds.conf
+check_contains "$UF" "src/gz entware https://bin.entware.net/armv7sf-k3.2" \
+	"the default source is written"
+# Exactly one source line: comments are fine, a second src line would mean
+# opkg reports "Duplicate src declaration" (§13.1.1).
+if [ "$(grep -c '^src' "$UF")" -eq 1 ]; then
+	pass "exactly one src line"
+else
+	fail "expected 1 src line, got $(grep -c '^src' "$UF")"
+fi
+if [ -n "$(find "$case_dir/opt/etc/opkg" -name '.userfeeds.conf.*' 2>/dev/null)" ]; then
+	fail "a temporary file was left behind"
+else
+	pass "no temporary file left behind"
+fi
+
+echo "Test 14: seeding happens only on creation -- a user who deletes the source keeps it deleted"
+new_case respect-deletion
+mkdir -p "$case_dir/opt/etc/opkg"
+# The realistic shape after someone removes the seeded line: comments remain,
+# no src line. The file exists, so it must not be touched.
+printf '# I do not want a third-party feed\n' > "$case_dir/opt/etc/opkg/userfeeds.conf"
+preset_opt_mount "$USERDATA_DEV" /opt
+run_s22opt start
+check_status 0 $? "start succeeds"
+if grep -q '^src' "$case_dir/opt/etc/opkg/userfeeds.conf"; then
+	fail "the default source was re-seeded over the user's choice"
+else
+	pass "no source is re-added"
+fi
+check_contains "$case_dir/opt/etc/opkg/userfeeds.conf" "I do not want" \
+	"the user's content is untouched"
+
+echo "Test 14b: an existing *empty* feed file is also left alone"
+new_case respect-empty
+mkdir -p "$case_dir/opt/etc/opkg"
+: > "$case_dir/opt/etc/opkg/userfeeds.conf"
+preset_opt_mount "$USERDATA_DEV" /opt
+run_s22opt start
+check_status 0 $? "start succeeds"
+if [ -s "$case_dir/opt/etc/opkg/userfeeds.conf" ]; then
+	fail "an existing empty file was seeded"
+else
+	pass "an existing empty file stays empty"
+fi
+
+echo "Test 15: DEFAULT_FEED= builds an image with no default source"
+new_case no-default-feed
+export DEFAULT_FEED=
+run_s22opt start
+unset DEFAULT_FEED
+check_status 0 $? "start succeeds"
+check_present "$case_dir/opt/etc/opkg/userfeeds.conf" "the feed file is still created"
+if [ -s "$case_dir/opt/etc/opkg/userfeeds.conf" ]; then
+	fail "a source was seeded despite DEFAULT_FEED being empty"
+else
+	pass "the file is empty"
+fi
 
 echo ""
 if [ "$failures" -eq 0 ]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable `/opt` storage setup with mount validation and a safe read-only fallback when unavailable.
  - Added persistent package-management databases, caches, and user feed support.
  - Added automatic access to `/opt/bin` and `/opt/sbin` while preserving system tool precedence.
  - Improved terminal database lookup for applications installed under `/opt`.

- **Documentation**
  - Added troubleshooting guidance for package-manager failures involving `/opt` mounts and user feed configuration.

- **Tests**
  - Added coverage for storage setup, recovery, package configuration, and shell environment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->