### PR TITLE
docs: align firmware docs with current runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The current development setup centers on:
 - A USB-C hub that provides HDMI output for capture and a USB data path back to the target device;
 - The Pico Zero Linux USB gadget stack for keyboard, pointer/touch, and ECM networking.
 
-Some prototype hardware revisions may include additional USB modules, but the firmware-documented HID path is the Linux gadget path exposed as `/dev/hidg0` and `/dev/hidg1`.
+Some prototype hardware revisions may include additional USB modules, but the firmware-documented HID path is the Linux gadget path: `/dev/hidg0` for the keyboard, `/dev/hidg1` for pointer/touch input, and `/dev/hidg2` for Android extension keys or Consumer Control media keys.
 
 For the complete parts list, self-assembly instructions, wiring diagram, and target-device prerequisites, see [Hardware & Wiring](docs/01-getting-started/hardware.md).
 
@@ -30,8 +30,8 @@ For the complete parts list, self-assembly instructions, wiring diagram, and tar
 The current hardware setup connects to a phone or computer through a USB-C hub:
 
 - the target device's display output is captured through HDMI and the TC358743 HDMI-to-CSI path;
-- the Luckfox Pico Zero exposes a composite USB gadget with keyboard/pointer HID and USB ECM networking;
-- the Go Agent sends screenshots to a configured multimodal model, decides the next action, and writes keyboard/mouse/touch reports to `/dev/hidg0` and `/dev/hidg1`;
+- the Luckfox Pico Zero exposes a composite USB gadget with keyboard, pointer/touch, auxiliary control HID, and USB ECM networking;
+- the Go Agent sends screenshots to a configured multimodal model, decides the next action, and writes keyboard, pointer/touch, and Android extension or Consumer Control reports to `/dev/hidg0`, `/dev/hidg1`, and `/dev/hidg2`;
 - voice mode records audio on the board, applies VAD, then uses configured STT, LLM, and TTS providers.
 
 The basic control path does not require jailbreak, ADB, developer mode, or a custom app on the target device. It does require a target that can output video to the capture path and accept USB HID input. iOS control also requires AssistiveTouch to be enabled.
@@ -47,7 +47,7 @@ Most mobile agent projects are lab prototypes that require a laptop or desktop t
 ### 2. **Fully Open**
 - **Open-source firmware** — Complete C++ services and Go agent code
 - **Development board reference** — Current prototyping board schematics and assembly guide available
-- **Any LLM** — Configure OpenAI, Anthropic, local models, or your own deployment
+- **Flexible model backends** — Configure registered providers such as OpenAI, OpenRouter, Kimi, Volcengine, or Ollama; use OpenRouter for Anthropic Claude and Google Gemini models
 - **Exportable data** — Your memory, skills, and learned behaviors are yours to keep and migrate
 - **Community-driven** — Contributions welcome; flash custom firmware freely
 
@@ -87,7 +87,7 @@ Target display
     -> screenshot tool
     -> Go Agent
     -> HID tools
-    -> /dev/hidg0 and /dev/hidg1
+    -> /dev/hidg0, /dev/hidg1, and /dev/hidg2
     -> target device input
 
 Board audio

--- a/docs/01-getting-started/hardware.md
+++ b/docs/01-getting-started/hardware.md
@@ -35,7 +35,7 @@ Target Device (iPhone / PC)
           └─ USB-A out ──→ Luckfox Pico Zero (CSI input + USB)
                                    │
                                    ├─ Video capture: /dev/video0 (from TC358743 CSI)
-                                   ├─ HID keyboard/mouse/touch: /dev/hidg0, /dev/hidg1
+                                   ├─ HID keyboard/pointer/control: /dev/hidg0, /dev/hidg1, /dev/hidg2
                                    ├─ Audio codec / ALSA
                                    └─ Network: Wi-Fi or USB gadget network
 ```
@@ -91,6 +91,7 @@ It is also recommended to enable **Show Onscreen Keyboard** on the AssistiveTouc
 | HDMI subdev | `/dev/v4l-subdev2` | EDID / DV timings / HDMI sync |
 | Keyboard HID | `/dev/hidg0` | Default keyboard device for Go Agent and example tools |
 | Mouse/touch HID | `/dev/hidg1` | Go Agent uses the same HID device for mouse/touch input |
+| Auxiliary control HID | `/dev/hidg2` | Android extension keys in touchscreen mode; Consumer Control media, volume, brightness, and screenshot keys in absolute mode |
 | Frame socket | `/run/frame_service/frame_service.sock` | Default path for system service deployment |
 | Audio socket | `/run/audio_service/audio_service.sock` | Default path for system service deployment |
 

--- a/docs/01-getting-started/quickstart.md
+++ b/docs/01-getting-started/quickstart.md
@@ -2,7 +2,7 @@
 
 This page is the main path for anyone touching Aiden hardware for the first time. It follows the order **wire up → flash → connect Wi-Fi → configure → run → develop → upgrade → troubleshoot**, stringing the whole onboarding flow into one page. Each step covers only the key action; details are linked to the corresponding topic docs.
 
-> Voice interaction is Aiden's core usage scenario. `text` mode is mainly for development and testing—it bypasses the audio hardware (recording/playback) and provides a Web UI to validate the agent logic chain without requiring the full voice pipeline.
+> Voice interaction is Aiden's core usage scenario. The Agent Web UI is available in every input mode. `text` mode is mainly for development and testing because it disables the device-side audio loop while keeping the HTTP interface available.
 
 ## Overview
 
@@ -24,7 +24,7 @@ Follow [Hardware & Wiring](hardware.md) to complete the wiring. Key connection f
 - The target device (iPhone / PC) connects to a **USB-C hub**;
 - The hub's **HDMI output** goes to the TC358743XBG HDMI-to-CSI bridge, which feeds the Pico Zero's `/dev/video0` via CSI;
 - The hub's **USB-C output** connects to the Pico Zero for data and power;
-- The Pico Zero emulates an HID keyboard/mouse/touch device (`/dev/hidg0`, `/dev/hidg1`) back to the target over the USB connection;
+- The Pico Zero exposes `/dev/hidg0` for keyboard input, `/dev/hidg1` for pointer/touch input, and `/dev/hidg2` for Android extension keys or Consumer Control media keys back to the target over USB;
 - Audio goes through the Pico Zero's onboard codec / ALSA; networking goes through Wi-Fi or the USB gadget network.
 
 To control an iOS device over USB HID, first enable `Settings > Accessibility > Touch > AssistiveTouch` on the target device, and it is recommended to enable **Show Onscreen Keyboard** as well.
@@ -76,16 +76,16 @@ Fill in the keys for each service on the same config page. Among them:
 
 ### Choosing the Agent mode
 
-Determined by `input_mode` in `agent.toml`. Two modes:
+The Agent HTTP server and Web UI always start. `input_mode` selects whether the device-side voice loop also runs:
 
 | Mode | Behavior | Use case |
 | --- | --- | --- |
-| `stt` | Device records → VAD → STT to text → LLM → TTS playback | Voice interaction |
-| `text` | Starts the HTTP server + Web UI | Mainly for testing; use the web page on port 8080 for text interaction |
+| `stt` | HTTP server + Web UI, with device recording → VAD → STT to text → LLM → TTS playback running in parallel | Voice interaction, with the Web UI still available |
+| `text` | HTTP server + Web UI only | Mainly for testing; use the web page on port 8080 for text interaction |
 
-`stt` mode transcribes voice to text before sending it to the LLM. `text` mode is mainly for testing — open the web page on the device's port `8080` for text interaction. The removed `audio` mode (raw audio sent directly to the LLM) is no longer supported.
+`stt` mode transcribes voice to text before sending it to the LLM while serving the same HTTP interface. `text` mode is mainly for testing because it skips the device audio loop. The removed `audio` mode (raw audio sent directly to the LLM) is no longer supported.
 
-> Note the two distinct web pages: `http://192.168.42.1` (port 80) is the device config page; `http://<device-ip>:8080` is the Agent Web UI in `text` mode.
+> Note the two distinct web pages: `http://192.168.42.1` (port 80) is the device config page; `http://<device-ip>:8080` is the Agent Web UI, available in both `text` and `stt` modes.
 
 Field meanings, minimal working config examples, and TTS/STT provider values are in [Agent Configuration](../04-agent/configuration.md).
 

