### PR TITLE
feat(ble): ingest Android system notifications

### DIFF
--- a/docs/03-services/ble-service.md
+++ b/docs/03-services/ble-service.md
@@ -1,4 +1,4 @@
-# BLE Service: Pairing and iOS System Notifications
+# BLE Service: Pairing and Phone System Notifications
 
 `ble_service` owns Aiden's Bluetooth Low Energy integration. It uses BlueZ on
 `hci0` in two roles at the same time:
@@ -7,9 +7,11 @@
   encrypted bond with the iOS companion app.
 - ANCS Consumer: subscribes to Apple's Notification Center Service exposed by
   the paired iPhone and normalizes system notification events.
+- Android notification sink: accepts normalized notification changes forwarded
+  by the companion app over the USB-restricted Agent HTTP API.
 
 BLE is intentionally narrow. It does not carry Phone Bridge tool commands or
-results, and ANCS events are not written to Agent memory.
+results, and phone notification events are not written to Agent memory.
 
 ## Boot and Persistence
 
@@ -88,7 +90,7 @@ before one fresh attempt.
 The characteristic supports only `encrypt-read`. Its purpose is to trigger and
 verify the encrypted system bond before ANCS is used.
 
-## ANCS Event Shape
+## Phone Notification Event Shape
 
 After the trusted iPhone is connected and its services are resolved,
 `ble_service` discovers ANCS and subscribes directly to Notification Source and
@@ -96,6 +98,8 @@ Data Source. It requests notification attributes through Control Point and
 stores a bounded in-memory ring. Events include:
 
 - monotonic string `id` for UDS cursors;
+- `source`, source notification/event IDs, and the companion `device_id` when
+  the event came from Android;
 - ANCS `notification_uid`, event type, flags, category, and category count;
 - app identifier, title, subtitle, message, and date when attribute retrieval
   succeeds;
@@ -104,6 +108,14 @@ stores a bounded in-memory ring. Events include:
 
 The ring defaults to 512 events. Reboot clears events but does not clear the
 Bluetooth bond.
+
+On Android, the companion app uses `NotificationListenerService` after the
+user grants Notification Access. It filters the Aiden app's own notifications
+and group summaries, queues added/modified/removed events locally, and posts
+batches to `/api/phone-notifications/events` over USB ECM. Each source event has
+a stable `source_event_id`; `ble_service` deduplicates retries while that event
+remains in the bounded ring. Android notification forwarding does not require
+Bluetooth pairing.
 
 ## UDS API
 
@@ -138,6 +150,30 @@ Returns the current `generation` with events after the cursor. Start with
 After `ble_service` restarts, a stale generation returns `reset_required=true`
 with no events; retry with `since=0`. Within one generation, `truncated=true`
 means the requested cursor is older than the bounded ring's retained history.
+
+### `notification_publish`
+
+```json
+{
+  "op": "notification_publish",
+  "phone_id": "android-...",
+  "events": [
+    {
+      "source_id": "0|com.example.mail|42|null|1000",
+      "source_event_id": "<sha256>",
+      "event": "added",
+      "app_identifier": "com.example.mail",
+      "title": "New message",
+      "message": "Hello"
+    }
+  ]
+}
+```
+
+Accepts 1-8 Android notification events, validates bounded metadata fields,
+sets `source=android` and the request `device_id`, and returns accepted and
+duplicate counts. This operation is intended for the Agent HTTP bridge rather
+than arbitrary local publishers.
 
 ### `pairing_start`
 
@@ -181,11 +217,12 @@ The companion app reaches the pairing operations through the Agent on USB ECM:
 | `POST` | `/api/bluetooth/pairing/start` | Open or refresh the user-initiated connection window |
 | `POST` | `/api/bluetooth/pairing/reset` | Remove a confirmed stale board bond before one fresh pairing attempt |
 | `POST` | `/api/bluetooth/disconnect` | Disconnect the physical BLE/ANCS link without deleting the bond |
+| `POST` | `/api/phone-notifications/events` | Ingest a batch of Android notification changes |
 
-Bluetooth control writes are accepted only over the board's USB ECM address
+Bluetooth control and phone-notification writes are accepted only over the board's USB ECM address
 (`192.168.42.1/24`) or loopback; requests arriving through Wi-Fi and other
-listeners receive `403`. BLE keys and ANCS bodies never pass through these
-endpoints.
+listeners receive `403`. Android notification bodies use this local USB path;
+BLE keys and iOS ANCS bodies never pass through these endpoints.
 
 ## Operations
 

--- a/docs/04-agent/phone-bridge.md
+++ b/docs/04-agent/phone-bridge.md
@@ -43,6 +43,12 @@ PiP Bridge is a narrow exception. When the app reports `pip_bridge_enabled=true`
 
 Android FGS Bridge follows the same HTTP queue contract without using WebSocket as a background transport. When the Android foreground service polls `/api/phone-bridge/commands` with `app_state=background` and `fgs_bridge_enabled=true`, the Agent keeps `open_app` unavailable and routes only background-safe data tools through the HTTP queue.
 
+Android system-notification ingestion is a separate one-way path. After the
+user grants Notification Access, the app's native listener posts bounded,
+retry-safe event batches to `/api/phone-notifications/events` over USB ECM. The
+Agent forwards them to the same `ble_service` event ring used by iOS ANCS;
+Android does not need BLE pairing for this path.
+
 ## Desktop Agent With ADB Reverse
 
 When running the Agent on a development computer instead of the Luckfox board, the phone cannot reach `192.168.42.1` because the USB ECM board network does not exist. For Android development, use the ADB input backend and let the phone app connect through ADB reverse:
