### PR TITLE
perf(boot): remove blocking waits from rcS and add boot profiling

### DIFF
--- a/overlay/etc/aiden_boot.conf
+++ b/overlay/etc/aiden_boot.conf
@@ -30,6 +30,11 @@ ENABLE_USB0CONFIG_SHIM=1
 # System baseline network stack switches
 ENABLE_DBUS=1
 ENABLE_NETWORK=1
+
+# Start dhcpcd with -b so it detaches immediately instead of holding up rcS
+# until a lease arrives (or its 30s timeout expires). Set to 0 to restore the
+# SDK's blocking behaviour. See /etc/init.d/S41dhcpcd.
+DHCPCD_BACKGROUND=1
 ENABLE_WIFIDRV=1
 ENABLE_WLAN_GUARD=1
 ENABLE_NTP=1

--- a/overlay/etc/aiden_boot_timeline.sh
+++ b/overlay/etc/aiden_boot_timeline.sh
@@ -1,0 +1,174 @@
+#!/bin/sh
+# Aiden boot timeline recorder.
+#
+# Records monotonic (/proc/uptime) timestamps for each init script and for
+# service-defined milestones, so "the board boots slowly" can be answered with
+# numbers instead of impressions.
+#
+# Lives in /etc (not /etc/init.d) so it is available before /oem is mounted and
+# so rcS does not try to run it as a service.
+#
+# Record format, one event per line:
+#   <uptime_s> <delta_s> <event> [detail...]
+#
+# Usage:
+#   . /etc/aiden_boot_timeline.sh          # source to get the helper functions
+#   /etc/aiden_boot_timeline.sh mark LABEL # append a milestone from any script
+#   /etc/aiden_boot_timeline.sh report     # print the current boot's summary
+
+BOOT_TIMELINE_LOG=${BOOT_TIMELINE_LOG:-/var/log/aiden_boot_timeline.log}
+BOOT_TIMELINE_ARCHIVE_DIR=${BOOT_TIMELINE_ARCHIVE_DIR:-/userdata/log/boot_timeline}
+BOOT_TIMELINE_ARCHIVE_KEEP=${BOOT_TIMELINE_ARCHIVE_KEEP:-5}
+BOOT_TIMELINE_UPTIME_PATH=${BOOT_TIMELINE_UPTIME_PATH:-/proc/uptime}
+
+# Centiseconds since boot. Prints an integer, or 0 when /proc/uptime is
+# unreadable, so callers never have to guard the result.
+boot_timeline_now_cs() {
+    _bt_raw=""
+    # Guard readability first: an input redirection on a missing path reports on
+    # stderr before any "2>/dev/null" on the same command can take effect.
+    if [ -r "$BOOT_TIMELINE_UPTIME_PATH" ]; then
+        read -r _bt_raw _ < "$BOOT_TIMELINE_UPTIME_PATH" 2>/dev/null || _bt_raw=""
+    fi
+    case "$_bt_raw" in
+        ''|*[!0-9.]*) echo 0; return 0 ;;
+    esac
+
+    case "$_bt_raw" in
+        *.*)
+            _bt_whole="${_bt_raw%%.*}"
+            _bt_frac="${_bt_raw#*.}"
+            ;;
+        *)
+            _bt_whole="$_bt_raw"
+            _bt_frac="00"
+            ;;
+    esac
+
+    # Normalise the fraction to exactly two digits: pad, then keep the first two.
+    _bt_frac="${_bt_frac}00"
+    _bt_frac="${_bt_frac%"${_bt_frac#??}"}"
+
+    # Strip leading zeroes so arithmetic does not treat them as octal.
+    _bt_whole="${_bt_whole#"${_bt_whole%%[!0]*}"}"
+    [ -n "$_bt_whole" ] || _bt_whole=0
+    _bt_frac="${_bt_frac#"${_bt_frac%%[!0]*}"}"
+    [ -n "$_bt_frac" ] || _bt_frac=0
+
+    echo "$((_bt_whole * 100 + _bt_frac))"
+}
+
+# Render centiseconds as seconds with two decimals.
+boot_timeline_fmt_cs() {
+    _bt_cs="$1"
+    case "$_bt_cs" in
+        ''|*[!0-9]*) _bt_cs=0 ;;
+    esac
+    printf '%d.%02d' "$((_bt_cs / 100))" "$((_bt_cs % 100))"
+}
+
+boot_timeline_init() {
+    mkdir -p "$(dirname "$BOOT_TIMELINE_LOG")" 2>/dev/null || return 0
+    : > "$BOOT_TIMELINE_LOG" 2>/dev/null || return 0
+    BOOT_TIMELINE_LAST_CS="$(boot_timeline_now_cs)"
+    export BOOT_TIMELINE_LAST_CS
+}
+
+# boot_timeline_record EVENT [DETAIL...]
+# Never fails: boot must not depend on the profiler.
+boot_timeline_record() {
+    [ -n "${BOOT_TIMELINE_LOG:-}" ] || return 0
+    _bt_now="$(boot_timeline_now_cs)"
+    case "${BOOT_TIMELINE_LAST_CS:-}" in
+        ''|*[!0-9]*) BOOT_TIMELINE_LAST_CS="$_bt_now" ;;
+    esac
+    _bt_delta=$((_bt_now - BOOT_TIMELINE_LAST_CS))
+    [ "$_bt_delta" -ge 0 ] || _bt_delta=0
+    BOOT_TIMELINE_LAST_CS="$_bt_now"
+    export BOOT_TIMELINE_LAST_CS
+    printf '%s %s %s\n' \
+        "$(boot_timeline_fmt_cs "$_bt_now")" \
+        "$(boot_timeline_fmt_cs "$_bt_delta")" \
+        "$*" >> "$BOOT_TIMELINE_LOG" 2>/dev/null || true
+    return 0
+}
+
+# Milestone marker for use from service scripts. Unlike boot_timeline_record
+# this runs in its own process, so it reports absolute uptime only and leaves
+# the caller's delta chain untouched.
+boot_timeline_mark() {
+    [ -n "${BOOT_TIMELINE_LOG:-}" ] || return 0
+    [ -f "$BOOT_TIMELINE_LOG" ] || return 0
+    printf '%s %s mark %s\n' \
+        "$(boot_timeline_fmt_cs "$(boot_timeline_now_cs)")" \
+        "0.00" \
+        "$*" >> "$BOOT_TIMELINE_LOG" 2>/dev/null || true
+    return 0
+}
+
+# Keep the last N boots on persistent storage so boots can be compared.
+boot_timeline_archive() {
+    [ -f "$BOOT_TIMELINE_LOG" ] || return 0
+    mkdir -p "$BOOT_TIMELINE_ARCHIVE_DIR" 2>/dev/null || return 0
+    _bt_stamp="$(date '+%Y%m%d-%H%M%S' 2>/dev/null || echo unknown)"
+    cat "$BOOT_TIMELINE_LOG" > "$BOOT_TIMELINE_ARCHIVE_DIR/boot-$_bt_stamp.log" 2>/dev/null || return 0
+
+    _bt_count=0
+    for _bt_old in $(ls -1 "$BOOT_TIMELINE_ARCHIVE_DIR" 2>/dev/null | sort -r); do
+        _bt_count=$((_bt_count + 1))
+        if [ "$_bt_count" -gt "$BOOT_TIMELINE_ARCHIVE_KEEP" ]; then
+            rm -f "$BOOT_TIMELINE_ARCHIVE_DIR/$_bt_old" 2>/dev/null || true
+        fi
+    done
+    return 0
+}
+
+# Human-readable summary: full sequence plus the slowest scripts.
+boot_timeline_report() {
+    _bt_src="${1:-$BOOT_TIMELINE_LOG}"
+    if [ ! -f "$_bt_src" ]; then
+        echo "no boot timeline at $_bt_src" >&2
+        return 1
+    fi
+
+    echo "=== boot timeline ($_bt_src) ==="
+    printf '%10s %8s  %s\n' "uptime_s" "delta_s" "event"
+    awk '{ ev = $3; for (i = 4; i <= NF; i++) ev = ev " " $i; printf "%10s %8s  %s\n", $1, $2, ev }' "$_bt_src"
+
+    echo
+    echo "=== slowest init scripts ==="
+    printf '%8s  %s\n' "secs" "script"
+    awk '$3 == "script:end" { printf "%8s  %s\n", $2, $4 }' "$_bt_src" | sort -rn | head -15
+
+    echo
+    echo "=== milestones ==="
+    awk '$3 == "mark" { ev = $4; for (i = 5; i <= NF; i++) ev = ev " " $i; printf "%10s  %s\n", $1, ev }' "$_bt_src"
+    return 0
+}
+
+# Dispatch only when this file is executed directly. When it is sourced, $0 is
+# the caller (rcS, an S?? script, ...) and its positional parameters are ours —
+# an init script sourcing us while invoked as "S49usbhid start" must not be read
+# as the subcommand "start".
+case "${0##*/}" in
+    aiden_boot_timeline.sh) ;;
+    *) return 0 2>/dev/null || exit 0 ;;
+esac
+
+case "${1:-}" in
+    mark)
+        shift
+        boot_timeline_mark "$@"
+        ;;
+    report)
+        shift
+        boot_timeline_report "$@"
+        ;;
+    archive)
+        boot_timeline_archive
+        ;;
+    *)
+        echo "Usage: $0 {mark LABEL|report [FILE]|archive}" >&2
+        exit 1
+        ;;
+esac

--- a/overlay/etc/aiden_boot_timeline.sh
+++ b/overlay/etc/aiden_boot_timeline.sh
@@ -20,6 +20,15 @@ BOOT_TIMELINE_LOG=${BOOT_TIMELINE_LOG:-/var/log/aiden_boot_timeline.log}
 BOOT_TIMELINE_ARCHIVE_DIR=${BOOT_TIMELINE_ARCHIVE_DIR:-/userdata/log/boot_timeline}
 BOOT_TIMELINE_ARCHIVE_KEEP=${BOOT_TIMELINE_ARCHIVE_KEEP:-5}
 BOOT_TIMELINE_UPTIME_PATH=${BOOT_TIMELINE_UPTIME_PATH:-/proc/uptime}
+# Records which archive file belongs to the current boot, so milestones written
+# after rcS has finished can refresh it (see boot_timeline_refresh_archive).
+BOOT_TIMELINE_ARCHIVE_STATE=${BOOT_TIMELINE_ARCHIVE_STATE:-/run/aiden_boot_timeline.archive}
+# Shell and Go writers take an exclusive flock on this file before appending a
+# milestone or replacing/publishing an archive. The shared lock closes the
+# snapshot-to-state race and prevents a stale concurrent refresh from winning.
+BOOT_TIMELINE_LOCK_FILE=${BOOT_TIMELINE_LOCK_FILE:-/run/aiden_boot_timeline.lock}
+BOOT_TIMELINE_FLOCK_BIN=${BOOT_TIMELINE_FLOCK_BIN:-flock}
+BOOT_TIMELINE_LOCK_WAIT_TICKS=${BOOT_TIMELINE_LOCK_WAIT_TICKS:-100}
 
 # Centiseconds since boot. Prints an integer, or 0 when /proc/uptime is
 # unreadable, so callers never have to guard the result.
@@ -67,9 +76,70 @@ boot_timeline_fmt_cs() {
     printf '%d.%02d' "$((_bt_cs / 100))" "$((_bt_cs % 100))"
 }
 
+# The target BusyBox enables the flock applet. The mkdir fallback keeps the
+# helper usable in host tests and minimal development environments that do not
+# ship the command; it is bounded so profiling can never stall boot forever.
+boot_timeline_lock_acquire() {
+    _bt_lock_parent="$(dirname "$BOOT_TIMELINE_LOCK_FILE")"
+    mkdir -p "$_bt_lock_parent" 2>/dev/null || return 1
+
+    if command -v "$BOOT_TIMELINE_FLOCK_BIN" >/dev/null 2>&1; then
+        touch "$BOOT_TIMELINE_LOCK_FILE" 2>/dev/null || return 1
+        exec 9>"$BOOT_TIMELINE_LOCK_FILE"
+        _bt_lock_tries=0
+        while ! "$BOOT_TIMELINE_FLOCK_BIN" -xn 9 2>/dev/null; do
+            _bt_lock_tries=$((_bt_lock_tries + 1))
+            if [ "$_bt_lock_tries" -ge "$BOOT_TIMELINE_LOCK_WAIT_TICKS" ]; then
+                exec 9>&-
+                return 1
+            fi
+            sleep 0.01 2>/dev/null || sleep 1
+        done
+        BOOT_TIMELINE_LOCK_KIND=flock
+        return 0
+    fi
+
+    _bt_lock_dir="${BOOT_TIMELINE_LOCK_FILE}.d"
+    _bt_lock_tries=0
+    while ! mkdir "$_bt_lock_dir" 2>/dev/null; do
+        _bt_lock_tries=$((_bt_lock_tries + 1))
+        if [ "$_bt_lock_tries" -ge "$BOOT_TIMELINE_LOCK_WAIT_TICKS" ]; then
+            return 1
+        fi
+        sleep 0.01 2>/dev/null || sleep 1
+    done
+    BOOT_TIMELINE_LOCK_KIND=mkdir
+    return 0
+}
+
+boot_timeline_lock_release() {
+    case "${BOOT_TIMELINE_LOCK_KIND:-}" in
+        flock)
+            # Closing the descriptor releases the kernel lock, including when
+            # this helper is sourced into rcS rather than run as a subprocess.
+            exec 9>&-
+            ;;
+        mkdir)
+            rmdir "${BOOT_TIMELINE_LOCK_FILE}.d" 2>/dev/null || true
+            ;;
+    esac
+    BOOT_TIMELINE_LOCK_KIND=""
+    return 0
+}
+
 boot_timeline_init() {
     mkdir -p "$(dirname "$BOOT_TIMELINE_LOG")" 2>/dev/null || return 0
-    : > "$BOOT_TIMELINE_LOG" 2>/dev/null || return 0
+    if boot_timeline_lock_acquire; then
+        : > "$BOOT_TIMELINE_LOG" 2>/dev/null || true
+        # /run is normally fresh each boot. Explicit removal also makes a
+        # restarted rcS unable to refresh an archive belonging to an older run.
+        rm -f "$BOOT_TIMELINE_ARCHIVE_STATE" 2>/dev/null || true
+        boot_timeline_lock_release
+    else
+        # Preserve the profiler's fail-open behaviour when locking is
+        # unavailable; there can be no reliable persisted refresh in that case.
+        : > "$BOOT_TIMELINE_LOG" 2>/dev/null || return 0
+    fi
     BOOT_TIMELINE_LAST_CS="$(boot_timeline_now_cs)"
     export BOOT_TIMELINE_LAST_CS
 }