--- a/docs/01-getting-started/testing.md
+++ b/docs/01-getting-started/testing.md
@@ -73,7 +73,7 @@ Check the service on the device:
 /etc/init.d/S53agent status
 ```
 
-In Web UI mode, open:
+The Agent Web UI is available in every input mode. Open:
 
 ```text
 http://<device-ip>:8080

--- a/docs/02-architecture/overview.md
+++ b/docs/02-architecture/overview.md
@@ -27,7 +27,7 @@ Aiden Hardware combines HDMI video capture, audio recording/playback, USB HID co
 
                  ┌──────────────────────────┐
                  │ USB HID Gadget           │
-                 │ /dev/hidg0 / /dev/hidg1  │
+                 │ hidg0 / hidg1 / hidg2     │
                  └───────────▲──────────────┘
                              │
                          Agent tools
@@ -62,7 +62,7 @@ TC358743 → /dev/video0 → frame_service ring buffer → Go screenshot tool �
 ### Device Control
 
 ```text
-LLM tool call → Go HID tool → /dev/hidg0 or /dev/hidg1 → target device
+LLM tool call → Go HID tool → /dev/hidg0, /dev/hidg1, or /dev/hidg2 → target device
 ```
 
 ### Voice Interaction

--- a/docs/02-architecture/source-tree.md
+++ b/docs/02-architecture/source-tree.md
@@ -37,7 +37,7 @@ aiden-firmware/
 
 | Path | Description |
 | --- | --- |
-| `cmd/daemon` | Long-running Agent daemon, providing Web UI or device voice mode |
+| `cmd/daemon` | Long-running Agent daemon providing the HTTP/Web UI in all input modes and an additional device voice loop in `stt` mode |
 | `cmd/abctl` | A/B partition control utility for OTA system |
 | `cmd/ota` | OTA update client |
 | `cmd/benchmark-http` | Standalone LLM endpoint latency probe |

--- a/docs/03-services/agent.md
+++ b/docs/03-services/agent.md
@@ -1,6 +1,6 @@
 # Agent: AI Assistant Service
 
-`agent` is the core Go service that provides AI interaction capabilities through voice and text modes. It orchestrates LLM calls, tool execution (HID control, screenshots, audio playback), and manages conversation sessions.
+`agent` is the core Go service that provides the Agent Web UI, HTTP APIs, and optional device-side voice interaction. It orchestrates model calls, tool execution (HID control, screenshots, audio playback), and conversation sessions.
 
 ## Default Parameters
 
@@ -19,25 +19,57 @@
 /etc/init.d/S53agent restart
 ```
 
-## Modes
+## Input Modes
 
-- **Voice mode**: Continuous voice interaction using audio_service for recording, the configured TTS playback backend for speech, and STT/TTS providers
-- **Text mode**: HTTP-based text interaction for testing and debugging
+The HTTP server and Web UI run in every input mode:
+
+- **`input_mode = "text"`**: HTTP-based interaction only, mainly for testing and debugging.
+- **`input_mode = "stt"`**: Runs the device audio loop in parallel with the HTTP server, using `audio_service`, VAD, the selected STT provider, the model, and the selected TTS provider.
 
 ## Configuration
 
-Key sections in `config.toml`:
+The service reads `/userdata/agent/agent.toml`. Provider tables define named provider instances, and the corresponding selection table references one of those names:
 
 ```toml
-[llm]
-provider = "anthropic"  # or "openai", "gemini"
+input_mode = "stt"
+
+[model_providers.openai-main]
+type = "openai"
+token_env = "OPENAI_API_KEY"
+
+[model]
+provider = "openai-main"
+model = "gpt-5.5"
+# base_url = "https://api.openai.com/v1"
+# temperature = 0.2
+# max_response_tokens = 1000
 
 [audio]
-socket = "/run/audio_service/audio_service.sock"
-playback_backend = "auto"
+# socket = "/run/audio_service/audio_service.sock"
+# playback_backend = "auto"
 
 [hid]
-frame_socket = "/run/frame_service/frame_service.sock"
+# keyboard_device = "/dev/hidg0"
+# mouse_device = "/dev/hidg1"
+# android_keyboard_device = "/dev/hidg2"
+# frame_socket = "/run/frame_service/frame_service.sock"
+
+[stt_providers.openai-main]
+type = "openai-whisper"
+token_env = "OPENAI_API_KEY"
+model = "whisper-1"
 
 [stt]
-provider = "tencent"  # or "openai"
+provider = "openai-main"
+
+[tts_providers.minimax-main]
+type = "minimax-cn"
+token_env = "MINIMAX_API_KEY"
+voice_id = "male-qn-qingse"
+
+[tts]
+provider = "minimax-main"
+speed = 1.0
+```
+
+Built-in model provider types include `openai`, `openrouter`, `kimi`, `kimi-cn`, `volcengine`, and `ollama`. There are no native `anthropic` or `gemini` provider types; Anthropic Claude and Google Gemini models can be selected through a registered compatible provider such as `openrouter`.

--- a/docs/03-services/config-web.md
+++ b/docs/03-services/config-web.md
@@ -14,9 +14,14 @@
 
 ```bash
 /etc/init.d/S56config_web start
-/etc/init.d/S56config_web status
+/etc/init.d/S56config_web stop
 /etc/init.d/S56config_web restart
+/etc/init.d/S56config_web reload
 ```
+
+The init script supports `start`, `stop`, `restart`, and `reload`. It does not
+provide a `status` command; `reload` currently performs the same stop-and-start
+sequence as `restart`.
 
 ## Access
 
@@ -29,7 +34,7 @@ http://192.168.42.1
 The web interface allows:
 - Opening the browser terminal exposed by WeTTY at `http://192.168.42.1:3000/wetty/`
 - Switching the device language between Simplified Chinese (`zh-CN`) and English (`en-US`); this also controls user-facing Agent responses and `<tts>` content
-- Switching LLM providers (Anthropic, OpenAI, Gemini)
+- Switching among registered model provider types such as OpenAI, OpenRouter, Kimi, Volcengine, and Ollama; Anthropic Claude and Google Gemini models are available through compatible providers such as OpenRouter, not native `anthropic` or `gemini` provider types
 - Configuring API keys and model names
 - Selecting STT/TTS providers
 - Testing voice recognition and synthesis

