### PR TITLE
fix(agent): omit large tool results from public history

### DIFF
--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -404,7 +404,12 @@ func screenshotMIMEType(format string) string {
 }
 
 func compactToolObservation(observation string) string {
-	return compactToolObservationLimit(observation, maxToolObservationRunes)
+	compacted, _ := compactToolObservationWithStatus(observation)
+	return compacted
+}
+
+func compactToolObservationWithStatus(observation string) (string, bool) {
+	return compactToolObservationLimitWithStatus(observation, maxToolObservationRunes)
 }
 
 func compactToolObservationForTool(toolName, observation string) string {
@@ -415,12 +420,17 @@ func compactToolObservationForTool(toolName, observation string) string {
 }
 
 func compactToolObservationLimit(observation string, maxRunes int) string {
+	compacted, _ := compactToolObservationLimitWithStatus(observation, maxRunes)
+	return compacted
+}
+
+func compactToolObservationLimitWithStatus(observation string, maxRunes int) (string, bool) {
 	observation = strings.TrimSpace(observation)
 	if observation == "" || len([]rune(observation)) <= maxRunes {
-		return observation
+		return observation, false
 	}
 	runes := []rune(observation)
-	return string(runes[:maxRunes]) + fmt.Sprintf("\n...[truncated %d chars]", len(runes)-maxRunes)
+	return string(runes[:maxRunes]) + fmt.Sprintf("\n...[truncated %d chars]", len(runes)-maxRunes), true
 }
 
 func (a *FunctionAgent) isVisualObservationTool(name string) bool {

--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -425,11 +425,12 @@ func compactToolObservationLimit(observation string, maxRunes int) string {
 }
 
 func compactToolObservationLimitWithStatus(observation string, maxRunes int) (string, bool) {
+	originalRuneCount := len([]rune(observation))
 	observation = strings.TrimSpace(observation)
-	if observation == "" || len([]rune(observation)) <= maxRunes {
-		return observation, false
-	}
 	runes := []rune(observation)
+	if observation == "" || len(runes) <= maxRunes {
+		return observation, originalRuneCount > maxRunes
+	}
 	return string(runes[:maxRunes]) + fmt.Sprintf("\n...[truncated %d chars]", len(runes)-maxRunes), true
 }
 

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -44,6 +44,7 @@ func effectiveMaxIterations(configured int) int {
 const (
 	currentEnvironmentHintMaxAge      = 10 * time.Minute
 	runtimeSessionEventPersistTimeout = 2 * time.Second
+	maxPublicToolResultRunes          = maxToolObservationRunes
 )
 
 type Runtime struct {
@@ -1929,12 +1930,13 @@ func (h *runtimeCallbackHandler) AfterToolCall(ctx context.Context, call ToolCal
 }
 
 func (h *runtimeCallbackHandler) HandleToolCallResult(ctx context.Context, call ToolCall, result ToolResult) {
-	output := result.EventOutput()
+	output := publicToolResultContent(result)
+	logOutput := result.EventOutput()
 	if h.logger != nil {
 		if result.IsError() {
-			h.logger.Error("Tool result: name=%s output=%s", call.Spec.Name, truncateForLog(output, 240))
+			h.logger.Error("Tool result: name=%s output=%s", call.Spec.Name, truncateForLog(logOutput, 240))
 		} else {
-			h.logger.Info("Tool result: name=%s output=%s", call.Spec.Name, truncateForLog(output, 240))
+			h.logger.Info("Tool result: name=%s output=%s", call.Spec.Name, truncateForLog(logOutput, 240))
 		}
 	}
 	h.emitRunEvent(RunEvent{
@@ -1948,6 +1950,14 @@ func (h *runtimeCallbackHandler) HandleToolCallResult(ctx context.Context, call 
 		IsError:    result.IsError(),
 		ToolError:  cloneToolError(result.Error),
 	})
+}
+
+func publicToolResultContent(result ToolResult) string {
+	originalChars := utf8.RuneCountInString(result.Output)
+	if result.SummaryTruncated && originalChars > maxPublicToolResultRunes {
+		return fmt.Sprintf("[Large tool result omitted from public history (%d chars)]", originalChars)
+	}
+	return result.EventOutput()
 }
 
 func (h *runtimeCallbackHandler) HandleAgentAction(ctx context.Context, action schema.AgentAction) {

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -245,7 +245,7 @@ func TestServerPublicHistoryOmitsLargeToolResultContent(t *testing.T) {
 	tool := &stubTool{
 		name:        "shell",
 		description: "Run a shell command.",
-		output:      strings.Repeat("x", 4001),
+		output:      strings.Repeat(" ", 4001),
 	}
 	streamingDisabled := false
 	runtime := NewRuntimeWithDeps(

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -235,6 +235,88 @@ func TestServerHandleChatReturnsToolHistory(t *testing.T) {
 	}
 }
 
+func TestServerPublicHistoryOmitsLargeToolResultContent(t *testing.T) {
+	model := &scriptedModel{
+		responses: []*llms.ContentResponse{
+			toolCallResponse("call_1", "shell", `{"command":"read config.py"}`),
+			contentResponse("Done"),
+		},
+	}
+	tool := &stubTool{
+		name:        "shell",
+		description: "Run a shell command.",
+		output:      strings.Repeat("x", 4001),
+	}
+	streamingDisabled := false
+	runtime := NewRuntimeWithDeps(
+		withTestConfigDir(t, Config{
+			Model:                    ModelConfig{Provider: "fake"},
+			Instruction:              "Use tools when requested.",
+			VoiceStreamingTTSEnabled: &streamingDisabled,
+		}),
+		&testModelResolver{model: model},
+		NewMemoryManager(""),
+		&ToolSet{tools: map[string]langtools.Tool{"shell": tool}},
+		NewSkillIndex(),
+	)
+	defer runtime.Close()
+	server := newServerForTest(runtime)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewBufferString(`{"message":"Read the large config"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.handleChat(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("chat status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var startResp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&startResp); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+
+	var result ChatResultResponse
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resultReq := httptest.NewRequest(http.MethodGet, "/api/chat/result?request_id="+startResp["request_id"], nil)
+		resultRec := httptest.NewRecorder()
+		server.handleChatResult(resultRec, resultReq)
+		if resultRec.Code == http.StatusOK {
+			if err := json.NewDecoder(resultRec.Body).Decode(&result); err != nil {
+				t.Fatalf("decode result response: %v", err)
+			}
+			if result.Status == "complete" {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if result.Status != "complete" {
+		t.Fatalf("result never completed: status=%q", result.Status)
+	}
+
+	const want = "[Large tool result omitted from public history (4001 chars)]"
+	resultToolMessage, ok := firstMessageOfType(result.History, "tool_result")
+	if !ok || resultToolMessage.Content != want {
+		t.Fatalf("/api/chat/result tool result = %#v, want content %q", resultToolMessage, want)
+	}
+
+	reloaded := newServerForTest(runtime)
+	historyReq := httptest.NewRequest(http.MethodGet, "/api/history", nil)
+	historyRec := httptest.NewRecorder()
+	reloaded.handleHistory(historyRec, historyReq)
+	if historyRec.Code != http.StatusOK {
+		t.Fatalf("history status = %d body=%s", historyRec.Code, historyRec.Body.String())
+	}
+	var history []Message
+	if err := json.NewDecoder(historyRec.Body).Decode(&history); err != nil {
+		t.Fatalf("decode history response: %v", err)
+	}
+	historyToolMessage, ok := firstMessageOfType(history, "tool_result")
+	if !ok || historyToolMessage.Content != want {
+		t.Fatalf("/api/history tool result = %#v, want content %q", historyToolMessage, want)
+	}
+}
+
 func TestServerPersistsChatHistoryWithEpisodeReference(t *testing.T) {
 	configDir := ensureTestConfigDir(t, t.TempDir())
 	memoryDir := filepath.Join(configDir, "memory")

--- a/src/agent/internal/agent/tool_execution.go
+++ b/src/agent/internal/agent/tool_execution.go
@@ -22,11 +22,12 @@ type ToolCall struct {
 }
 
 type ToolResult struct {
-	Output    string
-	Summary   string
-	Error     *ToolError
-	Terminate bool
-	Duration  time.Duration
+	Output           string
+	Summary          string
+	SummaryTruncated bool
+	Error            *ToolError
+	Terminate        bool
+	Duration         time.Duration
 }
 
 func (r ToolResult) IsError() bool { return r.Error != nil }
@@ -406,7 +407,7 @@ func DefaultAfterToolCall(ctx context.Context, call ToolCall, result ToolResult)
 		if summary, ok := compactScreenshotObservation(call.Spec.Name, result.Output); ok {
 			result.Summary = summary
 		} else {
-			result.Summary = compactToolObservation(result.Output)
+			result.Summary, result.SummaryTruncated = compactToolObservationWithStatus(result.Output)
 		}
 	}
 	if call.Spec.Name == "screenshot" || returnsVisualObservation(call.Spec.Tool) {


### PR DESCRIPTION
## Summary

- replace default raw-and-truncated large tool results in public history with a stable plain-text placeholder
- preserve small tool results and safe custom summaries such as screenshot metadata
- keep internal diagnostic logging and AgentLoop/artifact handling unchanged
- cover both `/api/chat/result` and persisted `/api/history`

## Testing

- `go test ./internal/agent -run "^Test(ServerPublicHistoryOmitsLargeToolResultContent|ServerHandleChatReturnsToolHistory|DefaultAfterToolCallSummarizesScreenshotAndMarksTerminate)$" -count=1`
- `go test ./internal/agent -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Large tool results are now shortened in chat history and API responses to keep displayed content manageable.
  * Omitted content includes the original result size for added context.
  * Complete tool output remains available for diagnostic logging.

* **Tests**
  * Added coverage confirming large tool results are consistently shortened in chat results and persisted history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->