@@ -99,10 +169,43 @@ boot_timeline_record() {
 boot_timeline_mark() {
     [ -n "${BOOT_TIMELINE_LOG:-}" ] || return 0
     [ -f "$BOOT_TIMELINE_LOG" ] || return 0
+    boot_timeline_lock_acquire || return 0
     printf '%s %s mark %s\n' \
         "$(boot_timeline_fmt_cs "$(boot_timeline_now_cs)")" \
         "0.00" \
         "$*" >> "$BOOT_TIMELINE_LOG" 2>/dev/null || true
+    _boot_timeline_refresh_archive_locked
+    boot_timeline_lock_release
+    return 0
+}
+
+# Milestones can land after rcS has already archived the boot: the agent and
+# the swap worker both run asynchronously, so agent:listening and swap:active
+# are routinely written later. Refresh the archive so the persisted copy is not
+# a snapshot that stops at rcS:end. No-op until rcS has created the archive.
+boot_timeline_refresh_archive() {
+    boot_timeline_lock_acquire || return 0
+    _boot_timeline_refresh_archive_locked
+    boot_timeline_lock_release
+    return 0
+}
+
+# Caller must hold BOOT_TIMELINE_LOCK_FILE. Keeping append + refresh in one
+# critical section ensures every installed snapshot contains all earlier marks.
+_boot_timeline_refresh_archive_locked() {
+    [ -r "$BOOT_TIMELINE_ARCHIVE_STATE" ] || return 0
+    _bt_target="$(cat "$BOOT_TIMELINE_ARCHIVE_STATE" 2>/dev/null)" || return 0
+    [ -n "$_bt_target" ] || return 0
+    [ -f "$_bt_target" ] || return 0
+    [ -f "$BOOT_TIMELINE_LOG" ] || return 0
+
+    _bt_tmp="${_bt_target}.tmp.$$"
+    if cat "$BOOT_TIMELINE_LOG" > "$_bt_tmp" 2>/dev/null; then
+        # Rename so a reader never observes a half-written archive.
+        mv "$_bt_tmp" "$_bt_target" 2>/dev/null || rm -f "$_bt_tmp" 2>/dev/null
+    else
+        rm -f "$_bt_tmp" 2>/dev/null || true
+    fi
     return 0
 }
 
@@ -110,14 +213,59 @@ boot_timeline_mark() {
 boot_timeline_archive() {
     [ -f "$BOOT_TIMELINE_LOG" ] || return 0
     mkdir -p "$BOOT_TIMELINE_ARCHIVE_DIR" 2>/dev/null || return 0
-    _bt_stamp="$(date '+%Y%m%d-%H%M%S' 2>/dev/null || echo unknown)"
-    cat "$BOOT_TIMELINE_LOG" > "$BOOT_TIMELINE_ARCHIVE_DIR/boot-$_bt_stamp.log" 2>/dev/null || return 0
+    boot_timeline_lock_acquire || return 0
+    _boot_timeline_archive_locked
+    boot_timeline_lock_release
+    return 0
+}
 
+# Caller must hold BOOT_TIMELINE_LOCK_FILE from the snapshot through state
+# publication. A milestone therefore lands wholly before the snapshot or wholly
+# after publication, where its refresh can see the new archive.
+_boot_timeline_archive_locked() {
+    _bt_stamp="$(date '+%Y%m%d-%H%M%S' 2>/dev/null || echo unknown)"
+    _bt_archive="$BOOT_TIMELINE_ARCHIVE_DIR/boot-$_bt_stamp.log"
+    _bt_tmp="${_bt_archive}.tmp.$$"
+    if ! cat "$BOOT_TIMELINE_LOG" > "$_bt_tmp" 2>/dev/null; then
+        rm -f "$_bt_tmp" 2>/dev/null || true
+        return 0
+    fi
+    # Install the completed snapshot atomically so readers and retention never
+    # observe a partial boot-*.log archive.
+    if ! mv "$_bt_tmp" "$_bt_archive" 2>/dev/null; then
+        rm -f "$_bt_tmp" 2>/dev/null || true
+        return 0
+    fi
+
+    # Publish the path so later milestones can refresh this boot's archive.
+    # Check writability first: a redirection into a missing directory reports on
+    # stderr before any "2>/dev/null" on the same command can suppress it.
+    _bt_state_dir="$(dirname "$BOOT_TIMELINE_ARCHIVE_STATE")"
+    mkdir -p "$_bt_state_dir" 2>/dev/null || true
+    if [ -w "$_bt_state_dir" ]; then
+        printf '%s\n' "$_bt_archive" > "$BOOT_TIMELINE_ARCHIVE_STATE" 2>/dev/null || true
+    fi
+
+    # Drop leftovers from a refresh that died between cat and mv. They are not
+    # archives, and counting them below could evict a real one.
+    for _bt_stale in "$BOOT_TIMELINE_ARCHIVE_DIR"/boot-*.log.tmp.*; do
+        [ -e "$_bt_stale" ] || continue
+        rm -f "$_bt_stale" 2>/dev/null || true
+    done
+
+    # Retain only canonical timestamped archives. Pathname expansion preserves
+    # filenames and yields the fixed-width timestamps oldest-first, avoiding
+    # parsing ls output and ignoring unrelated boot-*.log files.
     _bt_count=0
-    for _bt_old in $(ls -1 "$BOOT_TIMELINE_ARCHIVE_DIR" 2>/dev/null | sort -r); do
+    for _bt_old in "$BOOT_TIMELINE_ARCHIVE_DIR"/boot-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].log; do
+        [ -f "$_bt_old" ] || continue
         _bt_count=$((_bt_count + 1))
-        if [ "$_bt_count" -gt "$BOOT_TIMELINE_ARCHIVE_KEEP" ]; then
-            rm -f "$BOOT_TIMELINE_ARCHIVE_DIR/$_bt_old" 2>/dev/null || true
+    done
+    for _bt_old in "$BOOT_TIMELINE_ARCHIVE_DIR"/boot-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].log; do
+        [ -f "$_bt_old" ] || continue
+        [ "$_bt_count" -gt "$BOOT_TIMELINE_ARCHIVE_KEEP" ] || break
+        if rm -f "$_bt_old" 2>/dev/null; then
+            _bt_count=$((_bt_count - 1))
         fi
     done
     return 0

--- a/overlay/etc/aiden_swap.conf
+++ b/overlay/etc/aiden_swap.conf
@@ -7,3 +7,7 @@
 : "${SWAP_REQUIRE_MOUNT:=1}"
 : "${SWAP_SIZE_MB:=256}"
 : "${SWAP_SWAPPINESS:=15}"
+# Activate the swapfile off the rcS critical path. swapon on a 256 MB file
+# costs ~7.4s on this eMMC and would otherwise delay the agent and the config
+# portal by the same amount. Set to 0 to activate synchronously.
+: "${SWAP_BACKGROUND:=1}"

--- a/overlay/etc/init.d/S41dhcpcd
+++ b/overlay/etc/init.d/S41dhcpcd
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Aiden override: start dhcpcd without blocking rcS.
+#
+# The SDK script runs `dhcpcd -f /etc/dhcpcd.conf` in the foreground. dhcpcd
+# only detaches once every interface has a lease, or after its built-in 30s
+# timeout — and the Pico Zero has no ethernet, so at this point in boot the only
+# interface is wlan0, which has not finished associating yet. Measured on a
+# Pico Zero, that cost a flat ~30s of dead time in the middle of rcS, delaying
+# every later service (frame_service, agent, config_web) by the same amount.
+#
+# `-b` makes dhcpcd fork immediately and keep configuring interfaces in the
+# background. Nothing later in rcS needs a lease to start: the agent, NTP and
+# wlan_guard all tolerate the network arriving late, and usb0 (192.168.42.1) is
+# configured statically by S49usbhid rather than by DHCP.
+#
+
+DAEMON=/sbin/dhcpcd
+CONFIG=/etc/dhcpcd.conf
+PIDFILE=/var/run/dhcpcd/pid
+BOOT_CONF=${BOOT_CONF:-/etc/aiden_boot.conf}
+
+if [ -f "$BOOT_CONF" ]; then
+	. "$BOOT_CONF"
+fi
+# Set to 0 to restore the SDK's blocking behaviour.
+: "${DHCPCD_BACKGROUND:=1}"
+
+[ -f $CONFIG ] || exit 0
+
+start() {
+	echo "Starting dhcpcd..."
+	if [ "$DHCPCD_BACKGROUND" = "1" ]; then
+		start-stop-daemon -S -x "$DAEMON" -p "$PIDFILE" -- -b -f "$CONFIG"
+	else
+		start-stop-daemon -S -x "$DAEMON" -p "$PIDFILE" -- -f "$CONFIG"
+	fi
+}
+
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	echo "Stopping dhcpcd..."
+	start-stop-daemon -K -x "$DAEMON" -p "$PIDFILE" -o
+	;;
+  reload|force-reload)
+	echo "Reloading dhcpcd configuration..."
+	"$DAEMON" -s reload
+	;;
+  restart)
+	"$0" stop
+	sleep 1 # Prevent race condition: ensure dhcpcd stops before start.
+	start
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart|reload|force-reload}"
+	exit 1
+esac

--- a/overlay/etc/init.d/S49usbhid
+++ b/overlay/etc/init.d/S49usbhid
@@ -15,6 +15,16 @@ USB0_NETMASK=255.255.255.0
 ECM_HOST_MAC=02:aa:bb:cc:dd:01
 ECM_DEV_MAC=02:aa:bb:cc:dd:02
 