--- a/docs/03-services/frame-service.md
+++ b/docs/03-services/frame-service.md
@@ -19,7 +19,8 @@ Allowing multiple processes to directly open `/dev/video0` can lead to resource 
 | Socket (firmware service) | `/run/frame_service/frame_service.sock` | Default value in init configuration |
 | EDID | Built-in 1080p30 CTA EDID | Used when `--edid` is not provided |
 | Ring size | `3` | `kDefaultFrameServiceRingSize` |
-| FPS | `3.0` | For default 1080p input, the service sampling FPS is kept low to control CPU, memory bandwidth, and heat |
+| FPS (binary default) | `3.0` | Used when `frame_service` is run directly without `--fps` |
+| FPS (firmware service default) | `30` | `S52frame_service` passes `--fps 30` from `/etc/aiden_frame_service.conf` |
 | Screenshot max edge | `960` | Related to Go screenshot tool default compression strategy |
 
 ## Startup
@@ -30,11 +31,18 @@ Development mode:
 ./build/bin/frame_service --socket /tmp/frame_service.sock
 ```
 
+This direct invocation uses the binary default of 3 FPS unless `--fps` is
+provided.
+
 Firmware service:
 
 ```bash
 /etc/init.d/S52frame_service start
 ```
+
+The firmware service overrides the binary default and samples at 30 FPS by
+default. Change `FRAME_SERVICE_FPS` in `/etc/aiden_frame_service.conf` to tune
+the deployed service.
 
 ## Parameters
 

--- a/docs/04-agent/audio-features.md
+++ b/docs/04-agent/audio-features.md
@@ -8,10 +8,9 @@ The Go Agent supports device-side voice interaction, primarily consisting of `in
 ┌─────────────┐
 │   daemon    │
 └──────┬──────┘
+       ├─────────────────────────► HTTP Server / Web UI (all input modes)
        │
-       ├─ input_mode=text ──────► HTTP Server / Web UI
-       │
-       └─ input_mode=stt ─────────► Audio Dialog Loop
+       └─ input_mode=stt ────────► Audio Dialog Loop
                                    │
                                    ├─ AudioServiceClient
                                    ├─ VAD
@@ -26,7 +25,7 @@ The Go Agent supports device-side voice interaction, primarily consisting of `in
 | --- | --- | --- |
 | Audio client | `audio_client.go` | Connects to `audio_service`, starts recording/playback sessions, reads/writes PCM chunks |
 | VAD | `vad.go` + `/oem/usr/bin/rknn_vad` or `/oem/usr/bin/cpu_vad` | Silero VAD inference; input is fixed at 16 kHz, 512 samples/32 ms, with `state` maintained in helper |
-| STT | `stt.go`, `tencent_asr_stt.go` | OpenAI Whisper / OpenRouter / Tencent Cloud ASR (`tencent-asr`; legacy values `tencent` / `tencent_asr` are compatible) |
+| STT | `stt.go`, provider-specific clients | OpenAI Whisper, OpenRouter, Tencent Cloud ASR, Qwen ASR, and Google Cloud STT; `tencent` / `tencent_asr` remain compatibility aliases for `tencent-asr` |
 | TTS | `tts/`, `tts_helpers.go` | Pluggable TTS provider, outputs PCM for the configured playback backend; automatically resamples to the target playback sample rate when necessary |
 | Dialog manager | `audio_dialog.go` | Orchestrates recording, VAD, STT/LLM/TTS flow |
 | Voice notifications | `voice_notification.go`, `tts_fallback.go` | Adds a persistent response tail or final-turn failure replacement before TTS, with bundled local WAV fallback when final TTS is unavailable |
@@ -35,14 +34,14 @@ The Go Agent supports device-side voice interaction, primarily consisting of `in
 
 ### `input_mode = "text"`
 
-Starts HTTP server and Web UI. Browser can upload/record audio:
+Runs the HTTP server and Web UI without starting the device-side audio loop. Browser clients can still upload or record audio:
 
 - If `[stt]` is configured, browser audio is transcribed to text first;
 - Otherwise audio is passed as model attachment.
 
 ### `input_mode = "stt"`
 
-Device-side audio loop:
+Runs the device-side audio loop alongside the HTTP server and Web UI:
 
 1. Records PCM via `audio_service`;
 2. VAD determines sentence boundaries;
@@ -71,16 +70,16 @@ vad_backend = "rknn"
 vad_model_path = "/oem/usr/model/silero_vad_6_2_encoder_rv1106_w8a8_v1.rknn"
 vad_helper_path = "/oem/usr/bin/rknn_vad"
 vad_speech_threshold = 0.5
-silence_ms = 650
+silence_ms = 550
 min_speech_ms = 300
 voice_followup_enabled = false
-voice_followup_timeout_ms = 6000
+voice_followup_timeout_ms = 5000
 voice_first_turn_timeout_ms = 10000
 voice_max_turns = 0
 voice_interrupt_on_wakeup = true
 voice_streaming_tts_enabled = true
 voice_tool_call_speech = true
-voice_max_response_tokens = 400
+voice_max_response_tokens = 300
 
 [audio]
 socket = "/run/audio_service/audio_service.sock"
@@ -89,21 +88,30 @@ channels = 1
 bit_width = 16
 playback_backend = "auto"
 
-[stt]
-provider = "openai-whisper"
-api_key = "sk-..."
+[stt_providers.openai-main]
+type = "openai-whisper"
+token_env = "OPENAI_API_KEY"
 model = "whisper-1"
 
-# OpenRouter alternative:
-# provider = "openrouter"
-# api_key = "OPENROUTER_API_KEY"
-# model = "qwen/qwen3-asr-flash-2026-02-10"
+[stt]
+provider = "openai-main"
 
-[tts]
-provider = "alicloud"
+# OpenRouter alternative:
+# [stt_providers.openrouter-main]
+# type = "openrouter"
+# token_env = "OPENROUTER_API_KEY"
+# model = "qwen/qwen3-asr-flash-2026-02-10"
+# Set [stt].provider = "openrouter-main" to select it.
+
+[tts_providers.alicloud-main]
+type = "alicloud"
+token_env = "DASHSCOPE_API_KEY"
 model = "qwen3-tts-flash-realtime"
 voice_id = "Cherry"
 emotion = "happy"
+
+[tts]
+provider = "alicloud-main"
 speed = 1.0
 ```
 
@@ -179,4 +187,4 @@ On success, it will output a line `P <probability>`; if there are still RKNN inp
 
 ## Known Limitations
 
-- Web UI and device voice loop currently cannot run simultaneously in the same daemon instance;
+- Web UI and device voice interactions share one Agent runtime, so only one Agent run can execute at a time;

--- a/docs/04-agent/configuration.md
+++ b/docs/04-agent/configuration.md
@@ -69,7 +69,7 @@ The page fields cover the following config sections (all detailed later on this 
 
 ## Minimal config examples
 
-### Web UI (text mode)
+### HTTP/Web UI without the device voice loop (`text`)
 
 ```toml
 locale = "zh-CN"
@@ -126,17 +126,17 @@ vad_backend = "rknn"
 vad_model_path = "/oem/usr/model/silero_vad_6_2_encoder_rv1106_w8a8_v1.rknn"
 vad_helper_path = "/oem/usr/bin/rknn_vad"
 vad_speech_threshold = 0.5
