### PR TITLE
fix(ci): validate BLE pairing service UUID

### DIFF
--- a/scripts/test_ble_init.sh
+++ b/scripts/test_ble_init.sh
@@ -68,7 +68,6 @@ grep -Fq "trap 'shutdown' INT TERM" "$BLE_INIT"
 grep -Fq 'retaining $PID_FILE and $SOCKET_PATH' "$BLE_INIT"
 grep -Fq 'restart|reload) stop && start' "$BLE_INIT"
 grep -Fq 'pairing-window must be positive' "$BLE_MAIN"
-# Aiden uses a custom encrypted GATT service for pairing rather than HOGP.
 grep -Fq 'a1de0001-7c4b-4f52-8d9a-6b4f6e6f7469' "$BLE_CONSTANTS"
 grep -Fq './cmd/ble_service' "$ROOT_DIR/_build.sh"
 

--- a/scripts/test_ble_init.sh
+++ b/scripts/test_ble_init.sh
@@ -70,7 +70,6 @@ grep -Fq 'restart|reload) stop && start' "$BLE_INIT"
 grep -Fq 'pairing-window must be positive' "$BLE_MAIN"
 # Aiden uses a custom encrypted GATT service for pairing rather than HOGP.
 grep -Fq 'a1de0001-7c4b-4f52-8d9a-6b4f6e6f7469' "$BLE_CONSTANTS"
-grep -Fq 'a1de0002-7c4b-4f52-8d9a-6b4f6e6f7469' "$BLE_CONSTANTS"
 grep -Fq './cmd/ble_service' "$ROOT_DIR/_build.sh"
 
 echo "BLE init tests passed"

--- a/scripts/test_ble_init.sh
+++ b/scripts/test_ble_init.sh
@@ -68,7 +68,9 @@ grep -Fq "trap 'shutdown' INT TERM" "$BLE_INIT"
 grep -Fq 'retaining $PID_FILE and $SOCKET_PATH' "$BLE_INIT"
 grep -Fq 'restart|reload) stop && start' "$BLE_INIT"
 grep -Fq 'pairing-window must be positive' "$BLE_MAIN"
-grep -Fq '00001812-0000-1000-8000-00805f9b34fb' "$BLE_CONSTANTS"
+# Aiden uses a custom encrypted GATT service for pairing rather than HOGP.
+grep -Fq 'a1de0001-7c4b-4f52-8d9a-6b4f6e6f7469' "$BLE_CONSTANTS"
+grep -Fq 'a1de0002-7c4b-4f52-8d9a-6b4f6e6f7469' "$BLE_CONSTANTS"
 grep -Fq './cmd/ble_service' "$ROOT_DIR/_build.sh"
 
 echo "BLE init tests passed"


### PR DESCRIPTION
## Summary

- replace the stale HOGP service UUID assertion with the pairing service UUID used by the current BLE implementation

## Verification

- `sh -n scripts/test_ble_init.sh`
- `sh scripts/test_ble_init.sh`
- `git diff --check`

Fixes the `Verify Bluetooth initialization` failure in scheduled run 31470040335.