@@ -524,6 +530,9 @@ Use the phone environment timezone when it is available. The Agent can use `shel
 - **Calendar read/write**: Both iOS and Android need runtime permissions, authorization popup on first call. When app receives command and permission not granted, should return `ok:false, error:"Calendar permission required"`; timeout controlled by board-side `timeout_ms`.
 - **Contacts read/write**: iOS needs `NSContactsUsageDescription` permission, Android needs `READ_CONTACTS` and `WRITE_CONTACTS` permissions. When unauthorized return `ok:false, error:"Contacts permission required"`.
 - **Notification permission**: iOS needs to request authorization via `UNUserNotificationCenter`, Android 13+ needs `POST_NOTIFICATIONS` permission. When unauthorized return `ok:false, error:"Notification permission required"`.
+- **Notification reading**: Android system-notification ingestion separately
+  requires the user to enable Aiden under Settings > Notification access.
+  `POST_NOTIFICATIONS` alone does not grant access to other apps' notifications.
 
 ### Implementation Notes
 

--- a/docs/06-protocols/uds-protocol.md
+++ b/docs/06-protocols/uds-protocol.md
@@ -29,7 +29,8 @@ JSON header describes the request or response; large binary data (such as raw HD
 | `src/frame_ipc.*` | Frame service compatibility wrapper |
 
 `ble_service` implements the same envelope in Go at
-`/run/ble_service/ble_service.sock`. Its `status`, pairing, and `events_since`
+`/run/ble_service/ble_service.sock`. Its `status`, pairing, `events_since`, and
+Android `notification_publish`
 operations are documented in [BLE Service](../03-services/ble-service.md).
 
 ## Cross-Language Clients

--- a/src/agent/internal/agent/bluetooth_http.go
+++ b/src/agent/internal/agent/bluetooth_http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/netip"
@@ -16,11 +17,26 @@ import (
 
 const defaultBLEServiceSocketPath = "/run/ble_service/ble_service.sock"
 
+const maxPhoneNotificationRequestBytes = 64 * 1024
+
 type bluetoothStatusResponse struct {
 	OK        bool              `json:"ok"`
 	Bluetooth ble.RuntimeStatus `json:"bluetooth"`
 	Removed   int               `json:"removed,omitempty"`
 	Error     string            `json:"error,omitempty"`
+}
+
+type phoneNotificationRequest struct {
+	PhoneID string                  `json:"phone_id"`
+	Events  []ble.NotificationEvent `json:"events"`
+}
+
+type phoneNotificationResponse struct {
+	OK         bool   `json:"ok"`
+	Accepted   int    `json:"accepted,omitempty"`
+	Duplicates int    `json:"duplicates,omitempty"`
+	LastID     string `json:"last_id,omitempty"`
+	Error      string `json:"error,omitempty"`
 }
 
 func (s *Server) handleBluetoothStatus(w http.ResponseWriter, r *http.Request) {
@@ -103,6 +119,67 @@ func (s *Server) handleBluetoothDisconnect(w http.ResponseWriter, r *http.Reques
 	writeBluetoothJSON(w, http.StatusOK, bluetoothStatusResponse{OK: true, Bluetooth: status})
 }
 
+func (s *Server) handlePhoneNotificationEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writePhoneNotificationJSON(w, http.StatusMethodNotAllowed, phoneNotificationResponse{
+			OK:    false,
+			Error: "method not allowed",
+		})
+		return
+	}
+	if !bluetoothControlRequestAllowed(r) {
+		writePhoneNotificationJSON(w, http.StatusForbidden, phoneNotificationResponse{
+			OK:    false,
+			Error: "phone notification ingestion is available only over USB",
+		})
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxPhoneNotificationRequestBytes)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	var request phoneNotificationRequest
+	if err := decoder.Decode(&request); err != nil {
+		writePhoneNotificationJSON(w, http.StatusBadRequest, phoneNotificationResponse{
+			OK:    false,
+			Error: "invalid notification request: " + err.Error(),
+		})
+		return
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		writePhoneNotificationJSON(w, http.StatusBadRequest, phoneNotificationResponse{
+			OK:    false,
+			Error: "invalid notification request: multiple JSON values",
+		})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
+	defer cancel()
+	result, err := s.bluetoothNotificationPublishRequest()(
+		ctx,
+		s.bluetoothServiceSocketPath(),
+		request.PhoneID,
+		request.Events,
+	)
+	if err != nil {
+		statusCode := http.StatusServiceUnavailable
+		var requestErr *ble.RequestError
+		if errors.As(err, &requestErr) && requestErr.Status == "INVALID_ARGUMENT" {
+			statusCode = http.StatusBadRequest
+		}
+		writePhoneNotificationJSON(w, statusCode, phoneNotificationResponse{OK: false, Error: err.Error()})
+		return
+	}
+	writePhoneNotificationJSON(w, http.StatusOK, phoneNotificationResponse{
+		OK:         true,
+		Accepted:   result.Accepted,
+		Duplicates: result.Duplicates,
+		LastID:     result.LastID,
+	})
+}
+
 func (s *Server) bluetoothServiceSocketPath() string {
 	if path := strings.TrimSpace(s.bleSocketPath); path != "" {
 		return path
@@ -177,6 +254,18 @@ func (s *Server) bluetoothDisconnectRequest() func(context.Context, string) (ble
 	return ble.RequestDisconnect
 }
 
+func (s *Server) bluetoothNotificationPublishRequest() func(
+	context.Context,
+	string,
+	string,
+	[]ble.NotificationEvent,
+) (ble.NotificationPublishResult, error) {
+	if s.bleNotifyRequest != nil {
+		return s.bleNotifyRequest
+	}
+	return ble.RequestPublishNotifications
+}
+
 func writeBluetoothRequestError(w http.ResponseWriter, err error) {
 	statusCode := http.StatusServiceUnavailable
 	var requestErr *ble.RequestError
@@ -200,6 +289,12 @@ func writeBluetoothError(w http.ResponseWriter, statusCode int, message string) 
 }
 
 func writeBluetoothJSON(w http.ResponseWriter, statusCode int, payload bluetoothStatusResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writePhoneNotificationJSON(w http.ResponseWriter, statusCode int, payload phoneNotificationResponse) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	_ = json.NewEncoder(w).Encode(payload)

--- a/src/agent/internal/agent/bluetooth_http.go
+++ b/src/agent/internal/agent/bluetooth_http.go
@@ -17,7 +17,8 @@ import (
 
 const defaultBLEServiceSocketPath = "/run/ble_service/ble_service.sock"
 
-const maxPhoneNotificationRequestBytes = 64 * 1024
+// Keep this above the largest valid eight-event batch after JSON escaping.
+const maxPhoneNotificationRequestBytes = 256 * 1024
 
 type bluetoothStatusResponse struct {
 	OK        bool              `json:"ok"`

--- a/src/agent/internal/agent/bluetooth_http.go
+++ b/src/agent/internal/agent/bluetooth_http.go
@@ -155,6 +155,13 @@ func (s *Server) handlePhoneNotificationEvents(w http.ResponseWriter, r *http.Re
 		})
 		return
 	}
+	if err := ble.ValidateNotificationPublishRequestFrame(request.PhoneID, request.Events); err != nil {
+		writePhoneNotificationJSON(w, http.StatusBadRequest, phoneNotificationResponse{
+			OK:    false,
+			Error: "invalid notification request: " + err.Error(),
+		})
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
 	defer cancel()

--- a/src/agent/internal/agent/bluetooth_http_test.go
+++ b/src/agent/internal/agent/bluetooth_http_test.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -83,6 +85,75 @@ func TestBluetoothHTTPResetsStaleBond(t *testing.T) {
 		`"connected":false`,
 	) {
 		t.Fatalf("pairing reset code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestPhoneNotificationEventsPublishesAndroidBatch(t *testing.T) {
+	var gotPhoneID string
+	var gotEvents []ble.NotificationEvent
+	server := &Server{
+		bleNotifyRequest: func(
+			_ context.Context,
+			_ string,
+			phoneID string,
+			events []ble.NotificationEvent,
+		) (ble.NotificationPublishResult, error) {
+			gotPhoneID = phoneID
+			gotEvents = events
+			return ble.NotificationPublishResult{Accepted: 1, LastID: "17"}, nil
+		},
+	}
+	body := []byte(`{"phone_id":"android-1","events":[{"source_id":"key","source_event_id":"event-1","event":"added","app_identifier":"com.example"}]}`)
+	request := bluetoothControlRequestForPath(http.MethodPost, "/api/phone-notifications/events")
+	request.Body = io.NopCloser(bytes.NewReader(body))
+	request.ContentLength = int64(len(body))
+	recorder := httptest.NewRecorder()
+	server.handlePhoneNotificationEvents(recorder, request)
+	if recorder.Code != http.StatusOK || !containsAll(
+		recorder.Body.String(),
+		`"ok":true`,
+		`"accepted":1`,
+		`"last_id":"17"`,
+	) {
+		t.Fatalf("publish code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if gotPhoneID != "android-1" || len(gotEvents) != 1 || gotEvents[0].SourceEventID != "event-1" {
+		t.Fatalf("unexpected publish request phone=%q events=%#v", gotPhoneID, gotEvents)
+	}
+}
+
+func TestPhoneNotificationEventsRejectsInvalidAndNonUSBRequests(t *testing.T) {
+	called := false
+	server := &Server{
+		bleNotifyRequest: func(
+			context.Context,
+			string,
+			string,
+			[]ble.NotificationEvent,
+		) (ble.NotificationPublishResult, error) {
+			called = true
+			return ble.NotificationPublishResult{}, nil
+		},
+	}
+
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/phone-notifications/events",
+		strings.NewReader(`{"phone_id":"android-1","events":[]}`),
+	)
+	request.RemoteAddr = "192.168.50.140:12345"
+	recorder := httptest.NewRecorder()
+	server.handlePhoneNotificationEvents(recorder, request)
+	if recorder.Code != http.StatusForbidden || called {
+		t.Fatalf("external publish code=%d called=%v", recorder.Code, called)
+	}
+
+	request = bluetoothControlRequestForPath(http.MethodPost, "/api/phone-notifications/events")
+	request.Body = io.NopCloser(strings.NewReader(`{"phone_id":`))
+	recorder = httptest.NewRecorder()
+	server.handlePhoneNotificationEvents(recorder, request)
+	if recorder.Code != http.StatusBadRequest || called {
+		t.Fatalf("invalid publish code=%d called=%v body=%s", recorder.Code, called, recorder.Body.String())
 	}
 }
 

--- a/src/agent/internal/agent/bluetooth_http_test.go
+++ b/src/agent/internal/agent/bluetooth_http_test.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -170,23 +172,66 @@ func TestPhoneNotificationEventsAcceptsMaximumValidatedBatch(t *testing.T) {
 	if len(body) > maxPhoneNotificationRequestBytes {
 		t.Fatalf("maximum notification batch exceeds HTTP limit: %d", len(body))
 	}
-
-	server := &Server{
-		bleNotifyRequest: func(
-			_ context.Context,
-			_ string,
-			_ string,
-			events []ble.NotificationEvent,
-		) (ble.NotificationPublishResult, error) {
-			return ble.NotificationPublishResult{Accepted: len(events), LastID: "8"}, nil
-		},
+	body = append(body, bytes.Repeat([]byte(" "), maxPhoneNotificationRequestBytes-len(body))...)
+	if len(body) != maxPhoneNotificationRequestBytes {
+		t.Fatalf("boundary notification request length=%d", len(body))
 	}
+
+	socketDir, err := os.MkdirTemp("/tmp", "aiden-ble-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(socketDir); err != nil {
+			t.Errorf("remove BLE socket directory: %v", err)
+		}
+	})
+	socketPath := filepath.Join(socketDir, "ble.sock")
+	udsServer := ble.NewUDSServer(socketPath, ble.NewService(16))
+	if err := udsServer.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := udsServer.Close(); err != nil {
+			t.Errorf("close BLE UDS server: %v", err)
+		}
+	})
+	server := &Server{bleSocketPath: socketPath}
 	request := bluetoothControlRequestForPath(http.MethodPost, "/api/phone-notifications/events")
 	request.Body = io.NopCloser(bytes.NewReader(body))
 	recorder := httptest.NewRecorder()
 	server.handlePhoneNotificationEvents(recorder, request)
 	if recorder.Code != http.StatusOK || !containsAll(recorder.Body.String(), `"accepted":8`) {
 		t.Fatalf("maximum publish code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestPhoneNotificationEventsRejectsUDSOversizedEncoding(t *testing.T) {
+	prefix := `{"phone_id":"`
+	suffix := `","events":[{}]}`
+	body := prefix + strings.Repeat("&", maxPhoneNotificationRequestBytes-len(prefix)-len(suffix)) + suffix
+	if len(body) != maxPhoneNotificationRequestBytes {
+		t.Fatalf("boundary request length=%d", len(body))
+	}
+
+	called := false
+	server := &Server{
+		bleNotifyRequest: func(
+			context.Context,
+			string,
+			string,
+			[]ble.NotificationEvent,
+		) (ble.NotificationPublishResult, error) {
+			called = true
+			return ble.NotificationPublishResult{}, nil
+		},
+	}
+	request := bluetoothControlRequestForPath(http.MethodPost, "/api/phone-notifications/events")
+	request.Body = io.NopCloser(strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+	server.handlePhoneNotificationEvents(recorder, request)
+	if recorder.Code != http.StatusBadRequest || called || !strings.Contains(recorder.Body.String(), "exceeds BLE UDS frame limit") {
+		t.Fatalf("UDS-oversized publish code=%d called=%v body=%s", recorder.Code, called, recorder.Body.String())
 	}
 }
 
@@ -295,7 +340,7 @@ func maximumPhoneNotificationRequest() phoneNotificationRequest {
 		}
 		events[index] = ble.NotificationEvent{
 			SourceID:      fill(512),
-			SourceEventID: fill(128),
+			SourceEventID: fill(127) + string(rune('0'+index)),
 			Event:         "added",
 			Flags:         flags,
 			AppIdentifier: fill(255),

--- a/src/agent/internal/agent/bluetooth_http_test.go
+++ b/src/agent/internal/agent/bluetooth_http_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net"
@@ -157,6 +158,49 @@ func TestPhoneNotificationEventsRejectsInvalidAndNonUSBRequests(t *testing.T) {
 	}
 }
 
+func TestPhoneNotificationEventsAcceptsMaximumValidatedBatch(t *testing.T) {
+	requestPayload := maximumPhoneNotificationRequest()
+	body, err := json.Marshal(requestPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) <= 64*1024 {
+		t.Fatalf("maximum notification batch did not exercise the old limit: %d", len(body))
+	}
+	if len(body) > maxPhoneNotificationRequestBytes {
+		t.Fatalf("maximum notification batch exceeds HTTP limit: %d", len(body))
+	}
+
+	server := &Server{
+		bleNotifyRequest: func(
+			_ context.Context,
+			_ string,
+			_ string,
+			events []ble.NotificationEvent,
+		) (ble.NotificationPublishResult, error) {
+			return ble.NotificationPublishResult{Accepted: len(events), LastID: "8"}, nil
+		},
+	}
+	request := bluetoothControlRequestForPath(http.MethodPost, "/api/phone-notifications/events")
+	request.Body = io.NopCloser(bytes.NewReader(body))
+	recorder := httptest.NewRecorder()
+	server.handlePhoneNotificationEvents(recorder, request)
+	if recorder.Code != http.StatusOK || !containsAll(recorder.Body.String(), `"accepted":8`) {
+		t.Fatalf("maximum publish code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestPhoneNotificationEventsRejectsOversizedBody(t *testing.T) {
+	body := `{"phone_id":"` + strings.Repeat("x", maxPhoneNotificationRequestBytes+1) + `","events":[]}`
+	request := bluetoothControlRequestForPath(http.MethodPost, "/api/phone-notifications/events")
+	request.Body = io.NopCloser(strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+	(&Server{}).handlePhoneNotificationEvents(recorder, request)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("oversized publish code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestBluetoothHTTPMapsPairingConflict(t *testing.T) {
 	server := &Server{
 		blePairingStartRequest: func(context.Context, string) (ble.RuntimeStatus, error) {
@@ -239,4 +283,28 @@ func bluetoothControlRequestForPath(method, path string) *http.Request {
 		http.LocalAddrContextKey,
 		&net.TCPAddr{IP: net.ParseIP("192.168.42.1"), Port: 8080},
 	))
+}
+
+func maximumPhoneNotificationRequest() phoneNotificationRequest {
+	fill := func(length int) string { return strings.Repeat(`"`, length) }
+	events := make([]ble.NotificationEvent, 8)
+	for index := range events {
+		flags := make([]string, 16)
+		for flagIndex := range flags {
+			flags[flagIndex] = fill(64)
+		}
+		events[index] = ble.NotificationEvent{
+			SourceID:      fill(512),
+			SourceEventID: fill(128),
+			Event:         "added",
+			Flags:         flags,
+			AppIdentifier: fill(255),
+			Title:         fill(512),
+			Subtitle:      fill(512),
+			Message:       fill(4096),
+			Category:      fill(128),
+			Date:          fill(64),
+		}
+	}
+	return phoneNotificationRequest{PhoneID: fill(128), Events: events}
 }

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -75,6 +75,7 @@ type Server struct {
 	blePairingStartRequest  func(context.Context, string) (ble.RuntimeStatus, error)
 	blePairingForgetRequest func(context.Context, string) (ble.ForgetResult, error)
 	bleDisconnectRequest    func(context.Context, string) (ble.RuntimeStatus, error)
+	bleNotifyRequest        func(context.Context, string, string, []ble.NotificationEvent) (ble.NotificationPublishResult, error)
 	androidADB              androidADBController
 	liveActivity            *LiveActivityManager
 	pendingResults          map[string]*chatPendingResult
@@ -391,6 +392,7 @@ func NewServer(runtime *Runtime, addr string) *Server {
 		blePairingStartRequest:  ble.RequestPairingStart,
 		blePairingForgetRequest: ble.RequestPairingForget,
 		bleDisconnectRequest:    ble.RequestDisconnect,
+		bleNotifyRequest:        ble.RequestPublishNotifications,
 		androidADB:              NewAndroidADBManager(runtime.config.HID.FrameSocketOrDefault(), runtime.logger),
 		liveActivity:            NewLiveActivityManager(runtime.config.LiveActivity, runtime.logger),
 		pendingResults:          make(map[string]*chatPendingResult),
@@ -505,6 +507,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/bluetooth/pairing/start", s.handleBluetoothPairingStart)
 	mux.HandleFunc("/api/bluetooth/pairing/reset", s.handleBluetoothPairingReset)
 	mux.HandleFunc("/api/bluetooth/disconnect", s.handleBluetoothDisconnect)
+	mux.HandleFunc("/api/phone-notifications/events", s.handlePhoneNotificationEvents)
 	mux.HandleFunc("/api/android-adb/status", s.handleAndroidADBStatus)
 	mux.HandleFunc("/api/android-adb/pair", s.handleAndroidADBPair)
 	mux.HandleFunc("/api/storage/monitor/status", s.handleStorageMonitorStatus)

--- a/src/agent/internal/ble/ancs.go
+++ b/src/agent/internal/ble/ancs.go
@@ -132,6 +132,8 @@ func (c *ANCSConsumer) HandleNotificationSource(data []byte) error {
 	var command []byte
 	for _, source := range sourceEvents {
 		event := NotificationEvent{
+			Source:          "ios_ancs",
+			SourceID:        fmt.Sprintf("%d", source.UID),
 			NotificationUID: source.UID,
 			Event:           eventName(source.EventID),
 			Flags:           eventFlags(source.EventFlags),

--- a/src/agent/internal/ble/android_notifications.go
+++ b/src/agent/internal/ble/android_notifications.go
@@ -1,0 +1,155 @@
+package ble
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strings"
+)
+
+const (
+	maxPublishedNotifications = 8
+	maxPhoneIDLength          = 128
+	maxSourceIDLength         = 512
+	maxSourceEventIDLength    = 128
+	maxAppIdentifierLength    = 255
+	maxNotificationTitle      = 512
+	maxNotificationSubtitle   = 512
+	maxNotificationMessage    = 4096
+	maxNotificationCategory   = 128
+	maxNotificationDate       = 64
+	maxNotificationFlags      = 16
+	maxNotificationFlagLength = 64
+)
+
+type NotificationPublishResult struct {
+	Accepted   int    `json:"accepted"`
+	Duplicates int    `json:"duplicates"`
+	LastID     string `json:"last_id"`
+}
+
+// PublishAndroidNotifications validates and appends notification events sent
+// by the Android companion app over the USB-restricted Agent HTTP endpoint.
+func (s *Service) PublishAndroidNotifications(
+	phoneID string,
+	events []NotificationEvent,
+) (NotificationPublishResult, error) {
+	normalized, err := normalizeAndroidNotifications(phoneID, events)
+	if err != nil {
+		return NotificationPublishResult{}, err
+	}
+
+	result := NotificationPublishResult{}
+	for _, event := range normalized {
+		_, created := s.store.AppendUnique(event)
+		if created {
+			result.Accepted++
+		} else {
+			result.Duplicates++
+		}
+	}
+	result.LastID = s.store.Stats().LastID
+	return result, nil
+}
+
+func normalizeAndroidNotifications(
+	phoneID string,
+	events []NotificationEvent,
+) ([]NotificationEvent, error) {
+	phoneID = strings.TrimSpace(phoneID)
+	if phoneID == "" || len(phoneID) > maxPhoneIDLength {
+		return nil, fmt.Errorf("phone_id must contain 1-%d bytes", maxPhoneIDLength)
+	}
+	if len(events) == 0 || len(events) > maxPublishedNotifications {
+		return nil, fmt.Errorf("events must contain 1-%d items", maxPublishedNotifications)
+	}
+
+	normalized := make([]NotificationEvent, 0, len(events))
+	for index, input := range events {
+		event := input
+		event.Event = strings.TrimSpace(event.Event)
+		if event.Event != "added" && event.Event != "modified" && event.Event != "removed" {
+			return nil, fmt.Errorf("events[%d].event must be added, modified, or removed", index)
+		}
+		event.SourceID = strings.TrimSpace(event.SourceID)
+		if event.SourceID == "" || len(event.SourceID) > maxSourceIDLength {
+			return nil, fmt.Errorf("events[%d].source_id must contain 1-%d bytes", index, maxSourceIDLength)
+		}
+		event.SourceEventID = strings.TrimSpace(event.SourceEventID)
+		if event.SourceEventID == "" || len(event.SourceEventID) > maxSourceEventIDLength {
+			return nil, fmt.Errorf(
+				"events[%d].source_event_id must contain 1-%d bytes",
+				index,
+				maxSourceEventIDLength,
+			)
+		}
+		event.AppIdentifier = strings.TrimSpace(event.AppIdentifier)
+		if event.AppIdentifier == "" || len(event.AppIdentifier) > maxAppIdentifierLength {
+			return nil, fmt.Errorf(
+				"events[%d].app_identifier must contain 1-%d bytes",
+				index,
+				maxAppIdentifierLength,
+			)
+		}
+		if err := validateNotificationText(index, "title", event.Title, maxNotificationTitle); err != nil {
+			return nil, err
+		}
+		if err := validateNotificationText(index, "subtitle", event.Subtitle, maxNotificationSubtitle); err != nil {
+			return nil, err
+		}
+		if err := validateNotificationText(index, "message", event.Message, maxNotificationMessage); err != nil {
+			return nil, err
+		}
+		if err := validateNotificationText(index, "category", event.Category, maxNotificationCategory); err != nil {
+			return nil, err
+		}
+		if err := validateNotificationText(index, "date", event.Date, maxNotificationDate); err != nil {
+			return nil, err
+		}
+		if len(event.Flags) > maxNotificationFlags {
+			return nil, fmt.Errorf("events[%d].flags exceeds %d items", index, maxNotificationFlags)
+		}
+		for flagIndex, flag := range event.Flags {
+			event.Flags[flagIndex] = strings.TrimSpace(flag)
+			if event.Flags[flagIndex] == "" || len(event.Flags[flagIndex]) > maxNotificationFlagLength {
+				return nil, fmt.Errorf(
+					"events[%d].flags[%d] must contain 1-%d bytes",
+					index,
+					flagIndex,
+					maxNotificationFlagLength,
+				)
+			}
+		}
+		if event.NotificationUID == 0 {
+			event.NotificationUID = notificationSourceHash(event.SourceID)
+		}
+		event.ID = ""
+		event.Source = "android"
+		event.DeviceID = phoneID
+		event.MetadataComplete = true
+		event.MetadataError = ""
+		event.ReceivedAt = ""
+		event.sequence = 0
+		if event.Flags == nil {
+			event.Flags = []string{}
+		}
+		normalized = append(normalized, event)
+	}
+	return normalized, nil
+}
+
+func validateNotificationText(index int, field, value string, maximum int) error {
+	if len(value) > maximum {
+		return fmt.Errorf("events[%d].%s exceeds %d bytes", index, field, maximum)
+	}
+	return nil
+}
+
+func notificationSourceHash(sourceID string) uint32 {
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(sourceID))
+	value := hash.Sum32()
+	if value == 0 {
+		return 1
+	}
+	return value
+}

--- a/src/agent/internal/ble/android_notifications_test.go
+++ b/src/agent/internal/ble/android_notifications_test.go
@@ -1,0 +1,101 @@
+package ble
+
+import "testing"
+
+func TestPublishAndroidNotificationsNormalizesAndDeduplicates(t *testing.T) {
+	service := NewService(8)
+	input := []NotificationEvent{{
+		SourceID:      "0|com.example.mail|42|message",
+		SourceEventID: "event-1",
+		Event:         "added",
+		AppIdentifier: "com.example.mail",
+		Title:         "New message",
+		Message:       "Hello",
+		Category:      "msg",
+		CategoryCount: 1,
+		Flags:         []string{"clearable"},
+	}}
+
+	result, err := service.PublishAndroidNotifications("android-phone-1", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Accepted != 1 || result.Duplicates != 0 || result.LastID != "1" {
+		t.Fatalf("unexpected publish result: %#v", result)
+	}
+	page := service.EventsSince(0, 10, "")
+	if len(page.Events) != 1 {
+		t.Fatalf("event count=%d", len(page.Events))
+	}
+	event := page.Events[0]
+	if event.Source != "android" || event.DeviceID != "android-phone-1" ||
+		event.SourceID != input[0].SourceID || event.NotificationUID == 0 ||
+		!event.MetadataComplete {
+		t.Fatalf("event was not normalized: %#v", event)
+	}
+
+	result, err = service.PublishAndroidNotifications("android-phone-1", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Accepted != 0 || result.Duplicates != 1 || result.LastID != "1" {
+		t.Fatalf("retry was not deduplicated: %#v", result)
+	}
+	if count := service.store.Stats().Count; count != 1 {
+		t.Fatalf("deduplicated store count=%d", count)
+	}
+}
+
+func TestPublishAndroidNotificationsValidatesBatch(t *testing.T) {
+	service := NewService(8)
+	tests := []struct {
+		name    string
+		phoneID string
+		events  []NotificationEvent
+	}{
+		{name: "missing phone", events: validAndroidNotification()},
+		{name: "empty events", phoneID: "phone"},
+		{name: "invalid event", phoneID: "phone", events: []NotificationEvent{{
+			SourceID: "source", SourceEventID: "event", Event: "unknown", AppIdentifier: "app",
+		}}},
+		{name: "missing source", phoneID: "phone", events: []NotificationEvent{{
+			SourceEventID: "event", Event: "added", AppIdentifier: "app",
+		}}},
+		{name: "missing event id", phoneID: "phone", events: []NotificationEvent{{
+			SourceID: "source", Event: "added", AppIdentifier: "app",
+		}}},
+		{name: "missing app", phoneID: "phone", events: []NotificationEvent{{
+			SourceID: "source", SourceEventID: "event", Event: "added",
+		}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := service.PublishAndroidNotifications(test.phoneID, test.events); err == nil {
+				t.Fatal("invalid notification batch was accepted")
+			}
+		})
+	}
+}
+
+func TestAndroidNotificationDedupeIsScopedByPhone(t *testing.T) {
+	service := NewService(8)
+	events := validAndroidNotification()
+	for _, phoneID := range []string{"phone-a", "phone-b"} {
+		result, err := service.PublishAndroidNotifications(phoneID, events)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Accepted != 1 {
+			t.Fatalf("phone %s result=%#v", phoneID, result)
+		}
+	}
+}
+
+func validAndroidNotification() []NotificationEvent {
+	return []NotificationEvent{{
+		SourceID:      "source",
+		SourceEventID: "event",
+		Event:         "added",
+		AppIdentifier: "com.example",
+	}}
+}

--- a/src/agent/internal/ble/client.go
+++ b/src/agent/internal/ble/client.go
@@ -71,6 +71,38 @@ func RequestPairingForget(ctx context.Context, socketPath string) (ForgetResult,
 	return ForgetResult{Removed: response.Removed, Bluetooth: response.Bluetooth}, nil
 }
 
+func RequestPublishNotifications(
+	ctx context.Context,
+	socketPath string,
+	phoneID string,
+	events []NotificationEvent,
+) (NotificationPublishResult, error) {
+	var response struct {
+		Status     string `json:"status"`
+		Error      string `json:"error"`
+		Accepted   int    `json:"accepted"`
+		Duplicates int    `json:"duplicates"`
+		LastID     string `json:"last_id"`
+	}
+	requestValue := struct {
+		Op      string              `json:"op"`
+		PhoneID string              `json:"phone_id"`
+		Events  []NotificationEvent `json:"events"`
+	}{
+		Op:      "notification_publish",
+		PhoneID: phoneID,
+		Events:  events,
+	}
+	if err := request(ctx, socketPath, requestValue, &response); err != nil {
+		return NotificationPublishResult{}, err
+	}
+	return NotificationPublishResult{
+		Accepted:   response.Accepted,
+		Duplicates: response.Duplicates,
+		LastID:     response.LastID,
+	}, nil
+}
+
 func request(ctx context.Context, socketPath string, requestValue any, responseValue any) error {
 	dialer := net.Dialer{Timeout: time.Second}
 	connection, err := dialer.DialContext(ctx, "unix", socketPath)

--- a/src/agent/internal/ble/client.go
+++ b/src/agent/internal/ble/client.go
@@ -84,16 +84,11 @@ func RequestPublishNotifications(
 		Duplicates int    `json:"duplicates"`
 		LastID     string `json:"last_id"`
 	}
-	requestValue := struct {
-		Op      string              `json:"op"`
-		PhoneID string              `json:"phone_id"`
-		Events  []NotificationEvent `json:"events"`
-	}{
-		Op:      "notification_publish",
-		PhoneID: phoneID,
-		Events:  events,
+	requestBytes, err := marshalNotificationPublishRequest(phoneID, events)
+	if err != nil {
+		return NotificationPublishResult{}, err
 	}
-	if err := request(ctx, socketPath, requestValue, &response); err != nil {
+	if err := requestEncoded(ctx, socketPath, requestBytes, &response); err != nil {
 		return NotificationPublishResult{}, err
 	}
 	return NotificationPublishResult{
@@ -103,7 +98,46 @@ func RequestPublishNotifications(
 	}, nil
 }
 
+// ValidateNotificationPublishRequestFrame verifies that the request's exact
+// UDS representation fits before an HTTP caller attempts to publish it.
+func ValidateNotificationPublishRequestFrame(phoneID string, events []NotificationEvent) error {
+	_, err := marshalNotificationPublishRequest(phoneID, events)
+	return err
+}
+
+func marshalNotificationPublishRequest(phoneID string, events []NotificationEvent) ([]byte, error) {
+	requestValue := struct {
+		Op      string              `json:"op"`
+		PhoneID string              `json:"phone_id"`
+		Events  []NotificationEvent `json:"events"`
+	}{
+		Op:      "notification_publish",
+		PhoneID: phoneID,
+		Events:  events,
+	}
+	requestBytes, err := json.Marshal(requestValue)
+	if err != nil {
+		return nil, err
+	}
+	if len(requestBytes) > maxUDSHeaderBytes {
+		return nil, fmt.Errorf(
+			"notification publish request exceeds BLE UDS frame limit: %d > %d bytes",
+			len(requestBytes),
+			maxUDSHeaderBytes,
+		)
+	}
+	return requestBytes, nil
+}
+
 func request(ctx context.Context, socketPath string, requestValue any, responseValue any) error {
+	requestBytes, err := json.Marshal(requestValue)
+	if err != nil {
+		return err
+	}
+	return requestEncoded(ctx, socketPath, requestBytes, responseValue)
+}
+
+func requestEncoded(ctx context.Context, socketPath string, requestBytes []byte, responseValue any) error {
 	dialer := net.Dialer{Timeout: time.Second}
 	connection, err := dialer.DialContext(ctx, "unix", socketPath)
 	if err != nil {
@@ -112,10 +146,6 @@ func request(ctx context.Context, socketPath string, requestValue any, responseV
 	defer connection.Close()
 	_ = connection.SetDeadline(requestDeadline(ctx, time.Now()))
 
-	requestBytes, err := json.Marshal(requestValue)
-	if err != nil {
-		return err
-	}
 	if err := writeUDSMessage(connection, requestBytes, nil); err != nil {
 		return fmt.Errorf("write ble_service request: %w", err)
 	}

--- a/src/agent/internal/ble/event_store.go
+++ b/src/agent/internal/ble/event_store.go
@@ -9,10 +9,14 @@ import (
 )
 
 // NotificationEvent is the normalized, memory-independent representation of
-// one ANCS notification change. IDs are decimal strings so every UDS client can
-// safely retain cursors without losing uint64 precision.
+// one phone notification change. IDs are decimal strings so every UDS client
+// can safely retain cursors without losing uint64 precision.
 type NotificationEvent struct {
 	ID               string   `json:"id"`
+	Source           string   `json:"source,omitempty"`
+	SourceID         string   `json:"source_id,omitempty"`
+	SourceEventID    string   `json:"source_event_id,omitempty"`
+	DeviceID         string   `json:"device_id,omitempty"`
 	NotificationUID  uint32   `json:"notification_uid"`
 	Event            string   `json:"event"`
 	Flags            []string `json:"flags"`
@@ -52,13 +56,18 @@ type EventStore struct {
 	generation string
 	next       uint64
 	events     []NotificationEvent
+	sourceSeen map[string]NotificationEvent
 }
 
 func NewEventStore(capacity int) *EventStore {
 	if capacity <= 0 {
 		capacity = 512
 	}
-	return &EventStore{capacity: capacity, generation: newEventGeneration()}
+	return &EventStore{
+		capacity:   capacity,
+		generation: newEventGeneration(),
+		sourceSeen: make(map[string]NotificationEvent),
+	}
 }
 
 func newEventGeneration() string {
@@ -70,8 +79,22 @@ func newEventGeneration() string {
 }
 
 func (s *EventStore) Append(event NotificationEvent) NotificationEvent {
+	appended, _ := s.AppendUnique(event)
+	return appended
+}
+
+// AppendUnique appends an event unless its source_event_id is still present in
+// the bounded ring. External publishers use this to retry safely after an HTTP
+// timeout without duplicating notification changes.
+func (s *EventStore) AppendUnique(event NotificationEvent) (NotificationEvent, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	dedupeKey := notificationDedupeKey(event)
+	if dedupeKey != "" {
+		if existing, ok := s.sourceSeen[dedupeKey]; ok {
+			return existing, false
+		}
+	}
 
 	s.next++
 	event.sequence = s.next
@@ -83,12 +106,31 @@ func (s *EventStore) Append(event NotificationEvent) NotificationEvent {
 		event.Flags = []string{}
 	}
 	s.events = append(s.events, event)
+	if dedupeKey != "" {
+		s.sourceSeen[dedupeKey] = event
+	}
 	if len(s.events) > s.capacity {
 		overflow := len(s.events) - s.capacity
+		for _, expired := range s.events[:overflow] {
+			expiredKey := notificationDedupeKey(expired)
+			if expiredKey == "" {
+				continue
+			}
+			if seen, ok := s.sourceSeen[expiredKey]; ok && seen.sequence == expired.sequence {
+				delete(s.sourceSeen, expiredKey)
+			}
+		}
 		copy(s.events, s.events[overflow:])
 		s.events = s.events[:s.capacity]
 	}
-	return event
+	return event, true
+}
+
+func notificationDedupeKey(event NotificationEvent) string {
+	if event.SourceEventID == "" {
+		return ""
+	}
+	return event.DeviceID + "\x00" + event.SourceEventID
 }
 
 func (s *EventStore) Page(since uint64, limit int) EventPage {

--- a/src/agent/internal/ble/event_store.go
+++ b/src/agent/internal/ble/event_store.go
@@ -56,7 +56,12 @@ type EventStore struct {
 	generation string
 	next       uint64
 	events     []NotificationEvent
-	sourceSeen map[string]NotificationEvent
+	sourceSeen map[notificationDedupeKey]NotificationEvent
+}
+
+type notificationDedupeKey struct {
+	deviceID      string
+	sourceEventID string
 }
 
 func NewEventStore(capacity int) *EventStore {
@@ -66,7 +71,7 @@ func NewEventStore(capacity int) *EventStore {
 	return &EventStore{
 		capacity:   capacity,
 		generation: newEventGeneration(),
-		sourceSeen: make(map[string]NotificationEvent),
+		sourceSeen: make(map[notificationDedupeKey]NotificationEvent),
 	}
 }
 
@@ -89,8 +94,8 @@ func (s *EventStore) Append(event NotificationEvent) NotificationEvent {
 func (s *EventStore) AppendUnique(event NotificationEvent) (NotificationEvent, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	dedupeKey := notificationDedupeKey(event)
-	if dedupeKey != "" {
+	dedupeKey, hasDedupeKey := notificationEventDedupeKey(event)
+	if hasDedupeKey {
 		if existing, ok := s.sourceSeen[dedupeKey]; ok {
 			return existing, false
 		}
@@ -106,14 +111,14 @@ func (s *EventStore) AppendUnique(event NotificationEvent) (NotificationEvent, b
 		event.Flags = []string{}
 	}
 	s.events = append(s.events, event)
-	if dedupeKey != "" {
+	if hasDedupeKey {
 		s.sourceSeen[dedupeKey] = event
 	}
 	if len(s.events) > s.capacity {
 		overflow := len(s.events) - s.capacity
 		for _, expired := range s.events[:overflow] {
-			expiredKey := notificationDedupeKey(expired)
-			if expiredKey == "" {
+			expiredKey, hasExpiredKey := notificationEventDedupeKey(expired)
+			if !hasExpiredKey {
 				continue
 			}
 			if seen, ok := s.sourceSeen[expiredKey]; ok && seen.sequence == expired.sequence {
@@ -126,11 +131,14 @@ func (s *EventStore) AppendUnique(event NotificationEvent) (NotificationEvent, b
 	return event, true
 }
 
-func notificationDedupeKey(event NotificationEvent) string {
+func notificationEventDedupeKey(event NotificationEvent) (notificationDedupeKey, bool) {
 	if event.SourceEventID == "" {
-		return ""
+		return notificationDedupeKey{}, false
 	}
-	return event.DeviceID + "\x00" + event.SourceEventID
+	return notificationDedupeKey{
+		deviceID:      event.DeviceID,
+		sourceEventID: event.SourceEventID,
+	}, true
 }
 
 func (s *EventStore) Page(since uint64, limit int) EventPage {

--- a/src/agent/internal/ble/event_store_test.go
+++ b/src/agent/internal/ble/event_store_test.go
@@ -64,3 +64,20 @@ func TestEventStoreRequiresCursorResetAcrossGenerations(t *testing.T) {
 		t.Fatalf("reset cursor did not return current generation: %#v", page)
 	}
 }
+
+func TestEventStoreAllowsExpiredExternalEventIDAgain(t *testing.T) {
+	store := NewEventStore(1)
+	first, created := store.AppendUnique(NotificationEvent{
+		DeviceID: "phone", SourceEventID: "event-1", Event: "added",
+	})
+	if !created || first.ID != "1" {
+		t.Fatalf("first append=%#v created=%v", first, created)
+	}
+	store.Append(NotificationEvent{Event: "added"})
+	retried, created := store.AppendUnique(NotificationEvent{
+		DeviceID: "phone", SourceEventID: "event-1", Event: "added",
+	})
+	if !created || retried.ID != "3" {
+		t.Fatalf("expired event ID was not reusable: %#v created=%v", retried, created)
+	}
+}

--- a/src/agent/internal/ble/event_store_test.go
+++ b/src/agent/internal/ble/event_store_test.go
@@ -81,3 +81,22 @@ func TestEventStoreAllowsExpiredExternalEventIDAgain(t *testing.T) {
 		t.Fatalf("expired event ID was not reusable: %#v created=%v", retried, created)
 	}
 }
+
+func TestEventStoreDedupeKeyDoesNotCollideOnEmbeddedNUL(t *testing.T) {
+	store := NewEventStore(4)
+	first, firstCreated := store.AppendUnique(NotificationEvent{
+		DeviceID: "a", SourceEventID: "b\x00c", Event: "added",
+	})
+	second, secondCreated := store.AppendUnique(NotificationEvent{
+		DeviceID: "a\x00b", SourceEventID: "c", Event: "added",
+	})
+	if !firstCreated || !secondCreated || first.ID != "1" || second.ID != "2" {
+		t.Fatalf(
+			"embedded NUL values collided: first=%#v created=%v second=%#v created=%v",
+			first,
+			firstCreated,
+			second,
+			secondCreated,
+		)
+	}
+}

--- a/src/agent/internal/ble/uds.go
+++ b/src/agent/internal/ble/uds.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	maxUDSHeaderBytes  = 64 * 1024
+	maxUDSHeaderBytes  = 256 * 1024
 	maxUDSPayloadBytes = 1024 * 1024
 )
 

--- a/src/agent/internal/ble/uds.go
+++ b/src/agent/internal/ble/uds.go
@@ -113,10 +113,12 @@ func (s *UDSServer) serveConnection(connection *net.UnixConn) {
 }
 
 type udsRequest struct {
-	Op         string          `json:"op"`
-	Since      json.RawMessage `json:"since"`
-	Generation string          `json:"generation"`
-	Limit      int             `json:"limit"`
+	Op         string              `json:"op"`
+	Since      json.RawMessage     `json:"since"`
+	Generation string              `json:"generation"`
+	Limit      int                 `json:"limit"`
+	PhoneID    string              `json:"phone_id"`
+	Events     []NotificationEvent `json:"events"`
 }
 
 func (s *UDSServer) handleRequest(header, payload []byte) []byte {
@@ -176,6 +178,17 @@ func (s *UDSServer) handleRequest(header, payload []byte) []byte {
 			"truncated":      page.Truncated,
 			"oldest_id":      page.OldestID,
 			"last_id":        page.LastID,
+		})
+	case "notification_publish":
+		result, err := s.service.PublishAndroidNotifications(request.PhoneID, request.Events)
+		if err != nil {
+			return marshalResponse(map[string]any{"status": "INVALID_ARGUMENT", "error": err.Error()})
+		}
+		return marshalResponse(map[string]any{
+			"status":     "OK",
+			"accepted":   result.Accepted,
+			"duplicates": result.Duplicates,
+			"last_id":    result.LastID,
 		})
 	default:
 		return marshalResponse(map[string]any{

--- a/src/agent/internal/ble/uds_test.go
+++ b/src/agent/internal/ble/uds_test.go
@@ -135,7 +135,7 @@ func TestUDSEventsSinceRejectsOversizedResponse(t *testing.T) {
 		service.store.Append(NotificationEvent{
 			NotificationUID: uint32(index + 1),
 			Event:           "added",
-			Message:         strings.Repeat("x", 8*1024),
+			Message:         strings.Repeat("x", 16*1024),
 		})
 	}
 	server := NewUDSServer("unused", service)
@@ -167,6 +167,46 @@ func TestWriteUDSMessageEnforcesFrameLimits(t *testing.T) {
 	}
 	if err := writeUDSMessage(&bytes.Buffer{}, []byte(`{}`), make([]byte, maxUDSPayloadBytes+1)); err == nil {
 		t.Fatal("oversized payload was accepted")
+	}
+}
+
+func TestWriteUDSMessageAcceptsMaximumNotificationBatch(t *testing.T) {
+	fill := func(length int) string { return strings.Repeat(`"`, length) }
+	events := make([]NotificationEvent, maxPublishedNotifications)
+	for index := range events {
+		flags := make([]string, maxNotificationFlags)
+		for flagIndex := range flags {
+			flags[flagIndex] = fill(maxNotificationFlagLength)
+		}
+		events[index] = NotificationEvent{
+			SourceID:      fill(maxSourceIDLength),
+			SourceEventID: fill(maxSourceEventIDLength),
+			Event:         "added",
+			Flags:         flags,
+			AppIdentifier: fill(maxAppIdentifierLength),
+			Title:         fill(maxNotificationTitle),
+			Subtitle:      fill(maxNotificationSubtitle),
+			Message:       fill(maxNotificationMessage),
+			Category:      fill(maxNotificationCategory),
+			Date:          fill(maxNotificationDate),
+		}
+	}
+	header, err := json.Marshal(udsRequest{
+		Op:      "notification_publish",
+		PhoneID: fill(maxPhoneIDLength),
+		Events:  events,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(header) <= 64*1024 {
+		t.Fatalf("maximum notification batch did not exercise the old limit: %d", len(header))
+	}
+	if len(header) > maxUDSHeaderBytes {
+		t.Fatalf("maximum notification batch exceeds UDS header limit: %d", len(header))
+	}
+	if err := writeUDSMessage(&bytes.Buffer{}, header, nil); err != nil {
+		t.Fatalf("maximum valid notification header was rejected: %v", err)
 	}
 }
 

--- a/src/agent/internal/ble/uds_test.go
+++ b/src/agent/internal/ble/uds_test.go
@@ -95,6 +95,16 @@ func TestUDSOperations(t *testing.T) {
 	if response["status"] != "INVALID_ARGUMENT" {
 		t.Fatalf("invalid cursor was accepted: %#v", response)
 	}
+
+	publishRequest := []byte(`{"op":"notification_publish","phone_id":"android-1","events":[{"source_id":"notification-key","source_event_id":"event-1","event":"added","app_identifier":"com.example","title":"Hello"}]}`)
+	response = decodeResponse(t, server.handleRequest(publishRequest, nil))
+	if response["status"] != "OK" || response["accepted"] != float64(1) || response["last_id"] != "2" {
+		t.Fatalf("notification publish failed: %#v", response)
+	}
+	response = decodeResponse(t, server.handleRequest(publishRequest, nil))
+	if response["status"] != "OK" || response["duplicates"] != float64(1) || response["last_id"] != "2" {
+		t.Fatalf("notification retry was not deduplicated: %#v", response)
+	}
 }
 
 func TestUDSPairingFailures(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add the USB/loopback-restricted `POST /api/phone-notifications/events` endpoint.
- Forward Android notification batches to `ble_service` through the new `notification_publish` UDS operation.
- Normalize added, modified, and removed events into the existing notification event ring.
- Deduplicate retry-safe source event IDs independently for each phone.
- Mark existing iOS ANCS events with an explicit source.
- Document the Android Notification Access and USB ECM ingestion path.

## Architecture

```text
Android NotificationListenerService
  -> USB ECM HTTP
  -> Agent /api/phone-notifications/events
  -> ble_service notification_publish
  -> shared notification event ring
```

Android notification ingestion does not require BLE pairing. The existing `ble_service` ring is reused so Android events and iOS ANCS events share the same cursor and query semantics.

## Companion App

- AidenAI-IO/aiden-app#44

## Verification

- `go test ./internal/ble ./internal/agent`
- `GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build ./cmd/daemon ./cmd/ble_service`
- `git diff --check`

## Not Verified

- Board deployment was not performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android system-notification forwarding over USB ECM.
  * Added the `/api/phone-notifications/events` endpoint for submitting bounded notification batches.
  * Added Android and iOS notification source and device metadata.
  * Added validation, retry-safe deduplication, batching, and accepted/duplicate result reporting.
  * Added the `notification_publish` protocol operation with size-limit handling.

* **Documentation**
  * Documented Android Notification Access requirements, USB and loopback restrictions, batching, notification formats, and API behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