-silence_ms = 650
+silence_ms = 550
 min_speech_ms = 300
 voice_followup_enabled = false
-voice_followup_timeout_ms = 6000
+voice_followup_timeout_ms = 5000
 voice_first_turn_timeout_ms = 10000
 voice_max_turns = 0
 voice_interrupt_on_wakeup = true
 voice_streaming_tts_enabled = true
 voice_tool_call_speech = true
 voice_progress_speech_enabled = true
-voice_max_response_tokens = 400
+voice_max_response_tokens = 300
 
 [model_providers.openrouter-main]
 type = "openrouter"
@@ -210,17 +210,17 @@ These fields apply to the `stt` input mode.
 | `vad_model_path`                | `/oem/usr/model/silero_vad_6_2_encoder_rv1106_w8a8_v1.rknn` | Silero VAD RKNN encoder model path; not used when `vad_backend="cpu"`                                                                                                                  |
 | `vad_helper_path`               | `/oem/usr/bin/rknn_vad`                                     | VAD helper executable path; the CPU backend defaults to `/oem/usr/bin/cpu_vad`                                                                                                         |
 | `vad_speech_threshold`          | `0.5`                                                       | Silero VAD speech probability threshold                                                                                                                                                |
-| `silence_ms`                    | `650`                                                       | How many milliseconds of silence before an utterance is considered finished                                                                                                            |
+| `silence_ms`                    | `550`                                                       | How many milliseconds of silence before an utterance is considered finished                                                                                                            |
 | `min_speech_ms`                 | `300`                                                       | Minimum valid speech duration                                                                                                                                                          |
 | `voice_followup_enabled`        | `false`                                                     | Enable continuous follow-up after a single wakeup in wakeup mode; defaults to one wakeup per turn                                                                                      |
-| `voice_followup_timeout_ms`     | `6000`                                                      | Window to wait for a user follow-up after the Agent replies                                                                                                                            |
+| `voice_followup_timeout_ms`     | `5000`                                                      | Window to wait for a user follow-up after the Agent replies                                                                                                                            |
 | `voice_first_turn_timeout_ms`   | `10000`                                                     | Window to wait for the first utterance after wakeup                                                                                                                                    |
 | `voice_max_turns`               | `0`                                                         | Maximum turns per wakeup session; `0` means unlimited                                                                                                                                  |
 | `voice_interrupt_on_wakeup`     | `true`                                                      | When a wakeup is received again within a session, cancel thinking/TTS and listen again; repeated wakeups during the listening or recording phase are merged or ignored                 |
 | `voice_streaming_tts_enabled`   | `true`                                                      | Feed the LLM streaming output into TTS sentence by sentence, reducing the wait before the first sentence plays                                                                         |
 | `voice_tool_call_speech`        | `true`                                                      | Whether to asynchronously read the `content` of a tool-call event; this content comes only from the assistant content in the same LLM tool-call response, and stays silent when absent |
 | `voice_progress_speech_enabled` | `true`                                                      | Whether to announce a short progress message when a todo item enters `in_progress`; todo state is still sent to the UI/trace                                                           |
-| `voice_max_response_tokens`     | `400`                                                       | Per-turn output token limit for voice replies (must be `>= 0`)                                                                                                                         |
+| `voice_max_response_tokens`     | `300`                                                       | Per-turn output token limit for voice replies (must be `>= 0`)                                                                                                                         |
 
 The model pointed to by `vad_model_path` must first be converted from the Silero ONNX to RV1106 RKNN on a PC using `silero-vad/convert_silero_vad_to_rknn.py`, then placed at the corresponding path on the device. The CPU backend requires `silero_vad_6_2_lstm_decoder_weights.bin` to include the Conv1d encoder extension, which can be generated from the TorchScript file shipped with the repo using `silero-vad/export_silero_vad_v6_2_weights.py`.
 When `vad_helper_path` is still the built-in default, switching `vad_backend` automatically switches the helper; only when set to a custom path does it run that custom path.
@@ -313,7 +313,7 @@ built. When a section is named exactly like a provider type, the section wins.
 | `base_url`                | Custom OpenAI-compatible endpoint. Only `openai` and `ollama` accept a `base_url` override; other providers use their built-in endpoints and a stored value is dropped on load. |
 | `api_key`                 | API key written directly                                                                                                                                                                                                                             |
 | `temperature`             | Sampling temperature. When unset, the default is model-dependent (some models such as Kimi K3 require a fixed temperature), falling back to `0.2`. An explicit value always takes precedence.                                                        |
-| `reasoning_effort`        | Thinking budget. Unset is auto: the field is omitted and the provider decides, except that reasoning is disabled for no-tool requests. `low`/`medium`/`high` work everywhere; `minimal` is Volcengine Ark only; `none` is accepted by the others but not by Ark. Some models pin a lighter default (see the registry in `model_specs.go`); an explicit value always wins. |
+| `reasoning_effort`        | Thinking budget. Unset is auto: the field is omitted and the provider decides, except that reasoning is disabled for no-tool requests. `low`/`medium`/`high` work everywhere; `minimal` is supported by OpenRouter and Volcengine Ark; `none` is supported by OpenRouter, OpenAI, Kimi, Ollama, and the fake provider, but not by Ark. Some models pin a lighter default (see the registry in `model_specs.go`); an explicit value always wins. |
 | `max_response_tokens`     | Maximum output tokens passed to the model on request                                                                                                                                                                                                 |
 | `context_window`          | Optional total context window override in tokens. Unset or `0` uses provider metadata for OpenRouter/Ollama when available, then the built-in registry, then memory fallback.                                                                        |
 | `model_max_output_tokens` | Optional advertised max output override in tokens. Unset or `0` uses provider metadata when fetched, then the built-in registry.                                                                                                                     |
@@ -541,7 +541,9 @@ STT:
 
 - `provider = "openai-whisper"`: currently available;
 - `provider = "openrouter"`: currently available, default endpoint is `https://openrouter.ai/api/v1/audio/transcriptions`, request body uses base64 WAV;
-- `provider = "tencent-asr"`: Tencent Cloud Sentence Recognition (SentenceRecognition), uses `secret_id` / `secret_key`, no `base_url` needed; the legacy values `tencent` / `tencent_asr` are retained only as compatibility aliases.
+- `provider = "tencent-asr"`: Tencent Cloud Sentence Recognition (SentenceRecognition), uses `secret_id` / `secret_key`, no `base_url` needed; the legacy values `tencent` / `tencent_asr` are retained only as compatibility aliases;
+- `provider = "qwen-asr"`: Alibaba Cloud DashScope Realtime ASR over WebSocket, default model `qwen3-asr-flash-realtime`; supports streaming upload and accepts optional `model` / `base_url` overrides;
+- `provider = "google-cloud"`: Google Cloud Speech-to-Text REST API with API key authentication, default endpoint `https://speech.googleapis.com/v1/speech:recognize`; accepts optional `model` / `base_url` overrides and does not support streaming upload.
 
 TTS:
 
@@ -549,7 +551,9 @@ TTS:
 - `provider = "minimax-cn"`: Minimax WebSocket, mainland China endpoint `api.minimaxi.com`;
 - `provider = "fish-audio"`: Fish Audio WebSocket;
 - `provider = "alicloud"`: Alibaba Cloud Qwen-TTS Realtime;
