### PR TITLE
refactor(config-web): delegate provider tests to agent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,8 +184,6 @@ add_executable(config_web
     src/config_web.cpp
     src/config_web_static_assets.cpp
     src/agent_toml.cpp
-    src/audio_service_client.cpp
-    src/audio_service_protocol.cpp
     src/frame_service_protocol.cpp
     src/service_status.cpp
     src/uds_client.cpp

--- a/src/agent/cmd/daemon/config_commands.go
+++ b/src/agent/cmd/daemon/config_commands.go
@@ -96,6 +96,15 @@ type modelDTO struct {
 	ModelMaxOutputTokens int      `json:"model_max_output_tokens"`
 }
 
+func (d modelDTO) providerTestRequest() agent.ModelProviderTestRequest {
+	return agent.ModelProviderTestRequest{
+		Provider: d.Provider,
+		APIKey:   d.APIKey,
+		Model:    d.Model,
+		BaseURL:  d.BaseURL,
+	}
+}
+
 // modelProviderDTO mirrors a single [model_providers.<name>] section. Named providers hold
 // the credentials; a model section references one by putting the provider name
 // in its own "provider" field.
@@ -1002,8 +1011,8 @@ type configTestInput struct {
 	AudioBase64 string          `json:"audio_base64"`
 }
 
-// runConfigTest implements `agent config-test` for checks that need agent
-// runtime code instead of config_web's lightweight shell probes.
+// runConfigTest implements provider checks through the same runtime registries
+// and adapters used by the agent itself.
 func runConfigTest(args []string) int {
 	fs := flag.NewFlagSet("config-test", flag.ExitOnError)
 	formatFlag := fs.String("format", "json", "output format (only json supported)")
@@ -1038,7 +1047,7 @@ func runConfigTest(args []string) int {
 	if section == "" {
 		section = strings.TrimSpace(*sectionFlag)
 	}
-	if section != "tts" && section != "stt" {
+	if section != "model" && section != "tts" && section != "stt" {
 		writeConfigTestResult(configTestFailure("request", "unsupported section: "+section))
 		return 1
 	}
@@ -1056,11 +1065,43 @@ func runConfigTest(args []string) int {
 
 	ctx, cancel := context.WithTimeout(context.Background(), *timeoutFlag)
 	defer cancel()
+	result := executeConfigTest(ctx, cfg, input, section)
+	writeConfigTestResult(result)
+	if result.OK {
+		return 0
+	}
+	return 1
+}
+
+func executeConfigTest(ctx context.Context, cfg agent.Config, input configTestInput, section string) ConfigTestResult {
+	if section == "model" {
+		var modelValues modelDTO
+		if err := json.Unmarshal(input.Values, &modelValues); err != nil {
+			return configTestFailure("request", "invalid model values: "+err.Error())
+		}
+
+		result, err := agent.RunModelProviderTest(ctx, cfg, modelValues.providerTestRequest())
+		if err != nil {
+			detail := err.Error()
+			if result.Provider != "" {
+				detail = fmt.Sprintf("[provider=%s model=%s] %s", result.Provider, result.Model, detail)
+			}
+			return configTestFailure("provider_request", detail)
+		}
+		return ConfigTestResult{
+			OK: true,
+			Results: []ConfigTestCheck{{
+				Check:  "provider_request",
+				Passed: true,
+				Detail: fmt.Sprintf("received a response from %s (model: %s)", result.Provider, result.Model),
+			}},
+		}
+	}
+
 	if section == "tts" {
 		var ttsValues ttsDTO
 		if err := json.Unmarshal(input.Values, &ttsValues); err != nil {
-			writeConfigTestResult(configTestFailure("request", "invalid tts values: "+err.Error()))
-			return 1
+			return configTestFailure("request", "invalid tts values: "+err.Error())
 		}
 
 		playback, err := agent.RunTTSPlaybackTest(ctx, cfg, ttsValues.playbackTestRequest(input.Text))
@@ -1069,36 +1110,48 @@ func runConfigTest(args []string) int {
 			if ttsValues.Provider != "" {
 				detail = fmt.Sprintf("[provider=%s model=%s voice=%s] %s", ttsValues.Provider, ttsValues.Model, ttsValues.VoiceID, detail)
 			}
-			writeConfigTestResult(configTestFailure("tts_playback", detail))
-			return 1
+			return configTestFailure("tts_playback", detail)
 		}
-		writeConfigTestResult(ConfigTestResult{
+		return ConfigTestResult{
 			OK: true,
 			Results: []ConfigTestCheck{{
 				Check:  "tts_playback",
 				Passed: true,
 				Detail: fmt.Sprintf("played %q with %s", playback.Text, playback.Provider),
 			}},
-		})
-		return 0
+		}
+	}
+	if section != "stt" {
+		return configTestFailure("request", "unsupported section: "+section)
 	}
 
 	var sttValues sttDTO
 	if err := json.Unmarshal(input.Values, &sttValues); err != nil {
-		writeConfigTestResult(configTestFailure("request", "invalid stt values: "+err.Error()))
-		return 1
+		return configTestFailure("request", "invalid stt values: "+err.Error())
+	}
+	if strings.TrimSpace(input.AudioBase64) == "" {
+		result, err := agent.RunSTTProviderTest(ctx, cfg, sttValues.transcriptionTestRequest(nil))
+		if err != nil {
+			return configTestFailure("provider_config", err.Error())
+		}
+		return ConfigTestResult{
+			OK: true,
+			Results: []ConfigTestCheck{{
+				Check:  "provider_config",
+				Passed: true,
+				Detail: fmt.Sprintf("created the %s STT client", result.Provider),
+			}},
+		}
 	}
 	wavData, err := base64.StdEncoding.DecodeString(strings.TrimSpace(input.AudioBase64))
 	if err != nil {
-		writeConfigTestResult(configTestFailure("request", "invalid audio_base64: "+err.Error()))
-		return 1
+		return configTestFailure("request", "invalid audio_base64: "+err.Error())
 	}
 	transcription, err := agent.RunSTTTranscriptionTest(ctx, cfg, sttValues.transcriptionTestRequest(wavData))
 	if err != nil {
-		writeConfigTestResult(configTestFailure("stt_transcription", err.Error()))
-		return 1
+		return configTestFailure("stt_transcription", err.Error())
 	}
-	writeConfigTestResult(ConfigTestResult{
+	return ConfigTestResult{
 		OK:         true,
 		Transcript: transcription.Transcript,
 		Results: []ConfigTestCheck{{
@@ -1106,8 +1159,7 @@ func runConfigTest(args []string) int {
 			Passed: true,
 			Detail: fmt.Sprintf("transcribed audio with %s", transcription.Provider),
 		}},
-	})
-	return 0
+	}
 }
 
 func configTestFailure(check, detail string) ConfigTestResult {

--- a/src/agent/cmd/daemon/config_commands.go
+++ b/src/agent/cmd/daemon/config_commands.go
@@ -98,14 +98,12 @@ type modelDTO struct {
 
 func (d modelDTO) providerTestRequest() agent.ModelProviderTestRequest {
 	return agent.ModelProviderTestRequest{
-		Provider:           d.Provider,
-		APIKey:             d.APIKey,
-		Model:              d.Model,
-		BaseURL:            d.BaseURL,
-		Temperature:        d.Temperature,
-		TemperatureSet:     d.Temperature != nil,
-		ReasoningEffort:    d.ReasoningEffort,
-		ReasoningEffortSet: strings.TrimSpace(d.ReasoningEffort) != "",
+		Provider:        d.Provider,
+		APIKey:          d.APIKey,
+		Model:           d.Model,
+		BaseURL:         d.BaseURL,
+		Temperature:     d.Temperature,
+		ReasoningEffort: d.ReasoningEffort,
 	}
 }
 

--- a/src/agent/cmd/daemon/config_commands.go
+++ b/src/agent/cmd/daemon/config_commands.go
@@ -98,10 +98,14 @@ type modelDTO struct {
 
 func (d modelDTO) providerTestRequest() agent.ModelProviderTestRequest {
 	return agent.ModelProviderTestRequest{
-		Provider: d.Provider,
-		APIKey:   d.APIKey,
-		Model:    d.Model,
-		BaseURL:  d.BaseURL,
+		Provider:           d.Provider,
+		APIKey:             d.APIKey,
+		Model:              d.Model,
+		BaseURL:            d.BaseURL,
+		Temperature:        d.Temperature,
+		TemperatureSet:     d.Temperature != nil,
+		ReasoningEffort:    d.ReasoningEffort,
+		ReasoningEffortSet: strings.TrimSpace(d.ReasoningEffort) != "",
 	}
 }
 

--- a/src/agent/cmd/daemon/config_commands_test.go
+++ b/src/agent/cmd/daemon/config_commands_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -12,6 +13,34 @@ import (
 
 	"aiden-agent/internal/agent"
 )
+
+func TestExecuteConfigTestUsesModelRuntime(t *testing.T) {
+	values, err := json.Marshal(modelDTO{Provider: "fake"})
+	if err != nil {
+		t.Fatalf("marshal values: %v", err)
+	}
+	result := executeConfigTest(context.Background(), agent.Config{
+		Model: agent.ModelConfig{Provider: "fake", Responses: []string{"hello"}},
+	}, configTestInput{Section: "model", Values: values}, "model")
+	if !result.OK || len(result.Results) != 1 || result.Results[0].Check != "provider_request" {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestExecuteConfigTestUsesSTTRuntimeWithoutAudio(t *testing.T) {
+	values, err := json.Marshal(sttDTO{Provider: "qwen-main", Language: "zh"})
+	if err != nil {
+		t.Fatalf("marshal values: %v", err)
+	}
+	result := executeConfigTest(context.Background(), agent.Config{
+		STTProviders: map[string]agent.STTProvider{
+			"qwen-main": {Type: "qwen-asr", APIKey: "test-key"},
+		},
+	}, configTestInput{Section: "stt", Values: values}, "stt")
+	if !result.OK || len(result.Results) != 1 || result.Results[0].Check != "provider_config" {
+		t.Fatalf("result = %+v", result)
+	}
+}
 
 func TestConfigCheck_ValidConfig(t *testing.T) {
 	validConfig := agent.Config{

--- a/src/agent/cmd/daemon/config_commands_test.go
+++ b/src/agent/cmd/daemon/config_commands_test.go
@@ -27,29 +27,62 @@ func TestExecuteConfigTestUsesModelRuntime(t *testing.T) {
 	}
 }
 
-func TestModelDTOProviderTestRequestCarriesSamplingState(t *testing.T) {
-	temperature := 0.7
-	req := (modelDTO{
-		Provider:        "openai",
-		Model:           "kimi-k3",
-		Temperature:     &temperature,
-		ReasoningEffort: "medium",
-	}).providerTestRequest()
+func TestModelDTOProviderTestRequestPreservesSamplingPresenceFromJSON(t *testing.T) {
+	tests := []struct {
+		name                string
+		payload             string
+		wantTemperature     *float64
+		wantReasoningEffort string
+	}{
+		{
+			name:    "omitted fields remain unset",
+			payload: `{"provider":"openai","model":"kimi-k3"}`,
+		},
+		{
+			name:    "null temperature remains unset",
+			payload: `{"provider":"openai","model":"kimi-k3","temperature":null}`,
+		},
+		{
+			name:                "explicit zero remains present",
+			payload:             `{"provider":"openai","model":"kimi-k3","temperature":0,"reasoning_effort":"none"}`,
+			wantTemperature:     testFloat64Ptr(0),
+			wantReasoningEffort: "none",
+		},
+		{
+			name:                "explicit nonzero values are preserved",
+			payload:             `{"provider":"openai","model":"kimi-k3","temperature":0.7,"reasoning_effort":"medium"}`,
+			wantTemperature:     testFloat64Ptr(0.7),
+			wantReasoningEffort: "medium",
+		},
+		{
+			name:    "explicit empty reasoning remains auto",
+			payload: `{"provider":"openai","model":"kimi-k3","reasoning_effort":""}`,
+		},
+	}
 
-	if !req.TemperatureSet || req.Temperature == nil || *req.Temperature != temperature {
-		t.Fatalf("temperature request = set:%v value:%v, want set %v", req.TemperatureSet, req.Temperature, temperature)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dto modelDTO
+			if err := json.Unmarshal([]byte(tt.payload), &dto); err != nil {
+				t.Fatalf("unmarshal model values: %v", err)
+			}
+			req := dto.providerTestRequest()
+			if tt.wantTemperature == nil {
+				if req.Temperature != nil {
+					t.Fatalf("temperature request = %v, want unset", req.Temperature)
+				}
+			} else if req.Temperature == nil || *req.Temperature != *tt.wantTemperature {
+				t.Fatalf("temperature request = %v, want %v", req.Temperature, *tt.wantTemperature)
+			}
+			if req.ReasoningEffort != tt.wantReasoningEffort {
+				t.Fatalf("reasoning request = %q, want %q", req.ReasoningEffort, tt.wantReasoningEffort)
+			}
+		})
 	}
-	if !req.ReasoningEffortSet || req.ReasoningEffort != "medium" {
-		t.Fatalf("reasoning request = set:%v value:%q, want set medium", req.ReasoningEffortSet, req.ReasoningEffort)
-	}
+}
 
-	cleared := (modelDTO{Provider: "openai", Model: "kimi-k3"}).providerTestRequest()
-	if cleared.TemperatureSet || cleared.Temperature != nil {
-		t.Fatalf("cleared temperature request = set:%v value:%v, want unset", cleared.TemperatureSet, cleared.Temperature)
-	}
-	if cleared.ReasoningEffortSet || cleared.ReasoningEffort != "" {
-		t.Fatalf("cleared reasoning request = set:%v value:%q, want unset", cleared.ReasoningEffortSet, cleared.ReasoningEffort)
-	}
+func testFloat64Ptr(value float64) *float64 {
+	return &value
 }
 
 func TestExecuteConfigTestUsesSTTRuntimeWithoutAudio(t *testing.T) {

--- a/src/agent/cmd/daemon/config_commands_test.go
+++ b/src/agent/cmd/daemon/config_commands_test.go
@@ -27,6 +27,31 @@ func TestExecuteConfigTestUsesModelRuntime(t *testing.T) {
 	}
 }
 
+func TestModelDTOProviderTestRequestCarriesSamplingState(t *testing.T) {
+	temperature := 0.7
+	req := (modelDTO{
+		Provider:        "openai",
+		Model:           "kimi-k3",
+		Temperature:     &temperature,
+		ReasoningEffort: "medium",
+	}).providerTestRequest()
+
+	if !req.TemperatureSet || req.Temperature == nil || *req.Temperature != temperature {
+		t.Fatalf("temperature request = set:%v value:%v, want set %v", req.TemperatureSet, req.Temperature, temperature)
+	}
+	if !req.ReasoningEffortSet || req.ReasoningEffort != "medium" {
+		t.Fatalf("reasoning request = set:%v value:%q, want set medium", req.ReasoningEffortSet, req.ReasoningEffort)
+	}
+
+	cleared := (modelDTO{Provider: "openai", Model: "kimi-k3"}).providerTestRequest()
+	if cleared.TemperatureSet || cleared.Temperature != nil {
+		t.Fatalf("cleared temperature request = set:%v value:%v, want unset", cleared.TemperatureSet, cleared.Temperature)
+	}
+	if cleared.ReasoningEffortSet || cleared.ReasoningEffort != "" {
+		t.Fatalf("cleared reasoning request = set:%v value:%q, want unset", cleared.ReasoningEffortSet, cleared.ReasoningEffort)
+	}
+}
+
 func TestExecuteConfigTestUsesSTTRuntimeWithoutAudio(t *testing.T) {
 	values, err := json.Marshal(sttDTO{Provider: "qwen-main", Language: "zh"})
 	if err != nil {

--- a/src/agent/internal/agent/model_config_test_runner.go
+++ b/src/agent/internal/agent/model_config_test_runner.go
@@ -1,0 +1,68 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+type ModelProviderTestRequest struct {
+	Provider string
+	APIKey   string
+	Model    string
+	BaseURL  string
+}
+
+type ModelProviderTestResult struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
+func RunModelProviderTest(ctx context.Context, cfg Config, req ModelProviderTestRequest) (ModelProviderTestResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return ModelProviderTestResult{}, err
+	}
+
+	if err := applyModelProviderTestRequest(&cfg, req); err != nil {
+		return ModelProviderTestResult{}, err
+	}
+	if strings.TrimSpace(cfg.Model.Provider) == "" {
+		return ModelProviderTestResult{}, errors.New("model.provider is required")
+	}
+	if cfg.Model.Provider != "fake" && strings.TrimSpace(cfg.Model.Model) == "" {
+		return ModelProviderTestResult{Provider: cfg.Model.Provider}, errors.New("model.model is required")
+	}
+
+	manager := NewModelManager(cfg.Model, ProxyConfigFromEnvironment())
+	if _, err := manager.Call(ctx, "hello", llms.WithMaxTokens(4)); err != nil {
+		return ModelProviderTestResult{Provider: cfg.Model.Provider, Model: cfg.Model.Model}, err
+	}
+	return ModelProviderTestResult{Provider: cfg.Model.Provider, Model: cfg.Model.Model}, nil
+}
+
+func applyModelProviderTestRequest(cfg *Config, req ModelProviderTestRequest) error {
+	if cfg == nil {
+		return nil
+	}
+	if provider := strings.TrimSpace(req.Provider); provider != "" {
+		cfg.Model.Provider = provider
+	}
+	if req.APIKey != "" {
+		cfg.Model.APIKey = req.APIKey
+	}
+	cfg.Model.Model = req.Model
+	cfg.Model.BaseURL = req.BaseURL
+
+	if err := resolveModelProvider(cfg, &cfg.Model); err != nil {
+		return err
+	}
+	clearNonAllowedModelBaseURL(&cfg.Model)
+	applyModelTemperatureDefault(&cfg.Model)
+	applyModelReasoningEffortDefault(&cfg.Model)
+	return nil
+}

--- a/src/agent/internal/agent/model_config_test_runner.go
+++ b/src/agent/internal/agent/model_config_test_runner.go
@@ -9,10 +9,14 @@ import (
 )
 
 type ModelProviderTestRequest struct {
-	Provider string
-	APIKey   string
-	Model    string
-	BaseURL  string
+	Provider           string
+	APIKey             string
+	Model              string
+	BaseURL            string
+	Temperature        *float64
+	TemperatureSet     bool
+	ReasoningEffort    string
+	ReasoningEffortSet bool
 }
 
 type ModelProviderTestResult struct {
@@ -57,6 +61,15 @@ func applyModelProviderTestRequest(cfg *Config, req ModelProviderTestRequest) er
 	}
 	cfg.Model.Model = req.Model
 	cfg.Model.BaseURL = req.BaseURL
+	cfg.Model.Temperature = nil
+	if req.TemperatureSet && req.Temperature != nil {
+		temperature := *req.Temperature
+		cfg.Model.Temperature = &temperature
+	}
+	cfg.Model.ReasoningEffort = ""
+	if req.ReasoningEffortSet {
+		cfg.Model.ReasoningEffort = req.ReasoningEffort
+	}
 
 	if err := resolveModelProvider(cfg, &cfg.Model); err != nil {
 		return err

--- a/src/agent/internal/agent/model_config_test_runner.go
+++ b/src/agent/internal/agent/model_config_test_runner.go
@@ -9,14 +9,12 @@ import (
 )
 
 type ModelProviderTestRequest struct {
-	Provider           string
-	APIKey             string
-	Model              string
-	BaseURL            string
-	Temperature        *float64
-	TemperatureSet     bool
-	ReasoningEffort    string
-	ReasoningEffortSet bool
+	Provider        string
+	APIKey          string
+	Model           string
+	BaseURL         string
+	Temperature     *float64
+	ReasoningEffort string
 }
 
 type ModelProviderTestResult struct {
@@ -62,14 +60,11 @@ func applyModelProviderTestRequest(cfg *Config, req ModelProviderTestRequest) er
 	cfg.Model.Model = req.Model
 	cfg.Model.BaseURL = req.BaseURL
 	cfg.Model.Temperature = nil
-	if req.TemperatureSet && req.Temperature != nil {
+	if req.Temperature != nil {
 		temperature := *req.Temperature
 		cfg.Model.Temperature = &temperature
 	}
-	cfg.Model.ReasoningEffort = ""
-	if req.ReasoningEffortSet {
-		cfg.Model.ReasoningEffort = req.ReasoningEffort
-	}
+	cfg.Model.ReasoningEffort = req.ReasoningEffort
 
 	if err := resolveModelProvider(cfg, &cfg.Model); err != nil {
 		return err

--- a/src/agent/internal/agent/model_config_test_runner_test.go
+++ b/src/agent/internal/agent/model_config_test_runner_test.go
@@ -57,3 +57,56 @@ func TestRunModelProviderTestReportsInvalidProviderRecord(t *testing.T) {
 		t.Fatalf("error = %v", err)
 	}
 }
+
+func TestApplyModelProviderTestRequestClearsStoredSamplingValuesBeforeDefaults(t *testing.T) {
+	storedTemperature := 0.2
+	cfg := Config{Model: ModelConfig{
+		Provider:        "openai",
+		Model:           "gpt-4o",
+		Temperature:     &storedTemperature,
+		ReasoningEffort: "high",
+	}}
+
+	err := applyModelProviderTestRequest(&cfg, ModelProviderTestRequest{
+		Provider: "openai",
+		Model:    "kimi-k3",
+	})
+	if err != nil {
+		t.Fatalf("applyModelProviderTestRequest() error = %v", err)
+	}
+	if cfg.Model.Temperature == nil || *cfg.Model.Temperature != 1 {
+		t.Fatalf("temperature = %v, want Kimi K3 default 1", cfg.Model.Temperature)
+	}
+	if cfg.Model.ReasoningEffort != "low" {
+		t.Fatalf("reasoning_effort = %q, want Kimi K3 default low", cfg.Model.ReasoningEffort)
+	}
+}
+
+func TestApplyModelProviderTestRequestKeepsExplicitSamplingValues(t *testing.T) {
+	storedTemperature := 0.2
+	requestedTemperature := 0.7
+	cfg := Config{Model: ModelConfig{
+		Provider:        "openai",
+		Model:           "gpt-4o",
+		Temperature:     &storedTemperature,
+		ReasoningEffort: "high",
+	}}
+
+	err := applyModelProviderTestRequest(&cfg, ModelProviderTestRequest{
+		Provider:           "openai",
+		Model:              "kimi-k3",
+		Temperature:        &requestedTemperature,
+		TemperatureSet:     true,
+		ReasoningEffort:    "medium",
+		ReasoningEffortSet: true,
+	})
+	if err != nil {
+		t.Fatalf("applyModelProviderTestRequest() error = %v", err)
+	}
+	if cfg.Model.Temperature == nil || *cfg.Model.Temperature != requestedTemperature {
+		t.Fatalf("temperature = %v, want explicit %v", cfg.Model.Temperature, requestedTemperature)
+	}
+	if cfg.Model.ReasoningEffort != "medium" {
+		t.Fatalf("reasoning_effort = %q, want explicit medium", cfg.Model.ReasoningEffort)
+	}
+}

--- a/src/agent/internal/agent/model_config_test_runner_test.go
+++ b/src/agent/internal/agent/model_config_test_runner_test.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunModelProviderTestUsesRuntimeProviderResolution(t *testing.T) {
+	t.Setenv("AIDEN_MODEL_CONFIG_TEST_KEY", "model-config-test-secret")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("request path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer model-config-test-secret" {
+			t.Errorf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{
+				"message": map[string]any{"role": "assistant", "content": "hello"},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ModelProviders: map[string]ModelProvider{
+			"work": {
+				Type:    "openai",
+				APIKey:  "$AIDEN_MODEL_CONFIG_TEST_KEY",
+				BaseURL: server.URL + "/v1",
+			},
+		},
+	}
+	result, err := RunModelProviderTest(context.Background(), cfg, ModelProviderTestRequest{
+		Provider: "work",
+		Model:    "test-model",
+	})
+	if err != nil {
+		t.Fatalf("RunModelProviderTest() error = %v", err)
+	}
+	if result.Provider != "openai" || result.Model != "test-model" {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestRunModelProviderTestReportsInvalidProviderRecord(t *testing.T) {
+	_, err := RunModelProviderTest(context.Background(), Config{
+		ModelProviders: map[string]ModelProvider{"broken": {}},
+	}, ModelProviderTestRequest{Provider: "broken", Model: "test-model"})
+	if err == nil || !strings.Contains(err.Error(), "has no provider type specified") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/src/agent/internal/agent/model_config_test_runner_test.go
+++ b/src/agent/internal/agent/model_config_test_runner_test.go
@@ -58,55 +58,158 @@ func TestRunModelProviderTestReportsInvalidProviderRecord(t *testing.T) {
 	}
 }
 
-func TestApplyModelProviderTestRequestClearsStoredSamplingValuesBeforeDefaults(t *testing.T) {
-	storedTemperature := 0.2
-	cfg := Config{Model: ModelConfig{
-		Provider:        "openai",
-		Model:           "gpt-4o",
-		Temperature:     &storedTemperature,
-		ReasoningEffort: "high",
-	}}
+func TestRunModelProviderTestSendsEffectiveSamplingValues(t *testing.T) {
+	tests := []struct {
+		name                string
+		request             ModelProviderTestRequest
+		wantTemperature     float64
+		wantReasoningEffort string
+	}{
+		{
+			name: "unset values use model defaults",
+			request: ModelProviderTestRequest{
+				Provider: "openai",
+				Model:    "kimi-k3",
+			},
+			wantTemperature:     1,
+			wantReasoningEffort: "low",
+		},
+		{
+			name: "explicit zero and reasoning value reach provider",
+			request: ModelProviderTestRequest{
+				Provider:        "openai",
+				Model:           "kimi-k3",
+				Temperature:     floatPtr(0),
+				ReasoningEffort: "none",
+			},
+			wantTemperature:     0,
+			wantReasoningEffort: "none",
+		},
+	}
 
-	err := applyModelProviderTestRequest(&cfg, ModelProviderTestRequest{
-		Provider: "openai",
-		Model:    "kimi-k3",
-	})
-	if err != nil {
-		t.Fatalf("applyModelProviderTestRequest() error = %v", err)
-	}
-	if cfg.Model.Temperature == nil || *cfg.Model.Temperature != 1 {
-		t.Fatalf("temperature = %v, want Kimi K3 default 1", cfg.Model.Temperature)
-	}
-	if cfg.Model.ReasoningEffort != "low" {
-		t.Fatalf("reasoning_effort = %q, want Kimi K3 default low", cfg.Model.ReasoningEffort)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured struct {
+				Temperature     *float64 `json:"temperature"`
+				ReasoningEffort string   `json:"reasoning_effort"`
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					t.Errorf("decode request body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hello"}}]}`))
+			}))
+			defer server.Close()
+
+			tt.request.APIKey = "test-key"
+			tt.request.BaseURL = server.URL + "/v1"
+			if _, err := RunModelProviderTest(context.Background(), Config{}, tt.request); err != nil {
+				t.Fatalf("RunModelProviderTest() error = %v", err)
+			}
+			if captured.Temperature == nil || *captured.Temperature != tt.wantTemperature {
+				t.Fatalf("request temperature = %v, want %v", captured.Temperature, tt.wantTemperature)
+			}
+			if captured.ReasoningEffort != tt.wantReasoningEffort {
+				t.Fatalf("request reasoning_effort = %q, want %q", captured.ReasoningEffort, tt.wantReasoningEffort)
+			}
+		})
 	}
 }
 
-func TestApplyModelProviderTestRequestKeepsExplicitSamplingValues(t *testing.T) {
-	storedTemperature := 0.2
-	requestedTemperature := 0.7
-	cfg := Config{Model: ModelConfig{
-		Provider:        "openai",
-		Model:           "gpt-4o",
-		Temperature:     &storedTemperature,
-		ReasoningEffort: "high",
-	}}
+func TestApplyModelProviderTestRequestSamplingSemantics(t *testing.T) {
+	tests := []struct {
+		name                string
+		request             ModelProviderTestRequest
+		wantTemperature     float64
+		wantReasoningEffort string
+	}{
+		{
+			name:                "unset clears stored values and uses Kimi defaults",
+			request:             ModelProviderTestRequest{Provider: "openai", Model: "kimi-k3"},
+			wantTemperature:     1,
+			wantReasoningEffort: "low",
+		},
+		{
+			name: "explicit zero remains set",
+			request: ModelProviderTestRequest{
+				Provider:        "openai",
+				Model:           "kimi-k3",
+				Temperature:     floatPtr(0),
+				ReasoningEffort: "none",
+			},
+			wantTemperature:     0,
+			wantReasoningEffort: "none",
+		},
+		{
+			name: "explicit nonzero values remain set",
+			request: ModelProviderTestRequest{
+				Provider:        "openai",
+				Model:           "kimi-k3",
+				Temperature:     floatPtr(0.7),
+				ReasoningEffort: "medium",
+			},
+			wantTemperature:     0.7,
+			wantReasoningEffort: "medium",
+		},
+		{
+			name: "blank reasoning is unset",
+			request: ModelProviderTestRequest{
+				Provider:        "openai",
+				Model:           "kimi-k3",
+				ReasoningEffort: "  \t",
+			},
+			wantTemperature:     1,
+			wantReasoningEffort: "low",
+		},
+		{
+			name:                "unknown model uses global temperature and auto reasoning",
+			request:             ModelProviderTestRequest{Provider: "openai", Model: "custom-model"},
+			wantTemperature:     defaultModelTemperature,
+			wantReasoningEffort: "",
+		},
+	}
 
-	err := applyModelProviderTestRequest(&cfg, ModelProviderTestRequest{
-		Provider:           "openai",
-		Model:              "kimi-k3",
-		Temperature:        &requestedTemperature,
-		TemperatureSet:     true,
-		ReasoningEffort:    "medium",
-		ReasoningEffortSet: true,
-	})
-	if err != nil {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storedTemperature := 0.2
+			cfg := Config{Model: ModelConfig{
+				Provider:        "openai",
+				Model:           "gpt-4o",
+				Temperature:     &storedTemperature,
+				ReasoningEffort: "high",
+			}}
+
+			if err := applyModelProviderTestRequest(&cfg, tt.request); err != nil {
+				t.Fatalf("applyModelProviderTestRequest() error = %v", err)
+			}
+			if cfg.Model.Temperature == nil || *cfg.Model.Temperature != tt.wantTemperature {
+				t.Fatalf("temperature = %v, want %v", cfg.Model.Temperature, tt.wantTemperature)
+			}
+			if cfg.Model.ReasoningEffort != tt.wantReasoningEffort {
+				t.Fatalf("reasoning_effort = %q, want %q", cfg.Model.ReasoningEffort, tt.wantReasoningEffort)
+			}
+		})
+	}
+}
+
+func TestApplyModelProviderTestRequestCopiesExplicitTemperature(t *testing.T) {
+	requestedTemperature := 0.7
+	req := ModelProviderTestRequest{
+		Provider:    "openai",
+		Model:       "kimi-k3",
+		Temperature: &requestedTemperature,
+	}
+	cfg := Config{}
+
+	if err := applyModelProviderTestRequest(&cfg, req); err != nil {
 		t.Fatalf("applyModelProviderTestRequest() error = %v", err)
 	}
-	if cfg.Model.Temperature == nil || *cfg.Model.Temperature != requestedTemperature {
-		t.Fatalf("temperature = %v, want explicit %v", cfg.Model.Temperature, requestedTemperature)
+	requestedTemperature = 0.1
+	if cfg.Model.Temperature == req.Temperature {
+		t.Fatal("temperature pointer aliases request storage")
 	}
-	if cfg.Model.ReasoningEffort != "medium" {
-		t.Fatalf("reasoning_effort = %q, want explicit medium", cfg.Model.ReasoningEffort)
+	if cfg.Model.Temperature == nil || *cfg.Model.Temperature != 0.7 {
+		t.Fatalf("temperature = %v, want copied value 0.7", cfg.Model.Temperature)
 	}
 }

--- a/src/agent/internal/agent/stt_config_test_runner.go
+++ b/src/agent/internal/agent/stt_config_test_runner.go
@@ -86,7 +86,18 @@ func applySTTTranscriptionTestRequest(cfg *Config, req STTTranscriptionTestReque
 		return
 	}
 	if provider := strings.TrimSpace(req.Provider); provider != "" {
-		cfg.STT.Provider = provider
+		if _, isRecord := cfg.STTProviders[provider]; isRecord {
+			// Runtime config has already expanded the active provider record, so
+			// its provider-specific values must not become fallbacks when the test
+			// request selects another record. Rebuild from the selected record and
+			// retain only the global preference shared by all STT providers.
+			cfg.STT = STTConfig{
+				Provider: provider,
+				Language: cfg.STT.Language,
+			}
+		} else {
+			cfg.STT.Provider = provider
+		}
 	}
 	if language := strings.TrimSpace(req.Language); language != "" {
 		cfg.STT.Language = language

--- a/src/agent/internal/agent/stt_config_test_runner.go
+++ b/src/agent/internal/agent/stt_config_test_runner.go
@@ -25,6 +25,28 @@ type STTTranscriptionTestResult struct {
 	Transcript string `json:"transcript"`
 }
 
+type STTProviderTestResult struct {
+	Provider string `json:"provider"`
+}
+
+func RunSTTProviderTest(ctx context.Context, cfg Config, req STTTranscriptionTestRequest) (STTProviderTestResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return STTProviderTestResult{}, err
+	}
+
+	applySTTTranscriptionTestRequest(&cfg, req)
+	if strings.TrimSpace(cfg.STT.Provider) == "" {
+		return STTProviderTestResult{}, errors.New("stt.provider is required")
+	}
+	if _, err := NewSTTClientFromConfig(cfg); err != nil {
+		return STTProviderTestResult{Provider: cfg.STT.Provider}, err
+	}
+	return STTProviderTestResult{Provider: cfg.STT.Provider}, nil
+}
+
 func RunSTTTranscriptionTest(ctx context.Context, cfg Config, req STTTranscriptionTestRequest) (STTTranscriptionTestResult, error) {
 	if ctx == nil {
 		ctx = context.Background()

--- a/src/agent/internal/agent/stt_config_test_runner_test.go
+++ b/src/agent/internal/agent/stt_config_test_runner_test.go
@@ -94,3 +94,40 @@ func TestRunSTTTranscriptionTestRequiresAudio(t *testing.T) {
 		t.Fatalf("error = %v, want audio data is required", err)
 	}
 }
+
+func TestRunSTTProviderTestUsesRuntimeDefaultEndpoint(t *testing.T) {
+	cfg := Config{
+		STTProviders: map[string]STTProvider{
+			"qwen-main": {
+				Type:   "qwen-asr",
+				APIKey: "test-key",
+			},
+		},
+	}
+	result, err := RunSTTProviderTest(context.Background(), cfg, STTTranscriptionTestRequest{
+		Provider: "qwen-main",
+		Language: "zh",
+	})
+	if err != nil {
+		t.Fatalf("RunSTTProviderTest() error = %v", err)
+	}
+	if result.Provider != "qwen-asr" {
+		t.Fatalf("provider = %q, want qwen-asr", result.Provider)
+	}
+}
+
+func TestRunSTTProviderTestAcceptsTencentWithoutAppID(t *testing.T) {
+	result, err := RunSTTProviderTest(context.Background(), Config{}, STTTranscriptionTestRequest{
+		Provider:  "tencent-asr",
+		SecretID:  "test-id",
+		SecretKey: "test-key",
+		Region:    "ap-shanghai",
+		Language:  "zh",
+	})
+	if err != nil {
+		t.Fatalf("RunSTTProviderTest() error = %v", err)
+	}
+	if result.Provider != "tencent-asr" {
+		t.Fatalf("provider = %q, want tencent-asr", result.Provider)
+	}
+}

--- a/src/agent/internal/agent/voice_test_path_resolution_test.go
+++ b/src/agent/internal/agent/voice_test_path_resolution_test.go
@@ -64,6 +64,29 @@ func TestApplySTTTestRequestFormValueOverridesRecord(t *testing.T) {
 	}
 }
 
+func TestApplySTTTestRequestSwitchesRecordCredential(t *testing.T) {
+	cfg := Config{
+		STTProviders: map[string]STTProvider{
+			"openai-main": {Type: "openai-whisper", APIKey: "sk-openai"},
+			"qwen-main":   {Type: "qwen-asr", APIKey: "sk-qwen"},
+		},
+		// Runtime config has already expanded openai-main into this effective
+		// provider configuration before the config-test request arrives.
+		STT: STTConfig{Provider: "openai-whisper", APIKey: "sk-openai"},
+	}
+
+	applySTTTranscriptionTestRequest(&cfg, STTTranscriptionTestRequest{
+		Provider: "qwen-main",
+	})
+
+	if cfg.STT.Provider != "qwen-asr" {
+		t.Errorf("stt.provider = %q, want %q", cfg.STT.Provider, "qwen-asr")
+	}
+	if cfg.STT.APIKey != "sk-qwen" {
+		t.Errorf("stt.api_key = %q, want the selected record credential %q", cfg.STT.APIKey, "sk-qwen")
+	}
+}
+
 func TestApplyTTSTestRequestResolvesRecordRef(t *testing.T) {
 	cfg := Config{
 		TTSProviders: map[string]TTSProvider{

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -138,6 +138,10 @@ struct AgentHttpResponse {
 };
 
 volatile sig_atomic_t g_should_stop = 0;
+pid_t g_agent_restart_pid = -1;
+bool g_agent_restart_readiness_pending = false;
+bool g_agent_restart_deferred = false;
+bool g_stt_live_test_active = false;
 
 const char* kAnyBindAddress = "0.0.0.0";
 const char* kUsbBindAddress = "192.168.42.1";
@@ -164,6 +168,19 @@ const char* agent_bin_path() {
     }();
     return cached;
 }
+
+// Tests replace the init script with a deterministic fixture. Production uses
+// the fixed on-device path.
+const char* agent_init_script_path() {
+    static const char* cached = []() -> const char* {
+        const char* override_path = std::getenv("AIDEN_AGENT_INIT_SCRIPT");
+        if (override_path && override_path[0] != '\0') {
+            return override_path;
+        }
+        return kAgentInitScript;
+    }();
+    return cached;
+}
 const char* kOtaBin = "/oem/usr/bin/ota";
 const char* kEnvRunBin = "/oem/usr/bin/aiden-env-run";
 const char* kOtaHealthLogPath = "/var/log/ota/ota.log";
@@ -172,6 +189,8 @@ const char* kOtaWebUpdateLogPath = "/userdata/ota/config_web_ota_update.log";
 const char* kAgentPortHost = "127.0.0.1";
 const int kDefaultAgentPort = 8080;
 const int kAgentStatusCommandTimeoutMs = 1500;
+const int kAgentRestartWaitTimeoutMs = 15000;
+const int kAgentRestartPollIntervalMs = 50;
 const size_t kAgentStatusLogReadSize = 16 * 1024;
 const size_t kAgentStatusLogDisplaySize = 4096;
 const size_t kAgentLogReadSize = 64 * 1024;
@@ -267,6 +286,9 @@ ApiResponse proxy_agent_get_request(const Options& options,
 ApiResponse handle_api_models(const Options& options, const std::string& query_string);
 ApiResponse handle_usb_reenumerate(const Options& options);
 void preserve_redacted_agent_secrets(const Options& options, aiden::AgentToml* config);
+long long monotonic_millis();
+bool reap_agent_restart_process(bool wait, std::string* error);
+void start_deferred_agent_restart_if_idle();
 ApiResponse handle_stt_test_start(const Options& options, const std::string& body);
 ApiResponse handle_stt_test_stop(const Options& options, const std::string& body);
 
@@ -2411,6 +2433,49 @@ ApiResponse proxy_agent_json_request(const Options& options,
     return proxy_agent_request(options, "POST", agent_path, body, true);
 }
 
+ApiResponse proxy_stt_test_start_after_restart(const Options& options,
+                                               const std::string& body) {
+    const bool wait_for_readiness = g_agent_restart_readiness_pending;
+    if (wait_for_readiness) {
+        std::string wait_error;
+        if (!reap_agent_restart_process(true, &wait_error)) {
+            return make_json_error(503, wait_error);
+        }
+    }
+
+    AgentHttpTarget target;
+    std::string target_error;
+    if (!resolve_agent_http_target(options, &target, &target_error)) {
+        return make_json_error(503, target_error.empty() ? "resolve agent HTTP target failed" : target_error);
+    }
+
+    const long long deadline = monotonic_millis() + kAgentRestartWaitTimeoutMs;
+    AgentHttpResponse upstream;
+    while (!send_agent_http_request(
+            target, "POST", "/api/config-test/stt/start", body, true, &upstream)) {
+        if (!wait_for_readiness || monotonic_millis() >= deadline) {
+            return make_json_error(503, upstream.error.empty() ? "agent HTTP request failed" : upstream.error);
+        }
+        usleep(kAgentRestartPollIntervalMs * 1000);
+    }
+
+    if (wait_for_readiness) {
+        g_agent_restart_readiness_pending = false;
+    }
+
+    ApiResponse response;
+    response.status_code = upstream.status_code > 0 ? upstream.status_code : 200;
+    response.status_text = upstream.status_text.empty() ? "OK" : upstream.status_text;
+    response.content_type = upstream.content_type.empty()
+        ? "application/json; charset=utf-8"
+        : upstream.content_type;
+    response.body = upstream.body;
+    if (response.status_code >= 200 && response.status_code < 300) {
+        g_stt_live_test_active = true;
+    }
+    return response;
+}
+
 ApiResponse handle_stt_test_start(const Options& options, const std::string& body) {
     cJSON* root = cJSON_Parse(body.c_str());
     if (!root) {
@@ -2429,11 +2494,14 @@ ApiResponse handle_stt_test_start(const Options& options, const std::string& bod
     }
 
     cJSON_Delete(root);
-    return proxy_agent_json_request(options, "/api/config-test/stt/start", body);
+    return proxy_stt_test_start_after_restart(options, body);
 }
 
 ApiResponse handle_stt_test_stop(const Options& options, const std::string& body) {
-    return proxy_agent_json_request(options, "/api/config-test/stt/stop", body);
+    ApiResponse response = proxy_agent_json_request(options, "/api/config-test/stt/stop", body);
+    g_stt_live_test_active = false;
+    start_deferred_agent_restart_if_idle();
+    return response;
 }
 
 // GET request proxy to agent. `agent_path_with_query` keeps its query string.
@@ -3637,17 +3705,111 @@ void restart_wpa_supplicant(const Options& options, std::ostringstream& log) {
         << " -c " << options.wifi_config_path << "\n" << start.output;
 }
 
-void schedule_init_script_restart(const char* init_script) {
-    if (!init_script || init_script[0] == '\0') {
-        return;
+long long monotonic_millis() {
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return static_cast<long long>(time(NULL)) * 1000LL;
     }
-    std::string cmd = shell_quote(init_script) + " restart >/dev/null 2>&1 &";
-    int rc = system(cmd.c_str());
-    (void)rc;
+    return static_cast<long long>(now.tv_sec) * 1000LL + now.tv_nsec / 1000000LL;
+}
+
+bool reap_agent_restart_process(bool wait, std::string* error) {
+    if (error) error->clear();
+    if (g_agent_restart_pid <= 0) {
+        return true;
+    }
+
+    const long long deadline = monotonic_millis() + kAgentRestartWaitTimeoutMs;
+    while (true) {
+        int status = 0;
+        pid_t result = waitpid(g_agent_restart_pid, &status, WNOHANG);
+        if (result == g_agent_restart_pid) {
+            g_agent_restart_pid = -1;
+            return true;
+        }
+        if (result < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            if (errno == ECHILD) {
+                g_agent_restart_pid = -1;
+                return true;
+            }
+            if (error) *error = std::string("wait for agent restart: ") + strerror(errno);
+            return false;
+        }
+        if (!wait) {
+            return true;
+        }
+        if (monotonic_millis() >= deadline) {
+            if (error) *error = "timed out waiting for agent restart";
+            return false;
+        }
+        usleep(kAgentRestartPollIntervalMs * 1000);
+    }
+}
+
+bool launch_agent_restart(std::string* error) {
+    if (error) error->clear();
+    const char* init_script = agent_init_script_path();
+    if (!init_script || init_script[0] == '\0') {
+        if (error) *error = "agent init script path is empty";
+        return false;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        if (error) *error = std::string("fork agent restart: ") + strerror(errno);
+        return false;
+    }
+    if (pid == 0) {
+        int devnull = open("/dev/null", O_RDWR);
+        if (devnull >= 0) {
+            dup2(devnull, STDIN_FILENO);
+            dup2(devnull, STDOUT_FILENO);
+            dup2(devnull, STDERR_FILENO);
+            if (devnull > STDERR_FILENO) close(devnull);
+        }
+        execl(init_script, init_script, "restart", static_cast<char*>(NULL));
+        execl("/bin/sh", "sh", init_script, "restart", static_cast<char*>(NULL));
+        _exit(127);
+    }
+
+    g_agent_restart_pid = pid;
+    g_agent_restart_readiness_pending = true;
+    return true;
+}
+
+void start_deferred_agent_restart_if_idle() {
+    std::string ignored_error;
+    (void)reap_agent_restart_process(false, &ignored_error);
+    if (!g_stt_live_test_active && g_agent_restart_deferred && g_agent_restart_pid <= 0) {
+        g_agent_restart_deferred = false;
+        if (!launch_agent_restart(&ignored_error)) {
+            AIDEN_LOG_ERROR("agent_restart", "launch_failed", "error=%s",
+                            ignored_error.c_str());
+        }
+    }
 }
 
 void schedule_agent_restart() {
-    schedule_init_script_restart(kAgentInitScript);
+    if (g_stt_live_test_active) {
+        g_agent_restart_deferred = true;
+        g_agent_restart_readiness_pending = true;
+        return;
+    }
+
+    std::string ignored_error;
+    (void)reap_agent_restart_process(false, &ignored_error);
+    if (g_agent_restart_pid > 0) {
+        g_agent_restart_deferred = true;
+        g_agent_restart_readiness_pending = true;
+        return;
+    }
+    if (!launch_agent_restart(&ignored_error)) {
+        AIDEN_LOG_ERROR("agent_restart", "launch_failed", "error=%s",
+                        ignored_error.c_str());
+    }
 }
 
 int acquire_ota_update_launch_lock(std::string* error) {
@@ -4947,14 +5109,15 @@ AgentRuntimeStatus query_agent_status(const Options& options) {
     status.addr = ":8080";
     status.port_host = kAgentPortHost;
     status.port = kDefaultAgentPort;
+    const char* init_script = agent_init_script_path();
 
-    if (!file_exists(kAgentInitScript)) {
+    if (!file_exists(init_script)) {
         status.state = "unknown";
-        status.detail = std::string("agent init script not found: ") + kAgentInitScript;
+        status.detail = std::string("agent init script not found: ") + init_script;
         status.startup_error = status.detail;
     } else {
         CommandResult script_status = run_shell_command_with_timeout(
-            std::string(kAgentInitScript) + " status 2>&1", kAgentStatusCommandTimeoutMs);
+            shell_quote(init_script) + " status 2>&1", kAgentStatusCommandTimeoutMs);
         status.detail = trim_trailing_newlines(script_status.output);
 
         if (script_status.timed_out) {
@@ -6952,6 +7115,8 @@ ApiResponse handle_config_test(const Options& options, const std::string& body) 
 }
 
 ApiResponse handle_request(const Options& options, const HttpRequest& request) {
+    start_deferred_agent_restart_if_idle();
+
     if (request.error_status_code != 0) {
         ApiResponse response;
         response.status_code = request.error_status_code;
@@ -7230,6 +7395,11 @@ int main(int argc, char** argv) {
             }
             break;
         }
+
+        // Restart helpers are forked while a request is being handled. Do not
+        // let them inherit the client connection and keep the response socket
+        // open until the init script exits.
+        fcntl(client_fd, F_SETFD, FD_CLOEXEC);
 
         if (!set_socket_recv_timeout(client_fd, kClientReadTimeoutSeconds)) {
             close(client_fd);

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -2499,8 +2499,10 @@ ApiResponse handle_stt_test_start(const Options& options, const std::string& bod
 
 ApiResponse handle_stt_test_stop(const Options& options, const std::string& body) {
     ApiResponse response = proxy_agent_json_request(options, "/api/config-test/stt/stop", body);
-    g_stt_live_test_active = false;
-    start_deferred_agent_restart_if_idle();
+    if (response.status_code >= 200 && response.status_code < 300) {
+        g_stt_live_test_active = false;
+        start_deferred_agent_restart_if_idle();
+    }
     return response;
 }
 

--- a/src/config_web.cpp
+++ b/src/config_web.cpp
@@ -1,6 +1,5 @@
 #include "agent_toml.h"
 #include "aiden_log.h"
-#include "audio_service_client.h"
 #include "config_web_static_assets.h"
 #include "system_env_parser.h"
 #include "wifi_config.h"
@@ -117,13 +116,6 @@ struct AgentLogSnapshot {
     std::string error;
 };
 
-struct STTTestRecordingState {
-    bool active = false;
-    uint64_t session_id = 0;
-    std::string socket_path;
-    aiden::AudioFormat format;
-};
-
 using SystemProxy = aiden::SystemEnvProxy;
 
 struct TcpPortStatus {
@@ -146,7 +138,6 @@ struct AgentHttpResponse {
 };
 
 volatile sig_atomic_t g_should_stop = 0;
-STTTestRecordingState g_stt_test_recording;
 
 const char* kAnyBindAddress = "0.0.0.0";
 const char* kUsbBindAddress = "192.168.42.1";
@@ -243,22 +234,8 @@ bool atomic_write_file(const std::string& path, const std::string& content, mode
 std::string cjson_to_string(cJSON* json);
 ApiResponse make_json_error(int status_code, const std::string& message);
 ApiResponse make_json_ok(cJSON* root);
-bool parse_stt_test_audio_request(cJSON* root,
-                                  std::string* socket_path,
-                                  aiden::AudioFormat* format,
-                                  std::string* error);
 bool parse_stt_test_values_request(cJSON* root, cJSON** stt_values, std::string* error);
-void discard_stt_test_recording(const STTTestRecordingState& state);
-bool finish_stt_test_recording(const STTTestRecordingState& state,
-                               std::vector<uint8_t>* pcm,
-                               std::string* error);
-std::string base64_encode_bytes(const uint8_t* data, size_t len);
-std::vector<uint8_t> wrap_pcm_in_wav(const std::vector<uint8_t>& pcm,
-                                     const aiden::AudioFormat& format);
 AgentRuntimeStatus query_agent_status(const Options& options);
-ApiResponse run_agent_stt_config_test(const Options& options,
-                                      cJSON* stt_values,
-                                      const std::string& audio_base64);
 bool parse_http_base_url(const std::string& base_url,
                          AgentHttpTarget* target,
                          std::string* error);
@@ -290,13 +267,6 @@ ApiResponse proxy_agent_get_request(const Options& options,
 ApiResponse handle_api_models(const Options& options, const std::string& query_string);
 ApiResponse handle_usb_reenumerate(const Options& options);
 void preserve_redacted_agent_secrets(const Options& options, aiden::AgentToml* config);
-bool flatten_provider_reference(const Options& options,
-                                const std::string& section,
-                                cJSON* values,
-                                std::string* error);
-bool resolve_config_test_api_key(const Options& options,
-                                 cJSON* values,
-                                 std::string* error);
 ApiResponse handle_stt_test_start(const Options& options, const std::string& body);
 ApiResponse handle_stt_test_stop(const Options& options, const std::string& body);
 
@@ -1955,60 +1925,6 @@ bool json_secret_present(cJSON* obj, const char* key) {
     return json_bool_value(obj, has_key.c_str());
 }
 
-bool parse_stt_test_audio_request(cJSON* root,
-                                  std::string* socket_path,
-                                  aiden::AudioFormat* format,
-                                  std::string* error) {
-    if (socket_path) {
-        socket_path->clear();
-    }
-    if (format) {
-        *format = aiden::AudioFormat();
-    }
-
-    cJSON* audio_values = root ? cJSON_GetObjectItem(root, "audio_values") : NULL;
-    if (!json_is_object(audio_values)) {
-        if (error) *error = "missing 'audio_values' object";
-        return false;
-    }
-
-    cJSON* socket_item = cJSON_GetObjectItem(audio_values, "socket");
-    cJSON* sample_rate_item = cJSON_GetObjectItem(audio_values, "sample_rate");
-    cJSON* channels_item = cJSON_GetObjectItem(audio_values, "channels");
-    cJSON* bit_width_item = cJSON_GetObjectItem(audio_values, "bit_width");
-
-    const std::string socket = json_is_string(socket_item) ? trim_copy(socket_item->valuestring) : "";
-    if (socket.empty()) {
-        if (error) *error = "audio.socket is required";
-        return false;
-    }
-    if (!json_is_number(sample_rate_item) || sample_rate_item->valueint <= 0) {
-        if (error) *error = "audio.sample_rate must be > 0";
-        return false;
-    }
-    if (!json_is_number(channels_item) || channels_item->valueint != 1) {
-        if (error) *error = "audio.channels must be 1 for STT test";
-        return false;
-    }
-    if (!json_is_number(bit_width_item) || bit_width_item->valueint != 16) {
-        if (error) *error = "audio.bit_width must be 16 for STT test";
-        return false;
-    }
-
-    if (socket_path) {
-        *socket_path = socket;
-    }
-    if (format) {
-        format->sample_rate = static_cast<uint32_t>(sample_rate_item->valueint);
-        format->channels = static_cast<uint32_t>(channels_item->valueint);
-        format->bit_width = static_cast<uint32_t>(bit_width_item->valueint);
-    }
-    if (error) {
-        error->clear();
-    }
-    return true;
-}
-
 bool parse_stt_test_values_request(cJSON* root, cJSON** stt_values, std::string* error) {
     if (stt_values) {
         *stt_values = NULL;
@@ -2048,167 +1964,6 @@ bool validate_stt_test_provider_fields(cJSON* values, std::string* error) {
         }
     }
     return true;
-}
-
-void discard_stt_test_recording(const STTTestRecordingState& state) {
-    if (!state.active || state.socket_path.empty() || state.session_id == 0) {
-        return;
-    }
-    aiden::AudioServiceClient client(state.socket_path.c_str());
-    (void)client.stop_recording(state.session_id);
-}
-
-bool finish_stt_test_recording(const STTTestRecordingState& state,
-                               std::vector<uint8_t>* pcm,
-                               std::string* error) {
-    if (pcm) {
-        pcm->clear();
-    }
-    if (!state.active || state.socket_path.empty() || state.session_id == 0) {
-        if (error) *error = "STT test recording is not active";
-        return false;
-    }
-
-    aiden::AudioServiceClient client(state.socket_path.c_str());
-    aiden::AidenServiceStatus stop_status = client.stop_recording(state.session_id);
-    if (stop_status != aiden::AidenServiceStatus::OK) {
-        if (error) {
-            *error = std::string("stop device audio recording: ") +
-                     aiden::service_status_to_string(stop_status);
-        }
-        return false;
-    }
-
-    while (true) {
-        aiden::AudioChunkResult chunk;
-        aiden::AidenServiceStatus read_status = client.read_record_chunk(state.session_id, 1000, &chunk);
-        if (read_status == aiden::AidenServiceStatus::OK) {
-            if (pcm && !chunk.pcm.empty()) {
-                pcm->insert(pcm->end(), chunk.pcm.begin(), chunk.pcm.end());
-            }
-            if (chunk.end_of_stream) {
-                if (error) {
-                    error->clear();
-                }
-                return true;
-            }
-            continue;
-        }
-        if (read_status == aiden::AidenServiceStatus::SESSION_NOT_FOUND) {
-            if (error) {
-                error->clear();
-            }
-            return true;
-        }
-        if (error) {
-            *error = std::string("read recorded audio: ") +
-                     aiden::service_status_to_string(read_status);
-        }
-        return false;
-    }
-}
-
-std::string base64_encode_bytes(const uint8_t* data, size_t len) {
-    static const char table[] =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    if (!data || len == 0) {
-        return "";
-    }
-
-    std::string out;
-    out.reserve(((len + 2) / 3) * 4);
-    for (size_t i = 0; i < len; i += 3) {
-        const uint32_t b0 = data[i];
-        const uint32_t b1 = (i + 1 < len) ? data[i + 1] : 0;
-        const uint32_t b2 = (i + 2 < len) ? data[i + 2] : 0;
-        const uint32_t triple = (b0 << 16) | (b1 << 8) | b2;
-
-        out.push_back(table[(triple >> 18) & 0x3f]);
-        out.push_back(table[(triple >> 12) & 0x3f]);
-        out.push_back(i + 1 < len ? table[(triple >> 6) & 0x3f] : '=');
-        out.push_back(i + 2 < len ? table[triple & 0x3f] : '=');
-    }
-    return out;
-}
-
-void append_le16(std::vector<uint8_t>* out, uint16_t value) {
-    if (!out) {
-        return;
-    }
-    out->push_back(static_cast<uint8_t>(value & 0xff));
-    out->push_back(static_cast<uint8_t>((value >> 8) & 0xff));
-}
-
-void append_le32(std::vector<uint8_t>* out, uint32_t value) {
-    if (!out) {
-        return;
-    }
-    out->push_back(static_cast<uint8_t>(value & 0xff));
-    out->push_back(static_cast<uint8_t>((value >> 8) & 0xff));
-    out->push_back(static_cast<uint8_t>((value >> 16) & 0xff));
-    out->push_back(static_cast<uint8_t>((value >> 24) & 0xff));
-}
-
-std::vector<uint8_t> wrap_pcm_in_wav(const std::vector<uint8_t>& pcm,
-                                     const aiden::AudioFormat& format) {
-    std::vector<uint8_t> wav;
-    const uint16_t channels = static_cast<uint16_t>(format.channels);
-    const uint16_t bit_width = static_cast<uint16_t>(format.bit_width);
-    const uint32_t sample_rate = format.sample_rate;
-    const uint16_t block_align = static_cast<uint16_t>(channels * (bit_width / 8));
-    const uint32_t byte_rate = sample_rate * block_align;
-    const uint32_t data_size = static_cast<uint32_t>(pcm.size());
-
-    wav.reserve(44 + pcm.size());
-    wav.insert(wav.end(), {'R', 'I', 'F', 'F'});
-    append_le32(&wav, 36 + data_size);
-    wav.insert(wav.end(), {'W', 'A', 'V', 'E'});
-    wav.insert(wav.end(), {'f', 'm', 't', ' '});
-    append_le32(&wav, 16);
-    append_le16(&wav, 1);
-    append_le16(&wav, channels);
-    append_le32(&wav, sample_rate);
-    append_le32(&wav, byte_rate);
-    append_le16(&wav, block_align);
-    append_le16(&wav, bit_width);
-    wav.insert(wav.end(), {'d', 'a', 't', 'a'});
-    append_le32(&wav, data_size);
-    wav.insert(wav.end(), pcm.begin(), pcm.end());
-    return wav;
-}
-
-ApiResponse run_agent_stt_config_test(const Options& options,
-                                      cJSON* stt_values,
-                                      const std::string& audio_base64) {
-    cJSON* req = cJSON_CreateObject();
-    cJSON_AddStringToObject(req, "section", "stt");
-    cJSON_AddItemToObject(req, "values", cJSON_Duplicate(stt_values, 1));
-    cJSON_AddStringToObject(req, "audio_base64", audio_base64.c_str());
-    std::string req_body = cjson_to_string(req);
-    cJSON_Delete(req);
-
-    std::string cmd = shell_quote(agent_bin_path()) +
-                      " config-test --format=json --stdin --section=stt --config=" +
-                      shell_quote(options.agent_config_path) + " 2>&1";
-    CommandResult cr = run_command_with_stdin(cmd, req_body, 60000);
-    if (cr.timed_out) {
-        return make_json_error(503, "agent config-test timed out");
-    }
-
-    cJSON* root = parse_config_test_result(cr.output);
-    if (!json_is_object(root)) {
-        if (root) {
-            cJSON_Delete(root);
-        }
-        std::string detail = trim_trailing_newlines(cr.output);
-        if (detail.empty()) {
-            detail = "agent config-test returned an unexpected response";
-        } else if (detail.size() > 400) {
-            detail = detail.substr(0, 400) + "...";
-        }
-        return make_json_error(503, detail);
-    }
-    return make_json_ok(root);
 }
 
 bool parse_http_base_url(const std::string& base_url,
@@ -2673,19 +2428,8 @@ ApiResponse handle_stt_test_start(const Options& options, const std::string& bod
         return make_json_error(400, parse_error);
     }
 
-    std::string resolve_error;
-    if (!flatten_provider_reference(options, "stt", stt_values, &resolve_error)) {
-        cJSON_Delete(root);
-        return make_json_error(503, "provider config unavailable");
-    }
-    if (!resolve_config_test_api_key(options, stt_values, &resolve_error)) {
-        cJSON_Delete(root);
-        return make_json_error(503, resolve_error);
-    }
-
-    const std::string resolved_body = cjson_to_string(root);
     cJSON_Delete(root);
-    return proxy_agent_json_request(options, "/api/config-test/stt/start", resolved_body);
+    return proxy_agent_json_request(options, "/api/config-test/stt/start", body);
 }
 
 ApiResponse handle_stt_test_stop(const Options& options, const std::string& body) {
@@ -6662,213 +6406,74 @@ std::string validate_proxy_url(const std::string& url) {
     return aiden::validate_system_proxy_url(url);
 }
 
-static bool is_tencent_asr_provider(const std::string& provider) {
-    return provider == "tencent-asr" || provider == "tencent" || provider == "tencent_asr";
-}
-
-static bool is_streaming_tts_provider(const std::string& provider) {
-    return provider == "minimax" || provider == "minimax-cn" ||
-           provider == "fish-audio" || provider == "alicloud" ||
-           provider == "volcengine";
-}
-
-bool is_known_config_test_provider_type(const std::string& section,
-                                        const std::string& provider) {
-    const std::string normalized = lowercase_copy(trim_copy(provider));
-    const char* const* known = NULL;
-    static const char* const model_types[] = {
-        "openrouter", "openai", "kimi", "kimi-cn", "volcengine", "ollama", "fake", NULL,
-    };
-    static const char* const tts_types[] = {
-        "minimax", "minimax-cn", "minimax-ws", "fish-audio", "alicloud",
-        "volcengine", "openrouter", "google-cloud", NULL,
-    };
-    static const char* const stt_types[] = {
-        "openai-whisper", "openai", "tencent-asr", "tencent", "tencent_asr",
-        "openrouter", "qwen-asr", "google-cloud", NULL,
-    };
-    if (section == "model") {
-        known = model_types;
-    } else if (section == "tts") {
-        known = tts_types;
-    } else if (section == "stt") {
-        known = stt_types;
-    }
-    for (size_t i = 0; known && known[i]; ++i) {
-        if (normalized == known[i]) return true;
-    }
-    return false;
-}
-
-std::string provider_default_url(const std::string& provider, const std::string& section = "") {
-    if (provider == "openrouter") return "https://openrouter.ai/api/v1";
-    if (provider == "openai" || provider == "openai-whisper") return "https://api.openai.com/v1";
-    if (provider == "minimax") return "https://api.minimax.io";
-    if (provider == "minimax-cn" || provider == "minimax-ws") return "https://api.minimaxi.com";
-    if (is_tencent_asr_provider(provider)) return "https://asr.tencentcloudapi.com";
-    if (provider == "google-cloud") {
-        if (section == "tts") return "https://texttospeech.googleapis.com";
-        return "https://speech.googleapis.com";  // STT default
-    }
-    // Volcengine Ark's OpenAI-compatible endpoint, for [model] only. The [tts]
-    // provider of the same name speaks a separate WebSocket protocol with its own
-    // host and auth, so it must not inherit this URL.
-    if (provider == "volcengine" && section == "model") {
-        return "https://ark.cn-beijing.volces.com/api/v3";
-    }
-    return "";
-}
-
-// set_json_str_if_absent adds key=value only when `values` omits the field or
-// carries an empty string. A non-string value is malformed input and must remain
-// visible to the caller's validation instead of being replaced by stored data.
-void set_json_str_if_absent(cJSON* values, const char* key, const std::string& value) {
-    if (value.empty()) return;
-    cJSON* existing = cJSON_GetObjectItem(values, key);
-    if (json_is_string(existing) && !trim_copy(existing->valuestring).empty()) {
-        return;
-    }
-    if (existing && !json_is_string(existing)) {
-        return;
-    }
-    if (existing) {
-        cJSON_DeleteItemFromObject(values, key);
-    }
-    cJSON_AddStringToObject(values, key, value.c_str());
-}
-
-// flatten_provider_reference rewrites values.provider from a named provider
-// record to its provider type and fills the record's fields into `values`.
-// Without it the config-test pre-checks, which read the flat keys, would see an
-// unknown provider and an empty api_key.
-bool flatten_provider_reference(const Options& options,
-                                const std::string& section,
-                                cJSON* values,
-                                std::string* error) {
+bool build_agent_config_test_env_prefix(const Options& options,
+                                        std::string* prefix,
+                                        std::string* error) {
+    if (prefix) prefix->clear();
     if (error) error->clear();
-    if (!values) return true;
-    cJSON* provider_item = cJSON_GetObjectItem(values, "provider");
-    if (!json_is_string(provider_item)) return true;
-    const std::string ref = trim_copy(provider_item->valuestring);
-    if (ref.empty()) return true;
+    if (!file_exists(options.system_env_path.c_str())) {
+        return true;
+    }
 
-    aiden::AgentToml stored;
-    std::string load_error;
-    load_current_agent_config(options, &stored, &load_error);
-    if (!load_error.empty()) {
-        // A bare provider request is self-contained and does not need the
-        // stored config. Unknown names may be provider references, so failing
-        // to load their records must remain visible instead of being forwarded
-        // as an unknown provider.
-        if (is_known_config_test_provider_type(section, ref)) {
-            return true;
-        }
-        if (error) *error = load_error;
+    std::string content;
+    std::string read_error;
+    if (!read_file_contents_checked(options.system_env_path.c_str(),
+                                    kMaxSystemEnvSize,
+                                    &content,
+                                    &read_error)) {
+        AIDEN_LOG_ERROR("config_test", "system_env_read_failed", "error=%s",
+                        read_error.c_str());
+        if (error) *error = "system env file is unavailable";
         return false;
     }
 
-    if (section == "model") {
-        std::map<std::string, aiden::ModelProviderToml>::const_iterator it =
-            stored.model_providers.find(ref);
-        if (it == stored.model_providers.end()) return true;
-        const aiden::ModelProviderToml& record = it->second;
-        if (trim_copy(record.type).empty()) return true;
-
-        cJSON_DeleteItemFromObject(values, "provider");
-        cJSON_AddStringToObject(values, "provider", record.type.c_str());
-        set_json_str_if_absent(values, "api_key", record.api_key);
-        set_json_str_if_absent(values, "base_url", record.base_url);
-        return true;
+    std::string validation_error;
+    if (!validate_system_env_content(content, &validation_error)) {
+        AIDEN_LOG_ERROR("config_test", "system_env_parse_failed", "error=%s",
+                        validation_error.c_str());
+        if (error) *error = "system env file is invalid";
+        return false;
     }
 
-    if (section == "tts") {
-        std::map<std::string, aiden::TTSProviderToml>::const_iterator it =
-            stored.tts_providers.find(ref);
-        if (it == stored.tts_providers.end()) return true;
-        const aiden::TTSProviderToml& record = it->second;
-        if (trim_copy(record.type).empty()) return true;
-
-        cJSON_DeleteItemFromObject(values, "provider");
-        cJSON_AddStringToObject(values, "provider", record.type.c_str());
-        set_json_str_if_absent(values, "api_key", record.api_key);
-        set_json_str_if_absent(values, "model", record.model);
-        set_json_str_if_absent(values, "voice_id", record.voice_id);
-        set_json_str_if_absent(values, "emotion", record.emotion);
-        set_json_str_if_absent(values, "reference_id", record.reference_id);
-        return true;
+    if (prefix) {
+        *prefix = "set -a && . " + shell_quote(options.system_env_path) +
+                  " && set +a && ";
     }
-
-    std::map<std::string, aiden::STTProviderToml>::const_iterator it =
-        stored.stt_providers.find(ref);
-    if (it == stored.stt_providers.end()) return true;
-    const aiden::STTProviderToml& record = it->second;
-    if (trim_copy(record.type).empty()) return true;
-
-    cJSON_DeleteItemFromObject(values, "provider");
-    cJSON_AddStringToObject(values, "provider", record.type.c_str());
-    set_json_str_if_absent(values, "api_key", record.api_key);
-    set_json_str_if_absent(values, "model", record.model);
-    set_json_str_if_absent(values, "base_url", record.base_url);
-    set_json_str_if_absent(values, "app_id", record.app_id);
-    set_json_str_if_absent(values, "secret_id", record.secret_id);
-    set_json_str_if_absent(values, "secret_key", record.secret_key);
-    set_json_str_if_absent(values, "region", record.region);
-    set_json_str_if_absent(values, "engine_model_type", record.engine_model_type);
     return true;
 }
 
-bool resolve_config_test_api_key(const Options& options,
-                                 cJSON* values,
-                                 std::string* error) {
-    if (error) error->clear();
-    if (!values) return true;
-    cJSON* api_key_item = cJSON_GetObjectItem(values, "api_key");
-    if (!json_is_string(api_key_item)) return true;
-
-    const std::string api_key = trim_copy(api_key_item->valuestring);
-    if (api_key.empty() || api_key[0] != '$') return true;
-
-    const std::string env_name = trim_copy(api_key.substr(1));
-    std::string resolved;
-    bool found_in_file = false;
-
-    if (file_exists(options.system_env_path.c_str())) {
-        std::string content;
-        std::string read_error;
-        if (!read_file_contents_checked(options.system_env_path.c_str(),
-                                        kMaxSystemEnvSize,
-                                        &content,
-                                        &read_error)) {
-            AIDEN_LOG_ERROR("config_test", "system_env_read_failed", "error=%s",
-                            read_error.c_str());
-            if (error) *error = "system env file is unavailable";
-            return false;
-        }
-        std::vector<aiden::EnvAssignment> assignments;
-        aiden::SystemEnvProxy proxy;
-        std::string parse_error;
-        if (!aiden::parse_system_env_content(content, &assignments, &proxy, &parse_error)) {
-            AIDEN_LOG_ERROR("config_test", "system_env_parse_failed", "error=%s",
-                            parse_error.c_str());
-            if (error) *error = "system env file is invalid";
-            return false;
-        }
-        for (size_t i = 0; i < assignments.size(); ++i) {
-            if (assignments[i].key == env_name) {
-                resolved = assignments[i].value;
-                found_in_file = true;
-            }
-        }
+ApiResponse run_agent_provider_config_test(const Options& options,
+                                           const std::string& section,
+                                           const std::string& body) {
+    std::string env_prefix;
+    std::string env_error;
+    if (!build_agent_config_test_env_prefix(options, &env_prefix, &env_error)) {
+        return make_json_error(503, env_error);
     }
 
-    if (!found_in_file) {
-        const char* process_value = std::getenv(env_name.c_str());
-        resolved = process_value ? process_value : "";
+    std::string cmd = env_prefix + shell_quote(agent_bin_path()) +
+                      " config-test --format=json --stdin --section=" +
+                      shell_quote(section) + " --config=" +
+                      shell_quote(options.agent_config_path) + " 2>&1";
+    CommandResult cr = run_command_with_stdin(cmd, body, 60000);
+    if (cr.timed_out) {
+        return make_json_error(503, "agent config-test timed out");
     }
 
-    cJSON_DeleteItemFromObject(values, "api_key");
-    cJSON_AddStringToObject(values, "api_key", resolved.c_str());
-    return true;
+    cJSON* root = parse_config_test_result(cr.output);
+    if (!json_is_object(root)) {
+        if (root) {
+            cJSON_Delete(root);
+        }
+        std::string detail = trim_trailing_newlines(cr.output);
+        if (detail.empty()) {
+            detail = "agent config-test returned an unexpected response";
+        } else if (detail.size() > 400) {
+            detail = detail.substr(0, 400) + "...";
+        }
+        return make_json_error(503, detail);
+    }
+    return make_json_ok(root);
 }
 
 std::string build_curl_proxy_arg(const SystemProxy& proxy) {
@@ -6938,26 +6543,9 @@ ApiResponse handle_config_test(const Options& options, const std::string& body) 
         return make_json_error(400, "missing 'values' object");
     }
 
-    // Flatten a provider reference into `values` before anything reads it. The
-    // Test button posts the form state, and now that credentials live on provider
-    // records that form carries only the reference plus the globals. The checks
-    // below read values.provider and values.api_key directly, so an unresolved
-    // reference reads as an unknown provider with an empty key.
-    //
-    // A value already present in `values` wins, so a field the user typed still
-    // takes precedence over the stored record. The voice playback test resolves
-    // references again on its own side, which is idempotent: once flattened,
-    // provider holds a bare type and matches no record.
     if (section == "model" || section == "tts" || section == "stt") {
-        std::string resolve_error;
-        if (!flatten_provider_reference(options, section, values, &resolve_error)) {
-            cJSON_Delete(root);
-            return make_json_error(503, "provider config unavailable");
-        }
-        if (!resolve_config_test_api_key(options, values, &resolve_error)) {
-            cJSON_Delete(root);
-            return make_json_error(503, resolve_error);
-        }
+        cJSON_Delete(root);
+        return run_agent_provider_config_test(options, section, body);
     }
 
     cJSON* response = cJSON_CreateObject();
@@ -6969,237 +6557,7 @@ ApiResponse handle_config_test(const Options& options, const std::string& body) 
     std::string curl_proxy_arg = build_curl_proxy_arg(current_proxy);
     std::string curl_env_exports = build_proxy_env_exports(current_proxy);
 
-    if (section == "model" || section == "tts" || section == "stt") {
-        cJSON* provider_item = cJSON_GetObjectItem(values, "provider");
-        cJSON* base_url_item = cJSON_GetObjectItem(values, "base_url");
-        std::string provider = json_is_string(provider_item) ? trim_copy(provider_item->valuestring) : "";
-        std::string base_url = json_is_string(base_url_item) ? trim_copy(base_url_item->valuestring) : "";
-        std::string url = base_url.empty() ? provider_default_url(provider, section) : base_url;
-        const bool tencent_stt = section == "stt" && is_tencent_asr_provider(provider);
-        if (tencent_stt && url.empty()) {
-            url = "https://asr.tencentcloudapi.com";
-        }
-
-        cJSON* api_key_item = cJSON_GetObjectItem(values, "api_key");
-        std::string api_key = json_is_string(api_key_item) ? trim_copy(api_key_item->valuestring) : "";
-        bool api_key_present = json_secret_present(values, "api_key");
-
-        cJSON* r = cJSON_CreateObject();
-        cJSON_AddStringToObject(r, "check", "endpoint_reachable");
-        if (section == "tts" && is_streaming_tts_provider(provider)) {
-            cJSON_AddBoolToObject(r, "passed", 1);
-            cJSON_AddStringToObject(r, "detail", "streaming endpoint is verified by the TTS playback test");
-        } else if (url.empty()) {
-            cJSON_AddBoolToObject(r, "passed", 0);
-            cJSON_AddStringToObject(r, "detail", "no URL to test (provider unknown and base_url empty)");
-            all_passed = false;
-        } else {
-            std::string cmd = curl_env_exports + "curl -sI --max-time 6 " + curl_proxy_arg + shell_quote(url) + " 2>&1 | head -1";
-            CommandResult cr = run_shell_command(cmd);
-            bool reachable = cr.exit_code == 0 && cr.output.find("HTTP") != std::string::npos;
-            cJSON_AddBoolToObject(r, "passed", reachable ? 1 : 0);
-            std::string detail = url + " -> " + trim_trailing_newlines(cr.output);
-            cJSON_AddStringToObject(r, "detail", detail.c_str());
-            if (!reachable) all_passed = false;
-        }
-        cJSON_AddItemToArray(results, r);
-
-        if (tencent_stt) {
-            bool app_id_present = json_secret_present(values, "app_id");
-            bool secret_id_present = json_secret_present(values, "secret_id");
-            bool secret_key_present = json_secret_present(values, "secret_key");
-
-            cJSON* r_appid = cJSON_CreateObject();
-            cJSON_AddStringToObject(r_appid, "check", "streaming_app_id");
-            cJSON_AddBoolToObject(r_appid, "passed", 1);
-            cJSON_AddStringToObject(
-                r_appid,
-                "detail",
-                app_id_present
-                    ? "app_id is set; realtime upload is available"
-                    : "app_id is empty; recording will fall back to one-shot upload");
-            cJSON_AddItemToArray(results, r_appid);
-
-            cJSON* r_sid = cJSON_CreateObject();
-            cJSON_AddStringToObject(r_sid, "check", "secret_id_present");
-            cJSON_AddBoolToObject(r_sid, "passed", secret_id_present ? 1 : 0);
-            cJSON_AddStringToObject(r_sid, "detail", secret_id_present ? "secret_id is set" : "secret_id is empty");
-            if (!secret_id_present) all_passed = false;
-            cJSON_AddItemToArray(results, r_sid);
-
-            cJSON* r_skey = cJSON_CreateObject();
-            cJSON_AddStringToObject(r_skey, "check", "secret_key_present");
-            cJSON_AddBoolToObject(r_skey, "passed", secret_key_present ? 1 : 0);
-            cJSON_AddStringToObject(r_skey, "detail", secret_key_present ? "secret_key is set" : "secret_key is empty");
-            if (!secret_key_present) all_passed = false;
-            cJSON_AddItemToArray(results, r_skey);
-        } else {
-            cJSON* r2 = cJSON_CreateObject();
-            cJSON_AddStringToObject(r2, "check", "api_key_present");
-            cJSON_AddBoolToObject(r2, "passed", api_key_present ? 1 : 0);
-            cJSON_AddStringToObject(r2, "detail", api_key_present ? "api_key is set" : "api_key is empty");
-            if (!api_key_present) all_passed = false;
-            cJSON_AddItemToArray(results, r2);
-        }
-
-        bool endpoint_ok = false;
-        {
-            cJSON* first = cJSON_GetArrayItem(results, 0);
-            cJSON* p = cJSON_GetObjectItem(first, "passed");
-            endpoint_ok = json_is_type(p, cJSON_True);
-        }
-
-        if (section == "model" && endpoint_ok && !api_key.empty()) {
-            cJSON* model_item = cJSON_GetObjectItem(values, "model");
-            std::string model_name = json_is_string(model_item) ? trim_copy(model_item->valuestring) : "";
-
-            cJSON* r3 = cJSON_CreateObject();
-            cJSON_AddStringToObject(r3, "check", "api_key_valid");
-
-            if (model_name.empty()) {
-                cJSON_AddBoolToObject(r3, "passed", 0);
-                cJSON_AddStringToObject(r3, "detail", "model name is empty; cannot send hello request");
-                all_passed = false;
-            } else {
-                std::string chat_url = url;
-                while (!chat_url.empty() && chat_url[chat_url.size() - 1] == '/') {
-                    chat_url.erase(chat_url.size() - 1);
-                }
-                chat_url += "/chat/completions";
-
-                cJSON* req = cJSON_CreateObject();
-                cJSON_AddStringToObject(req, "model", model_name.c_str());
-                cJSON_AddNumberToObject(req, "max_tokens", 4);
-                // Omit temperature: this is only an auth/connectivity probe, and
-                // some models (e.g. Kimi K3) reject any temperature but their own
-                // fixed value. Letting the model use its default keeps the check
-                // valid across every provider.
-                cJSON* msgs = add_array(req, "messages");
-                cJSON* msg = cJSON_CreateObject();
-                cJSON_AddStringToObject(msg, "role", "user");
-                cJSON_AddStringToObject(msg, "content", "hello");
-                cJSON_AddItemToArray(msgs, msg);
-                std::string req_body = cjson_to_string(req);
-                cJSON_Delete(req);
-
-                std::string auth_header = "Authorization: Bearer " + api_key;
-                char response_path_template[] = "/tmp/config_test_body.XXXXXX";
-                int response_fd = mkstemp(response_path_template);
-                if (response_fd < 0) {
-                    cJSON_AddBoolToObject(r3, "passed", 0);
-                    cJSON_AddStringToObject(r3, "detail", "failed to create temporary response file");
-                    all_passed = false;
-                } else {
-                    close(response_fd);
-                    std::string response_path = response_path_template;
-
-                    std::string cmd =
-                        curl_env_exports +
-                        std::string("curl -sS --max-time 12 ") +
-                        curl_proxy_arg +
-                        "-o " + shell_quote(response_path) + " -w '%{http_code}' " +
-                        "-H " + shell_quote("Content-Type: application/json") + " " +
-                        "-H " + shell_quote(auth_header) + " " +
-                        "-d " + shell_quote(req_body) + " " +
-                        shell_quote(chat_url) + " 2>&1";
-
-                    CommandResult cr = run_shell_command(cmd);
-                    std::string http_code = trim_copy(cr.output);
-                    std::string resp_body = read_file_contents(response_path.c_str(), 4096);
-                    resp_body = trim_trailing_newlines(resp_body);
-                    if (resp_body.size() > 400) {
-                        resp_body = resp_body.substr(0, 400) + "...";
-                    }
-                    unlink(response_path.c_str());
-
-                    bool key_ok = (http_code == "200");
-                    cJSON_AddBoolToObject(r3, "passed", key_ok ? 1 : 0);
-
-                    std::string detail;
-                    if (cr.exit_code != 0 && http_code.empty()) {
-                        detail = "request failed: " + cr.output;
-                    } else if (key_ok) {
-                        detail = "HTTP 200 - key works (model: " + model_name + ")";
-                    } else {
-                        detail = "HTTP " + http_code + " - " + resp_body;
-                    }
-                    if (!key_ok) all_passed = false;
-                    cJSON_AddStringToObject(r3, "detail", detail.c_str());
-                }
-            }
-            cJSON_AddItemToArray(results, r3);
-        }
-
-        if (section == "tts") {
-            if (!api_key_present) {
-                cJSON* r3 = cJSON_CreateObject();
-                cJSON_AddStringToObject(r3, "check", "tts_playback");
-                cJSON_AddBoolToObject(r3, "passed", 0);
-                cJSON_AddStringToObject(r3, "detail", "skipped because api_key is empty");
-                cJSON_AddItemToArray(results, r3);
-                all_passed = false;
-            } else {
-                cJSON* req = cJSON_CreateObject();
-                cJSON_AddStringToObject(req, "section", "tts");
-                cJSON_AddStringToObject(req, "text", "test passed");
-                cJSON_AddItemToObject(req, "values", cJSON_Duplicate(values, 1));
-                std::string req_body = cjson_to_string(req);
-                cJSON_Delete(req);
-
-                std::string cmd = shell_quote(agent_bin_path()) +
-                                  " config-test --format=json --stdin --section=tts --config=" +
-                                  shell_quote(options.agent_config_path) + " 2>&1";
-                CommandResult cr = run_command_with_stdin(cmd, req_body, 60000);
-
-                bool appended_cli_result = false;
-                bool cli_passed = cr.exit_code == 0 && !cr.timed_out;
-                cJSON* cli_root = parse_config_test_result(cr.output);
-                if (cli_root) {
-                    cJSON* ok_item = cJSON_GetObjectItem(cli_root, "ok");
-                    if (!json_is_type(ok_item, cJSON_True)) {
-                        cli_passed = false;
-                    }
-                    cJSON* cli_results = cJSON_GetObjectItem(cli_root, "results");
-                    if (json_is_array(cli_results)) {
-                        int result_count = cJSON_GetArraySize(cli_results);
-                        for (int i = 0; i < result_count; ++i) {
-                            cJSON* item = cJSON_GetArrayItem(cli_results, i);
-                            cJSON* passed_item = cJSON_GetObjectItem(item, "passed");
-                            if (!json_is_type(passed_item, cJSON_True)) {
-                                cli_passed = false;
-                            }
-                            cJSON_AddItemToArray(results, cJSON_Duplicate(item, 1));
-                            appended_cli_result = true;
-                        }
-                    }
-                    cJSON_Delete(cli_root);
-                }
-
-                if (!appended_cli_result) {
-                    cJSON* r3 = cJSON_CreateObject();
-                    cJSON_AddStringToObject(r3, "check", "tts_playback");
-                    cJSON_AddBoolToObject(r3, "passed", 0);
-                    std::string detail;
-                    if (cr.timed_out) {
-                        detail = "agent config-test timed out";
-                    } else if (cr.output.empty()) {
-                        detail = "agent config-test returned exit code " + std::to_string(cr.exit_code);
-                    } else {
-                        detail = trim_trailing_newlines(cr.output);
-                        if (detail.size() > 400) {
-                            detail = detail.substr(0, 400) + "...";
-                        }
-                    }
-                    cJSON_AddStringToObject(r3, "detail", detail.c_str());
-                    cJSON_AddItemToArray(results, r3);
-                    cli_passed = false;
-                }
-                if (!cli_passed) {
-                    all_passed = false;
-                }
-            }
-        }
-    } else if (section == "audio") {
+    if (section == "audio") {
         cJSON* socket_item = cJSON_GetObjectItem(values, "socket");
         std::string socket_path = json_is_string(socket_item) ? trim_copy(socket_item->valuestring) : "";
         cJSON* r = cJSON_CreateObject();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,8 +139,6 @@ add_executable(config_web_for_tests
     ${CMAKE_SOURCE_DIR}/src/config_web.cpp
     ${CMAKE_SOURCE_DIR}/src/config_web_static_assets.cpp
     ${CMAKE_SOURCE_DIR}/src/agent_toml.cpp
-    ${CMAKE_SOURCE_DIR}/src/audio_service_client.cpp
-    ${CMAKE_SOURCE_DIR}/src/audio_service_protocol.cpp
     ${CMAKE_SOURCE_DIR}/src/frame_service_protocol.cpp
     ${CMAKE_SOURCE_DIR}/src/service_status.cpp
     ${CMAKE_SOURCE_DIR}/src/uds_client.cpp

--- a/tests/agent_stub_main.cpp
+++ b/tests/agent_stub_main.cpp
@@ -139,6 +139,11 @@ void maybe_write_config_test_log(int argc, char** argv, const std::string& stdin
     for (int i = 1; i < argc; ++i) {
         out << "\n" << argv[i];
     }
+    const char* env_key = std::getenv("AIDEN_AGENT_STUB_CONFIG_TEST_ENV_KEY");
+    if (env_key && env_key[0] != '\0') {
+        const char* env_value = std::getenv(env_key);
+        out << "\nenv:" << env_key << "=" << (env_value ? env_value : "<unset>");
+    }
     out << "\nstdin:\n" << stdin_body;
 }
 

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -2585,7 +2585,7 @@ TEST_CASE("config_web: config test reports removed audio input mode hint") {
     CHECK(test_resp.body.find("audio mode has been removed; use stt instead") != std::string::npos);
 }
 
-TEST_CASE("config_web: tts config test invokes playback of test passed") {
+TEST_CASE("config_web: tts config test invokes the agent runtime") {
     auto tmp = make_temp_dir();
     auto cleanup = std::unique_ptr<void, void(*)(void*)>(
         const_cast<char*>(tmp.c_str()),
@@ -2595,9 +2595,7 @@ TEST_CASE("config_web: tts config test invokes playback of test passed") {
     StubEnv env;
     env.set("AIDEN_AGENT_STUB_CONFIG_TEST_LOG", log_path);
     auto handle = start_server(env);
-    HeadProbeServer probe;
 
-    const std::string endpoint = "http://127.0.0.1:" + std::to_string(probe.port());
     const std::string test_body =
         "{\"section\":\"tts\",\"values\":{"
         "\"provider\":\"minimax-cn\","
@@ -2605,8 +2603,7 @@ TEST_CASE("config_web: tts config test invokes playback of test passed") {
         "\"model\":\"speech-2.8-hd\","
         "\"voice_id\":\"male-qn-qingse\","
         "\"emotion\":\"happy\","
-        "\"speed\":1,"
-        "\"base_url\":\"" + endpoint + "\""
+        "\"speed\":1"
         "}}";
 
     HttpResponse test_resp = http_request(handle->port, "POST", "/api/config/test", test_body);
@@ -2614,10 +2611,11 @@ TEST_CASE("config_web: tts config test invokes playback of test passed") {
     CHECK(test_resp.body.find("\"ok\":true") != std::string::npos);
     CHECK(test_resp.body.find("tts_playback") != std::string::npos);
     CHECK(test_resp.body.find("test passed") != std::string::npos);
-    REQUIRE(wait_for_file_contains(log_path, "test passed", 1000));
+    REQUIRE(wait_for_file_contains(log_path, "stdin:", 1000));
     const std::string log = read_file(log_path);
     CHECK(log.find("config-test") != std::string::npos);
     CHECK(log.find("--section=tts") != std::string::npos);
+    CHECK(log.find("stdin:\n" + test_body) != std::string::npos);
 }
 
 TEST_CASE("config_web: fish audio TTS test accepts empty reference id and agent logs") {
@@ -2644,37 +2642,12 @@ TEST_CASE("config_web: fish audio TTS test accepts empty reference id and agent 
     HttpResponse test_resp = http_request(handle->port, "POST", "/api/config/test", test_body);
     CHECK(test_resp.status == 200);
     CHECK(test_resp.body.find("\"ok\":true") != std::string::npos);
-    CHECK(test_resp.body.find("\"check\":\"endpoint_reachable\"") != std::string::npos);
-    CHECK(test_resp.body.find("verified by the TTS playback test") != std::string::npos);
+    CHECK(test_resp.body.find("\"check\":\"tts_playback\"") != std::string::npos);
     REQUIRE(wait_for_file_contains(log_path, "\"reference_id\":\"\"", 1000));
     const std::string log = read_file(log_path);
     CHECK(log.find("\"provider\":\"fish-audio\"") != std::string::npos);
     CHECK(log.find("\"model\":\"s2-pro\"") != std::string::npos);
     CHECK(log.find("\"reference_id\":\"\"") != std::string::npos);
-}
-
-TEST_CASE("config_web: tencent stt config test stays green without app_id") {
-    StubEnv env;
-    auto handle = start_server(env);
-    HeadProbeServer probe;
-
-    const std::string endpoint = "http://127.0.0.1:" + std::to_string(probe.port());
-    const std::string test_body =
-        "{\"section\":\"stt\",\"values\":{"
-        "\"provider\":\"tencent-asr\","
-        "\"base_url\":\"" + endpoint + "\","
-        "\"app_id\":\"\","
-        "\"secret_id\":\"id\","
-        "\"secret_key\":\"key\","
-        "\"region\":\"ap-shanghai\","
-        "\"engine_model_type\":\"16k_zh\""
-        "}}";
-
-    HttpResponse test_resp = http_request(handle->port, "POST", "/api/config/test", test_body);
-    CHECK(test_resp.status == 200);
-    CHECK(test_resp.body.find("\"ok\":true") != std::string::npos);
-    CHECK(test_resp.body.find("\"check\":\"streaming_app_id\"") != std::string::npos);
-    CHECK(test_resp.body.find("one-shot upload") != std::string::npos);
 }
 
 TEST_CASE("config_web: GET /api/models forwards the query string to the agent") {
@@ -2738,7 +2711,7 @@ TEST_CASE("config_web: stt live test proxies start and stop to agent") {
     CHECK(requests[1].path == "/api/config-test/stt/stop");
 }
 
-TEST_CASE("config_web: stt live test resolves provider api_key from system env") {
+TEST_CASE("config_web: stt live test leaves provider resolution to the running agent") {
     const std::string tmp = make_temp_dir();
     auto cleanup = std::unique_ptr<void, void(*)(void*)>(
         const_cast<char*>(tmp.c_str()),
@@ -2788,17 +2761,17 @@ TEST_CASE("config_web: stt live test resolves provider api_key from system env")
     REQUIRE(forwarded != nullptr);
     cJSON* stt_values = cJSON_GetObjectItem(forwarded, "stt_values");
     REQUIRE(stt_values != nullptr);
-    CHECK(required_json_string(stt_values, "provider") == "openai-whisper");
-    CHECK(required_json_string(stt_values, "api_key") == "stt-live-system-env-secret");
-    CHECK(required_json_string(stt_values, "model") == "whisper-live-1");
-    CHECK(required_json_string(stt_values, "base_url") == "https://stt.example.test/v1");
+    CHECK(required_json_string(stt_values, "provider") == "env-whisper");
     CHECK(required_json_string(stt_values, "language") == "zh");
+    CHECK(cJSON_GetObjectItem(stt_values, "api_key") == nullptr);
+    CHECK(cJSON_GetObjectItem(stt_values, "model") == nullptr);
+    CHECK(cJSON_GetObjectItem(stt_values, "base_url") == nullptr);
 
     cJSON* audio_values = cJSON_GetObjectItem(forwarded, "audio_values");
     REQUIRE(audio_values != nullptr);
     CHECK(required_json_string(audio_values, "socket") == "/tmp/live-audio.sock");
     CHECK(required_json_int(audio_values, "sample_rate") == 16000);
-    CHECK(requests[0].body.find("$AIDEN_STT_LIVE_TEST_API_KEY") == std::string::npos);
+    CHECK(requests[0].body.find("stt-live-system-env-secret") == std::string::npos);
     CHECK(requests[0].body.find("stale-process-env-key") == std::string::npos);
     cJSON_Delete(forwarded);
 }
@@ -2837,7 +2810,7 @@ TEST_CASE("config_web: stt live test rejects malformed provider fields before fl
     CHECK(agent_server.requests().empty());
 }
 
-TEST_CASE("config_web: stt live test reports provider config load failures") {
+TEST_CASE("config_web: stt live test does not load provider config in config web") {
     StubAgentHTTPServer agent_server;
     StubEnv env;
     env.set("AIDEN_AGENT_HTTP_BASE_URL", "http://127.0.0.1:" + std::to_string(agent_server.port()));
@@ -2851,9 +2824,11 @@ TEST_CASE("config_web: stt live test reports provider config load failures") {
     HttpResponse start_resp =
         http_request(handle->port, "POST", "/api/config/test/stt/start", start_body);
 
-    CHECK(start_resp.status == 503);
-    CHECK(start_resp.body.find("provider config unavailable") != std::string::npos);
-    CHECK(agent_server.requests().empty());
+    CHECK(start_resp.status == 200);
+    const std::vector<CapturedHTTPRequest> requests = agent_server.requests();
+    REQUIRE(requests.size() == 1);
+    CHECK(requests[0].path == "/api/config-test/stt/start");
+    CHECK(requests[0].body.find("\"provider\":\"env-whisper\"") != std::string::npos);
 }
 
 TEST_CASE("config_web: stt live test keeps bare providers independent of config loading") {
@@ -3844,13 +3819,57 @@ TEST_CASE("config_web: POST /api/config rejects a non-object voice provider entr
     CHECK(resp.body.find("tts_providers.fish") != std::string::npos);
 }
 
-// The Test button posts the form values, and after the credentials moved onto
-// records that form carries only the reference plus the globals. config_web's own
-// pre-checks read values.provider and values.api_key directly, so without
-// flattening the reference first they see an unknown provider and an empty key --
-// reporting "provider unknown" and "skipped because api_key is empty" for a
-// record that is configured correctly.
-TEST_CASE("config_web: config test flattens a model provider reference") {
+TEST_CASE("config_web: provider config tests are delegated unchanged to agent") {
+    struct Case {
+        const char* section;
+        const char* values;
+    };
+    const Case cases[] = {
+        {"model", "{\"provider\":\"kimi\",\"model\":\"kimi-k3\"}"},
+        {"tts", "{\"provider\":\"fish-audio\",\"api_key\":\"test-key\",\"reference_id\":\"ref\",\"speed\":1}"},
+        {"stt", "{\"provider\":\"qwen-asr\",\"api_key\":\"test-key\",\"language\":\"zh\"}"},
+    };
+
+    for (const Case& c : cases) {
+        const std::string tmp = make_temp_dir();
+        auto cleanup = std::unique_ptr<void, void(*)(void*)>(
+            const_cast<char*>(tmp.c_str()),
+            [](void* p) { std::string cmd = std::string("rm -rf '") + (char*)p + "'"; (void)std::system(cmd.c_str()); }
+        );
+        const std::string log_path = tmp + "/config-test.log";
+        const std::string result_path = tmp + "/config-test-result.json";
+        write_file(result_path,
+                   "{\"ok\":true,\"results\":[{\"check\":\"provider_runtime\","
+                   "\"passed\":true,\"detail\":\"tested by agent\"}]}\n");
+
+        StubEnv env;
+        env.set("AIDEN_AGENT_STUB_CONFIG_TEST_LOG", log_path);
+        env.set("AIDEN_AGENT_STUB_CONFIG_TEST_FILE", result_path);
+        auto handle = start_server(env);
+        write_file(handle->tmp_dir + "/system_env", "HTTPS_PROXY=http://127.0.0.1:9\n");
+
+        const std::string body =
+            std::string("{\"section\":\"") + c.section + "\",\"values\":" + c.values + "}";
+        HttpResponse resp = http_request(handle->port, "POST", "/api/config/test", body);
+        REQUIRE_MESSAGE(resp.status == 200, std::string(c.section));
+
+        cJSON* parsed = cJSON_Parse(resp.body.c_str());
+        REQUIRE(parsed != nullptr);
+        cJSON* results = cJSON_GetObjectItem(parsed, "results");
+        REQUIRE(results != nullptr);
+        CHECK_MESSAGE(cJSON_GetArraySize(results) == 1, std::string(c.section));
+        CHECK_MESSAGE(required_test_result(parsed, "provider_runtime") != nullptr, std::string(c.section));
+        cJSON_Delete(parsed);
+
+        REQUIRE_MESSAGE(wait_for_file_contains(log_path, "stdin:", 1000), std::string(c.section));
+        const std::string log = read_file(log_path);
+        CHECK_MESSAGE(log.find(std::string("--section=") + c.section) != std::string::npos,
+                      std::string(c.section));
+        CHECK_MESSAGE(log.find("stdin:\n" + body) != std::string::npos, std::string(c.section));
+    }
+}
+
+TEST_CASE("config_web: model config test leaves provider references for agent") {
     StubEnv env;
     const std::string tmp = make_temp_dir();
     auto cleanup = std::unique_ptr<void, void(*)(void*)>(
@@ -3866,24 +3885,18 @@ TEST_CASE("config_web: config test flattens a model provider reference") {
                "\"hid\":{\"pointer_mode\":\"absolute\"},"
                "\"search\":{\"provider\":\"duckduckgo\"},\"agent\":{}}");
     env.set("AIDEN_AGENT_STUB_CONFIG_FILE", tmp + "/config.json");
+    env.set("AIDEN_AGENT_STUB_CONFIG_TEST_LOG", tmp + "/config-test.log");
     auto handle = start_server(env);
 
     const std::string test_body =
         "{\"section\":\"model\",\"values\":{\"provider\":\"work-openai\",\"model\":\"gpt-4o\"}}";
     HttpResponse test_resp = http_request(handle->port, "POST", "/api/config/test", test_body);
     CHECK(test_resp.status == 200);
-
-    cJSON* parsed = cJSON_Parse(test_resp.body.c_str());
-    REQUIRE(parsed != nullptr);
-    cJSON* endpoint = required_test_result(parsed, "endpoint_reachable");
-    REQUIRE(endpoint != nullptr);
-    CHECK(required_json_string(endpoint, "detail").find("http://127.0.0.1:9") != std::string::npos);
-    cJSON* api_key = required_test_result(parsed, "api_key_present");
-    REQUIRE(api_key != nullptr);
-    cJSON* passed = cJSON_GetObjectItem(api_key, "passed");
-    REQUIRE(passed != nullptr);
-    CHECK((passed->type & 0xff) == cJSON_True);
-    cJSON_Delete(parsed);
+    REQUIRE(wait_for_file_contains(tmp + "/config-test.log", "stdin:", 1000));
+    const std::string log = read_file(tmp + "/config-test.log");
+    CHECK(log.find("stdin:\n" + test_body) != std::string::npos);
+    CHECK(log.find("sk-model-secret-1234") == std::string::npos);
+    CHECK(log.find("http://127.0.0.1:9") == std::string::npos);
 }
 
 TEST_CASE("config_web: model config test resolves provider api_key from system env") {
@@ -3892,8 +3905,8 @@ TEST_CASE("config_web: model config test resolves provider api_key from system e
         const_cast<char*>(tmp.c_str()),
         [](void* p) { std::string cmd = std::string("rm -rf '") + (char*)p + "'"; (void)std::system(cmd.c_str()); }
     );
-    HeadProbeServer probe;
-    const std::string base_url = "http://127.0.0.1:" + std::to_string(probe.port());
+    const std::string log_path = tmp + "/config-test.log";
+    const std::string base_url = "https://model.example.com/v1";
     write_file(tmp + "/config.json",
                "{\"model_providers\":{\"env-openai\":{\"type\":\"openai\","
                "\"has_api_key\":true,\"base_url\":\"" + base_url + "\"}},"
@@ -3905,6 +3918,8 @@ TEST_CASE("config_web: model config test resolves provider api_key from system e
 
     StubEnv env;
     env.set("AIDEN_AGENT_STUB_CONFIG_FILE", tmp + "/config.json");
+    env.set("AIDEN_AGENT_STUB_CONFIG_TEST_LOG", log_path);
+    env.set("AIDEN_AGENT_STUB_CONFIG_TEST_ENV_KEY", "AIDEN_CONFIG_TEST_MODEL_API_KEY");
     env.set("AIDEN_CONFIG_TEST_MODEL_API_KEY", "process-env-key-must-not-win");
     auto handle = start_server(env);
     write_file(handle->tmp_dir + "/agent.toml",
@@ -3922,24 +3937,10 @@ TEST_CASE("config_web: model config test resolves provider api_key from system e
         "{\"section\":\"model\",\"values\":{\"provider\":\"env-openai\",\"model\":\"gpt-4o\"}}";
     HttpResponse test_resp = http_request(handle->port, "POST", "/api/config/test", test_body);
     REQUIRE(test_resp.status == 200);
-
-    const std::vector<std::string> requests = probe.requests();
-    bool saw_chat_request = false;
-    bool saw_resolved_header = false;
-    bool saw_literal_reference = false;
-    for (size_t i = 0; i < requests.size(); ++i) {
-        if (requests[i].find("POST /chat/completions ") == std::string::npos) {
-            continue;
-        }
-        saw_chat_request = true;
-        saw_resolved_header =
-            requests[i].find("Authorization: Bearer model-system-env-secret\r\n") != std::string::npos;
-        saw_literal_reference =
-            requests[i].find("Authorization: Bearer $AIDEN_CONFIG_TEST_MODEL_API_KEY\r\n") != std::string::npos;
-    }
-    REQUIRE(saw_chat_request);
-    CHECK(saw_resolved_header);
-    CHECK_FALSE(saw_literal_reference);
+    REQUIRE(wait_for_file_contains(log_path, "env:AIDEN_CONFIG_TEST_MODEL_API_KEY=", 1000));
+    const std::string log = read_file(log_path);
+    CHECK(log.find("env:AIDEN_CONFIG_TEST_MODEL_API_KEY=model-system-env-secret") != std::string::npos);
+    CHECK(log.find("stdin:\n" + test_body) != std::string::npos);
 }
 
 TEST_CASE("config_web: config test fails closed when system env is invalid or oversized") {
@@ -3986,7 +3987,7 @@ TEST_CASE("config_web: config test fails closed when system env is invalid or ov
     CHECK(probe.requests().empty());
 }
 
-TEST_CASE("config_web: config test flattens a tts provider reference") {
+TEST_CASE("config_web: tts config test leaves provider references for agent") {
     StubEnv env;
     const std::string tmp = make_temp_dir();
     write_file(tmp + "/config.json",
@@ -3999,6 +4000,7 @@ TEST_CASE("config_web: config test flattens a tts provider reference") {
                "\"hid\":{\"pointer_mode\":\"absolute\"},"
                "\"search\":{\"provider\":\"duckduckgo\"},\"agent\":{}}");
     env.set("AIDEN_AGENT_STUB_CONFIG_FILE", tmp + "/config.json");
+    env.set("AIDEN_AGENT_STUB_CONFIG_TEST_LOG", tmp + "/config-test.log");
     auto handle = start_server(env);
 
     // What the slimmed form posts: the reference and the global speed only.
@@ -4006,15 +4008,14 @@ TEST_CASE("config_web: config test flattens a tts provider reference") {
         "{\"section\":\"tts\",\"values\":{\"provider\":\"fish\",\"speed\":1}}";
     HttpResponse test_resp = http_request(handle->port, "POST", "/api/config/test", test_body);
     CHECK(test_resp.status == 200);
-
-    // The key lives on the record, so it must not be reported as missing.
-    CHECK(test_resp.body.find("skipped because api_key is empty") == std::string::npos);
-    // And the endpoint check must resolve the provider type rather than treating
-    // the record name as an unknown provider.
-    CHECK(test_resp.body.find("provider unknown and base_url empty") == std::string::npos);
+    REQUIRE(wait_for_file_contains(tmp + "/config-test.log", "stdin:", 1000));
+    const std::string log = read_file(tmp + "/config-test.log");
+    CHECK(log.find("stdin:\n" + test_body) != std::string::npos);
+    CHECK(log.find("sk-fish-secret-1234") == std::string::npos);
+    CHECK(log.find("ref-abc") == std::string::npos);
 }
 
-TEST_CASE("config_web: tts config test resolves provider api_key from process env fallback") {
+TEST_CASE("config_web: tts config test exposes process env to agent") {
     const std::string tmp = make_temp_dir();
     auto cleanup = std::unique_ptr<void, void(*)(void*)>(
         const_cast<char*>(tmp.c_str()),
@@ -4034,6 +4035,7 @@ TEST_CASE("config_web: tts config test resolves provider api_key from process en
     StubEnv env;
     env.set("AIDEN_AGENT_STUB_CONFIG_FILE", tmp + "/config.json");
     env.set("AIDEN_AGENT_STUB_CONFIG_TEST_LOG", log_path);
+    env.set("AIDEN_AGENT_STUB_CONFIG_TEST_ENV_KEY", "AIDEN_CONFIG_TEST_TTS_API_KEY");
     env.set("AIDEN_CONFIG_TEST_TTS_API_KEY", "tts-process-env-secret");
     auto handle = start_server(env);
     write_file(handle->tmp_dir + "/agent.toml",
@@ -4049,11 +4051,12 @@ TEST_CASE("config_web: tts config test resolves provider api_key from process en
     REQUIRE(wait_for_file_contains(log_path, "stdin:", 1000));
 
     const std::string log = read_file(log_path);
-    CHECK(log.find("\"api_key\":\"tts-process-env-secret\"") != std::string::npos);
-    CHECK(log.find("\"api_key\":\"$AIDEN_CONFIG_TEST_TTS_API_KEY\"") == std::string::npos);
+    CHECK(log.find("env:AIDEN_CONFIG_TEST_TTS_API_KEY=tts-process-env-secret") != std::string::npos);
+    CHECK(log.find("stdin:\n" + test_body) != std::string::npos);
+    CHECK(log.find("\"api_key\"") == std::string::npos);
 }
 
-TEST_CASE("config_web: config test flattens an stt provider reference") {
+TEST_CASE("config_web: stt config test leaves provider references for agent") {
     StubEnv env;
     const std::string tmp = make_temp_dir();
     write_file(tmp + "/config.json",
@@ -4067,17 +4070,18 @@ TEST_CASE("config_web: config test flattens an stt provider reference") {
                "\"hid\":{\"pointer_mode\":\"absolute\"},"
                "\"search\":{\"provider\":\"duckduckgo\"},\"agent\":{}}");
     env.set("AIDEN_AGENT_STUB_CONFIG_FILE", tmp + "/config.json");
+    env.set("AIDEN_AGENT_STUB_CONFIG_TEST_LOG", tmp + "/config-test.log");
     auto handle = start_server(env);
 
     const std::string test_body =
         "{\"section\":\"stt\",\"values\":{\"provider\":\"tencent-main\",\"language\":\"zh\"}}";
     HttpResponse test_resp = http_request(handle->port, "POST", "/api/config/test", test_body);
     CHECK(test_resp.status == 200);
-
-    // The Tencent-specific credential checks only run once the reference has
-    // resolved to tencent-asr, so their presence proves the flattening happened.
-    CHECK(test_resp.body.find("\"check\":\"streaming_app_id\"") != std::string::npos);
-    CHECK(test_resp.body.find("provider unknown and base_url empty") == std::string::npos);
+    REQUIRE(wait_for_file_contains(tmp + "/config-test.log", "stdin:", 1000));
+    const std::string log = read_file(tmp + "/config-test.log");
+    CHECK(log.find("stdin:\n" + test_body) != std::string::npos);
+    CHECK(log.find("AKID-xxx") == std::string::npos);
+    CHECK(log.find("secret-yyy") == std::string::npos);
 }
 
 TEST_CASE("config_web: stt config test honors an empty provider api_key in system env") {
@@ -4086,8 +4090,8 @@ TEST_CASE("config_web: stt config test honors an empty provider api_key in syste
         const_cast<char*>(tmp.c_str()),
         [](void* p) { std::string cmd = std::string("rm -rf '") + (char*)p + "'"; (void)std::system(cmd.c_str()); }
     );
-    HeadProbeServer probe;
-    const std::string base_url = "http://127.0.0.1:" + std::to_string(probe.port());
+    const std::string log_path = tmp + "/config-test.log";
+    const std::string base_url = "https://stt.example.com/v1";
     write_file(tmp + "/config.json",
                "{\"stt_providers\":{\"env-whisper\":{\"type\":\"openai-whisper\","
                "\"has_api_key\":true,\"model\":\"whisper-1\","
@@ -4101,6 +4105,8 @@ TEST_CASE("config_web: stt config test honors an empty provider api_key in syste
 
     StubEnv env;
     env.set("AIDEN_AGENT_STUB_CONFIG_FILE", tmp + "/config.json");
+    env.set("AIDEN_AGENT_STUB_CONFIG_TEST_LOG", log_path);
+    env.set("AIDEN_AGENT_STUB_CONFIG_TEST_ENV_KEY", "AIDEN_CONFIG_TEST_MISSING_KEY");
     env.set("AIDEN_CONFIG_TEST_MISSING_KEY", "process-env-key-must-not-win");
     auto handle = start_server(env);
     write_file(handle->tmp_dir + "/agent.toml",
@@ -4118,16 +4124,10 @@ TEST_CASE("config_web: stt config test honors an empty provider api_key in syste
         "{\"section\":\"stt\",\"values\":{\"provider\":\"env-whisper\",\"language\":\"en\"}}";
     HttpResponse test_resp = http_request(handle->port, "POST", "/api/config/test", test_body);
     REQUIRE(test_resp.status == 200);
-
-    cJSON* parsed = cJSON_Parse(test_resp.body.c_str());
-    REQUIRE(parsed != nullptr);
-    cJSON* api_key = required_test_result(parsed, "api_key_present");
-    REQUIRE(api_key != nullptr);
-    cJSON* passed = cJSON_GetObjectItem(api_key, "passed");
-    REQUIRE(passed != nullptr);
-    CHECK((passed->type & 0xff) == cJSON_False);
-    CHECK(required_json_string(api_key, "detail") == "api_key is empty");
-    cJSON_Delete(parsed);
+    REQUIRE(wait_for_file_contains(log_path, "env:AIDEN_CONFIG_TEST_MISSING_KEY=", 1000));
+    const std::string log = read_file(log_path);
+    CHECK(log.find("env:AIDEN_CONFIG_TEST_MISSING_KEY=\n") != std::string::npos);
+    CHECK(log.find("stdin:\n" + test_body) != std::string::npos);
 }
 
 TEST_CASE("config_web: GET /api/config returns voice providers from the resolved config") {

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -405,7 +405,8 @@ struct CapturedHTTPRequest {
 
 class StubAgentHTTPServer {
 public:
-    StubAgentHTTPServer() {
+    explicit StubAgentHTTPServer(int stt_stop_status = 200)
+        : stt_stop_status_(stt_stop_status) {
         fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
         REQUIRE(fd_ >= 0);
         int opt = 1;
@@ -442,7 +443,7 @@ public:
     }
 
 private:
-    static std::string build_response(const std::string& path) {
+    std::string build_response(const std::string& path) const {
         // Echo the request target back so callers can assert the query string
         // survived the proxy hop: config_web strips the query off the path when
         // parsing the request line and must forward it from the saved copy.
@@ -484,12 +485,14 @@ private:
             return out.str();
         }
         if (path == "/api/config-test/stt/stop") {
-            const std::string body =
-                "{\"ok\":true,\"transcript\":\"agent live transcript\","
-                "\"results\":[{\"check\":\"stt_transcription\",\"passed\":true,"
-                "\"detail\":\"transcribed live recording with tencent-asr via streaming upload\"}]}";
+            const bool ok = stt_stop_status_ >= 200 && stt_stop_status_ < 300;
+            const std::string body = ok
+                ? "{\"ok\":true,\"transcript\":\"agent live transcript\","
+                  "\"results\":[{\"check\":\"stt_transcription\",\"passed\":true,"
+                  "\"detail\":\"transcribed live recording with tencent-asr via streaming upload\"}]}"
+                : "{\"ok\":false,\"error\":\"stop failed\"}";
             std::ostringstream out;
-            out << "HTTP/1.1 200 OK\r\n"
+            out << "HTTP/1.1 " << stt_stop_status_ << (ok ? " OK\r\n" : " Service Unavailable\r\n")
                 << "Content-Type: application/json\r\n"
                 << "Content-Length: " << body.size() << "\r\n"
                 << "Connection: close\r\n"
@@ -579,6 +582,7 @@ private:
 
     int fd_ = -1;
     int port_ = 0;
+    int stt_stop_status_ = 200;
     mutable std::mutex mu_;
     std::atomic<bool> stop_{false};
     std::vector<CapturedHTTPRequest> requests_;
@@ -2781,6 +2785,46 @@ TEST_CASE("config_web: stt live test defers agent restart until recording stops"
 
     REQUIRE(http_request(handle->port, "POST", "/api/config/test/stt/stop", "{}").status == 200);
     REQUIRE(wait_for_file_contains(restart_log, "restarted", 1000));
+}
+
+TEST_CASE("config_web: failed stt stop keeps the deferred agent restart pending") {
+    const std::string tmp = make_temp_dir();
+    auto cleanup = std::unique_ptr<void, void(*)(void*)>(
+        const_cast<char*>(tmp.c_str()),
+        [](void* p) { std::string cmd = std::string("rm -rf '") + (char*)p + "'"; (void)std::system(cmd.c_str()); }
+    );
+    const std::string restart_script = tmp + "/restart-agent.sh";
+    const std::string restart_log = tmp + "/restart.log";
+    write_file(restart_script,
+               "#!/bin/sh\n"
+               "echo restarted >> \"$AIDEN_AGENT_RESTART_TEST_LOG\"\n");
+    REQUIRE(::chmod(restart_script.c_str(), 0755) == 0);
+
+    StubAgentHTTPServer agent_server(503);
+    StubEnv env;
+    env.set("AIDEN_AGENT_HTTP_BASE_URL", "http://127.0.0.1:" + std::to_string(agent_server.port()));
+    env.set("AIDEN_AGENT_INIT_SCRIPT", restart_script);
+    env.set("AIDEN_AGENT_RESTART_TEST_LOG", restart_log);
+    auto handle = start_server(env);
+
+    const std::string start_body =
+        "{\"stt_values\":{\"provider\":\"openai-whisper\",\"api_key\":\"sk-live\",\"model\":\"whisper-1\"},"
+        "\"audio_values\":{\"socket\":\"/tmp/audio.sock\",\"sample_rate\":16000,\"channels\":1,\"bit_width\":16}}";
+    REQUIRE(http_request(handle->port, "POST", "/api/config/test/stt/start", start_body).status == 200);
+    REQUIRE(http_request(handle->port, "POST", "/api/system/env", "{\"system_env\":\"\"}").status == 200);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    REQUIRE(::access(restart_log.c_str(), F_OK) != 0);
+
+    HttpResponse stop_response =
+        http_request(handle->port, "POST", "/api/config/test/stt/stop", "{}");
+    CHECK(stop_response.status == 503);
+
+    // A failed stop means the live recording is still active. A later config
+    // change must therefore remain deferred rather than restarting the agent.
+    REQUIRE(http_request(handle->port, "POST", "/api/system/env",
+                         "{\"system_env\":\"HTTP_PROXY=http://proxy.example:8080\\n\"}").status == 200);
+    CHECK_FALSE(wait_for_file_contains(restart_log, "restarted", 1000));
 }
 
 TEST_CASE("config_web: stt live test leaves provider resolution to the running agent") {

--- a/tests/config_web_e2e_test.cpp
+++ b/tests/config_web_e2e_test.cpp
@@ -2711,6 +2711,78 @@ TEST_CASE("config_web: stt live test proxies start and stop to agent") {
     CHECK(requests[1].path == "/api/config-test/stt/stop");
 }
 
+TEST_CASE("config_web: stt live test waits for a scheduled agent restart") {
+    const std::string tmp = make_temp_dir();
+    auto cleanup = std::unique_ptr<void, void(*)(void*)>(
+        const_cast<char*>(tmp.c_str()),
+        [](void* p) { std::string cmd = std::string("rm -rf '") + (char*)p + "'"; (void)std::system(cmd.c_str()); }
+    );
+    const std::string restart_script = tmp + "/restart-agent.sh";
+    const std::string restart_log = tmp + "/restart.log";
+    write_file(restart_script,
+               "#!/bin/sh\n"
+               "echo started >> \"$AIDEN_AGENT_RESTART_TEST_LOG\"\n"
+               "sleep 0.35\n"
+               "echo ready >> \"$AIDEN_AGENT_RESTART_TEST_LOG\"\n");
+    REQUIRE(::chmod(restart_script.c_str(), 0755) == 0);
+
+    StubAgentHTTPServer agent_server;
+    StubEnv env;
+    env.set("AIDEN_AGENT_HTTP_BASE_URL", "http://127.0.0.1:" + std::to_string(agent_server.port()));
+    env.set("AIDEN_AGENT_INIT_SCRIPT", restart_script);
+    env.set("AIDEN_AGENT_RESTART_TEST_LOG", restart_log);
+    auto handle = start_server(env);
+
+    REQUIRE(http_request(handle->port, "POST", "/api/system/env", "{\"system_env\":\"\"}").status == 200);
+
+    const std::string start_body =
+        "{\"stt_values\":{\"provider\":\"openai-whisper\",\"api_key\":\"sk-live\",\"model\":\"whisper-1\"},"
+        "\"audio_values\":{\"socket\":\"/tmp/audio.sock\",\"sample_rate\":16000,\"channels\":1,\"bit_width\":16}}";
+    const auto started_at = std::chrono::steady_clock::now();
+    HttpResponse start_resp =
+        http_request(handle->port, "POST", "/api/config/test/stt/start", start_body);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - started_at);
+
+    REQUIRE(start_resp.status == 200);
+    CHECK(elapsed.count() >= 250);
+    REQUIRE(wait_for_file_contains(restart_log, "ready", 1000));
+    REQUIRE(agent_server.requests().size() == 1);
+}
+
+TEST_CASE("config_web: stt live test defers agent restart until recording stops") {
+    const std::string tmp = make_temp_dir();
+    auto cleanup = std::unique_ptr<void, void(*)(void*)>(
+        const_cast<char*>(tmp.c_str()),
+        [](void* p) { std::string cmd = std::string("rm -rf '") + (char*)p + "'"; (void)std::system(cmd.c_str()); }
+    );
+    const std::string restart_script = tmp + "/restart-agent.sh";
+    const std::string restart_log = tmp + "/restart.log";
+    write_file(restart_script,
+               "#!/bin/sh\n"
+               "echo restarted >> \"$AIDEN_AGENT_RESTART_TEST_LOG\"\n");
+    REQUIRE(::chmod(restart_script.c_str(), 0755) == 0);
+
+    StubAgentHTTPServer agent_server;
+    StubEnv env;
+    env.set("AIDEN_AGENT_HTTP_BASE_URL", "http://127.0.0.1:" + std::to_string(agent_server.port()));
+    env.set("AIDEN_AGENT_INIT_SCRIPT", restart_script);
+    env.set("AIDEN_AGENT_RESTART_TEST_LOG", restart_log);
+    auto handle = start_server(env);
+
+    const std::string start_body =
+        "{\"stt_values\":{\"provider\":\"openai-whisper\",\"api_key\":\"sk-live\",\"model\":\"whisper-1\"},"
+        "\"audio_values\":{\"socket\":\"/tmp/audio.sock\",\"sample_rate\":16000,\"channels\":1,\"bit_width\":16}}";
+    REQUIRE(http_request(handle->port, "POST", "/api/config/test/stt/start", start_body).status == 200);
+    REQUIRE(http_request(handle->port, "POST", "/api/system/env", "{\"system_env\":\"\"}").status == 200);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    CHECK(::access(restart_log.c_str(), F_OK) != 0);
+
+    REQUIRE(http_request(handle->port, "POST", "/api/config/test/stt/stop", "{}").status == 200);
+    REQUIRE(wait_for_file_contains(restart_log, "restarted", 1000));
+}
+
 TEST_CASE("config_web: stt live test leaves provider resolution to the running agent") {
     const std::string tmp = make_temp_dir();
     auto cleanup = std::unique_ptr<void, void(*)(void*)>(

--- a/tests/config_web_source_test.cpp
+++ b/tests/config_web_source_test.cpp
@@ -205,6 +205,25 @@ TEST_CASE("config web agent tests do not reference legacy energy threshold") {
     CHECK(source.find("\"vad_speech_threshold\"") != std::string::npos);
 }
 
+TEST_CASE("config web delegates provider tests to the agent runtime") {
+    const std::string path = std::string(AIDEN_SOURCE_DIR) + "/src/config_web.cpp";
+    std::ifstream in(path.c_str());
+    REQUIRE(in.good());
+
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    const std::string source = buffer.str();
+
+    CHECK(source.find("run_agent_provider_config_test") != std::string::npos);
+    CHECK(source.find("provider_default_url") == std::string::npos);
+    CHECK(source.find("is_known_config_test_provider_type") == std::string::npos);
+    CHECK(source.find("is_streaming_tts_provider") == std::string::npos);
+    CHECK(source.find("flatten_provider_reference") == std::string::npos);
+    CHECK(source.find("resolve_config_test_api_key") == std::string::npos);
+    CHECK(source.find("no URL to test (provider unknown and base_url empty)") == std::string::npos);
+    CHECK(source.find("api_key_valid") == std::string::npos);
+}
+
 TEST_CASE("config web exposes agent runtime status") {
     const std::string source_path = std::string(AIDEN_SOURCE_DIR) + "/src/config_web.cpp";
     std::ifstream source_in(source_path.c_str());


### PR DESCRIPTION
## Summary

- delegate model, TTS, and STT provider tests from config_web to the Go agent runtime
- use the runtime provider registries, endpoint defaults, credentials, and proxy behavior for tests
- remove duplicated C++ provider URL tables, provider-specific checks, credential expansion, and legacy local STT test code
- load the latest system environment before invoking agent config-test
- keep live STT provider resolution in the running Go agent

## Tests

- go test ./...
- C++ host suite: 327 test cases and 8771 assertions passed
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model provider configuration testing.
  * Improved speech-to-text provider checks, including validation without audio input.
  * Centralized provider testing through the agent while preserving credentials, endpoints, models, and environment-based settings.
  * Added reliable live speech-to-text testing with agent readiness handling.

* **Bug Fixes**
  * Improved validation and error handling for unsupported sections, missing providers, invalid responses, and timeouts.
  * Added support for runtime provider defaults and environment-variable credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->