### PR TITLE
fix(agent): refresh user files report on demand

### DIFF
--- a/scripts/agent_files_template.html
+++ b/scripts/agent_files_template.html
@@ -27,7 +27,10 @@ body { min-height: 100vh; background: linear-gradient(to bottom, var(--surface),
 .mark::before,.mark::after { content: ""; position: absolute; left: 6px; right: 6px; height: 2px; border-radius: 999px; background: white }
 .mark::before { top: 7px } .mark::after { bottom: 7px }
 .brand strong { font-size: 14px; letter-spacing: -0.01em }
+.topbar-actions { display: flex; align-items: center; gap: 10px }
 .meta-info { color: var(--muted); font-size: 12px }
+.refresh-btn { display: inline-flex; align-items: center; height: 32px; padding: 0 12px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--fg); text-decoration: none; font-size: 12px; font-weight: 650 }
+.refresh-btn:hover { background: color-mix(in oklch, var(--accent) 5%, white); border-color: color-mix(in oklch, var(--accent) 24%, var(--border)) }
 .summary { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 20px }
 .summary-card { border: 1px solid var(--border); border-radius: 14px; background: var(--surface); padding: 14px }
 .summary-card .label { color: var(--muted); font-size: 11px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase }
@@ -131,7 +134,10 @@ pre.block-body { margin: 0; white-space: pre-wrap; word-break: break-word; font-
 <main class="page">
 <header class="topbar">
   <div class="brand"><div class="mark"></div><strong>Agent Files Browser</strong></div>
-  <div class="meta-info">{{TIMESTAMP}}</div>
+  <div class="topbar-actions">
+    <div class="meta-info">Generated {{TIMESTAMP}}</div>
+    <a id="user-files-refresh" class="refresh-btn" href="/user_files?refresh=1">Refresh data</a>
+  </div>
 </header>
 <section class="summary">
   <article class="summary-card"><div class="label">Memory Files</div><div class="value">{{MEMORY_COUNT}}</div></article>

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -57,8 +57,7 @@ type Server struct {
 	userFilesSkillsDir      string
 	userFilesSkillStateDir  string
 	userFilesGenerateMu     sync.Mutex
-	userFilesLastGenAt      time.Time
-	userFilesLastGenErr     error
+	userFilesGeneration     *userFilesReportGeneration
 	mu                      sync.Mutex
 	history                 []Message
 	historyStore            *ChatHistoryStore

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -56,6 +56,9 @@ type Server struct {
 	userFilesMemoryDir      string
 	userFilesSkillsDir      string
 	userFilesSkillStateDir  string
+	userFilesGenerateMu     sync.Mutex
+	userFilesLastGenAt      time.Time
+	userFilesLastGenErr     error
 	mu                      sync.Mutex
 	history                 []Message
 	historyStore            *ChatHistoryStore

--- a/src/agent/internal/agent/user_files.go
+++ b/src/agent/internal/agent/user_files.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"fmt"
 	"mime"
 	"net/http"
@@ -11,7 +12,14 @@ import (
 	"time"
 )
 
-const userFilesGenerateTimeout = 30 * time.Second
+const (
+	userFilesGenerateTimeout       = 30 * time.Second
+	userFilesRefreshCoalesceWindow = 2 * time.Second
+)
+
+const userFilesRefreshHref = "/user_files?refresh=1"
+
+const userFilesRefreshControlMarker = `id="user-files-refresh"`
 
 // runUserFilesScript runs view_agent_files.sh under a fixed timeout, killing
 // the process if it exceeds the deadline. Output is collected for diagnostics.
@@ -42,22 +50,43 @@ func (s *Server) runUserFilesScript(stdoutSink string) error {
 	return nil
 }
 
-func (s *Server) ensureUserFilesReport() error {
-	if _, err := os.Stat(s.userFilesReportPath); err == nil {
+func (s *Server) ensureUserFilesReport(forceRefresh bool, stdoutSink string) error {
+	if _, err := os.Stat(s.userFilesReportPath); err == nil && !forceRefresh {
 		return nil
 	}
-	if err := s.runUserFilesScript(""); err != nil {
-		return err
+
+	s.userFilesGenerateMu.Lock()
+	defer s.userFilesGenerateMu.Unlock()
+
+	_, reportErr := os.Stat(s.userFilesReportPath)
+	if reportErr == nil && !forceRefresh {
+		return nil
 	}
-	if _, err := os.Stat(s.userFilesReportPath); err != nil {
-		return fmt.Errorf("script ran but report not produced")
+	if time.Since(s.userFilesLastGenAt) <= userFilesRefreshCoalesceWindow &&
+		(forceRefresh || s.userFilesLastGenErr != nil) {
+		return s.userFilesLastGenErr
 	}
-	return nil
+
+	err := s.runUserFilesScript(stdoutSink)
+	if err == nil {
+		if _, statErr := os.Stat(s.userFilesReportPath); statErr != nil {
+			err = fmt.Errorf("script ran but report not produced")
+		}
+	}
+	s.userFilesLastGenAt = time.Now()
+	s.userFilesLastGenErr = err
+	return err
 }
 
 func (s *Server) handleUserFiles(w http.ResponseWriter, r *http.Request) {
-	if err := s.ensureUserFilesReport(); err != nil {
+	w.Header().Set("Cache-Control", "no-store")
+	forceRefresh := r.URL.Query().Get("refresh") == "1"
+	if err := s.ensureUserFilesReport(forceRefresh, ""); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if forceRefresh {
+		http.Redirect(w, r, "/user_files", http.StatusSeeOther)
 		return
 	}
 	data, err := os.ReadFile(s.userFilesReportPath)
@@ -65,8 +94,24 @@ func (s *Server) handleUserFiles(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	data = userFilesReportWithRefreshControl(data)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write(data)
+}
+
+func userFilesReportWithRefreshControl(data []byte) []byte {
+	if bytes.Contains(data, []byte(userFilesRefreshControlMarker)) {
+		return data
+	}
+	control := []byte(fmt.Sprintf(`<a id="user-files-refresh" href="%s" style="position:fixed;top:16px;right:16px;z-index:100;padding:8px 12px;border:1px solid #ddd;border-radius:8px;background:#fff;color:#222;text-decoration:none;font:600 12px system-ui,sans-serif">Refresh data</a>`, userFilesRefreshHref))
+	if index := bytes.LastIndex(data, []byte("</body>")); index >= 0 {
+		result := make([]byte, 0, len(data)+len(control))
+		result = append(result, data[:index]...)
+		result = append(result, control...)
+		result = append(result, data[index:]...)
+		return result
+	}
+	return append(append([]byte(nil), data...), control...)
 }
 
 func (s *Server) handleUserFilesPreview(w http.ResponseWriter, r *http.Request) {
@@ -114,7 +159,7 @@ func (s *Server) handleUserFilesRegenerate(w http.ResponseWriter, r *http.Reques
 	go func() {
 		// Reuse the same timeout budget so a hung script cannot pile up
 		// long-lived background generators on repeated calls.
-		_ = s.runUserFilesScript("/tmp/user_files_regenerate.log")
+		_ = s.ensureUserFilesReport(true, "/tmp/user_files_regenerate.log")
 	}()
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(`{"ok":true,"regenerating":true}`))

--- a/src/agent/internal/agent/user_files.go
+++ b/src/agent/internal/agent/user_files.go
@@ -12,21 +12,35 @@ import (
 	"time"
 )
 
-const (
-	userFilesGenerateTimeout       = 30 * time.Second
-	userFilesRefreshCoalesceWindow = 2 * time.Second
-)
+const userFilesGenerateTimeout = 30 * time.Second
 
 const userFilesRefreshHref = "/user_files?refresh=1"
 
 const userFilesRefreshControlMarker = `id="user-files-refresh"`
+
+type userFilesReportGeneration struct {
+	done chan struct{}
+	err  error
+}
 
 // runUserFilesScript runs view_agent_files.sh under a fixed timeout, killing
 // the process if it exceeds the deadline. Output is collected for diagnostics.
 // Used by both ensureUserFilesReport (synchronous) and handleUserFilesRegenerate
 // (async) so a hung script can never leak a long-lived child.
 func (s *Server) runUserFilesScript(stdoutSink string) error {
-	script := "cd " + shellQuote(s.userFilesToolsDir) + " && ./view_agent_files.sh"
+	reportDir := filepath.Dir(s.userFilesReportPath)
+	tempReport, err := os.CreateTemp(reportDir, ".files_report-*.html")
+	if err != nil {
+		return fmt.Errorf("create temporary user_files report: %w", err)
+	}
+	tempReportPath := tempReport.Name()
+	if err := tempReport.Close(); err != nil {
+		os.Remove(tempReportPath)
+		return fmt.Errorf("close temporary user_files report: %w", err)
+	}
+	defer os.Remove(tempReportPath)
+
+	script := "cd " + shellQuote(s.userFilesToolsDir) + " && ./view_agent_files.sh " + shellQuote(tempReportPath)
 	if stdoutSink != "" {
 		script += " > " + shellQuote(stdoutSink) + " 2>&1"
 	} else {
@@ -41,11 +55,26 @@ func (s *Server) runUserFilesScript(stdoutSink string) error {
 	defer timer.Stop()
 	if stdoutSink != "" {
 		// Caller redirected stdout to a file; we only need exit status.
-		return cmd.Run()
+		err = cmd.Run()
+	} else {
+		var out []byte
+		out, err = cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("user_files generation failed: %s", string(out))
+		}
 	}
-	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("user_files generation failed: %s", string(out))
+		return err
+	}
+	info, err := os.Stat(tempReportPath)
+	if err != nil || info.Size() == 0 {
+		return fmt.Errorf("script ran but report not produced")
+	}
+	if err := os.Chmod(tempReportPath, 0o644); err != nil {
+		return fmt.Errorf("set user_files report permissions: %w", err)
+	}
+	if err := os.Rename(tempReportPath, s.userFilesReportPath); err != nil {
+		return fmt.Errorf("publish user_files report: %w", err)
 	}
 	return nil
 }
@@ -56,16 +85,20 @@ func (s *Server) ensureUserFilesReport(forceRefresh bool, stdoutSink string) err
 	}
 
 	s.userFilesGenerateMu.Lock()
-	defer s.userFilesGenerateMu.Unlock()
+	if generation := s.userFilesGeneration; generation != nil {
+		s.userFilesGenerateMu.Unlock()
+		<-generation.done
+		return generation.err
+	}
 
 	_, reportErr := os.Stat(s.userFilesReportPath)
 	if reportErr == nil && !forceRefresh {
+		s.userFilesGenerateMu.Unlock()
 		return nil
 	}
-	if time.Since(s.userFilesLastGenAt) <= userFilesRefreshCoalesceWindow &&
-		(forceRefresh || s.userFilesLastGenErr != nil) {
-		return s.userFilesLastGenErr
-	}
+	generation := &userFilesReportGeneration{done: make(chan struct{})}
+	s.userFilesGeneration = generation
+	s.userFilesGenerateMu.Unlock()
 
 	err := s.runUserFilesScript(stdoutSink)
 	if err == nil {
@@ -73,8 +106,12 @@ func (s *Server) ensureUserFilesReport(forceRefresh bool, stdoutSink string) err
 			err = fmt.Errorf("script ran but report not produced")
 		}
 	}
-	s.userFilesLastGenAt = time.Now()
-	s.userFilesLastGenErr = err
+
+	s.userFilesGenerateMu.Lock()
+	generation.err = err
+	s.userFilesGeneration = nil
+	close(generation.done)
+	s.userFilesGenerateMu.Unlock()
 	return err
 }
 

--- a/src/agent/internal/agent/user_files_test.go
+++ b/src/agent/internal/agent/user_files_test.go
@@ -31,7 +31,7 @@ func TestHandleUserFiles_GeneratesIfMissing(t *testing.T) {
 	tools := t.TempDir()
 	rpt := filepath.Join(t.TempDir(), "report.html")
 	script := filepath.Join(tools, "view_agent_files.sh")
-	body := "#!/bin/sh\necho '<html>generated</html>' > " + rpt + "\n"
+	body := "#!/bin/sh\necho '<html>generated</html>' > \"$1\"\n"
 	os.WriteFile(script, []byte(body), 0o755)
 	s := &Server{userFilesReportPath: rpt, userFilesToolsDir: tools}
 	req := httptest.NewRequest(http.MethodGet, "/user_files", nil)
@@ -50,7 +50,7 @@ func TestHandleUserFiles_RefreshQueryRegeneratesReport(t *testing.T) {
 	}
 
 	script := filepath.Join(tools, "view_agent_files.sh")
-	body := "#!/bin/sh\necho '<html>fresh</html>' > " + rpt + "\n"
+	body := "#!/bin/sh\necho '<html>fresh</html>' > \"$1\"\n"
 	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestHandleUserFiles_ConcurrentRefreshCoalescesGeneration(t *testing.T) {
 	}
 
 	script := filepath.Join(tools, "view_agent_files.sh")
-	body := "#!/bin/sh\necho run >> " + marker + "\nsleep 0.2\necho '<html>fresh</html>' > " + rpt + "\n"
+	body := "#!/bin/sh\necho run >> " + marker + "\nsleep 0.2\necho '<html>fresh</html>' > \"$1\"\n"
 	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -117,6 +117,100 @@ func TestHandleUserFiles_ConcurrentRefreshCoalescesGeneration(t *testing.T) {
 	}
 	if got := strings.Count(string(runs), "run\n"); got != 1 {
 		t.Fatalf("generation runs = %d, want 1", got)
+	}
+}
+
+func TestHandleUserFiles_SequentialRefreshRunsAgain(t *testing.T) {
+	tools := t.TempDir()
+	rpt := filepath.Join(t.TempDir(), "report.html")
+	marker := filepath.Join(t.TempDir(), "runs")
+	if err := os.WriteFile(rpt, []byte("<html>stale</html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := filepath.Join(tools, "view_agent_files.sh")
+	body := "#!/bin/sh\necho run >> " + marker + "\necho '<html>fresh</html>' > \"$1\"\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{userFilesReportPath: rpt, userFilesToolsDir: tools}
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/user_files?refresh=1", nil)
+		rec := httptest.NewRecorder()
+		s.handleUserFiles(rec, req)
+		if rec.Code != http.StatusSeeOther {
+			t.Fatalf("refresh %d: code=%d body=%q", i+1, rec.Code, rec.Body.String())
+		}
+	}
+
+	runs, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(runs), "run\n"); got != 2 {
+		t.Fatalf("generation runs = %d, want 2", got)
+	}
+}
+
+func TestHandleUserFiles_ServesCompleteReportDuringRefresh(t *testing.T) {
+	tools := t.TempDir()
+	rpt := filepath.Join(t.TempDir(), "report.html")
+	marker := filepath.Join(t.TempDir(), "writing")
+	release := filepath.Join(t.TempDir(), "release")
+	if err := os.WriteFile(rpt, []byte("<html>stale</html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := filepath.Join(tools, "view_agent_files.sh")
+	body := "#!/bin/sh\nprintf '<html>partial' > \"$1\"\ntouch \"" + marker + "\"\nwhile [ ! -e \"" + release + "\" ]; do sleep 0.01; done\nprintf '<html>fresh</html>' > \"$1\"\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{userFilesReportPath: rpt, userFilesToolsDir: tools}
+	refreshCode := make(chan int, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodGet, "/user_files?refresh=1", nil)
+		rec := httptest.NewRecorder()
+		s.handleUserFiles(rec, req)
+		refreshCode <- rec.Code
+	}()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(marker); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("generator did not begin writing temporary report")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/user_files", nil)
+	rec := httptest.NewRecorder()
+	s.handleUserFiles(rec, req)
+	if err := os.WriteFile(release, []byte("continue"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "stale") || strings.Contains(rec.Body.String(), "partial") {
+		t.Fatalf("code=%d body=%q", rec.Code, rec.Body.String())
+	}
+	select {
+	case code := <-refreshCode:
+		if code != http.StatusSeeOther {
+			t.Fatalf("refresh code=%d, want %d", code, http.StatusSeeOther)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("refresh did not finish after generator release")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/user_files", nil)
+	rec = httptest.NewRecorder()
+	s.handleUserFiles(rec, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "fresh") {
+		t.Fatalf("code=%d body=%q", rec.Code, rec.Body.String())
 	}
 }
 
@@ -169,7 +263,7 @@ func TestHandleUserFilesRegenerate_RunsAsync(t *testing.T) {
 	script := filepath.Join(tools, "view_agent_files.sh")
 	// 200ms sleep is long enough that a synchronous handler would not yet
 	// have created the marker by the time we check immediately afterwards.
-	body := "#!/bin/sh\nsleep 0.2\ntouch " + marker + "\necho '<html>regen</html>' > " + rpt + "\n"
+	body := "#!/bin/sh\nsleep 0.2\ntouch " + marker + "\necho '<html>regen</html>' > \"$1\"\n"
 	os.WriteFile(script, []byte(body), 0o755)
 	s := &Server{userFilesReportPath: rpt, userFilesToolsDir: tools}
 	req := httptest.NewRequest(http.MethodPost, "/user_files/regenerate", nil)

--- a/src/agent/internal/agent/user_files_test.go
+++ b/src/agent/internal/agent/user_files_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -13,13 +14,16 @@ import (
 func TestHandleUserFiles_ServesExistingReport(t *testing.T) {
 	dir := t.TempDir()
 	rpt := filepath.Join(dir, "files_report.html")
-	os.WriteFile(rpt, []byte("<html>cached</html>"), 0o644)
+	os.WriteFile(rpt, []byte("<html><body>cached text mentions /user_files?refresh=1</body></html>"), 0o644)
 	s := &Server{userFilesReportPath: rpt}
 	req := httptest.NewRequest(http.MethodGet, "/user_files", nil)
 	rec := httptest.NewRecorder()
 	s.handleUserFiles(rec, req)
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "cached") {
 		t.Errorf("code=%d body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), userFilesRefreshControlMarker) {
+		t.Errorf("legacy report response is missing refresh control: %q", rec.Body.String())
 	}
 }
 
@@ -35,6 +39,126 @@ func TestHandleUserFiles_GeneratesIfMissing(t *testing.T) {
 	s.handleUserFiles(rec, req)
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "generated") {
 		t.Errorf("code=%d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleUserFiles_RefreshQueryRegeneratesReport(t *testing.T) {
+	tools := t.TempDir()
+	rpt := filepath.Join(t.TempDir(), "report.html")
+	if err := os.WriteFile(rpt, []byte("<html>stale</html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := filepath.Join(tools, "view_agent_files.sh")
+	body := "#!/bin/sh\necho '<html>fresh</html>' > " + rpt + "\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{userFilesReportPath: rpt, userFilesToolsDir: tools}
+	req := httptest.NewRequest(http.MethodGet, "/user_files?refresh=1", nil)
+	rec := httptest.NewRecorder()
+	s.handleUserFiles(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("code=%d body=%q", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Location"); got != "/user_files" {
+		t.Fatalf("Location = %q, want /user_files", got)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/user_files", nil)
+	rec = httptest.NewRecorder()
+	s.handleUserFiles(rec, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "fresh") {
+		t.Fatalf("code=%d body=%q", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+}
+
+func TestHandleUserFiles_ConcurrentRefreshCoalescesGeneration(t *testing.T) {
+	tools := t.TempDir()
+	rpt := filepath.Join(t.TempDir(), "report.html")
+	marker := filepath.Join(t.TempDir(), "runs")
+	if err := os.WriteFile(rpt, []byte("<html>stale</html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := filepath.Join(tools, "view_agent_files.sh")
+	body := "#!/bin/sh\necho run >> " + marker + "\nsleep 0.2\necho '<html>fresh</html>' > " + rpt + "\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{userFilesReportPath: rpt, userFilesToolsDir: tools}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			req := httptest.NewRequest(http.MethodGet, "/user_files?refresh=1", nil)
+			rec := httptest.NewRecorder()
+			s.handleUserFiles(rec, req)
+			if rec.Code != http.StatusSeeOther {
+				t.Errorf("code=%d body=%q", rec.Code, rec.Body.String())
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	runs, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(runs), "run\n"); got != 1 {
+		t.Fatalf("generation runs = %d, want 1", got)
+	}
+}
+
+func TestHandleUserFiles_ConcurrentRefreshSharesGenerationFailure(t *testing.T) {
+	tools := t.TempDir()
+	rpt := filepath.Join(t.TempDir(), "report.html")
+	marker := filepath.Join(t.TempDir(), "runs")
+	if err := os.WriteFile(rpt, []byte("<html>stale</html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := filepath.Join(tools, "view_agent_files.sh")
+	body := "#!/bin/sh\necho run >> " + marker + "\nsleep 0.2\necho generation-failed\nexit 1\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{userFilesReportPath: rpt, userFilesToolsDir: tools}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			req := httptest.NewRequest(http.MethodGet, "/user_files?refresh=1", nil)
+			rec := httptest.NewRecorder()
+			s.handleUserFiles(rec, req)
+			if rec.Code != http.StatusInternalServerError {
+				t.Errorf("code=%d body=%q", rec.Code, rec.Body.String())
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	runs, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(runs), "run\n"); got != 1 {
+		t.Fatalf("generation runs = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a manual Refresh data control to /user_files
- regenerate the report only for explicit refresh requests, then redirect to the clean URL
- disable browser caching and coalesce overlapping refresh attempts
- inject a compatibility refresh control into existing cached reports
- keep the page free of timers and periodic polling

## Testing

- go test -race ./internal/agent -run TestHandleUserFiles -count=5
- go vet ./internal/agent
- go test ./internal/agent -count=1
- deployed to 192.168.31.108 and verified that refreshing exposes the latest booking Episode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Refresh data” control to regenerate user-file reports on demand.
  * Displayed the latest report generation time alongside the refresh control.
  * Added automatic redirect behavior after refreshing.

* **Bug Fixes**
  * Prevented stale cached reports from being served.
  * Preserved the previous complete report while a refresh is in progress.
  * Coordinated simultaneous refresh requests and shared generation errors consistently.
  * Improved report publishing reliability so incomplete reports are not displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->