-- `provider = "volcengine"`: Volcengine WebSocket bidirectional streaming V3. Currently only the new console's `X-Api-Key` authentication is supported: `api_key` maps to `X-Api-Key`, `model` maps to `X-Api-Resource-Id` (default `seed-tts-2.0`), and `voice_id` maps to the speaker.
+- `provider = "volcengine"`: Volcengine WebSocket bidirectional streaming V3. Currently only the new console's `X-Api-Key` authentication is supported: `api_key` maps to `X-Api-Key`, `model` maps to `X-Api-Resource-Id` (default `seed-tts-2.0`), and `voice_id` maps to the speaker;
+- `provider = "openrouter"`: OpenRouter HTTP speech API, default model `google/gemini-3.1-flash-tts-preview`; `model` and `voice_id` select the routed TTS model and its voice;
+- `provider = "google-cloud"`: Google Cloud Text-to-Speech REST API with API key authentication; `voice_id` defaults to `en-US-Neural2-C`.
 
 TTS configuration fields:
 
@@ -557,8 +561,8 @@ TTS configuration fields:
 | -------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `provider`     | `[tts]`                          | Required reference to a named provider record; a bare provider type remains supported for backward compatibility        |
 | `api_key`      | `[tts_providers.<name>]`         | Required authentication key for the selected provider                                                                   |
-| `model`        | `[tts_providers.<name>]`         | Optional Minimax model, Fish Audio model header, Alibaba Cloud Realtime model, or Volcengine `X-Api-Resource-Id`         |
-| `voice_id`     | `[tts_providers.<name>]`         | Optional Minimax voice id, Alibaba Cloud voice, or Volcengine speaker. Not used by Fish Audio (see `reference_id`)       |
+| `model`        | `[tts_providers.<name>]`         | Optional Minimax model, Fish Audio model header, Alibaba Cloud Realtime model, Volcengine `X-Api-Resource-Id`, or OpenRouter model |
+| `voice_id`     | `[tts_providers.<name>]`         | Optional Minimax, Alibaba Cloud, OpenRouter, or Google Cloud voice; Volcengine speaker. Not used by Fish Audio (see `reference_id`) |
 | `reference_id` | `[tts_providers.<name>]`         | Optional Fish Audio reference id; defaults to the built-in demo voice shown by Config Web. Ignored by other providers    |
 | `emotion`      | `[tts_providers.<name>]`         | Optional Minimax emotion; Volcengine passes it through as `audio_params.emotion` and requires voice support             |
 | `speed`        | `[tts]`                          | Optional speech rate, default `1.0`; the supported range varies by provider, refer to the official docs                 |
@@ -567,13 +571,15 @@ The examples use placeholder keys to make the required record placement explicit
 
 Common TTS adapter configs:
 
-| Provider     | `model` example            | Voice/reference field                               | Description                                                                                                         |
-| ------------ | -------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `minimax`    | `speech-2.8-hd`            | `voice_id = "male-qn-qingse"`                       | Minimax WebSocket via `api.minimax.io`; `emotion` is passed through to Minimax                                      |
-| `minimax-cn` | `speech-2.8-hd`            | `voice_id = "male-qn-qingse"`                       | Minimax WebSocket via `api.minimaxi.com`; `emotion` is passed through to Minimax                                    |
-| `fish-audio` | `s2-pro`                   | `reference_id = "98655a12fa944e26b274c535e5e03842"` | WebSocket live TTS; the shown reference is used by default, and `voice_id` is not used                              |
-| `alicloud`   | `qwen3-tts-flash-realtime` | `voice_id = "Cherry"`                               | DashScope Realtime; the adapter outputs 24 kHz PCM, automatically resampling when the sample rate differs           |
-| `volcengine` | `seed-tts-2.0`             | `voice_id = "zh_female_vv_uranus_bigtts"`           | `model` maps to `X-Api-Resource-Id`, `voice_id` maps to the speaker, and the two must match                         |
+| Provider       | `model` example                           | Voice/reference field                               | Description                                                                                                         |
+| -------------- | ----------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `minimax`      | `speech-2.8-hd`                           | `voice_id = "male-qn-qingse"`                       | Minimax WebSocket via `api.minimax.io`; `emotion` is passed through to Minimax                                      |
+| `minimax-cn`   | `speech-2.8-hd`                           | `voice_id = "male-qn-qingse"`                       | Minimax WebSocket via `api.minimaxi.com`; `emotion` is passed through to Minimax                                    |
+| `fish-audio`   | `s2-pro`                                  | `reference_id = "98655a12fa944e26b274c535e5e03842"` | WebSocket live TTS; the shown reference is used by default, and `voice_id` is not used                              |
+| `alicloud`     | `qwen3-tts-flash-realtime`                | `voice_id = "Cherry"`                               | DashScope Realtime; the adapter outputs 24 kHz PCM, automatically resampling when the sample rate differs           |
+| `volcengine`   | `seed-tts-2.0`                            | `voice_id = "zh_female_vv_uranus_bigtts"`           | `model` maps to `X-Api-Resource-Id`, `voice_id` maps to the speaker, and the two must match                         |
+| `openrouter`   | `google/gemini-3.1-flash-tts-preview`     | `voice_id = "Kore"`                                 | OpenRouter `/audio/speech`; voice defaults depend on the selected model and output is 24 kHz PCM                    |
+| `google-cloud` | —                                         | `voice_id = "en-US-Neural2-C"`                      | Google Cloud Text-to-Speech REST API with API key authentication; output is 24 kHz PCM                              |
 
 ### Provider examples
 