+BOOT_TIMELINE_HELPER=${BOOT_TIMELINE_HELPER:-/etc/aiden_boot_timeline.sh}
+
+# This script holds several fixed sleeps and two polling waits, so it is worth
+# timing from the inside rather than only as a whole.
+mark() {
+	[ -x "$BOOT_TIMELINE_HELPER" ] || return 0
+	"$BOOT_TIMELINE_HELPER" mark "$@" 2>/dev/null || true
+	return 0
+}
+
 read_pointer_mode() {
 	POINTER_MODE=absolute
 	if [ ! -f "$AGENT_TOML" ]; then
@@ -59,15 +69,18 @@ start() {
 		return
 	fi
 
+	mark usbhid:udc-wait-begin
 	for i in $(seq 1 30); do
 		UDC=$(ls /sys/class/udc/ 2>/dev/null | head -n1)
 		[ -n "$UDC" ] && break
 		sleep 1
 	done
 	if [ -z "$UDC" ]; then
+		mark usbhid:udc-wait-timeout
 		echo "No UDC found"
 		return
 	fi
+	mark usbhid:udc-ready
 
 	mountpoint -q /sys/kernel/config || mount -t configfs none /sys/kernel/config
 	modprobe dwc2 2>/dev/null
@@ -75,6 +88,7 @@ start() {
 	modprobe usb_f_hid 2>/dev/null
 	modprobe usb_f_ecm 2>/dev/null
 	sleep 1
+	mark usbhid:modules-loaded
 
 	# Clean up stale instance
 	if [ -d "$GADGET_DIR" ]; then
@@ -162,6 +176,7 @@ start() {
 	ln -s "$GADGET_DIR/functions/ecm.usb0" "$GADGET_DIR/configs/c.1/ecm.usb0" 2>/dev/null
 
 	echo "$UDC" > "$GADGET_DIR/UDC"
+	mark usbhid:udc-bound
 
 	# Bring up usb0 with a static address once the kernel netdev appears.
 	for i in $(seq 1 20); do
@@ -170,11 +185,13 @@ start() {
 	done
 	if [ -d /sys/class/net/usb0 ]; then
 		if ifconfig usb0 "$USB0_ADDR" netmask "$USB0_NETMASK" up; then
+			mark usbhid:usb0-up
 			echo "usb0 up at $USB0_ADDR/$USB0_NETMASK"
 		else
 			echo "usb0 ifconfig failed"
 		fi
 	else
+		mark usbhid:usb0-missing
 		echo "usb0 did not appear; ECM may not be bound"
 	fi
 

--- a/overlay/etc/init.d/S51swap
+++ b/overlay/etc/init.d/S51swap
@@ -20,6 +20,14 @@ fi
 : "${SWAP_REQUIRE_MOUNT:=1}"
 : "${SWAP_SIZE_MB:=256}"
 : "${SWAP_SWAPPINESS:=15}"
+: "${SWAP_BACKGROUND:=1}"
+BOOT_TIMELINE_HELPER=${BOOT_TIMELINE_HELPER:-/etc/aiden_boot_timeline.sh}
+
+mark() {
+    [ -x "$BOOT_TIMELINE_HELPER" ] || return 0
+    "$BOOT_TIMELINE_HELPER" mark "$@" 2>/dev/null || true
+    return 0
+}
 
 case "$SWAP_SIZE_MB" in
     ''|*[!0-9]*|0)
@@ -107,6 +115,21 @@ create_swapfile() {
     mv "$swap_tmp" "$SWAP_FILE"
 }
 
+activate_swap() {
+    if ! file_has_expected_size; then
+        create_swapfile || return 1
+    else
+        chmod 0600 "$SWAP_FILE" || return 1
+    fi
+
+    if ! "$SWAPON_BIN" "$SWAP_FILE"; then
+        echo "failed to enable swapfile: $SWAP_FILE" >&2
+        return 1
+    fi
+    mark swap:active
+    echo "Enabled ${SWAP_SIZE_MB} MB swap at $SWAP_FILE (swappiness=$SWAP_SWAPPINESS)"
+}
+
 start() {
     if [ "$ENABLE_SWAP" != "1" ]; then
         echo "swap disabled by config (ENABLE_SWAP=$ENABLE_SWAP)"
@@ -121,18 +144,22 @@ start() {
         return 0
     fi
 
-    if ! file_has_expected_size; then
-        create_swapfile || return 1
-    else
-        chmod 0600 "$SWAP_FILE" || return 1
+    # Swappiness is a global vm knob and costs nothing, so apply it up front
+    # regardless of how the swapfile itself is activated.
+    configure_swappiness || return 1
+
+    if [ "$SWAP_BACKGROUND" = "1" ]; then
+        # swapon on the 256 MB swapfile measures ~7.4s on this eMMC, and rcS is
+        # strictly sequential — paying that here delays every later service,
+        # including the agent (S53) and the config portal (S56). Nothing between
+        # here and the end of rcS needs disk swap: zram (S21zram) is already
+        # active and absorbs early memory pressure at a higher priority.
+        activate_swap &
+        echo "Activating ${SWAP_SIZE_MB} MB swap at $SWAP_FILE in background (swappiness=$SWAP_SWAPPINESS)"
+        return 0
     fi
 
-    configure_swappiness || return 1
-    if ! "$SWAPON_BIN" "$SWAP_FILE"; then
-        echo "failed to enable swapfile: $SWAP_FILE" >&2
-        return 1
-    fi
-    echo "Enabled ${SWAP_SIZE_MB} MB swap at $SWAP_FILE (swappiness=$SWAP_SWAPPINESS)"
+    activate_swap
 }
 
 stop() {

--- a/overlay/etc/init.d/S53agent
+++ b/overlay/etc/init.d/S53agent
@@ -13,11 +13,18 @@ BOOT_CONF=/etc/aiden_boot.conf
 AIDEN_LOG_HELPER=${AIDEN_LOG_HELPER:-/oem/usr/lib/aiden-log.sh}
 [ -r "$AIDEN_LOG_HELPER" ] || AIDEN_LOG_HELPER="$(dirname "$0")/../../oem/usr/lib/aiden-log.sh"
 . "$AIDEN_LOG_HELPER"
+BOOT_TIMELINE_HELPER=${BOOT_TIMELINE_HELPER:-/etc/aiden_boot_timeline.sh}
 
 if [ -f "$BOOT_CONF" ]; then
     . "$BOOT_CONF"
 fi
 : "${ENABLE_AGENT:=1}"
+
+mark() {
+    [ -x "$BOOT_TIMELINE_HELPER" ] || return 0
+    "$BOOT_TIMELINE_HELPER" mark "$@" 2>/dev/null || true
+    return 0
+}
 LOG_PATH=${LOG_PATH:-$CONFIG_DIR/log/agent.log}
 
 supervisor_log() {
@@ -151,6 +158,7 @@ start() {
 
             supervisor_log INFO process_starting \
                 "starting $AGENT_BIN -dir $CONFIG_DIR -addr $ADDR"
+            mark agent:spawn
             "$ENV_RUN_BIN" "$AGENT_BIN" -dir "$CONFIG_DIR" -addr "$ADDR" >> "$LOG_PATH" 2>&1 &
             child="$!"
             echo "$child" > "$PID_FILE"

--- a/overlay/etc/init.d/S55aiden_usb_dhcp
+++ b/overlay/etc/init.d/S55aiden_usb_dhcp
@@ -27,6 +27,30 @@ current_pid() {
 	echo "$pid"
 }
 
+# busybox sleep supports fractional seconds only when built with FANCY_SLEEP;
+# fall back to a whole second so the poll still terminates either way.
+short_sleep() {
+	sleep 0.05 2>/dev/null || sleep 1
+}
+
+# Poll for the daemon instead of sleeping a flat second: dnsmasq is up in a few
+# tens of milliseconds, and rcS is sequential so the wait is dead time.
+# STARTUP_TIMEOUT_TICKS x 0.05s bounds the wait at the original ~1s budget.
+STARTUP_TIMEOUT_TICKS=${STARTUP_TIMEOUT_TICKS:-20}
+
+wait_until_running() {
+	i=0
+	while [ "$i" -lt "$STARTUP_TIMEOUT_TICKS" ]; do
+		pid="$(current_pid)"
+		if is_running "$pid"; then
+			return 0
+		fi
+		short_sleep
+		i=$((i + 1))
+	done
+	return 1
+}
+
 start() {
 	pid="$(current_pid)"
 	if is_running "$pid"; then
@@ -64,13 +88,12 @@ start() {
 		--keep-in-foreground &
 	child_pid=$!
 	echo "$child_pid" > "$PID_FILE"
-	sleep 1
-	pid="$(current_pid)"
-	if ! is_running "$pid"; then
+	if ! wait_until_running; then
 		rm -f "$PID_FILE"
 		echo "Failed to start aiden_usb_dhcp"
 		return 1
 	fi
+	pid="$(current_pid)"
 	echo "Started aiden_usb_dhcp (pid $pid)"
 }
 

--- a/overlay/etc/init.d/S55aiden_usb_dhcp
+++ b/overlay/etc/init.d/S55aiden_usb_dhcp
@@ -34,9 +34,11 @@ short_sleep() {
 }
 
 # Poll for the daemon instead of sleeping a flat second: dnsmasq is up in a few
-# tens of milliseconds, and rcS is sequential so the wait is dead time.
-# STARTUP_TIMEOUT_TICKS x 0.05s bounds the wait at the original ~1s budget.
-STARTUP_TIMEOUT_TICKS=${STARTUP_TIMEOUT_TICKS:-20}
+# tens of milliseconds, and rcS is sequential so the wait is dead time. The
+# budget is generous (60 x 0.05s = 3s) because the loop exits as soon as the
+# daemon is up — dnsmasq is also launched via a shell that execs into it, so
+# the first polls legitimately see the wrapper rather than dnsmasq.
+STARTUP_TIMEOUT_TICKS=${STARTUP_TIMEOUT_TICKS:-60}
 
 wait_until_running() {
 	i=0

--- a/overlay/etc/init.d/S55aiden_usb_dhcp
+++ b/overlay/etc/init.d/S55aiden_usb_dhcp
@@ -27,23 +27,48 @@ current_pid() {
 	echo "$pid"
 }
 
-# busybox sleep supports fractional seconds only when built with FANCY_SLEEP;
-# fall back to a whole second so the poll still terminates either way.
+# busybox sleep supports fractional seconds only when built with FANCY_SLEEP.
+# Probe once and derive the tick budget from the interval, so the wall-clock
+# timeout is the same either way instead of ballooning to one second per tick.
+if sleep 0.05 2>/dev/null; then
+	POLL_INTERVAL_CS=5
+else
+	POLL_INTERVAL_CS=100
+fi
+
 short_sleep() {
-	sleep 0.05 2>/dev/null || sleep 1
+	if [ "$POLL_INTERVAL_CS" = "5" ]; then
+		sleep 0.05
+	else
+		sleep 1
+	fi
 }
 
 # Poll for the daemon instead of sleeping a flat second: dnsmasq is up in a few
-# tens of milliseconds, and rcS is sequential so the wait is dead time. The
-# budget is generous (60 x 0.05s = 3s) because the loop exits as soon as the
-# daemon is up — dnsmasq is also launched via a shell that execs into it, so
-# the first polls legitimately see the wrapper rather than dnsmasq.
-STARTUP_TIMEOUT_TICKS=${STARTUP_TIMEOUT_TICKS:-60}
+# tens of milliseconds, and rcS is sequential so the wait is dead time. dnsmasq
+# is launched via a shell that execs into it, so the first polls legitimately
+# see the wrapper rather than dnsmasq.
+STARTUP_TIMEOUT_SECONDS=${STARTUP_TIMEOUT_SECONDS:-3}
+STARTUP_TIMEOUT_TICKS=${STARTUP_TIMEOUT_TICKS:-$((STARTUP_TIMEOUT_SECONDS * 100 / POLL_INTERVAL_CS))}
+[ "$STARTUP_TIMEOUT_TICKS" -ge 1 ] 2>/dev/null || STARTUP_TIMEOUT_TICKS=1
+
+# Liveness only — deliberately weaker than is_running(), which also checks the
+# exe identity and so is legitimately false during the launcher's exec window.
+pid_alive() {
+	pid="$1"
+	[ -n "$pid" ] || return 1
+	kill -0 "$pid" 2>/dev/null
+}
 
 wait_until_running() {
 	i=0
 	while [ "$i" -lt "$STARTUP_TIMEOUT_TICKS" ]; do
 		pid="$(current_pid)"
+		# A process that is gone will never become ready; fail immediately
+		# rather than sleeping out the remaining budget.
+		if ! pid_alive "$pid"; then
+			return 1
+		fi
 		if is_running "$pid"; then
 			return 0
 		fi
@@ -51,6 +76,26 @@ wait_until_running() {
 		i=$((i + 1))
 	done
 	return 1
+}
+
+# Reap the process we launched before dropping its PID file, otherwise the only
+# record of it is gone while it keeps running — a later start would then spawn a
+# second instance.
+terminate_child() {
+	pid="$1"
+	[ -n "$pid" ] || return 0
+	kill -0 "$pid" 2>/dev/null || return 0
+	kill "$pid" 2>/dev/null || true
+	i=0
+	while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 20 ]; do
+		short_sleep
+		i=$((i + 1))
+	done
+	if kill -0 "$pid" 2>/dev/null; then
+		kill -9 "$pid" 2>/dev/null || true
+	fi
+	wait "$pid" 2>/dev/null || true
+	return 0
 }
 
 start() {
@@ -91,6 +136,7 @@ start() {
 	child_pid=$!
 	echo "$child_pid" > "$PID_FILE"
 	if ! wait_until_running; then
+		terminate_child "$child_pid"
 		rm -f "$PID_FILE"
 		echo "Failed to start aiden_usb_dhcp"
 		return 1

--- a/overlay/etc/init.d/S56config_web
+++ b/overlay/etc/init.d/S56config_web
@@ -9,11 +9,18 @@ CONFIG_DIR=${CONFIG_DIR:-/userdata/agent}
 WIFI_CONFIG_PATH=/userdata/wpa_supplicant.conf
 SYSTEM_ENV_PATH=${SYSTEM_ENV_PATH:-/userdata/system/env}
 BOOT_CONF=${BOOT_CONF:-/etc/aiden_boot.conf}
+BOOT_TIMELINE_HELPER=${BOOT_TIMELINE_HELPER:-/etc/aiden_boot_timeline.sh}
 
 if [ -f "$BOOT_CONF" ]; then
     . "$BOOT_CONF"
 fi
 CONFIG_PATH=${CONFIG_PATH:-$CONFIG_DIR/agent.toml}
+
+mark() {
+    [ -x "$BOOT_TIMELINE_HELPER" ] || return 0
+    "$BOOT_TIMELINE_HELPER" mark "$@" 2>/dev/null || true
+    return 0
+}
 
 is_running() {
     pid="$1"
@@ -66,6 +73,9 @@ start() {
         return 1
     fi
 
+    # Milestone: http://192.168.42.1 (the settings portal) is now accepting
+    # connections. This is one of the two numbers users actually wait on.
+    mark config_web:listening
     echo "Started config_web (pid $pid)"
 }
 

--- a/overlay/etc/init.d/S56config_web
+++ b/overlay/etc/init.d/S56config_web
@@ -42,6 +42,50 @@ current_pid() {
     echo "$pid"
 }
 
+# busybox sleep supports fractional seconds only when built with FANCY_SLEEP;
+# fall back to a whole second so the poll still terminates either way.
+short_sleep() {
+    sleep 0.05 2>/dev/null || sleep 1
+}
+
+PORT=${PORT:-80}
+PROC_NET_TCP=${PROC_NET_TCP:-/proc/net/tcp}
+STARTUP_TIMEOUT_TICKS=${STARTUP_TIMEOUT_TICKS:-40}
+
+# /proc/net/tcp lists local_address as HEX_IP:HEX_PORT and state 0A = LISTEN.
+port_is_listening() {
+    [ -r "$PROC_NET_TCP" ] || return 1
+    port_hex="$(printf '%04X' "$PORT" 2>/dev/null)" || return 1
+    awk -v ph="$port_hex" '
+        BEGIN { pat = ":" ph "$" }
+        $4 == "0A" && $2 ~ pat { found = 1 }
+        END { exit found ? 0 : 1 }
+    ' "$PROC_NET_TCP" 2>/dev/null
+}
+
+# Poll until the portal is actually accepting connections rather than sleeping a
+# flat second. config_web binds before its accept loop, so this normally returns
+# in tens of milliseconds — and unlike a sleep it verifies the socket is really
+# up, not merely that the process has not exited yet.
+wait_until_ready() {
+    i=0
+    while [ "$i" -lt "$STARTUP_TIMEOUT_TICKS" ]; do
+        pid="$(current_pid)"
+        if ! is_running "$pid"; then
+            return 1
+        fi
+        if port_is_listening; then
+            return 0
+        fi
+        short_sleep
+        i=$((i + 1))
+    done
+    # The socket never showed up, but a live process is still better than
+    # tearing it down: fall back to the pre-poll liveness check.
+    pid="$(current_pid)"
+    is_running "$pid"
+}
+
 start() {
     pid="$(current_pid)"
     if is_running "$pid"; then
@@ -61,18 +105,17 @@ start() {
 
     mkdir -p "$(dirname "$CONFIG_PATH")" "$(dirname "$SYSTEM_ENV_PATH")"
 
-    "$ENV_RUN_BIN" "$BIN" --bind=0.0.0.0 --port=80 --config="$CONFIG_PATH" --wifi-config="$WIFI_CONFIG_PATH" --system-env="$SYSTEM_ENV_PATH" &
+    "$ENV_RUN_BIN" "$BIN" --bind=0.0.0.0 --port="$PORT" --config="$CONFIG_PATH" --wifi-config="$WIFI_CONFIG_PATH" --system-env="$SYSTEM_ENV_PATH" &
     child_pid=$!
     echo "$child_pid" > "$PID_FILE"
-    sleep 1
 
-    pid="$(current_pid)"
-    if ! is_running "$pid"; then
+    if ! wait_until_ready; then
         rm -f "$PID_FILE"
         echo "Failed to start config_web"
         return 1
     fi
 
+    pid="$(current_pid)"
     # Milestone: http://192.168.42.1 (the settings portal) is now accepting
     # connections. This is one of the two numbers users actually wait on.
     mark config_web:listening

--- a/overlay/etc/init.d/S56config_web
+++ b/overlay/etc/init.d/S56config_web
@@ -42,15 +42,28 @@ current_pid() {
     echo "$pid"
 }
 
-# busybox sleep supports fractional seconds only when built with FANCY_SLEEP;
-# fall back to a whole second so the poll still terminates either way.
+# busybox sleep supports fractional seconds only when built with FANCY_SLEEP.
+# Probe once and derive the tick budget from the interval, so the wall-clock
+# timeout is the same either way instead of ballooning to one second per tick.
+if sleep 0.05 2>/dev/null; then
+    POLL_INTERVAL_CS=5
+else
+    POLL_INTERVAL_CS=100
+fi
+
 short_sleep() {
-    sleep 0.05 2>/dev/null || sleep 1
+    if [ "$POLL_INTERVAL_CS" = "5" ]; then
+        sleep 0.05
+    else
+        sleep 1
+    fi
 }
 
 PORT=${PORT:-80}
 PROC_NET_TCP=${PROC_NET_TCP:-/proc/net/tcp}
-STARTUP_TIMEOUT_TICKS=${STARTUP_TIMEOUT_TICKS:-60}
+STARTUP_TIMEOUT_SECONDS=${STARTUP_TIMEOUT_SECONDS:-3}
+STARTUP_TIMEOUT_TICKS=${STARTUP_TIMEOUT_TICKS:-$((STARTUP_TIMEOUT_SECONDS * 100 / POLL_INTERVAL_CS))}
+[ "$STARTUP_TIMEOUT_TICKS" -ge 1 ] 2>/dev/null || STARTUP_TIMEOUT_TICKS=1
 
 # Liveness only — deliberately weaker than is_running(). The launcher is a shell
 # that execs into config_web, so for the first few milliseconds after the fork
@@ -73,10 +86,36 @@ port_is_listening() {
     ' "$PROC_NET_TCP" 2>/dev/null
 }
 
+# Reap the process we launched before dropping its PID file, otherwise the only
+# record of it is gone while it keeps running — a later start would then spawn a
+# second instance.
+terminate_child() {
+    pid="$1"
+    [ -n "$pid" ] || return 0
+    kill -0 "$pid" 2>/dev/null || return 0
+    kill "$pid" 2>/dev/null || true
+    i=0
+    while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 20 ]; do
+        short_sleep
+        i=$((i + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null || true
+    fi
+    wait "$pid" 2>/dev/null || true
+    return 0
+}
+
 # Poll until the portal is actually accepting connections rather than sleeping a
 # flat second. config_web binds before its accept loop, so this normally returns
 # in tens of milliseconds — and unlike a sleep it verifies the socket is really
 # up, not merely that the process has not exited yet.
+#
+# Exit status:
+#   0 - listening on $PORT, confirmed
+#   2 - process is up but $PROC_NET_TCP is unreadable, so the socket state
+#       cannot be determined either way
+#   1 - failed to start
 wait_until_ready() {
     i=0
     while [ "$i" -lt "$STARTUP_TIMEOUT_TICKS" ]; do
@@ -85,15 +124,30 @@ wait_until_ready() {
             return 1
         fi
         if is_running "$pid" && port_is_listening; then
-            return 0
+            # port_is_listening only proves $PORT is occupied, not by whom.
+            # config_web exits immediately when bind() fails, so re-checking
+            # liveness after the socket is observed rules out the narrow window
+            # where a doomed process is still alive while some other process
+            # holds the port.
+            if is_running "$pid"; then
+                return 0
+            fi
         fi
         short_sleep
         i=$((i + 1))
     done
-    # The socket never showed up, but a live process is still better than
-    # tearing it down: fall back to the pre-poll liveness check.
+
     pid="$(current_pid)"
-    is_running "$pid"
+    if ! is_running "$pid"; then
+        return 1
+    fi
+    # Process is alive but never appeared as LISTEN. Only excuse that when the
+    # socket table could not be read at all; if it was readable, the port
+    # genuinely never opened and reporting readiness would be a lie.
+    if [ -r "$PROC_NET_TCP" ]; then
+        return 1
+    fi
+    return 2
 }
 
 start() {
@@ -113,19 +167,37 @@ start() {
         return 1
     fi
 
+    # A listener present before launch cannot belong to this process. Reject it
+    # up front so an unrelated service cannot satisfy the readiness poll while
+    # config_web is still alive in its launcher or bind-failure path.
+    if port_is_listening; then
+        echo "Cannot start config_web: port $PORT is already in use"
+        return 1
+    fi
+
     mkdir -p "$(dirname "$CONFIG_PATH")" "$(dirname "$SYSTEM_ENV_PATH")"
 
     "$ENV_RUN_BIN" "$BIN" --bind=0.0.0.0 --port="$PORT" --config="$CONFIG_PATH" --wifi-config="$WIFI_CONFIG_PATH" --system-env="$SYSTEM_ENV_PATH" &
     child_pid=$!
     echo "$child_pid" > "$PID_FILE"
 
-    if ! wait_until_ready; then
+    wait_until_ready
+    ready_state="$?"
+    if [ "$ready_state" = "1" ]; then
+        terminate_child "$child_pid"
         rm -f "$PID_FILE"
         echo "Failed to start config_web"
         return 1
     fi
 
     pid="$(current_pid)"
+    if [ "$ready_state" = "2" ]; then
+        # Running, but readiness could not be confirmed. Do not record the
+        # listening milestone for something that was never observed listening.
+        echo "Started config_web (pid $pid; listening state unverified, $PROC_NET_TCP unreadable)"
+        return 0
+    fi
+
     # Milestone: http://192.168.42.1 (the settings portal) is now accepting
     # connections. This is one of the two numbers users actually wait on.
     mark config_web:listening

--- a/overlay/etc/init.d/S56config_web
+++ b/overlay/etc/init.d/S56config_web
@@ -50,7 +50,17 @@ short_sleep() {
 
 PORT=${PORT:-80}
 PROC_NET_TCP=${PROC_NET_TCP:-/proc/net/tcp}
-STARTUP_TIMEOUT_TICKS=${STARTUP_TIMEOUT_TICKS:-40}
+STARTUP_TIMEOUT_TICKS=${STARTUP_TIMEOUT_TICKS:-60}
+
+# Liveness only — deliberately weaker than is_running(). The launcher is a shell
+# that execs into config_web, so for the first few milliseconds after the fork
+# /proc/<pid>/exe still points at the shell and is_running() is legitimately
+# false. Only a pid that is actually gone means startup failed.
+pid_alive() {
+    pid="$1"
+    [ -n "$pid" ] || return 1
+    kill -0 "$pid" 2>/dev/null
+}
 
 # /proc/net/tcp lists local_address as HEX_IP:HEX_PORT and state 0A = LISTEN.
 port_is_listening() {
@@ -71,10 +81,10 @@ wait_until_ready() {
     i=0
     while [ "$i" -lt "$STARTUP_TIMEOUT_TICKS" ]; do
         pid="$(current_pid)"
-        if ! is_running "$pid"; then
+        if ! pid_alive "$pid"; then
             return 1
         fi
-        if port_is_listening; then
+        if is_running "$pid" && port_is_listening; then
             return 0
         fi
         short_sleep

--- a/overlay/etc/init.d/rcS
+++ b/overlay/etc/init.d/rcS
@@ -1,0 +1,74 @@
+#!/bin/sh
+#
+# Aiden override of the Buildroot rcS.
+#
+# Same semantics as the stock script — every /etc/init.d/S??* runs once, in
+# numerical order, in the same shell context as before — with per-script
+# monotonic timing recorded to /var/log/aiden_boot_timeline.log.
+#
+# The profiler is deliberately fail-open: if the helper is missing or a timing
+# call fails, scripts still run exactly as they would without it. Boot must
+# never depend on the profiler.
+#
+
+# Both paths are overridable so scripts/test_boot_timeline.sh can exercise this
+# file against a fixture tree. Production always uses the defaults.
+INIT_D_DIR=${INIT_D_DIR:-/etc/init.d}
+BOOT_TIMELINE_HELPER=${BOOT_TIMELINE_HELPER:-/etc/aiden_boot_timeline.sh}
+BOOT_TIMELINE_ENABLED=0
+
+if [ -f "$BOOT_TIMELINE_HELPER" ]; then
+	# shellcheck source=/dev/null
+	. "$BOOT_TIMELINE_HELPER" 2>/dev/null && BOOT_TIMELINE_ENABLED=1
+fi
+
+if [ "$BOOT_TIMELINE_ENABLED" = "1" ]; then
+	boot_timeline_init 2>/dev/null || BOOT_TIMELINE_ENABLED=0
+fi
+
+rcs_timeline() {
+	[ "$BOOT_TIMELINE_ENABLED" = "1" ] || return 0
+	boot_timeline_record "$@" 2>/dev/null || true
+	return 0
+}
+
+rcs_timeline rcS:begin
+
+# Start all init scripts in /etc/init.d
+# executing them in numerical order.
+#
+for i in "$INIT_D_DIR"/S??* ;do
+
+     # Ignore dangling symlinks (if any).
+     [ ! -f "$i" ] && continue
+
+     name="${i##*/}"
+     rcs_timeline script:begin "$name"
+
+     case "$i" in
+	*.sh)
+	    # Source shell script for speed.
+	    (
+		trap - INT QUIT TSTP
+		set start
+		. $i
+	    )
+	    rc="$?"
+	    ;;
+	*)
+	    # No sh extension, so fork subprocess.
+	    $i start
+	    rc="$?"
+	    ;;
+    esac
+
+     rcs_timeline script:end "$name" "rc=$rc"
+done
+
+rcs_timeline rcS:end
+
+if [ "$BOOT_TIMELINE_ENABLED" = "1" ]; then
+	# Persist this boot so it can be compared against later ones. /userdata is
+	# mounted well before rcS finishes; if it is not, the archive is skipped.
+	boot_timeline_archive 2>/dev/null || true
+fi

--- a/scripts/test_boot_timeline.sh
+++ b/scripts/test_boot_timeline.sh
@@ -1,0 +1,184 @@
+#!/bin/sh
+# Guards the boot profiler: rcS must keep stock Buildroot semantics (every
+# S??* runs once, in order, with "start"), and must keep booting the board
+# even when the profiler is broken or absent.
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+RCS="$ROOT_DIR/overlay/etc/init.d/rcS"
+HELPER="$ROOT_DIR/overlay/etc/aiden_boot_timeline.sh"
+
+for path in "$RCS" "$HELPER"; do
+    if [ ! -f "$path" ]; then
+        echo "missing boot timeline file: $path" >&2
+        exit 1
+    fi
+    if [ ! -x "$path" ]; then
+        echo "must be executable: $path" >&2
+        exit 1
+    fi
+done
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# Fixture init.d: one forked script, one sourced *.sh, one non-matching file,
+# and one dangling symlink.
+make_fixture() {
+    fixture="$1"
+    mkdir -p "$fixture"
+    cat > "$fixture/S10first" <<EOF
+#!/bin/sh
+echo "S10first \$1" >> "$TMP_DIR/order.log"
+EOF
+    cat > "$fixture/S20second.sh" <<EOF
+echo "S20second.sh \$1" >> "$TMP_DIR/order.log"
+EOF
+    cat > "$fixture/S30third" <<EOF
+#!/bin/sh
+echo "S30third \$1" >> "$TMP_DIR/order.log"
+exit 3
+EOF
+    cat > "$fixture/notaservice" <<EOF
+#!/bin/sh
+echo "notaservice ran" >> "$TMP_DIR/order.log"
+EOF
+    chmod +x "$fixture/S10first" "$fixture/S30third" "$fixture/notaservice"
+    ln -sf "$fixture/missing-target" "$fixture/S40dangling"
+}
+
+run_rcs() {
+    # rcS is a boot script: it must succeed even though a fixture returns 3.
+    env INIT_D_DIR="$1" \
+        BOOT_TIMELINE_HELPER="$2" \
+        BOOT_TIMELINE_LOG="$3" \
+        BOOT_TIMELINE_ARCHIVE_DIR="$TMP_DIR/archive" \
+        sh "$RCS"
+}
+
+# --- 1. Stock semantics: order, "start" argument, sourcing, skips ------------
+FIXTURE="$TMP_DIR/init.d"
+TIMELINE="$TMP_DIR/timeline.log"
+make_fixture "$FIXTURE"
+: > "$TMP_DIR/order.log"
+
+run_rcs "$FIXTURE" "$HELPER" "$TIMELINE" || fail "rcS exited non-zero"
+
+expected="S10first start
+S20second.sh start
+S30third start"
+actual=$(cat "$TMP_DIR/order.log")
+[ "$actual" = "$expected" ] || fail "wrong execution order/args:
+--- got ---
+$actual
+--- want ---
+$expected"
+
+grep -q "notaservice ran" "$TMP_DIR/order.log" && fail "ran a non-S??* file"
+
+# --- 2. Timeline records every script, with a usable rc ---------------------
+[ -f "$TIMELINE" ] || fail "no timeline written at $TIMELINE"
+
+for event in "rcS:begin" "rcS:end"; do
+    grep -q " $event\$" "$TIMELINE" || fail "timeline missing $event"
+done
+for name in S10first S20second.sh S30third; do
+    grep -q "script:begin $name\$" "$TIMELINE" || fail "timeline missing begin for $name"
+    grep -q "script:end $name " "$TIMELINE" || fail "timeline missing end for $name"
+done
+grep -q "script:end S30third rc=3" "$TIMELINE" || fail "timeline lost the exit status of S30third"
+grep -q "S40dangling" "$TIMELINE" && fail "dangling symlink should be skipped"
+
+# Records must be "<uptime> <delta> <event>" with numeric, non-decreasing uptime.
+awk '
+    { if ($1 !~ /^[0-9]+\.[0-9][0-9]$/ || $2 !~ /^[0-9]+\.[0-9][0-9]$/) { print "bad record: " $0; exit 1 }
+      if ($1 + 0 < prev) { print "uptime went backwards: " $0; exit 1 }
+      prev = $1 + 0 }
+' "$TIMELINE" || fail "malformed timeline records"
+
+# --- 3. Fail-open: a missing helper must not stop the boot ------------------
+: > "$TMP_DIR/order.log"
+run_rcs "$FIXTURE" "$TMP_DIR/no-such-helper.sh" "$TMP_DIR/unused.log" \
+    || fail "rcS must still run scripts when the profiler helper is missing"
+actual=$(cat "$TMP_DIR/order.log")
+[ "$actual" = "$expected" ] || fail "scripts did not run without the profiler:
+$actual"
+
+# --- 4. Fail-open: an unwritable timeline must not stop the boot ------------
+: > "$TMP_DIR/order.log"
+run_rcs "$FIXTURE" "$HELPER" "/proc/definitely/not/writable/timeline.log" \
+    || fail "rcS must survive an unwritable timeline path"
+actual=$(cat "$TMP_DIR/order.log")
+[ "$actual" = "$expected" ] || fail "scripts did not run with an unwritable timeline:
+$actual"
+
+# --- 5. Uptime parsing, including leading-zero fractions --------------------
+check_cs() {
+    raw="$1"
+    want="$2"
+    printf '%s\n' "$raw" > "$TMP_DIR/uptime"
+    got=$(
+        BOOT_TIMELINE_UPTIME_PATH="$TMP_DIR/uptime"
+        export BOOT_TIMELINE_UPTIME_PATH
+        # shellcheck source=/dev/null
+        . "$HELPER"
+        boot_timeline_now_cs
+    )
+    [ "$got" = "$want" ] || fail "uptime '$raw' parsed as $got centiseconds, want $want"
+}
+
+check_cs "7717.92 6832.62" 771792
+check_cs "51.08 40.00" 5108      # leading-zero fraction must not read as octal
+check_cs "08.09 1.00" 809        # leading-zero whole part too
+check_cs "100 50" 10000          # no fractional part
+check_cs "0.00 0.00" 0
+
+# A garbage /proc/uptime must yield 0 rather than an error.
+check_cs "garbage" 0
+
+# --- 6. Milestone marks and the report ------------------------------------
+BOOT_TIMELINE_LOG="$TIMELINE" "$HELPER" mark config_web:listening
+grep -q "mark config_web:listening\$" "$TIMELINE" || fail "mark subcommand did not append"
+
+# mark must not create a timeline out of thin air (no boot context).
+BOOT_TIMELINE_LOG="$TMP_DIR/absent.log" "$HELPER" mark agent:listening
+[ ! -f "$TMP_DIR/absent.log" ] || fail "mark created a timeline with no boot context"
+
+report=$("$HELPER" report "$TIMELINE")
+for section in "boot timeline" "slowest init scripts" "milestones"; do
+    printf '%s' "$report" | grep -q "$section" || fail "report missing section: $section"
+done
+printf '%s' "$report" | grep -q "config_web:listening" || fail "report omitted the milestone"
+
+# --- 7. Archiving keeps a bounded history ---------------------------------
+ARCHIVE="$TMP_DIR/archive2"
+mkdir -p "$ARCHIVE"
+i=1
+while [ "$i" -le 8 ]; do
+    printf 'old boot %s\n' "$i" > "$ARCHIVE/boot-2020010$i-000000.log"
+    i=$((i + 1))
+done
+
+BOOT_TIMELINE_LOG="$TIMELINE" \
+BOOT_TIMELINE_ARCHIVE_DIR="$ARCHIVE" \
+BOOT_TIMELINE_ARCHIVE_KEEP=3 \
+    "$HELPER" archive || fail "archive subcommand failed"
+
+kept=$(ls -1 "$ARCHIVE" | wc -l | tr -d ' ')
+[ "$kept" -eq 3 ] || fail "archive kept $kept files, expected 3"
+
+# The newest archive must be this boot's timeline, not a pruned old one.
+newest=$(ls -1 "$ARCHIVE" | sort -r | head -1)
+grep -q "rcS:begin" "$ARCHIVE/$newest" || fail "newest archive is not the current boot timeline"
+
+# Archiving must be a no-op, not an error, when there is no timeline to save.
+BOOT_TIMELINE_LOG="$TMP_DIR/absent.log" \
+BOOT_TIMELINE_ARCHIVE_DIR="$ARCHIVE" \
+    "$HELPER" archive || fail "archive must succeed when no timeline exists"
+
+echo "PASS: boot timeline profiler"

--- a/scripts/test_boot_timeline.sh
+++ b/scripts/test_boot_timeline.sh
@@ -21,6 +21,8 @@ done
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+BOOT_TIMELINE_LOCK_FILE="$TMP_DIR/aiden_boot_timeline.lock"
+export BOOT_TIMELINE_LOCK_FILE
 
 fail() {
     echo "FAIL: $*" >&2
@@ -157,6 +159,7 @@ printf '%s' "$report" | grep -q "config_web:listening" || fail "report omitted t
 
 # --- 7. Archiving keeps a bounded history ---------------------------------
 ARCHIVE="$TMP_DIR/archive2"
+ARCHIVE_STATE="$TMP_DIR/archive2.state"
 mkdir -p "$ARCHIVE"
 i=1
 while [ "$i" -le 8 ]; do
@@ -166,19 +169,223 @@ done
 
 BOOT_TIMELINE_LOG="$TIMELINE" \
 BOOT_TIMELINE_ARCHIVE_DIR="$ARCHIVE" \
+BOOT_TIMELINE_ARCHIVE_STATE="$ARCHIVE_STATE" \
 BOOT_TIMELINE_ARCHIVE_KEEP=3 \
     "$HELPER" archive || fail "archive subcommand failed"
 
-kept=$(ls -1 "$ARCHIVE" | wc -l | tr -d ' ')
+kept=0
+for archive_path in "$ARCHIVE"/boot-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].log; do
+    [ -f "$archive_path" ] || continue
+    kept=$((kept + 1))
+done
 [ "$kept" -eq 3 ] || fail "archive kept $kept files, expected 3"
 
 # The newest archive must be this boot's timeline, not a pruned old one.
-newest=$(ls -1 "$ARCHIVE" | sort -r | head -1)
-grep -q "rcS:begin" "$ARCHIVE/$newest" || fail "newest archive is not the current boot timeline"
+newest="$(cat "$ARCHIVE_STATE")"
+[ -f "$newest" ] || fail "archive state points at a missing file: $newest"
+grep -q "rcS:begin" "$newest" || fail "newest archive is not the current boot timeline"
 
 # Archiving must be a no-op, not an error, when there is no timeline to save.
 BOOT_TIMELINE_LOG="$TMP_DIR/absent.log" \
 BOOT_TIMELINE_ARCHIVE_DIR="$ARCHIVE" \
     "$HELPER" archive || fail "archive must succeed when no timeline exists"
+
+# A failed copy must not install a partial completed archive. Simulate cat
+# writing some bytes before it fails, which is the case that exposed the direct
+# write to boot-*.log.
+ATOMIC_BIN="$TMP_DIR/atomic_bin"
+ATOMIC_ARCHIVE="$TMP_DIR/archive_atomic"
+mkdir -p "$ATOMIC_BIN" "$ATOMIC_ARCHIVE"
+cat > "$ATOMIC_BIN/cat" <<'EOF'
+#!/bin/sh
+printf 'partial\n'
+exit 1
+EOF
+chmod +x "$ATOMIC_BIN/cat"
+
+PATH="$ATOMIC_BIN:$PATH" \
+BOOT_TIMELINE_LOG="$TIMELINE" \
+BOOT_TIMELINE_ARCHIVE_DIR="$ATOMIC_ARCHIVE" \
+BOOT_TIMELINE_ARCHIVE_STATE="$TMP_DIR/atomic.state" \
+    "$HELPER" archive || fail "archive must remain fail-open when the copy fails"
+
+for atomic_entry in "$ATOMIC_ARCHIVE"/*; do
+    [ -e "$atomic_entry" ] || continue
+    fail "failed copy left an archive artifact: $atomic_entry"
+done
+[ ! -e "$TMP_DIR/atomic.state" ] \
+    || fail "failed copy published an archive state file"
+
+# --- 8. Late milestones must reach the archive -----------------------------
+# rcS archives at rcS:end, but agent:listening and swap:active are written by
+# asynchronous workers and routinely land afterwards. A snapshot taken at
+# rcS:end would silently drop them.
+LATE_ARCHIVE="$TMP_DIR/archive_late"
+LATE_STATE="$TMP_DIR/archive_late.state"
+LATE_LOG="$TMP_DIR/late_timeline.log"
+mkdir -p "$LATE_ARCHIVE"
+printf '0.10 0.10 rcS:begin\n25.52 0.03 rcS:end\n' > "$LATE_LOG"
+
+BOOT_TIMELINE_LOG="$LATE_LOG" \
+BOOT_TIMELINE_ARCHIVE_DIR="$LATE_ARCHIVE" \
+BOOT_TIMELINE_ARCHIVE_STATE="$LATE_STATE" \
+    "$HELPER" archive || fail "archive failed"
+
+[ -s "$LATE_STATE" ] || fail "archive did not publish its path for later refresh"
+archived_path="$(cat "$LATE_STATE")"
+[ -f "$archived_path" ] || fail "archive state points at a missing file: $archived_path"
+grep -q "swap:active" "$archived_path" && fail "archive should not contain the late mark yet"
+
+# A milestone written after rcS finished must refresh the archive in place.
+BOOT_TIMELINE_LOG="$LATE_LOG" \
+BOOT_TIMELINE_ARCHIVE_STATE="$LATE_STATE" \
+    "$HELPER" mark swap:active
+
+grep -q "mark swap:active" "$archived_path" \
+    || fail "late milestone did not reach the archive: $(cat "$archived_path")"
+grep -q "rcS:end" "$archived_path" || fail "refresh dropped earlier records"
+late_archive_count=0
+for late_archive_path in "$LATE_ARCHIVE"/*; do
+    [ -e "$late_archive_path" ] || continue
+    late_archive_count=$((late_archive_count + 1))
+done
+[ "$late_archive_count" -eq 1 ] \
+    || fail "refresh created $late_archive_count archive files; expected one"
+
+# With no archive yet (marks during rcS), refreshing must stay a silent no-op.
+BOOT_TIMELINE_LOG="$LATE_LOG" \
+BOOT_TIMELINE_ARCHIVE_STATE="$TMP_DIR/no-such.state" \
+    "$HELPER" mark usbhid:udc-ready || fail "mark must succeed with no archive state"
+
+# Reproduce the original review race exactly: pause the initial archive after
+# its timeline snapshot has been copied but before the archive is installed and
+# its state path is published. A milestone arriving in that window must wait on
+# the shared lock, then append and refresh the newly published archive.
+RACE_BIN="$TMP_DIR/race_bin"
+RACE_ARCHIVE="$TMP_DIR/archive_race"
+RACE_LOG="$TMP_DIR/race_timeline.log"
+RACE_STATE="$TMP_DIR/race.state"
+RACE_LOCK="$TMP_DIR/race.lock"
+RACE_PAUSED="$TMP_DIR/race.paused"
+RACE_RELEASE="$TMP_DIR/race.release"
+RACE_UPTIME="$TMP_DIR/race.uptime"
+REAL_CAT="$(command -v cat)"
+mkdir -p "$RACE_BIN" "$RACE_ARCHIVE"
+printf '0.10 0.10 rcS:begin\n25.52 0.03 rcS:end\n' > "$RACE_LOG"
+printf '31.41 5.00\n' > "$RACE_UPTIME"
+cat > "$RACE_BIN/cat" <<EOF
+#!/bin/sh
+if [ "\$#" -eq 1 ] && [ "\$1" = "\$RACE_TIMELINE" ] && [ ! -e "\$RACE_PAUSED" ]; then
+    "$REAL_CAT" "\$@"
+    : > "\$RACE_PAUSED"
+    while [ ! -e "\$RACE_RELEASE" ]; do
+        sleep 0.01
+    done
+    exit 0
+fi
+exec "$REAL_CAT" "\$@"
+EOF
+chmod +x "$RACE_BIN/cat"
+
+PATH="$RACE_BIN:$PATH" \
+RACE_TIMELINE="$RACE_LOG" \
+RACE_PAUSED="$RACE_PAUSED" \
+RACE_RELEASE="$RACE_RELEASE" \
+BOOT_TIMELINE_LOG="$RACE_LOG" \
+BOOT_TIMELINE_ARCHIVE_DIR="$RACE_ARCHIVE" \
+BOOT_TIMELINE_ARCHIVE_STATE="$RACE_STATE" \
+BOOT_TIMELINE_LOCK_FILE="$RACE_LOCK" \
+    "$HELPER" archive &
+race_archive_pid=$!
+
+i=0
+while [ ! -e "$RACE_PAUSED" ]; do
+    i=$((i + 1))
+    if [ "$i" -ge 500 ]; then
+        kill "$race_archive_pid" 2>/dev/null || true
+        fail "archive did not reach the pre-publication race point"
+    fi
+    sleep 0.01
+done
+
+PATH="$RACE_BIN:$PATH" \
+RACE_TIMELINE="$RACE_LOG" \
+RACE_PAUSED="$RACE_PAUSED" \
+RACE_RELEASE="$RACE_RELEASE" \
+BOOT_TIMELINE_LOG="$RACE_LOG" \
+BOOT_TIMELINE_ARCHIVE_DIR="$RACE_ARCHIVE" \
+BOOT_TIMELINE_ARCHIVE_STATE="$RACE_STATE" \
+BOOT_TIMELINE_LOCK_FILE="$RACE_LOCK" \
+BOOT_TIMELINE_UPTIME_PATH="$RACE_UPTIME" \
+    "$HELPER" mark agent:listening &
+race_mark_pid=$!
+
+sleep 0.1
+if ! kill -0 "$race_mark_pid" 2>/dev/null; then
+    : > "$RACE_RELEASE"
+    wait "$race_archive_pid" 2>/dev/null || true
+    fail "milestone writer did not wait for archive publication"
+fi
+if grep -q 'agent:listening' "$RACE_LOG"; then
+    : > "$RACE_RELEASE"
+    wait "$race_archive_pid" 2>/dev/null || true
+    wait "$race_mark_pid" 2>/dev/null || true
+    fail "milestone was appended inside the archive publication window"
+fi
+
+: > "$RACE_RELEASE"
+wait "$race_archive_pid" || fail "paused archive failed"
+wait "$race_mark_pid" || fail "blocked milestone writer failed"
+
+[ -s "$RACE_STATE" ] || fail "race archive did not publish its state"
+race_archive_path="$(cat "$RACE_STATE")"
+[ -f "$race_archive_path" ] || fail "race state points at a missing archive"
+grep -q 'mark agent:listening' "$race_archive_path" \
+    || fail "pre-publication milestone was lost from the archive"
+[ ! -d "${RACE_LOCK}.d" ] || fail "fallback timeline lock was not released"
+
+# A refresh interrupted between cat and mv leaves a .tmp file in the archive
+# directory. It must not count toward retention, or it would evict a real
+# archive; and it should be cleaned up.
+RETAIN="$TMP_DIR/archive_retain"
+mkdir -p "$RETAIN"
+i=1
+while [ "$i" -le 3 ]; do
+    printf 'boot %s\n' "$i" > "$RETAIN/boot-2020010$i-000000.log"
+    i=$((i + 1))
+done
+printf 'partial\n' > "$RETAIN/boot-20200109-000000.log.tmp.999"
+printf 'partial\n' > "$RETAIN/boot-20200108-000000.log.tmp.998"
+# Anything else that shares the directory must also be ignored by retention,
+# not counted as an archive and not deleted.
+printf 'notes\n' > "$RETAIN/zz-unrelated.txt"
+printf 'not a managed archive\n' > "$RETAIN/boot-not-an-archive.log"
+
+BOOT_TIMELINE_LOG="$TIMELINE" \
+BOOT_TIMELINE_ARCHIVE_DIR="$RETAIN" \
+BOOT_TIMELINE_ARCHIVE_STATE="$TMP_DIR/retain.state" \
+BOOT_TIMELINE_ARCHIVE_KEEP=3 \
+    "$HELPER" archive || fail "archive failed with stale temp files present"
+
+for stale_tmp in "$RETAIN"/boot-*.log.tmp.*; do
+    [ -e "$stale_tmp" ] || continue
+    fail "stale refresh temp file was not cleaned up: $stale_tmp"
+done
+kept_logs=0
+for kept_log in "$RETAIN"/boot-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].log; do
+    [ -f "$kept_log" ] || continue
+    kept_logs=$((kept_logs + 1))
+done
+[ "$kept_logs" -eq 3 ] || fail "expected 3 retained archives, got $kept_logs"
+# Unrelated files, including an archive-shaped name that the helper never
+# generates, must neither be deleted nor consume a retention slot.
+[ -f "$RETAIN/zz-unrelated.txt" ] || fail "retention deleted an unrelated file"
+[ -f "$RETAIN/boot-not-an-archive.log" ] \
+    || fail "retention deleted a non-canonical boot log"
+# The current boot's archive is the newest and must have survived retention.
+retained_path="$(cat "$TMP_DIR/retain.state")"
+[ -f "$retained_path" ] || fail "retention state points at a missing archive"
+grep -q "rcS:begin" "$retained_path" \
+    || fail "current boot archive was evicted by stale temp files"
 
 echo "PASS: boot timeline profiler"

--- a/scripts/test_dhcpcd_init.sh
+++ b/scripts/test_dhcpcd_init.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# S41dhcpcd must start dhcpcd detached by default (-b), because the SDK's
+# blocking form stalls rcS for dhcpcd's full 30s lease timeout on a board whose
+# only interface has not associated yet.
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SCRIPT="$ROOT_DIR/overlay/etc/init.d/S41dhcpcd"
+BOOT_CONF="$ROOT_DIR/overlay/etc/aiden_boot.conf"
+
+for path in "$SCRIPT" "$BOOT_CONF"; do
+    [ -f "$path" ] || { echo "missing file: $path" >&2; exit 1; }
+done
+[ -x "$SCRIPT" ] || { echo "S41dhcpcd must be executable" >&2; exit 1; }
+
+grep -Eq '^DHCPCD_BACKGROUND=' "$BOOT_CONF" \
+    || { echo "aiden_boot.conf must define DHCPCD_BACKGROUND" >&2; exit 1; }
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+mkdir -p "$TMP_DIR/bin"
+cat > "$TMP_DIR/bin/start-stop-daemon" <<'STUB'
+#!/bin/sh
+echo "$@" >> "$SSD_LOG"
+STUB
+chmod +x "$TMP_DIR/bin/start-stop-daemon"
+
+SSD_LOG="$TMP_DIR/ssd.log"
+export SSD_LOG
+
+# Point the script at a fixture dhcpcd.conf so the "config absent" guard passes.
+touch "$TMP_DIR/dhcpcd.conf"
+sed "s#^CONFIG=.*#CONFIG=$TMP_DIR/dhcpcd.conf#" "$SCRIPT" > "$TMP_DIR/S41dhcpcd"
+
+run_start() {
+    printf 'DHCPCD_BACKGROUND=%s\n' "$1" > "$TMP_DIR/boot.conf"
+    : > "$SSD_LOG"
+    PATH="$TMP_DIR/bin:$PATH" BOOT_CONF="$TMP_DIR/boot.conf" \
+        sh "$TMP_DIR/S41dhcpcd" start >/dev/null
+}
+
+# Default / explicit 1: detach immediately.
+run_start 1
+grep -q -- '-b -f' "$SSD_LOG" || fail "expected '-b -f' with DHCPCD_BACKGROUND=1, got: $(cat "$SSD_LOG")"
+
+# Escape hatch: 0 restores the SDK's blocking invocation.
+run_start 0
+if grep -q -- ' -b ' "$SSD_LOG" || grep -q -- ' -b$' "$SSD_LOG"; then
+    fail "-b must not be passed when DHCPCD_BACKGROUND=0: $(cat "$SSD_LOG")"
+fi
+grep -q -- '-f' "$SSD_LOG" || fail "config path must still be passed: $(cat "$SSD_LOG")"
+
+# With no boot.conf at all the default must still be the non-blocking form.
+: > "$SSD_LOG"
+PATH="$TMP_DIR/bin:$PATH" BOOT_CONF="$TMP_DIR/absent.conf" \
+    sh "$TMP_DIR/S41dhcpcd" start >/dev/null
+grep -q -- '-b -f' "$SSD_LOG" || fail "default (no boot.conf) must pass -b, got: $(cat "$SSD_LOG")"
+
+# A missing dhcpcd.conf must remain a clean no-op, as in the SDK script.
+: > "$SSD_LOG"
+sed "s#^CONFIG=.*#CONFIG=$TMP_DIR/no-such.conf#" "$SCRIPT" > "$TMP_DIR/S41missing"
+PATH="$TMP_DIR/bin:$PATH" sh "$TMP_DIR/S41missing" start >/dev/null \
+    || fail "missing dhcpcd.conf must exit 0"
+[ ! -s "$SSD_LOG" ] || fail "must not start dhcpcd without a config: $(cat "$SSD_LOG")"
+
+echo "PASS: S41dhcpcd non-blocking start"

--- a/scripts/test_service_startup_poll.sh
+++ b/scripts/test_service_startup_poll.sh
@@ -64,6 +64,39 @@ probe_port 80 "$TCP_OTHER_PORT" && fail "port 80 matched a socket on port 8080"
 probe_port 8080 "$TCP_OTHER_PORT" || fail "port 8080 (0x1F90) not detected"
 probe_port 80 "$TMP_DIR/no-such-file" && fail "reported listening with no /proc/net/tcp"
 
+# A listener that exists before launch belongs to another process. start() must
+# reject it without spawning config_web; otherwise the readiness poll could
+# mistake the unrelated socket for the portal's listener.
+PREOCCUPIED_BIN="$TMP_DIR/config_web"
+PREOCCUPIED_ENV_RUN="$TMP_DIR/aiden-env-run"
+PREOCCUPIED_LAUNCH_LOG="$TMP_DIR/preoccupied.launch"
+printf '#!/bin/sh\nexit 0\n' > "$PREOCCUPIED_BIN"
+cat > "$PREOCCUPIED_ENV_RUN" <<'EOF'
+#!/bin/sh
+printf 'launched\n' > "$PREOCCUPIED_LAUNCH_LOG"
+exec "$@"
+EOF
+chmod +x "$PREOCCUPIED_BIN" "$PREOCCUPIED_ENV_RUN"
+
+rc=0
+PREOCCUPIED_LAUNCH_LOG="$PREOCCUPIED_LAUNCH_LOG" \
+sh -c '
+        . "$1"
+        BIN="$2"
+        ENV_RUN_BIN="$3"
+        PID_FILE="$4"
+        PROC_NET_TCP="$5"
+        CONFIG_PATH="$6/agent.toml"
+        SYSTEM_ENV_PATH="$6/system.env"
+        PORT=80
+        start
+    ' _ "$WEB_FUNCS" "$PREOCCUPIED_BIN" "$PREOCCUPIED_ENV_RUN" \
+        "$TMP_DIR/preoccupied.pid" "$TCP_LISTENING" "$TMP_DIR/preoccupied" \
+        >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 1 ] || fail "start with a preoccupied port returned status $rc, want 1"
+[ ! -e "$PREOCCUPIED_LAUNCH_LOG" ] \
+    || fail "config_web was launched even though its port was already occupied"
+
 # --- S56config_web: the exec race must not be read as a failed start -------
 # Regression: aiden-env-run is a shell that execs into config_web, so for the
 # first few milliseconds /proc/<pid>/exe still points at the shell and
@@ -100,37 +133,135 @@ fi
 elapsed=$(( $(date +%s) - start_s ))
 [ "$elapsed" -le 2 ] || fail "dead pid took ${elapsed}s to detect; must fail fast"
 
-# A live process that never opens the port must still be reported as started
-# rather than torn down.
+# A live process whose port never appears is NOT ready: reporting success there
+# would record a config_web:listening milestone for a portal nobody can reach.
+# Status must be exactly 1 (failed) — 2 would mean "unverified", which the
+# caller treats as started, and the socket table was readable here.
+rc=0
 sh -c '
         . "$1"
         PID_FILE="$2"
+        PROC_NET_TCP="$3"
         STARTUP_TIMEOUT_TICKS=3
         is_running() { [ -n "$1" ]; }
         port_is_listening() { return 1; }
         wait_until_ready
-    ' _ "$WEB_FUNCS" "$LIVE_PID_FILE" 2>/dev/null \
-    || fail "a live process with no socket must fall back to the liveness check"
+    ' _ "$WEB_FUNCS" "$LIVE_PID_FILE" "$TCP_EMPTY" 2>/dev/null || rc=$?
+[ "$rc" -eq 1 ] \
+    || fail "a live process that never listened must fail readiness (status 1), got $rc"
+
+# ...unless the socket table itself is unreadable, in which case readiness is
+# unknown rather than failed (status 2) and the caller must not tear the
+# process down.
+rc=0
+sh -c '
+        . "$1"
+        PID_FILE="$2"
+        PROC_NET_TCP="$3"
+        STARTUP_TIMEOUT_TICKS=3
+        is_running() { [ -n "$1" ]; }
+        wait_until_ready
+    ' _ "$WEB_FUNCS" "$LIVE_PID_FILE" "$TMP_DIR/no-such-proc-net-tcp" || rc=$?
+[ "$rc" -eq 2 ] || fail "unreadable socket table must yield status 2, got $rc"
+
+# A process that dies just after the port is observed does not own that socket:
+# config_web exits on bind failure, so another process must be holding $PORT.
+rc=0
+sh -c '
+        . "$1"
+        PID_FILE="$2"
+        PROC_NET_TCP="$3"
+        STARTUP_TIMEOUT_TICKS=2
+        # Alive when first checked, gone on the confirming re-check.
+        checks=0
+        is_running() { checks=$((checks + 1)); [ "$checks" -lt 2 ]; }
+        wait_until_ready
+    ' _ "$WEB_FUNCS" "$LIVE_PID_FILE" "$TCP_LISTENING" 2>/dev/null || rc=$?
+[ "$rc" -ne 0 ] \
+    || fail "a process that exited right after the port appeared must not be reported ready"
+
+# --- Timeout must be wall-clock bounded, not tick-bounded ------------------
+# Without fractional sleep each tick costs a whole second. The budget must be
+# derived from the interval so the wait stays ~3s either way.
+for funcs in "$WEB_FUNCS" "$DHCP_FUNCS"; do
+    ticks=$(sh -c '. "$1"; echo "$STARTUP_TIMEOUT_TICKS"' _ "$funcs" 2>/dev/null)
+    interval=$(sh -c '. "$1"; echo "$POLL_INTERVAL_CS"' _ "$funcs" 2>/dev/null)
+    case "$ticks" in ''|*[!0-9]*) fail "$funcs: bad tick budget '$ticks'" ;; esac
+    case "$interval" in ''|*[!0-9]*) fail "$funcs: bad poll interval '$interval'" ;; esac
+    budget=$(( ticks * interval / 100 ))
+    [ "$budget" -ge 1 ] && [ "$budget" -le 5 ] \
+        || fail "$funcs: wall-clock budget ${budget}s outside 1-5s (ticks=$ticks interval=${interval}cs)"
+done
+
+# The important case is a BusyBox without FANCY_SLEEP, where each tick costs a
+# whole second. Simulate it with a `sleep` that rejects fractional arguments and
+# confirm the scripts shrink the tick budget instead of waiting 60 seconds.
+FAKE_BIN="$TMP_DIR/fakebin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/sleep" <<'STUB'
+#!/bin/sh
+case "$1" in
+    *.*) exit 1 ;;   # no fractional support
+esac
+exit 0
+STUB
+chmod +x "$FAKE_BIN/sleep"
+
+for funcs in "$WEB_FUNCS" "$DHCP_FUNCS"; do
+    out=$(PATH="$FAKE_BIN:$PATH" sh -c '. "$1"; echo "$POLL_INTERVAL_CS $STARTUP_TIMEOUT_TICKS"' _ "$funcs" 2>/dev/null)
+    slow_interval=${out% *}
+    slow_ticks=${out#* }
+    [ "$slow_interval" = "100" ] \
+        || fail "$funcs: expected whole-second interval without fractional sleep, got '$slow_interval'"
+    slow_budget=$(( slow_ticks * slow_interval / 100 ))
+    [ "$slow_budget" -le 5 ] \
+        || fail "$funcs: without fractional sleep the wait balloons to ${slow_budget}s (ticks=$slow_ticks)"
+done
 
 # --- S55aiden_usb_dhcp: poll must bail out on a dead daemon ---------------
 # wait_until_running must not spin for its whole budget when the pid is gone;
-# with a stale pid file it should fail fast.
+# with a stale pid file it should fail fast and without sleeping at all.
 PID_FILE="$TMP_DIR/dhcp.pid"
 echo 999999 > "$PID_FILE"
+SLEEP_LOG="$TMP_DIR/short_sleep.log"
+: > "$SLEEP_LOG"
 
 # PID_FILE is assigned unconditionally at the top of the script, so it has to be
 # overridden after sourcing rather than through the environment.
+# Note: inside a shell function $3 is the function's own argument, so the log
+# path has to be captured into a variable before short_sleep is redefined.
 start_s=$(date +%s)
 if sh -c '
         . "$1"
         PID_FILE="$2"
-        STARTUP_TIMEOUT_TICKS=4
+        SLEEP_LOG_PATH="$3"
+        STARTUP_TIMEOUT_TICKS=40
+        short_sleep() { echo slept >> "$SLEEP_LOG_PATH"; }
         wait_until_running
-    ' _ "$DHCP_FUNCS" "$PID_FILE" 2>/dev/null; then
+    ' _ "$DHCP_FUNCS" "$PID_FILE" "$SLEEP_LOG" 2>/dev/null; then
     fail "wait_until_running succeeded for a dead pid"
 fi
 elapsed=$(( $(date +%s) - start_s ))
-[ "$elapsed" -le 6 ] || fail "poll took ${elapsed}s; budget should be bounded"
+[ "$elapsed" -le 2 ] || fail "poll took ${elapsed}s; must fail fast"
+[ ! -s "$SLEEP_LOG" ] || fail "dead pid path slept $(wc -l < "$SLEEP_LOG") time(s); must not sleep"
+
+# --- Failure paths must reap the launched child ---------------------------
+# Removing the PID file while the child keeps running leaves an untracked
+# process that a later start would duplicate.
+for script in "$DHCP_SCRIPT" "$WEB_SCRIPT"; do
+    grep -q 'terminate_child "\$child_pid"' "$script" \
+        || fail "$script must reap \$child_pid before removing the PID file"
+done
+
+# terminate_child must actually stop a live process.
+sleep 30 &
+victim=$!
+sh -c '. "$1"; terminate_child "$2"' _ "$DHCP_FUNCS" "$victim" 2>/dev/null || true
+sleep 1
+if kill -0 "$victim" 2>/dev/null; then
+    kill -9 "$victim" 2>/dev/null || true
+    fail "terminate_child left the process running"
+fi
 
 # The whole point: a ready daemon is detected without burning a full second.
 # Point the poll at this very shell's pid via a stub is_running override.

--- a/scripts/test_service_startup_poll.sh
+++ b/scripts/test_service_startup_poll.sh
@@ -64,6 +64,54 @@ probe_port 80 "$TCP_OTHER_PORT" && fail "port 80 matched a socket on port 8080"
 probe_port 8080 "$TCP_OTHER_PORT" || fail "port 8080 (0x1F90) not detected"
 probe_port 80 "$TMP_DIR/no-such-file" && fail "reported listening with no /proc/net/tcp"
 
+# --- S56config_web: the exec race must not be read as a failed start -------
+# Regression: aiden-env-run is a shell that execs into config_web, so for the
+# first few milliseconds /proc/<pid>/exe still points at the shell and
+# is_running() is legitimately false. Treating that as failure made
+# S56config_web report rc=1 and delete its pidfile while the portal was in fact
+# coming up fine.
+LIVE_PID_FILE="$TMP_DIR/live.pid"
+echo $$ > "$LIVE_PID_FILE"
+
+sh -c '
+        . "$1"
+        PID_FILE="$2"
+        STARTUP_TIMEOUT_TICKS=40
+        polls=0
+        # Not config_web yet, and no socket, for the first few polls.
+        is_running() { polls=$((polls + 1)); [ "$polls" -ge 5 ]; }
+        port_is_listening() { [ "$polls" -ge 5 ]; }
+        wait_until_ready
+    ' _ "$WEB_FUNCS" "$LIVE_PID_FILE" 2>/dev/null \
+    || fail "wait_until_ready gave up during the launcher exec window"
+
+# A pid that is genuinely gone must still fail fast.
+DEAD_PID_FILE="$TMP_DIR/dead.pid"
+echo 999999 > "$DEAD_PID_FILE"
+start_s=$(date +%s)
+if sh -c '
+        . "$1"
+        PID_FILE="$2"
+        STARTUP_TIMEOUT_TICKS=40
+        wait_until_ready
+    ' _ "$WEB_FUNCS" "$DEAD_PID_FILE" 2>/dev/null; then
+    fail "wait_until_ready succeeded for a dead pid"
+fi
+elapsed=$(( $(date +%s) - start_s ))
+[ "$elapsed" -le 2 ] || fail "dead pid took ${elapsed}s to detect; must fail fast"
+
+# A live process that never opens the port must still be reported as started
+# rather than torn down.
+sh -c '
+        . "$1"
+        PID_FILE="$2"
+        STARTUP_TIMEOUT_TICKS=3
+        is_running() { [ -n "$1" ]; }
+        port_is_listening() { return 1; }
+        wait_until_ready
+    ' _ "$WEB_FUNCS" "$LIVE_PID_FILE" 2>/dev/null \
+    || fail "a live process with no socket must fall back to the liveness check"
+
 # --- S55aiden_usb_dhcp: poll must bail out on a dead daemon ---------------
 # wait_until_running must not spin for its whole budget when the pid is gone;
 # with a stale pid file it should fail fast.

--- a/scripts/test_service_startup_poll.sh
+++ b/scripts/test_service_startup_poll.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# S55aiden_usb_dhcp and S56config_web used to sleep a flat second after
+# spawning their daemon. rcS is sequential, so that was dead time on the path
+# to http://192.168.42.1. Both now poll for readiness instead; these tests
+# check the poll is both fast and still a real check.
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+DHCP_SCRIPT="$ROOT_DIR/overlay/etc/init.d/S55aiden_usb_dhcp"
+WEB_SCRIPT="$ROOT_DIR/overlay/etc/init.d/S56config_web"
+
+for path in "$DHCP_SCRIPT" "$WEB_SCRIPT"; do
+    [ -x "$path" ] || { echo "missing executable: $path" >&2; exit 1; }
+done
+
+# Neither start path may reintroduce a flat "sleep 1".
+for path in "$DHCP_SCRIPT" "$WEB_SCRIPT"; do
+    if awk '/^start\(\)/ { in_start = 1 } in_start && /^\tsleep 1$|^    sleep 1$/ { found = 1 } /^}/ { in_start = 0 } END { exit found ? 0 : 1 }' "$path"; then
+        echo "$path still sleeps a flat second in start()" >&2
+        exit 1
+    fi
+done
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# --- S56config_web: readiness is "the port is listening" -------------------
+# /proc/net/tcp fixture: field 2 is local_address (HEX_IP:HEX_PORT), field 4 is
+# the state, 0A = LISTEN.
+TCP_LISTENING="$TMP_DIR/tcp_listening"
+TCP_EMPTY="$TMP_DIR/tcp_empty"
+TCP_OTHER_PORT="$TMP_DIR/tcp_other"
+header='  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode'
+printf '%s\n   0: 00000000:0050 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 1\n' "$header" > "$TCP_LISTENING"
+printf '%s\n' "$header" > "$TCP_EMPTY"
+printf '%s\n   0: 00000000:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 1\n' "$header" > "$TCP_OTHER_PORT"
+
+# Sourcing an init script runs its trailing case dispatch, which would start a
+# real service. Strip the dispatch and keep the function definitions so the
+# helpers can be exercised in isolation.
+functions_only() {
+    sed '/^case "${1:-}" in/,$d' "$1"
+}
+
+WEB_FUNCS="$TMP_DIR/config_web_funcs.sh"
+DHCP_FUNCS="$TMP_DIR/usb_dhcp_funcs.sh"
+functions_only "$WEB_SCRIPT" > "$WEB_FUNCS"
+functions_only "$DHCP_SCRIPT" > "$DHCP_FUNCS"
+grep -q 'port_is_listening' "$WEB_FUNCS" || fail "could not isolate config_web helpers"
+grep -q 'wait_until_running' "$DHCP_FUNCS" || fail "could not isolate usb_dhcp helpers"
+
+probe_port() {
+    PORT="$1" PROC_NET_TCP="$2" sh -c '
+        . "$1"
+        port_is_listening
+    ' _ "$WEB_FUNCS" 2>/dev/null
+}
+
+probe_port 80 "$TCP_LISTENING" || fail "port 80 LISTEN not detected"
+probe_port 80 "$TCP_EMPTY" && fail "reported listening on an empty table"
+probe_port 80 "$TCP_OTHER_PORT" && fail "port 80 matched a socket on port 8080"
+probe_port 8080 "$TCP_OTHER_PORT" || fail "port 8080 (0x1F90) not detected"
+probe_port 80 "$TMP_DIR/no-such-file" && fail "reported listening with no /proc/net/tcp"
+
+# --- S55aiden_usb_dhcp: poll must bail out on a dead daemon ---------------
+# wait_until_running must not spin for its whole budget when the pid is gone;
+# with a stale pid file it should fail fast.
+PID_FILE="$TMP_DIR/dhcp.pid"
+echo 999999 > "$PID_FILE"
+
+# PID_FILE is assigned unconditionally at the top of the script, so it has to be
+# overridden after sourcing rather than through the environment.
+start_s=$(date +%s)
+if sh -c '
+        . "$1"
+        PID_FILE="$2"
+        STARTUP_TIMEOUT_TICKS=4
+        wait_until_running
+    ' _ "$DHCP_FUNCS" "$PID_FILE" 2>/dev/null; then
+    fail "wait_until_running succeeded for a dead pid"
+fi
+elapsed=$(( $(date +%s) - start_s ))
+[ "$elapsed" -le 6 ] || fail "poll took ${elapsed}s; budget should be bounded"
+
+# The whole point: a ready daemon is detected without burning a full second.
+# Point the poll at this very shell's pid via a stub is_running override.
+READY_PID_FILE="$TMP_DIR/ready.pid"
+echo $$ > "$READY_PID_FILE"
+start_s=$(date +%s)
+sh -c '
+        . "$1"
+        PID_FILE="$2"
+        is_running() { [ -n "$1" ]; }
+        wait_until_running
+    ' _ "$DHCP_FUNCS" "$READY_PID_FILE" 2>/dev/null || fail "wait_until_running missed a live daemon"
+elapsed=$(( $(date +%s) - start_s ))
+[ "$elapsed" -le 1 ] || fail "ready daemon took ${elapsed}s to detect; poll is too slow"
+
+echo "PASS: service startup polling"

--- a/scripts/test_swap_init.sh
+++ b/scripts/test_swap_init.sh
@@ -16,7 +16,8 @@ for expected in \
     'SWAP_MOUNT_POINT:=/userdata' \
     'SWAP_REQUIRE_MOUNT:=1' \
     'SWAP_SIZE_MB:=256' \
-    'SWAP_SWAPPINESS:=15'; do
+    'SWAP_SWAPPINESS:=15' \
+    'SWAP_BACKGROUND:=1'; do
     if ! grep -q "$expected" "$CONFIG"; then
         echo "swap config missing default: $expected" >&2
         exit 1
@@ -74,8 +75,12 @@ mv "$tmp" "$MOCK_PROC_SWAPS"
 EOF
 chmod +x "$MOCK_BIN/mkswap" "$MOCK_BIN/swapon" "$MOCK_BIN/swapoff"
 
+# Activation is backgrounded by default (see SWAP_BACKGROUND); pin it to
+# synchronous here so these assertions stay deterministic. The background path
+# has its own coverage at the end of this file.
 run_swap() {
     SWAP_CONFIG_FILE="$TMP_DIR/missing.conf" \
+    SWAP_BACKGROUND=0 \
     ENABLE_SWAP=1 \
     SWAP_FILE="$SWAP_FILE" \
     SWAP_MOUNT_POINT="$(dirname "$SWAP_FILE")" \
@@ -205,5 +210,77 @@ if ! grep -q 'swap mount point is not mounted' "$TMP_DIR/unmounted.err"; then
     cat "$TMP_DIR/unmounted.err" >&2
     exit 1
 fi
+
+# --- background activation (the default) ----------------------------------
+# swapon must not block rcS: start() returns immediately and the swapfile is
+# activated by a background worker.
+printf '/dev/test %s ext4 rw 0 0\n' "$(dirname "$SWAP_FILE")" > "$MOUNTS_PATH"
+printf 'Filename Type Size Used Priority\n' > "$PROC_SWAPS"
+rm -f "$SWAP_FILE"
+: > "$COMMAND_LOG"
+
+run_swap_bg() {
+    SWAP_CONFIG_FILE="$TMP_DIR/missing.conf" \
+    SWAP_BACKGROUND=1 \
+    ENABLE_SWAP=1 \
+    SWAP_FILE="$SWAP_FILE" \
+    SWAP_MOUNT_POINT="$(dirname "$SWAP_FILE")" \
+    SWAP_REQUIRE_MOUNT=1 \
+    SWAP_SIZE_MB=1 \
+    SWAP_SWAPPINESS=15 \
+    PROC_SWAPS="$PROC_SWAPS" \
+    MOUNTS_PATH="$MOUNTS_PATH" \
+    SWAPPINESS_PATH="$SWAPPINESS_PATH" \
+    MKSWAP_BIN="$MOCK_BIN/mkswap" \
+    SWAPON_BIN="$MOCK_BIN/swapon" \
+    SWAPOFF_BIN="$MOCK_BIN/swapoff" \
+    BOOT_TIMELINE_HELPER="$TMP_DIR/no-timeline.sh" \
+    COMMAND_LOG="$COMMAND_LOG" \
+    MOCK_PROC_SWAPS="$PROC_SWAPS" \
+    sh "$SCRIPT" "$1"
+}
+
+bg_output="$(run_swap_bg start)"
+case "$bg_output" in
+    *"in background"*) ;;
+    *)
+        echo "background start must say so: $bg_output" >&2
+        exit 1
+        ;;
+esac
+
+# Swappiness is applied up front, not deferred to the worker.
+if [ "$(cat "$SWAPPINESS_PATH")" != "15" ]; then
+    echo "background start must still configure swappiness synchronously" >&2
+    exit 1
+fi
+
+# The worker finishes shortly after; poll rather than assuming a fixed delay.
+activated=0
+i=0
+while [ "$i" -lt 100 ]; do
+    if grep -q "^$SWAP_FILE " "$PROC_SWAPS"; then
+        activated=1
+        break
+    fi
+    sleep 0.1 2>/dev/null || sleep 1
+    i=$((i + 1))
+done
+if [ "$activated" != "1" ]; then
+    echo "background worker never activated the swapfile" >&2
+    cat "$COMMAND_LOG" >&2
+    exit 1
+fi
+if [ "$(wc -c < "$SWAP_FILE" | tr -d '[:space:]')" != "1048576" ]; then
+    echo "background worker did not allocate the requested size" >&2
+    exit 1
+fi
+
+# A disabled background flag must remain synchronous for operators who need
+# swap guaranteed before later services start.
+grep -q 'SWAP_BACKGROUND' "$SCRIPT" || {
+    echo "S51swap must honour SWAP_BACKGROUND" >&2
+    exit 1
+}
 
 echo "swap init tests passed"

--- a/scripts/test_swap_init.sh
+++ b/scripts/test_swap_init.sh
@@ -59,6 +59,11 @@ EOF
 
 cat > "$MOCK_BIN/swapon" <<'EOF'
 #!/bin/sh
+# MOCK_SWAPON_DELAY lets a test prove that activation really is off the
+# critical path: a slow swapon must not hold up the init script's return.
+if [ -n "${MOCK_SWAPON_DELAY:-}" ]; then
+    sleep "$MOCK_SWAPON_DELAY"
+fi
 printf 'swapon %s\n' "$1" >> "$COMMAND_LOG"
 printf '%s file 1020 0 -2\n' "$1" >> "$MOCK_PROC_SWAPS"
 EOF
@@ -240,7 +245,30 @@ run_swap_bg() {
     sh "$SCRIPT" "$1"
 }
 
-bg_output="$(run_swap_bg start)"
+# Redirect to a file rather than using command substitution: $( ) keeps reading
+# until every writer closes the pipe, so it would wait for the background worker
+# and mask exactly the blocking this test is meant to catch.
+BG_OUT="$TMP_DIR/bg_start.out"
+MOCK_SWAPON_DELAY=5
+export MOCK_SWAPON_DELAY
+
+bg_start_s=$(date +%s)
+run_swap_bg start > "$BG_OUT" 2>&1
+bg_elapsed=$(( $(date +%s) - bg_start_s ))
+
+# swapon is mocked to take 5s; start must return well before that.
+if [ "$bg_elapsed" -ge 3 ]; then
+    echo "background start blocked for ${bg_elapsed}s; activation is not off the critical path" >&2
+    exit 1
+fi
+
+# And the activation must genuinely still be pending at this point.
+if grep -q "^$SWAP_FILE " "$PROC_SWAPS"; then
+    echo "swapfile was activated synchronously despite SWAP_BACKGROUND=1" >&2
+    exit 1
+fi
+
+bg_output="$(cat "$BG_OUT")"
 case "$bg_output" in
     *"in background"*) ;;
     *)

--- a/src/agent/internal/agent/boot_uptime.go
+++ b/src/agent/internal/agent/boot_uptime.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -15,6 +16,16 @@ var bootUptimePath = "/proc/uptime"
 // (see overlay/etc/aiden_boot_timeline.sh). The agent appends its own
 // milestones so the whole boot lives in one file. Overridable in tests.
 var bootTimelinePath = "/var/log/aiden_boot_timeline.log"
+
+// bootTimelineArchiveStatePath holds the path of the archive rcS wrote for this
+// boot, published by boot_timeline_archive. Overridable in tests.
+var bootTimelineArchiveStatePath = "/run/aiden_boot_timeline.archive"
+
+// bootTimelineLockPath is shared with overlay/etc/aiden_boot_timeline.sh.
+// Holding an exclusive flock serializes Shell and Go milestone/archive writers.
+var bootTimelineLockPath = "/run/aiden_boot_timeline.lock"
+
+const bootTimelineLockTimeout = time.Second
 
 // BootUptime reports how long the kernel has been up. The second return value
 // is false when /proc/uptime is unavailable or malformed, which is the normal
@@ -46,14 +57,99 @@ func MarkBootTimeline(label string) {
 	if !ok {
 		return
 	}
-	// Only append to an existing timeline: creating it here would produce a
-	// stray file with no boot context on every agent restart.
-	f, err := os.OpenFile(bootTimelinePath, os.O_APPEND|os.O_WRONLY, 0o644)
+	withBootTimelineLock(func() {
+		// Only append to an existing timeline: creating it here would produce a
+		// stray file with no boot context on every agent restart.
+		f, err := os.OpenFile(bootTimelinePath, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			return
+		}
+		if _, err := fmt.Fprintf(f, "%.2f 0.00 mark %s\n", uptime.Seconds(), label); err != nil {
+			f.Close()
+			return
+		}
+		// Close before refreshing so the archive copy always includes this record.
+		if err := f.Close(); err != nil {
+			return
+		}
+
+		refreshBootTimelineArchiveLocked()
+	})
+}
+
+// withBootTimelineLock coordinates with the Shell helper through flock(2).
+// Kernel locks are released automatically if either writer exits unexpectedly.
+// Acquisition is bounded so a stuck diagnostic writer cannot delay agent
+// startup. Failure skips the best-effort mark and leaves normal startup intact.
+func withBootTimelineLock(fn func()) {
+	lock, err := os.OpenFile(bootTimelineLockPath, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
 		return
 	}
-	defer f.Close()
-	fmt.Fprintf(f, "%.2f 0.00 mark %s\n", uptime.Seconds(), label)
+	defer lock.Close()
+
+	deadline := time.Now().Add(bootTimelineLockTimeout)
+	for {
+		err = syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			break
+		}
+		if err != syscall.EWOULDBLOCK && err != syscall.EAGAIN {
+			return
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	defer func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) }()
+
+	fn()
+}
+
+// refreshBootTimelineArchive mirrors boot_timeline_refresh_archive in
+// overlay/etc/aiden_boot_timeline.sh.
+//
+// rcS archives the timeline when it finishes, but the agent is started by a
+// background watchdog and can reach "listening" after that point — on a slow
+// boot, or on any watchdog restart. Without this the persisted archive would
+// stop at rcS:end and omit the very milestone it exists to record.
+//
+// Best-effort, like the rest of the timeline: no archive yet (the usual case
+// during rcS) simply means there is nothing to refresh.
+func refreshBootTimelineArchive() {
+	withBootTimelineLock(refreshBootTimelineArchiveLocked)
+}
+
+// refreshBootTimelineArchiveLocked replaces the archive from a consistent
+// point in the append/archive sequence. The caller holds bootTimelineLockPath.
+func refreshBootTimelineArchiveLocked() {
+	state, err := os.ReadFile(bootTimelineArchiveStatePath)
+	if err != nil {
+		return
+	}
+	target := strings.TrimSpace(string(state))
+	if target == "" {
+		return
+	}
+	if _, err := os.Stat(target); err != nil {
+		return
+	}
+	content, err := os.ReadFile(bootTimelinePath)
+	if err != nil {
+		return
+	}
+
+	// Write beside the target and rename, so a reader never sees a partial
+	// archive. Same directory keeps the rename atomic.
+	tmp := fmt.Sprintf("%s.tmp.%d", target, os.Getpid())
+	if err := os.WriteFile(tmp, content, 0o644); err != nil {
+		os.Remove(tmp)
+		return
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		os.Remove(tmp)
+	}
 }
 
 // bootUptimeLogSuffix renders " uptime=12.34s" for log lines, or "" when the

--- a/src/agent/internal/agent/boot_uptime.go
+++ b/src/agent/internal/agent/boot_uptime.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// bootUptimePath is the kernel's monotonic since-boot clock. Overridable in tests.
+var bootUptimePath = "/proc/uptime"
+
+// bootTimelinePath is the per-boot profile written by /etc/init.d/rcS
+// (see overlay/etc/aiden_boot_timeline.sh). The agent appends its own
+// milestones so the whole boot lives in one file. Overridable in tests.
+var bootTimelinePath = "/var/log/aiden_boot_timeline.log"
+
+// BootUptime reports how long the kernel has been up. The second return value
+// is false when /proc/uptime is unavailable or malformed, which is the normal
+// case on non-Linux hosts and in unit tests.
+func BootUptime() (time.Duration, bool) {
+	data, err := os.ReadFile(bootUptimePath)
+	if err != nil {
+		return 0, false
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return 0, false
+	}
+	secs, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil || secs < 0 {
+		return 0, false
+	}
+	return time.Duration(secs * float64(time.Second)), true
+}
+
+// MarkBootTimeline appends a milestone to the boot timeline recorded by rcS,
+// matching the "<uptime_s> <delta_s> mark <label>" record format.
+//
+// Best-effort by design: the timeline is a diagnostic, so a missing file (the
+// usual case once the tmpfs log is rotated, or on a dev host) is not an error
+// and never affects the caller.
+func MarkBootTimeline(label string) {
+	uptime, ok := BootUptime()
+	if !ok {
+		return
+	}
+	// Only append to an existing timeline: creating it here would produce a
+	// stray file with no boot context on every agent restart.
+	f, err := os.OpenFile(bootTimelinePath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "%.2f 0.00 mark %s\n", uptime.Seconds(), label)
+}
+
+// bootUptimeLogSuffix renders " uptime=12.34s" for log lines, or "" when the
+// uptime is unavailable, so callers can append it unconditionally.
+func bootUptimeLogSuffix() string {
+	uptime, ok := BootUptime()
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf(" uptime=%.2fs", uptime.Seconds())
+}

--- a/src/agent/internal/agent/boot_uptime_test.go
+++ b/src/agent/internal/agent/boot_uptime_test.go
@@ -1,10 +1,15 @@
 package agent
 
 import (
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func withBootUptimeFile(t *testing.T, contents string) {
@@ -16,6 +21,19 @@ func withBootUptimeFile(t *testing.T, contents string) {
 	original := bootUptimePath
 	bootUptimePath = path
 	t.Cleanup(func() { bootUptimePath = original })
+}
+
+func withBootTimelineFiles(t *testing.T, timeline, state string) {
+	t.Helper()
+	origTimeline, origState, origLock :=
+		bootTimelinePath, bootTimelineArchiveStatePath, bootTimelineLockPath
+	bootTimelinePath = timeline
+	bootTimelineArchiveStatePath = state
+	bootTimelineLockPath = filepath.Join(filepath.Dir(timeline), "timeline.lock")
+	t.Cleanup(func() {
+		bootTimelinePath, bootTimelineArchiveStatePath, bootTimelineLockPath =
+			origTimeline, origState, origLock
+	})
 }
 
 func TestBootUptimeParsesProcUptime(t *testing.T) {
@@ -64,9 +82,7 @@ func TestMarkBootTimelineAppendsRecord(t *testing.T) {
 	if err := os.WriteFile(timeline, []byte("0.10 0.10 rcS:begin\n"), 0o644); err != nil {
 		t.Fatalf("seed timeline: %v", err)
 	}
-	original := bootTimelinePath
-	bootTimelinePath = timeline
-	t.Cleanup(func() { bootTimelinePath = original })
+	withBootTimelineFiles(t, timeline, filepath.Join(filepath.Dir(timeline), "absent.state"))
 
 	MarkBootTimeline("agent:listening")
 
@@ -89,14 +105,243 @@ func TestMarkBootTimelineDoesNotCreateFile(t *testing.T) {
 	withBootUptimeFile(t, "51.18 40.00\n")
 
 	timeline := filepath.Join(t.TempDir(), "absent.log")
-	original := bootTimelinePath
-	bootTimelinePath = timeline
-	t.Cleanup(func() { bootTimelinePath = original })
+	withBootTimelineFiles(t, timeline, filepath.Join(filepath.Dir(timeline), "absent.state"))
 
 	MarkBootTimeline("agent:listening")
 
 	if _, err := os.Stat(timeline); !os.IsNotExist(err) {
 		t.Fatalf("expected no timeline file to be created, stat err = %v", err)
+	}
+}
+
+// A failed bind must not leave a readiness milestone behind: the timeline is
+// used to answer "when did :8080 become reachable", so a marker for a server
+// that never listened would be worse than no marker at all.
+func TestStartDoesNotMarkListeningWhenBindFails(t *testing.T) {
+	withBootUptimeFile(t, "15.26 5.00\n")
+
+	timeline := filepath.Join(t.TempDir(), "aiden_boot_timeline.log")
+	if err := os.WriteFile(timeline, []byte("0.10 0.10 rcS:begin\n"), 0o644); err != nil {
+		t.Fatalf("seed timeline: %v", err)
+	}
+	withBootTimelineFiles(t, timeline, filepath.Join(filepath.Dir(timeline), "absent.state"))
+
+	// Hold the port so the server's own bind is guaranteed to fail.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	defer occupied.Close()
+
+	srv := &Server{addr: occupied.Addr().String()}
+	if err := srv.Start(); err == nil {
+		t.Fatal("expected Start to fail when the address is already in use")
+	}
+
+	data, err := os.ReadFile(timeline)
+	if err != nil {
+		t.Fatalf("read timeline: %v", err)
+	}
+	if strings.Contains(string(data), "agent:listening") {
+		t.Fatalf("bind failure must not record agent:listening: %q", string(data))
+	}
+}
+
+// rcS archives at rcS:end, but the agent is launched by a background watchdog
+// and can reach "listening" afterwards. The Go writer must refresh the archive
+// too, otherwise the persisted copy omits the milestone it exists to record.
+func TestMarkBootTimelineRefreshesArchive(t *testing.T) {
+	withBootUptimeFile(t, "31.40 5.00\n")
+	dir := t.TempDir()
+
+	timeline := filepath.Join(dir, "aiden_boot_timeline.log")
+	if err := os.WriteFile(timeline, []byte("0.10 0.10 rcS:begin\n25.52 0.03 rcS:end\n"), 0o644); err != nil {
+		t.Fatalf("seed timeline: %v", err)
+	}
+	archive := filepath.Join(dir, "boot-20260807-000000.log")
+	if err := os.WriteFile(archive, []byte("0.10 0.10 rcS:begin\n25.52 0.03 rcS:end\n"), 0o644); err != nil {
+		t.Fatalf("seed archive: %v", err)
+	}
+	state := filepath.Join(dir, "archive.state")
+	if err := os.WriteFile(state, []byte(archive+"\n"), 0o644); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	withBootTimelineFiles(t, timeline, state)
+
+	MarkBootTimeline("agent:listening")
+
+	data, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "mark agent:listening") {
+		t.Fatalf("archive was not refreshed with the late milestone: %q", got)
+	}
+	if !strings.Contains(got, "rcS:end") {
+		t.Fatalf("refresh dropped earlier records: %q", got)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp.") {
+			t.Fatalf("refresh left a temp file behind: %s", e.Name())
+		}
+	}
+}
+
+// No archive yet (the usual case for marks written during rcS) must be a
+// silent no-op rather than an attempt to create one.
+func TestMarkBootTimelineArchiveRefreshNoopWithoutState(t *testing.T) {
+	withBootUptimeFile(t, "31.40 5.00\n")
+	dir := t.TempDir()
+
+	timeline := filepath.Join(dir, "aiden_boot_timeline.log")
+	if err := os.WriteFile(timeline, []byte("0.10 0.10 rcS:begin\n"), 0o644); err != nil {
+		t.Fatalf("seed timeline: %v", err)
+	}
+	withBootTimelineFiles(t, timeline, filepath.Join(dir, "absent.state"))
+
+	MarkBootTimeline("agent:listening")
+
+	data, err := os.ReadFile(timeline)
+	if err != nil {
+		t.Fatalf("read timeline: %v", err)
+	}
+	if !strings.Contains(string(data), "mark agent:listening") {
+		t.Fatal("milestone must still be appended to the live timeline")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "boot-") {
+			t.Fatalf("mark without archive state created an archive: %s", entry.Name())
+		}
+	}
+}
+
+// The Shell archiver holds the same flock while it snapshots the timeline and
+// publishes the archive state. A Go milestone arriving in that window must wait
+// and then refresh the published archive, never disappear between the two.
+func TestMarkBootTimelineWaitsForArchivePublicationLock(t *testing.T) {
+	withBootUptimeFile(t, "31.41 5.00\n")
+	dir := t.TempDir()
+	timeline := filepath.Join(dir, "aiden_boot_timeline.log")
+	archive := filepath.Join(dir, "boot-20260807-000000.log")
+	state := filepath.Join(dir, "archive.state")
+	if err := os.WriteFile(timeline, []byte("0.10 0.10 rcS:begin\n25.52 0.03 rcS:end\n"), 0o644); err != nil {
+		t.Fatalf("seed timeline: %v", err)
+	}
+	if err := os.WriteFile(archive, []byte("0.10 0.10 rcS:begin\n25.52 0.03 rcS:end\n"), 0o644); err != nil {
+		t.Fatalf("seed archive: %v", err)
+	}
+	if err := os.WriteFile(state, []byte(archive+"\n"), 0o644); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	withBootTimelineFiles(t, timeline, state)
+
+	lock, err := os.OpenFile(bootTimelineLockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("open timeline lock: %v", err)
+	}
+	defer lock.Close()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatalf("hold timeline lock: %v", err)
+	}
+	locked := true
+	defer func() {
+		if locked {
+			_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		MarkBootTimeline("agent:listening")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("milestone writer ignored the archive publication lock")
+	case <-time.After(100 * time.Millisecond):
+	}
+	data, err := os.ReadFile(timeline)
+	if err != nil {
+		t.Fatalf("read blocked timeline: %v", err)
+	}
+	if strings.Contains(string(data), "agent:listening") {
+		t.Fatal("milestone was appended while archive publication held the lock")
+	}
+
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatalf("release timeline lock: %v", err)
+	}
+	locked = false
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("milestone writer did not resume after archive publication")
+	}
+
+	data, err = os.ReadFile(archive)
+	if err != nil {
+		t.Fatalf("read refreshed archive: %v", err)
+	}
+	if !strings.Contains(string(data), "mark agent:listening") {
+		t.Fatalf("archive omitted milestone written after publication: %q", data)
+	}
+}
+
+// Concurrent marks used to copy the full timeline into per-process temporary
+// files and race their final rename. A slower stale snapshot could then replace
+// a newer one. Serializing append + refresh must preserve every completed mark.
+func TestConcurrentBootTimelineMarksDoNotRegressArchive(t *testing.T) {
+	withBootUptimeFile(t, "42.00 5.00\n")
+	dir := t.TempDir()
+	timeline := filepath.Join(dir, "aiden_boot_timeline.log")
+	archive := filepath.Join(dir, "boot-20260807-000000.log")
+	state := filepath.Join(dir, "archive.state")
+	initial := []byte("0.10 0.10 rcS:begin\n25.52 0.03 rcS:end\n")
+	if err := os.WriteFile(timeline, initial, 0o644); err != nil {
+		t.Fatalf("seed timeline: %v", err)
+	}
+	if err := os.WriteFile(archive, initial, 0o644); err != nil {
+		t.Fatalf("seed archive: %v", err)
+	}
+	if err := os.WriteFile(state, []byte(archive+"\n"), 0o644); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	withBootTimelineFiles(t, timeline, state)
+
+	const marks = 16
+	var wg sync.WaitGroup
+	wg.Add(marks)
+	for i := 0; i < marks; i++ {
+		label := fmt.Sprintf("agent:concurrent-%02d", i)
+		go func() {
+			defer wg.Done()
+			MarkBootTimeline(label)
+		}()
+	}
+	wg.Wait()
+
+	data, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	got := string(data)
+	for i := 0; i < marks; i++ {
+		label := fmt.Sprintf("mark agent:concurrent-%02d", i)
+		if !strings.Contains(got, label) {
+			t.Fatalf("concurrent archive omitted %s: %q", label, got)
+		}
 	}
 }
 

--- a/src/agent/internal/agent/boot_uptime_test.go
+++ b/src/agent/internal/agent/boot_uptime_test.go
@@ -1,0 +1,115 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func withBootUptimeFile(t *testing.T, contents string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "uptime")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write uptime: %v", err)
+	}
+	original := bootUptimePath
+	bootUptimePath = path
+	t.Cleanup(func() { bootUptimePath = original })
+}
+
+func TestBootUptimeParsesProcUptime(t *testing.T) {
+	withBootUptimeFile(t, "7717.92 6832.62\n")
+
+	uptime, ok := BootUptime()
+	if !ok {
+		t.Fatal("expected uptime to parse")
+	}
+	if got := uptime.Seconds(); got < 7717.91 || got > 7717.93 {
+		t.Fatalf("uptime = %v, want ~7717.92", got)
+	}
+}
+
+func TestBootUptimeRejectsUnusableInput(t *testing.T) {
+	cases := map[string]string{
+		"empty":     "",
+		"blank":     "   \n",
+		"malformed": "not-a-number 1.0\n",
+		"negative":  "-5.0 1.0\n",
+	}
+	for name, contents := range cases {
+		t.Run(name, func(t *testing.T) {
+			withBootUptimeFile(t, contents)
+			if _, ok := BootUptime(); ok {
+				t.Fatalf("expected %s input to be rejected", name)
+			}
+		})
+	}
+}
+
+func TestBootUptimeMissingFile(t *testing.T) {
+	original := bootUptimePath
+	bootUptimePath = filepath.Join(t.TempDir(), "does-not-exist")
+	t.Cleanup(func() { bootUptimePath = original })
+
+	if _, ok := BootUptime(); ok {
+		t.Fatal("expected missing /proc/uptime to report not-ok")
+	}
+}
+
+func TestMarkBootTimelineAppendsRecord(t *testing.T) {
+	withBootUptimeFile(t, "51.18 40.00\n")
+
+	timeline := filepath.Join(t.TempDir(), "aiden_boot_timeline.log")
+	if err := os.WriteFile(timeline, []byte("0.10 0.10 rcS:begin\n"), 0o644); err != nil {
+		t.Fatalf("seed timeline: %v", err)
+	}
+	original := bootTimelinePath
+	bootTimelinePath = timeline
+	t.Cleanup(func() { bootTimelinePath = original })
+
+	MarkBootTimeline("agent:listening")
+
+	data, err := os.ReadFile(timeline)
+	if err != nil {
+		t.Fatalf("read timeline: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "0.10 0.10 rcS:begin") {
+		t.Fatalf("existing records were lost: %q", got)
+	}
+	if !strings.Contains(got, "51.18 0.00 mark agent:listening") {
+		t.Fatalf("missing milestone record: %q", got)
+	}
+}
+
+// The timeline belongs to a boot. An agent restart must not resurrect it,
+// otherwise the file would hold records with no boot context.
+func TestMarkBootTimelineDoesNotCreateFile(t *testing.T) {
+	withBootUptimeFile(t, "51.18 40.00\n")
+
+	timeline := filepath.Join(t.TempDir(), "absent.log")
+	original := bootTimelinePath
+	bootTimelinePath = timeline
+	t.Cleanup(func() { bootTimelinePath = original })
+
+	MarkBootTimeline("agent:listening")
+
+	if _, err := os.Stat(timeline); !os.IsNotExist(err) {
+		t.Fatalf("expected no timeline file to be created, stat err = %v", err)
+	}
+}
+
+func TestBootUptimeLogSuffix(t *testing.T) {
+	withBootUptimeFile(t, "50.70 1.00\n")
+	if got := bootUptimeLogSuffix(); got != " uptime=50.70s" {
+		t.Fatalf("suffix = %q", got)
+	}
+
+	original := bootUptimePath
+	bootUptimePath = filepath.Join(t.TempDir(), "missing")
+	t.Cleanup(func() { bootUptimePath = original })
+	if got := bootUptimeLogSuffix(); got != "" {
+		t.Fatalf("expected empty suffix when uptime unavailable, got %q", got)
+	}
+}

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -515,9 +515,13 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) Start() error {
 	handler := s.Handler()
 
+	// Milestone: the agent Web UI (http://192.168.42.1:8080) is about to accept
+	// connections. Stamped with kernel uptime so it can be lined up against the
+	// init-script timeline in /var/log/aiden_boot_timeline.log.
 	if s.logger != nil {
-		s.logger.Info("Starting HTTP server on %s", s.addr)
+		s.logger.Info("Starting HTTP server on %s%s", s.addr, bootUptimeLogSuffix())
 	}
+	MarkBootTimeline("agent:listening")
 
 	srv := &http.Server{
 		Addr:              s.addr,

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -515,14 +515,6 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) Start() error {
 	handler := s.Handler()
 
-	// Milestone: the agent Web UI (http://192.168.42.1:8080) is about to accept
-	// connections. Stamped with kernel uptime so it can be lined up against the
-	// init-script timeline in /var/log/aiden_boot_timeline.log.
-	if s.logger != nil {
-		s.logger.Info("Starting HTTP server on %s%s", s.addr, bootUptimeLogSuffix())
-	}
-	MarkBootTimeline("agent:listening")
-
 	srv := &http.Server{
 		Addr:              s.addr,
 		Handler:           handler,
@@ -531,9 +523,26 @@ func (s *Server) Start() error {
 		IdleTimeout:       agentHTTPIdleTimeout,
 	}
 
+	// Bind explicitly rather than letting ListenAndServe do it, so the readiness
+	// milestone is recorded only once the port is actually held. Marking before
+	// the bind would report the agent Web UI as listening even when startup
+	// failed on, say, an address already in use.
+	listener, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", s.addr, err)
+	}
+
+	// Milestone: the agent Web UI (http://192.168.42.1:8080) is now accepting
+	// connections. Stamped with kernel uptime so it can be lined up against the
+	// init-script timeline in /var/log/aiden_boot_timeline.log.
+	if s.logger != nil {
+		s.logger.Info("Starting HTTP server on %s%s", s.addr, bootUptimeLogSuffix())
+	}
+	MarkBootTimeline("agent:listening")
+
 	errCh := make(chan error, 1)
 	go func() {
-		err := srv.ListenAndServe()
+		err := srv.Serve(listener)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 			return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added boot-time profiling with event tracking, milestone recording, reports, and archived timelines.
  * Added optional background startup for DHCP and swap activation.
  * Added configurable readiness polling and startup timeouts for DHCP and web services.
  * Added boot-uptime details to agent startup logs and service milestones.
* **Bug Fixes**
  * Boot continues safely when profiling is unavailable or fails.
  * Services now detect readiness and startup failures more accurately and clean up failed processes.
  * Agent readiness is reported only after successful listener setup.
* **Tests**
  * Added coverage for profiling, service polling, DHCP startup, swap behavior, and asynchronous milestones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->