### PR TITLE
fix(hid): enumerate pointer last to keep iOS soft keyboard stable

### DIFF
--- a/docs/03-services/usb-hid.md
+++ b/docs/03-services/usb-hid.md
@@ -148,6 +148,17 @@ After the action, including error and cancellation paths, it restores the normal
 composite. The isolated profile uses a distinct USB product ID and serial number
 so iOS does not reuse the pointer-bearing descriptor for the input.
 
+The normal composite must enumerate the pointer as the last HID interface:
+`keyboard -> Consumer Control -> pointer -> ECM`. iOS builds its keyboard and
+AssistiveTouch pointer subsystem state in interface order; a pointer that is
+enumerated immediately after the keyboard leaves the on-screen keyboard policy
+subject to an async race, so after an isolate/restore cycle the soft keyboard
+only reappears about 80% of the time. With the Consumer Control interface between
+them, the keyboard subsystem settles first and the pointer registers last, which
+closes that race: field tests showed 10/10 successful soft-keyboard restores.
+The pointer must stay before ECM: putting a HID interface after the ECM IAD
+causes continuous USB reset loops on iOS.
+
 One conversational Agent run owns a shared isolation scope. The first
 modifier-bearing keyboard operation removes the pointer, and later keyboard or
 Consumer Control operations reuse that profile without another enumeration. A

--- a/overlay/etc/init.d/S49usbhid
+++ b/overlay/etc/init.d/S49usbhid
@@ -157,8 +157,8 @@ start() {
 
 	# Link all functions, THEN bind UDC (configfs requires this order)
 	ln -s "$GADGET_DIR/functions/hid.usb0" "$GADGET_DIR/configs/c.1/hid.usb0" 2>/dev/null
-	ln -s "$GADGET_DIR/functions/hid.usb1" "$GADGET_DIR/configs/c.1/hid.usb1" 2>/dev/null
 	ln -s "$GADGET_DIR/functions/hid.usb2" "$GADGET_DIR/configs/c.1/hid.usb2" 2>/dev/null
+	ln -s "$GADGET_DIR/functions/hid.usb1" "$GADGET_DIR/configs/c.1/hid.usb1" 2>/dev/null
 	ln -s "$GADGET_DIR/functions/ecm.usb0" "$GADGET_DIR/configs/c.1/ecm.usb0" 2>/dev/null
 
 	echo "$UDC" > "$GADGET_DIR/UDC"

--- a/overlay/oem/usr/bin/aiden-dynamic-keyboard
+++ b/overlay/oem/usr/bin/aiden-dynamic-keyboard
@@ -79,8 +79,8 @@ unlink_functions() {
 
 link_normal_profile() {
 	ln -s "$KEYBOARD_FUNC" "$CONFIG_DIR/hid.usb0"
-	ln -s "$POINTER_FUNC" "$CONFIG_DIR/hid.usb1"
 	ln -s "$EXTRA_KEYS_FUNC" "$CONFIG_DIR/hid.usb2"
+	ln -s "$POINTER_FUNC" "$CONFIG_DIR/hid.usb1"
 }
 
 link_isolated_profile() {

--- a/src/example_usb_hid.cpp
+++ b/src/example_usb_hid.cpp
@@ -635,11 +635,11 @@ void setup_gadget(const Options& options, const std::string& mode) {
     if (mode == "keyboard" || mode == "composite") {
         setup_keyboard_function(gadget);
     }
-    if (mode == "touch" || mode == "composite") {
-        setup_touch_function(gadget, options);
-    }
     if (mode == "keyboard" || mode == "composite") {
         setup_android_extension_function(gadget, options.pointer_touchscreen);
+    }
+    if (mode == "touch" || mode == "composite") {
+        setup_touch_function(gadget, options);
     }
 
     std::string udc = options.udc.empty() ? first_udc_name() : options.udc;


### PR DESCRIPTION
## Summary

Reorder the USB composite config links so the pointer is the **last HID interface**: `keyboard -> Consumer Control -> pointer -> ECM` (previously `keyboard -> pointer -> Consumer Control -> ECM`).

## Problem

On iOS with AssistiveTouch, after the modifier-keyboard isolation mechanism runs (`aiden-dynamic-keyboard isolate` then `restore`), the on-screen keyboard only reappears **~80% of the time**. The pointer enumerating immediately after the keyboard leaves iOS's on-screen-keyboard policy in an async race between the keyboard subsystem and the AssistiveTouch pointer subsystem.

## Fix

Making the pointer the last HID interface (with Consumer Control between keyboard and pointer) lets the keyboard subsystem settle first; the pointer registers last, closing the race. **Field testing: 10/10 soft-keyboard restores** after isolate/restore (previous order: 8/10).

## Changes

- `overlay/etc/init.d/S49usbhid`: link order `hid.usb0 -> hid.usb2 -> hid.usb1 -> ecm.usb0`
- `overlay/oem/usr/bin/aiden-dynamic-keyboard`: `link_normal_profile` matches the same order
- `src/example_usb_hid.cpp`: `setup_gadget` links CC before touch/pointer for development setups
- `docs/03-services/usb-hid.md`: documents the required order and why

The pointer must stay **before ECM**: putting a HID interface after the ECM IAD causes continuous USB reset loops on iOS (previously reverted experiment).

## Verification

- 10/10 soft-keyboard restores after isolate/restore with the new order (vs 8/10 with old order)
- Modifier isolation (Cmd+A/C/V) still works
- ECM watchdog grace mechanism unchanged
- Syntax-checked both shell scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved USB HID device enumeration for better compatibility with iOS.
  - Improved restoration of the iOS soft keyboard after switching profiles.
  - Reduced the risk of USB reset loops by preserving the correct ordering of pointer and network interfaces.
  - Applied consistent ordering across standard, keyboard, touch, and composite USB modes.

- **Documentation**
  - Documented the required USB interface order and the compatibility considerations for iOS devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->