--- a/docs/04-agent/overview.md
+++ b/docs/04-agent/overview.md
@@ -6,7 +6,7 @@ The Aiden Go Agent is located in `src/agent/` and is built on `github.com/tmc/la
 
 | Entry Point  | Description                                                     |
 | ------------ | --------------------------------------------------------------- |
-| `cmd/daemon` | Long-running daemon supporting Web UI mode or device voice mode |
+| `cmd/daemon` | Long-running daemon providing the Web UI and optional device voice loop |
 
 After cross-compilation, the daemon binary is:
 
@@ -22,8 +22,7 @@ In the firmware, it is installed by default to:
 
 ## Current Capabilities
 
-- OpenAI-compatible model calls: `openai`, `openrouter`
-- Local text models: `ollama`
+- Registered model providers: `openai`, `openrouter`, `kimi`, `kimi-cn`, `volcengine`, `ollama`
 - Built-in tool calling: HID, screenshots, audio volume, shell
 - HTTP Tool API for Web UI, external agents, or manual invocation
 - Auto-discovery and runtime activation of skills from `SKILL.md`
@@ -36,14 +35,14 @@ In the firmware, it is installed by default to:
 
 ## Run Modes
 
-Determined by `input_mode` in `agent.toml`:
+The HTTP server and Web UI start in every input mode. `input_mode` controls whether the daemon also runs the device-side voice loop:
 
-| Mode   | Behavior                                 |
-| ------ | ---------------------------------------- |
-| `text` | Start HTTP server and Web UI             |
-| `stt`  | Device recording → VAD → STT → LLM → TTS |
+| Mode   | Behavior                                                                    |
+| ------ | --------------------------------------------------------------------------- |
+| `text` | HTTP server and Web UI only                                                  |
+| `stt`  | HTTP server and Web UI plus device recording → VAD → STT → LLM → TTS loop    |
 
-Currently, one daemon instance can only run in one mode: Web UI mode and device voice mode cannot run simultaneously in the same process.
+In `stt` mode, Web UI requests and device voice interactions share the same Agent runtime and run in the same daemon process.
 
 ## Startup
 

--- a/docs/04-agent/storage-manager.md
+++ b/docs/04-agent/storage-manager.md
@@ -1,8 +1,191 @@
-# Storage Manager
+# Storage Subsystem: StorageManager and StorageMonitor
 
 ## Overview
 
-The Storage Manager protects the Agent from persistent-storage exhaustion. Its Go implementation is named StorageMonitor and is responsible for:
+The Agent has two separate storage components. They share the `[storage]`
+configuration section, but they solve different problems and expose different
+HTTP APIs.
+
+| Component | Responsibility | Primary HTTP API |
+| --- | --- | --- |
+| `StorageManager` | Detects and mounts the SD card, derives eMMC-only or dual-storage mode, routes governed data, migrates older data, safely ejects the card, and formats the card | `/api/storage/status`, `/api/storage/eject`, `/api/storage/format` |
+| `StorageMonitor` | Samples persistent-storage capacity, classifies pressure levels, runs cleanup, and degrades non-essential writes when space is low | `/api/storage/monitor/status`, `/api/storage/cleanup` |
+
+`StorageManager` does not replace `StorageMonitor`. Adding an SD card provides a
+migration tier for governed data, while `StorageMonitor` continues to protect
+the configured persistent root, which defaults to `/userdata`.
+
+Related documentation:
+
+- [Paths, Artifacts & Config Cheat Sheet](../02-architecture/paths-and-artifacts.md)
+- [Agent Configuration Reference](configuration.md)
+
+## StorageManager: SD Card and Dual-Storage Routing
+
+The production Agent runtime creates and starts `StorageManager` unconditionally.
+Missing, removed, rejected, or unusable card hardware falls back to eMMC-only
+operation; there is no user preference that forces a storage mode.
+
+### Card Lifecycle and Effective Mode
+
+The manager polls for the configured SD block device and debounces insertion and
+removal. When a card appears, it:
+
+1. Prefers the first partition, falling back to the whole device when there is
+   no partition.
+2. Runs a best-effort `fsck`.
+3. Mounts the card read-write at the configured mount point.
+4. Verifies the mount with a probe write.
+5. Attempts to reject a card with less than the configured minimum free space
+   by unmounting it. If a busy filesystem cannot be unmounted, the manager
+   keeps the card mounted and reports it as usable rather than recording a false
+   unmounted state.
+
+The default mount point is `/mnt/sdcard`, the default block device base name is
+`mmcblk2`, and the default minimum free space is 64 MB. A card normally becomes
+usable only after it passes the mount and write checks; the busy-unmount case
+above is the exception to the minimum-free-space rejection.
+
+| Effective mode | JSON value | Condition |
+| --- | --- | --- |
+| eMMC only | `1` | No usable card is mounted |
+| Dual storage | `2` | A usable card is mounted |
+
+A positively identified blank card is automatically formatted as FAT32 once per
+insertion. Cards with an existing but unsupported, damaged, or otherwise
+unmountable filesystem are never automatically erased.
+
+The manager mirrors card, format, migration, and effective-mode state to
+`/run/aiden/storage.state` for other device services. This state file is
+separate from the StorageMonitor level file at `/run/agent/storage_level`.
+
+### Data Routing and Migration
+
+New governed data is always written to eMMC. The current production integration
+uses this routing for audio archives:
+
+| Operation | No mounted SD card | Mounted SD card |
+| --- | --- | --- |
+| New audio archive | `/userdata/audio` | `/userdata/audio` |
+| Read audio archives | `/userdata/audio` | eMMC first, then `/mnt/sdcard/aiden/audio` |
+| Retention cleanup roots | `/userdata/audio` | `/mnt/sdcard/aiden/audio` |
+
+Keeping new writes on eMMC avoids making active recording depend on removable
+media. When the SD tier is available and eMMC free space falls below the start
+watermark, the manager migrates older audio archives to the SD card, oldest
+first. It stops after eMMC reaches the stop watermark, no eligible files remain,
+the card becomes unavailable, or an eject or format operation cancels the run.
+
+The default migration watermarks are:
+
+- Start when eMMC free space is below 10%.
+- Stop when eMMC free space reaches 50%.
+
+Only regular files at least 60 seconds old are eligible. Each file is copied to
+an `.aiden-partial` path, synced, size-checked, renamed into place, and only then
+removed from eMMC. Readers prefer the eMMC copy during the brief window where
+both copies may exist. Failed or exhausted runs use a ten-minute retry cooldown.
+
+### Safe Eject and Formatting
+
+Safe eject cancels any active migration, syncs and unmounts the card, and latches
+the card as ejected. It is not mounted again until it is physically removed and
+reinserted.
+
+Manual formatting is destructive: it rewrites the whole card with a fresh MBR,
+one partition, and a new filesystem labeled `AIDEN`. Supported filesystems are
+FAT32, ext4, and exFAT. Formatting runs asynchronously. After `FormatDisk`
+succeeds, the manager attempts to mount the new filesystem; check `card.mounted`
+and `effective_mode` to confirm that dual-storage mode was restored, because the
+post-format mount can still fail.
+
+### StorageManager HTTP API
+
+These endpoints report and control the SD/eMMC manager. They are distinct from
+the StorageMonitor endpoints documented later.
+
+All three endpoints return HTTP 405 for the wrong method and HTTP 503 if the
+runtime has no StorageManager. A normal production runtime always creates the
+manager, even when no card is present.
+
+#### Get Manager Status
+
+~~~http
+GET /api/storage/status
+~~~
+
+Example response:
+
+~~~json
+{
+  "effective_mode": 2,
+  "card": {
+    "present": true,
+    "mounted": true,
+    "device": "/dev/mmcblk2p1",
+    "total_bytes": 68719476736,
+    "free_bytes": 64424509440
+  },
+  "mount_point": "/mnt/sdcard",
+  "format_job": {
+    "status": "idle"
+  },
+  "migration": {
+    "status": "idle"
+  }
+}
+~~~
+
+`format_job.status` and `migration.status` are `idle`, `running`, `success`, or
+`failed`. Active and completed jobs also report the applicable filesystem,
+timestamps, detail, error, moved-file count, and moved-byte count.
+
+#### Safely Eject the Card
+
+~~~http
+POST /api/storage/eject
+~~~
+
+The successful response is the updated manager status. The endpoint returns
+HTTP 409 when the card cannot be ejected, including when no card is mounted, a
+mount attempt or format is active, migration cannot stop promptly, or the
+filesystem is busy and cannot be unmounted.
+
+#### Format the Card
+
+~~~http
+POST /api/storage/format
+Content-Type: application/json
+~~~
+
+~~~json
+{
+  "fs": "fat32",
+  "confirm": "format-sd-card"
+}
+~~~
+
+`fs` may be `fat32`, `ext4`, or `exfat`; an empty value defaults to `fat32`.
+The exact confirmation token is required because formatting erases the entire
+card. HTTP 202 means that the asynchronous job was accepted, not that formatting
+has finished. Poll `GET /api/storage/status` and inspect `format_job` for the
+result. Invalid requests return HTTP 400.
+
+### StorageManager Configuration
+
+~~~toml
+[storage]
+mount_point = "/mnt/sdcard"
+device = "mmcblk2"
+min_card_free_mb = 64
+migrate_start_free_pct = 10
+migrate_stop_free_pct = 50
+~~~
+
+## StorageMonitor: Capacity Protection
+
+`StorageMonitor` protects the Agent from persistent-storage exhaustion. It is
+responsible for:
 
 - Sampling the configured storage root.
 - Classifying the final storage level.
@@ -14,14 +197,10 @@ The Storage Manager protects the Agent from persistent-storage exhaustion. Its G
 - Exposing status and manual-cleanup HTTP endpoints.
 - Publishing the final level to deployment-side guards.
 
-This module manages storage state and remediation only. Notification consumers, Companion App behavior, LED presentation, and other user-facing delivery policies are outside its scope.
+Notification consumers, Companion App behavior, LED presentation, and other
+user-facing delivery policies are outside StorageMonitor's scope.
 
-Related documentation:
-
-- [Paths, Artifacts & Config Cheat Sheet](../02-architecture/paths-and-artifacts.md)
-- [Agent Configuration Reference](configuration.md)
-
-## Implementation Status
+### Capabilities
 
 | Capability | Status | Notes |
 | --- | --- | --- |
@@ -33,16 +212,16 @@ Related documentation:
 | Post-cleanup resampling | Available | Final state always comes from statfs |
 | Degraded write controls | Available | Suspends non-essential persistence |
 | Write-error remediation | Available | Handles ENOSPC and EROFS |
-| Status endpoint | Available | GET /api/storage/monitor/status |
-| Cleanup endpoint | Available | POST /api/storage/cleanup |
+| Status endpoint | Available | `GET /api/storage/monitor/status` |
+| Cleanup endpoint | Available | `POST /api/storage/cleanup` |
 | Deployment state file | Available | /run/agent/storage_level |
 | Agent log integration | Available | Default path is /userdata/agent/log/agent.log |
 | Notification event output | Available | Publishes through the global VoiceNotificationManager |
 | LED and App presentation | Out of scope | Consumers can poll the status endpoint |
 
-## Storage Scope
+### Storage Scope
 
-### Managed Root
+#### Managed Root
 
 StorageMonitor manages one configured persistent-storage root. The default is:
 
@@ -66,9 +245,9 @@ The Agent main log has moved from /var/log/agent/agent.log to `<CONFIG_DIR>/log/
 
 Other services may still write logs under /var/log, including audio_service, frame_service, and adb. Those logs are not managed by the Agent StorageMonitor cleaners.
 
-### Protected Data
+#### Protected Data
 
-The Storage Manager does not delete:
+StorageMonitor does not delete:
 
 - The active session.
 - Long-term memory.
@@ -78,7 +257,7 @@ The Storage Manager does not delete:
 
 It also does not manage RAM, CPU, temperature, battery pressure, or volatile /tmp usage.
 
-### OTA Partition Interaction
+#### OTA Partition Interaction
 
 OTA uses a dedicated 300 MiB ext4 partition mounted at `/userdata/ota`.
 StorageMonitor still samples the `/userdata` filesystem, so OTA downloads do
@@ -90,7 +269,7 @@ coupling. Existing cleanup stages and user-facing storage notifications remain
 necessary for the non-OTA data stored on `/userdata`. See
 [OTA Dedicated Storage Partition](../08-ota/no-space-plan.md).
 
-## Runtime Flow
+### Runtime Flow
 
 ~~~text
 Startup check ───────┐
@@ -111,9 +290,9 @@ Manual cleanup ──────┘              │
 
 All entry points share the same remediation path. A monitor-wide mutex serializes checks so startup, periodic, write-failure, and manual cleanup requests cannot delete the same files concurrently.
 
-## Check Triggers
+### Check Triggers
 
-### Startup
+#### Startup
 
 The daemon calls StartStorageMonitor after creating the Agent runtime.
 
@@ -123,11 +302,11 @@ StartStorageMonitor:
 2. Starts the periodic monitor loop even if the initial check reports an error.
 3. Stops the loop and removes the deployment state file when the runtime closes.
 
-### Periodic Monitoring
+#### Periodic Monitoring
 
 The default interval is 300 seconds. Periodic checks can run maintenance cleaners while the storage level is Normal. For example, the normal LLM HTTP log stage removes files beyond the default retention window.
 
-### Write Errors
+#### Write Errors
 
 Writers pass storage-related errors to StorageMonitor. An immediate asynchronous check is scheduled only for:
 
@@ -136,7 +315,7 @@ Writers pass storage-related errors to StorageMonitor. An immediate asynchronous
 
 Repeated failures are coalesced. At most one write-failure remediation request is pending at a time.
 
-### Manual Cleanup
+#### Manual Cleanup
 
 POST /api/storage/cleanup uses the same CheckAndRemediate flow with the manual reason.
 
@@ -144,7 +323,7 @@ POST /api/storage/cleanup uses the same CheckAndRemediate flow with the manual r
 - With force=true, selected cleaners ignore ordinary retention thresholds and run their force-clean behavior.
 - Force cleanup still respects cleaner-directory boundaries and protected-data rules.
 
-## Storage Levels
+### Storage Levels
 
 Levels are based on available bytes, not percent used.
 
@@ -157,7 +336,7 @@ Levels are based on available bytes, not percent used.
 
 Threshold comparisons use exact bytes. Exactly 10 MB is Critical, and exactly 5 MB is Emergency.
 
-### Recovery Hysteresis
+#### Recovery Hysteresis
 
 Escalation takes effect immediately. De-escalation requires available space to exceed the previous level threshold plus recovery_hysteresis_mb.
 
@@ -171,15 +350,15 @@ With the default 5 MB hysteresis:
 
 This prevents repeated transitions when available space oscillates near a threshold.
 
-### Final-State Rule
+#### Final-State Rule
 
 The initial sample only decides whether remediation should begin. StorageMonitor resamples the filesystem after every cleaner.
 
 The final level, unavailable capabilities, deployment state file, and HTTP response are based on the final statfs sample after hysteresis. A cleaner's reported freed-byte count is retained for audit history but never replaces resampling.
 
-## Cleanup Pipeline
+### Cleanup Pipeline
 
-### Cleaner Interface
+#### Cleaner Interface
 
 ~~~go
 type StorageCleaner interface {
@@ -192,7 +371,7 @@ type StorageCleaner interface {
 
 Cleaners run in ascending Priority order. Non-force checks call EstimateReclaimable first and skip a cleaner when its estimate is zero.
 
-### Default Stages
+#### Default Stages
 
 The runtime builds cleanup stages from the configured retention arrays.
 
@@ -209,7 +388,7 @@ The runtime builds cleanup stages from the configured retention arrays.
 
 A retention value of 0 creates an emergency cleanup stage. The default session_archive_retention_days value is [30], so an all-session-archives emergency stage is not enabled unless 0 is explicitly added.
 
-### Stage Eligibility and Stop Conditions
+#### Stage Eligibility and Stop Conditions
 
 After each cleaner, StorageMonitor resamples and recalculates the effective level.
 
@@ -220,7 +399,7 @@ After each cleaner, StorageMonitor resamples and recalculates the effective leve
 - Force cleanup continues through all selected cleaners.
 - A cleaner failure is recorded and does not prevent later cleaners from running.
 
-### Cleanup Retry Interval
+#### Cleanup Retry Interval
 
 Automatic cleanup has a default minimum retry interval of 60 seconds to avoid repeatedly scanning directories under sustained pressure.
 
@@ -230,7 +409,7 @@ The retry interval is bypassed for:
 - Manual cleanup.
 - ENOSPC or EROFS remediation.
 
-## Degraded Writes
+### Degraded Writes
 
 Warning triggers cleanup but does not disable capabilities. Critical and Emergency compute unavailable capabilities from the degraded-mode configuration.
 
@@ -243,13 +422,13 @@ Warning triggers cleanup but does not disable capabilities. Critical and Emergen
 
 Capabilities are recalculated after every successful check and recover automatically when storage returns to a safe level.
 
-### Agent Main Log
+#### Agent Main Log
 
 The Agent main log is not completely disabled through AllowWrite. Instead, the S53agent deployment script reads /run/agent/storage_level.
 
 At Critical or Emergency, S53agent trims `<CONFIG_DIR>/log/agent.log` to storage.degraded_mode.max_agent_log_mb, which defaults to 1 MB. It preserves the newest content so storage pressure does not remove the most useful diagnostics.
 
-## Status Model
+### Status Model
 
 StorageMonitorStatus is the immutable snapshot produced by a successful check.
 
@@ -268,7 +447,7 @@ StorageMonitorStatus is the immutable snapshot produced by a successful check.
 
 Status returns copies of slice fields so callers cannot mutate the monitor's internal state.
 
-### Deployment State File
+#### Deployment State File
 
 Every successful check atomically updates:
 
@@ -280,9 +459,9 @@ The file contains normal, warning, critical, or emergency. Deployment-side guard
 
 Disabling or stopping StorageMonitor removes both the state file and its temporary file so deployment scripts do not consume stale state.
 
-## HTTP API
+### StorageMonitor HTTP API
 
-### Get Status
+#### Get Status
 
 ~~~http
 GET /api/storage/monitor/status
@@ -316,7 +495,7 @@ Example response:
 
 The endpoint provides a consistent snapshot suitable for polling. Real-time push and user-interface presentation are outside this module.
 
-### Run Cleanup
+#### Run Cleanup
 
 ~~~http
 POST /api/storage/cleanup
@@ -360,7 +539,7 @@ Example response:
 
 freed_mb reports only cleaners executed by the current POST request. It does not repeat the previous cleanup's freed-space value.
 
-## Configuration
+### StorageMonitor Configuration
 
 Default configuration:
 
@@ -397,7 +576,7 @@ Validation rules:
 - cleanup_retry_interval_seconds cannot be negative.
 - Retention values cannot be negative.
 
-## Optional Event Output
+### Optional Event Output
 
 StorageMonitor exposes a VoiceNotificationSink interface for final storage-state events. The Agent runtime injects the global VoiceNotificationManager as the production consumer.
 
@@ -409,7 +588,7 @@ StorageMonitor exposes a VoiceNotificationSink interface for final storage-state
 
 Queueing, presentation, playback, deduplication, and delivery policy remain owned by VoiceNotificationManager.
 
-## Testing
+### Testing
 
 The current test suite covers:
 
@@ -437,7 +616,7 @@ cd ../..
 ./scripts/test_agent_log_cap.sh
 ~~~
 
-## Current Limitations
+### Current Limitations
 
 - Only one root_path is managed.
 - Logs for other services under /var/log are not cleaned.

--- a/docs/04-agent/tools-http-api.md
+++ b/docs/04-agent/tools-http-api.md
@@ -1,6 +1,6 @@
 # Tools HTTP API
 
-In Web UI mode, the Agent exposes Agent-owned tools that can be safely invoked via HTTP for the browser Tool Lab, external agents, or manual calls. Internal maintenance tools (such as `skill_manage`) are not exposed via HTTP.
+In every input mode, the Agent exposes Agent-owned tools that can be safely invoked via HTTP for the browser Tool Lab, external agents, or manual calls. Internal maintenance tools (such as `skill_manage`) are not exposed via HTTP.
 
 ## Endpoints
 

--- a/docs/07-operations/troubleshooting.md
+++ b/docs/07-operations/troubleshooting.md
@@ -62,7 +62,7 @@ netstat -lntp | grep 8080
 
 Verify:
 
-- `input_mode = "text"`;
+- The daemon is listening on port `8080`; both `text` and `stt` modes serve the Web UI;
 - `agent.toml` TOML syntax is correct;
 - Model configuration and API key are available;
 - Firewall, USB network, or Wi-Fi IP is correct.

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ This documentation hub is the structured entry point for the project. The root `
 - [Phone Bridge Protocol](04-agent/phone-bridge-protocol.md)
 - [Swipe Interaction](04-agent/swipe-interaction.md)
 - [Telemetry with Langfuse](04-agent/telemetry-langfuse.md)
-- [Storage Manager / StorageMonitor](04-agent/storage-manager.md)
+- [Storage subsystem (StorageManager and StorageMonitor)](04-agent/storage-manager.md)
 
 ### 05. SDK & Tools
 

--- a/overlay/userdata/agent/agent.toml
+++ b/overlay/userdata/agent/agent.toml
@@ -13,9 +13,10 @@ locale = "zh-CN"  # "zh-CN" or "en-US"; also selects built-in voice notification
 # screenshot_keep_n = 3
 # screenshot_prune_interval = 2
 
-# Input mode:
-# - text: run HTTP server with Web UI
-# - stt: device audio -> STT -> LLM -> TTS
+# The HTTP server and Web UI run in every input mode.
+# Input mode controls the device-side audio loop:
+# - text: HTTP server and Web UI only
+# - stt: also run device audio -> STT -> LLM -> TTS
 input_mode = "stt"
 
 # Trigger mode: "manual" (push-to-talk) or "wakeup" (GPIO trigger)


### PR DESCRIPTION
## Summary

- clarify that the Agent HTTP server and Web UI run in every input mode while the device voice loop is added in stt mode
- update Agent, model, STT, and TTS configuration documentation to match the current agent.toml schema, provider registries, and defaults
- separate StorageManager from StorageMonitor and document SD routing, migration, formatting, eject, and HTTP APIs
- correct firmware Frame Service FPS, Config Web init commands, and the third HID interface

## Validation

- git diff --check
- parsed overlay/userdata/agent/agent.toml with Python tomllib
- parsed the updated TOML examples in the Agent service and audio feature docs
- ran targeted searches for stale mode, provider, default-value, service-command, and storage terminology
- no code tests run because this change only updates documentation and configuration comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the auxiliary HID control device for Android keys, media, volume, brightness, and screenshot controls.
  - Clarified that the Agent Web UI and HTTP APIs are available in both text and speech modes.
  - Updated speech, model, STT, and TTS provider configuration guidance, including compatible Anthropic and Gemini providers.
  - Clarified service commands, frame-rate defaults, troubleshooting steps, and shared Web UI/device voice limitations.
  - Expanded storage management and monitoring documentation, including migration, safe eject, formatting, cleanup, and degraded-storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->