### PR TITLE
feat(agent): support pasted image attachments

### DIFF
--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -118,6 +118,8 @@ type AudioRecordStopResponse struct {
 	Attachment MessageAttachment `json:"attachment"`
 }
 
+const maxChatImageAttachments = 4
+
 type MessageAttachment struct {
 	Kind       string `json:"kind"`
 	Name       string `json:"name,omitempty"`
@@ -3377,6 +3379,7 @@ func (s *Server) webAudioInputMode() string {
 func decodeMessageAttachments(payloads []MessageAttachment) ([]InputAttachment, []MessageAttachment, error) {
 	decoded := make([]InputAttachment, 0, len(payloads))
 	history := make([]MessageAttachment, 0, len(payloads))
+	imageCount := 0
 
 	for _, payload := range payloads {
 		data := strings.TrimSpace(payload.Data)
@@ -3390,14 +3393,22 @@ func decodeMessageAttachments(payloads []MessageAttachment) ([]InputAttachment, 
 		}
 
 		kind := strings.ToLower(strings.TrimSpace(payload.Kind))
+		mimeType := strings.ToLower(strings.TrimSpace(payload.MIMEType))
 		if kind == "" {
 			switch {
-			case strings.HasPrefix(payload.MIMEType, "image/"):
+			case isImageMIMEType(mimeType):
 				kind = AttachmentKindImage
-			case strings.HasPrefix(payload.MIMEType, "audio/"):
+			case strings.HasPrefix(mimeType, "audio/"):
 				kind = AttachmentKindAudio
 			default:
 				kind = "file"
+			}
+		}
+		if kind == AttachmentKindImage || isImageMIMEType(mimeType) {
+			kind = AttachmentKindImage
+			imageCount++
+			if imageCount > maxChatImageAttachments {
+				return nil, nil, fmt.Errorf("at most %d image attachments are supported", maxChatImageAttachments)
 			}
 		}
 
@@ -3419,6 +3430,10 @@ func decodeMessageAttachments(payloads []MessageAttachment) ([]InputAttachment, 
 	}
 
 	return decoded, history, nil
+}
+
+func isImageMIMEType(mimeType string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(mimeType)), "image/")
 }
 
 func splitAudioAttachment(attachments []InputAttachment) (*InputAttachment, []InputAttachment, error) {
@@ -4690,6 +4705,11 @@ const webUI = `<!DOCTYPE html>
             font-size: 0.76rem;
         }
 
+        .composer-hint.error {
+            color: #b91c1c;
+            font-weight: 600;
+        }
+
         .send-btn {
             padding: 0.64rem 1rem;
             border: none;
@@ -4937,7 +4957,7 @@ const webUI = `<!DOCTYPE html>
                         <div class="composer-toolbar">
                             <button type="button" class="composer-btn" id="imageBtn" onclick="openImagePicker()">Add image</button>
                             <button type="button" class="composer-btn" id="recordBtn" onclick="toggleRecording()">Record audio</button>
-                            <div class="composer-hint">Enter to send, Shift+Enter for newline</div>
+                            <div class="composer-hint" id="composerHint" aria-live="polite">Enter to send, Shift+Enter for newline</div>
                         </div>
                         <div class="composer-actions">
                             <button type="submit" class="send-btn" id="sendBtn">Send</button>
@@ -5021,6 +5041,7 @@ const webUI = `<!DOCTYPE html>
         const imageBtn = document.getElementById('imageBtn');
         const recordBtn = document.getElementById('recordBtn');
         const draftAttachmentsEl = document.getElementById('draftAttachments');
+        const composerHintEl = document.getElementById('composerHint');
         const loadingDiv = document.getElementById('loading');
         const stopRunBtn = document.getElementById('stopRunBtn');
         const pendingSteerEl = document.getElementById('pendingSteer');
@@ -5043,9 +5064,12 @@ const webUI = `<!DOCTYPE html>
         const skillStatusEl = document.getElementById('skillStatus');
         const copySkillBtnEl = document.getElementById('copySkillBtn');
         const targetAudioSampleRate = 16000;
+        const maxDraftImageAttachments = 4;
+        const defaultComposerHint = 'Enter to send, Shift+Enter for newline';
 
         let nextAttachmentId = 1;
         let draftAttachments = [];
+        let composerHintTimer = null;
         let recorderState = createRecorderState();
         let toolCatalog = [];
         let toolSkills = [];
@@ -5077,6 +5101,7 @@ const webUI = `<!DOCTYPE html>
 
         inputEl.addEventListener('input', autoResizeInput);
         imageInputEl.addEventListener('change', handleImageSelection);
+        inputEl.addEventListener('paste', handleComposerPaste);
         toolSelectEl.addEventListener('change', syncSelectedTool);
         skillSelectEl.addEventListener('change', syncSelectedSkill);
         inputEl.addEventListener('keydown', function(event) {
@@ -6257,7 +6282,9 @@ const webUI = `<!DOCTYPE html>
         function setComposerState(isLoading) {
             sendBtn.disabled = recorderState.isStopping || pendingSteerSubmitting || (isLoading && !currentChatRequestId);
             sendBtn.textContent = currentChatRequestId ? 'Steer' : 'Send';
-            imageBtn.disabled = isLoading || recorderState.isRecording || recorderState.isStopping;
+            const imageSlotsFull = getDraftImageCount() >= maxDraftImageAttachments;
+            imageBtn.disabled = isLoading || recorderState.isRecording || recorderState.isStopping || imageSlotsFull;
+            imageBtn.title = imageSlotsFull ? 'Maximum 4 images attached' : 'Add image';
             recordBtn.disabled = isLoading || recorderState.isStopping;
             stopRunBtn.disabled = !isLoading;
             if (!isLoading) {
@@ -6331,23 +6358,171 @@ const webUI = `<!DOCTYPE html>
             const files = Array.from(event.target.files || []);
             imageInputEl.value = '';
             if (files.length === 0) return;
+            await addImageFiles(files, 'selected');
+        }
 
-            for (const file of files) {
-                if (!file.type || file.type.indexOf('image/') !== 0) {
+        async function handleComposerPaste(event) {
+            const files = clipboardImageFiles(event.clipboardData);
+            if (files.length === 0) return;
+            event.preventDefault();
+            if (!canAttachImagesNow()) {
+                setComposerHint('Images can be attached after the current run finishes.', true);
+                return;
+            }
+            await addImageFiles(files, 'pasted');
+        }
+
+        function clipboardImageFiles(clipboardData) {
+            if (!clipboardData) return [];
+            const files = [];
+            const items = Array.from(clipboardData.items || []);
+            items.forEach(function(item) {
+                if (item.kind === 'file' && item.type && item.type.indexOf('image/') === 0) {
+                    const file = item.getAsFile();
+                    if (file) files.push(file);
+                }
+            });
+            if (files.length > 0) return files;
+            return Array.from(clipboardData.files || []).filter(isImageFile);
+        }
+
+        async function addImageFiles(files, source) {
+            const imageFiles = Array.from(files || []).filter(isImageFile);
+            if (imageFiles.length === 0) return;
+            if (!canAttachImagesNow()) {
+                setComposerHint('Images can be attached after the current run finishes.', true);
+                return;
+            }
+
+            let accepted = 0;
+            let skipped = 0;
+            let failed = 0;
+            for (const file of imageFiles) {
+                if (getDraftImageCount() >= maxDraftImageAttachments) {
+                    skipped++;
                     continue;
                 }
-                const dataUrl = await readFileAsDataURL(file);
-                draftAttachments.push({
-                    id: nextAttachmentId++,
-                    kind: 'image',
-                    name: file.name,
-                    mime_type: file.type,
-                    data: extractBase64(dataUrl),
-                    size: file.size
-                });
+                try {
+                    const id = nextAttachmentId++;
+                    const dataUrl = await readFileAsDataURL(file);
+                    if (!canAttachImagesNow()) {
+                        skipped++;
+                        continue;
+                    }
+                    if (getDraftImageCount() >= maxDraftImageAttachments) {
+                        skipped++;
+                        continue;
+                    }
+                    draftAttachments.push({
+                        id: id,
+                        kind: 'image',
+                        name: imageAttachmentName(file, source, id),
+                        mime_type: imageMIMEType(file, dataUrl),
+                        data: extractBase64(dataUrl),
+                        size: file.size || 0
+                    });
+                    accepted++;
+                } catch (err) {
+                    failed++;
+                    console.error('Failed to read image attachment:', err);
+                }
             }
 
             renderDraftAttachments();
+            reportImageAddResult(accepted, skipped, failed);
+        }
+
+        function isImageFile(file) {
+            if (!file) return false;
+            const mimeType = String(file.type || '').toLowerCase();
+            if (mimeType.indexOf('image/') === 0) return true;
+            return /\.(png|jpe?g|gif|webp|bmp|tiff?)$/i.test(file.name || '');
+        }
+
+        function getDraftImageCount() {
+            return draftAttachments.filter(function(attachment) {
+                return attachment.kind === 'image';
+            }).length;
+        }
+
+        function canAttachImagesNow() {
+            return !loadingDiv.classList.contains('active') && !recorderState.isRecording && !recorderState.isStopping;
+        }
+
+        function imageAttachmentName(file, source, id) {
+            if (file && file.name && file.name.trim()) return file.name.trim();
+            const prefix = source === 'pasted' ? 'pasted-image' : 'image';
+            return prefix + '-' + id + '.' + imageExtensionFromType(file ? file.type : '');
+        }
+
+        function imageExtensionFromType(mimeType) {
+            switch (String(mimeType || '').toLowerCase()) {
+            case 'image/jpeg':
+            case 'image/jpg':
+                return 'jpg';
+            case 'image/gif':
+                return 'gif';
+            case 'image/webp':
+                return 'webp';
+            case 'image/png':
+            default:
+                return 'png';
+            }
+        }
+
+        function imageMIMEType(file, dataUrl) {
+            const fileType = String(file && file.type || '').toLowerCase();
+            if (fileType.indexOf('image/') === 0) return fileType;
+            const name = String(file && file.name || '').toLowerCase();
+            if (/\.(jpe?g)$/.test(name)) return 'image/jpeg';
+            if (/\.gif$/.test(name)) return 'image/gif';
+            if (/\.webp$/.test(name)) return 'image/webp';
+            if (/\.bmp$/.test(name)) return 'image/bmp';
+            if (/\.tiff?$/.test(name)) return 'image/tiff';
+            return imageMIMETypeFromDataURL(dataUrl);
+        }
+
+        function imageMIMETypeFromDataURL(dataUrl) {
+            const match = String(dataUrl || '').match(/^data:([^;,]+)[;,]/);
+            const mimeType = match && match[1] ? match[1].toLowerCase() : '';
+            return mimeType.indexOf('image/') === 0 ? mimeType : 'image/png';
+        }
+
+        function reportImageAddResult(accepted, skipped, failed) {
+            if (skipped > 0) {
+                setComposerHint('Only 4 images can be attached.', true);
+                return;
+            }
+            if (failed > 0) {
+                setComposerHint('Some images could not be read.', true);
+                return;
+            }
+            if (accepted > 0) {
+                resetComposerHint();
+            }
+        }
+
+        function setComposerHint(text, isError) {
+            if (!composerHintEl) return;
+            if (composerHintTimer) {
+                clearTimeout(composerHintTimer);
+                composerHintTimer = null;
+            }
+            composerHintEl.textContent = text || defaultComposerHint;
+            composerHintEl.classList.toggle('error', !!isError);
+            if (text) {
+                composerHintTimer = setTimeout(resetComposerHint, 2800);
+            }
+        }
+
+        function resetComposerHint() {
+            if (!composerHintEl) return;
+            if (composerHintTimer) {
+                clearTimeout(composerHintTimer);
+                composerHintTimer = null;
+            }
+            composerHintEl.textContent = defaultComposerHint;
+            composerHintEl.classList.remove('error');
         }
 
         async function toggleRecording() {
@@ -6631,6 +6806,8 @@ const webUI = `<!DOCTYPE html>
 
                 draftAttachmentsEl.appendChild(row);
             });
+
+            setComposerState(loadingDiv.classList.contains('active'));
         }
 
         function removeDraftAttachment(id) {

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -2489,6 +2489,20 @@ func TestWebUISteerModeControlsArePresent(t *testing.T) {
 	}
 }
 
+func TestWebUIImagePasteControlsArePresent(t *testing.T) {
+	for _, want := range []string{
+		"const maxDraftImageAttachments = 4;",
+		"inputEl.addEventListener('paste', handleComposerPaste);",
+		"async function handleComposerPaste(event)",
+		"await addImageFiles(files, 'pasted');",
+		"Only 4 images can be attached.",
+	} {
+		if !strings.Contains(webUI, want) {
+			t.Fatalf("web UI missing %q", want)
+		}
+	}
+}
+
 func TestServerHandleChatAsyncDuplicateRequestIDDoesNotAppendHistory(t *testing.T) {
 	server := &Server{logger: newTestLogger(),
 		activeRuns:     make(map[string]context.CancelFunc),
@@ -2955,6 +2969,54 @@ func TestServerHandleChatWithAudioAttachmentUsesSTT(t *testing.T) {
 	assistant, ok := firstMessageOfType(resp.History, "assistant")
 	if !ok || assistant.Content != "Completed" {
 		t.Fatalf("unexpected assistant message: %#v", resp.History)
+	}
+}
+
+func TestDecodeMessageAttachmentsLimitsImages(t *testing.T) {
+	payloads := make([]MessageAttachment, maxChatImageAttachments+1)
+	for i := range payloads {
+		payloads[i] = MessageAttachment{
+			Kind:     AttachmentKindImage,
+			Name:     fmt.Sprintf("image-%d.png", i+1),
+			MIMEType: "image/png",
+			Data:     base64.StdEncoding.EncodeToString([]byte{byte(i + 1)}),
+		}
+	}
+
+	if decoded, history, err := decodeMessageAttachments(payloads[:maxChatImageAttachments]); err != nil {
+		t.Fatalf("decodeMessageAttachments(%d images) error = %v", maxChatImageAttachments, err)
+	} else if len(decoded) != maxChatImageAttachments || len(history) != maxChatImageAttachments {
+		t.Fatalf("decoded=%d history=%d, want %d", len(decoded), len(history), maxChatImageAttachments)
+	}
+
+	_, _, err := decodeMessageAttachments(payloads)
+	if err == nil || !strings.Contains(err.Error(), "at most 4 image attachments") {
+		t.Fatalf("decodeMessageAttachments(%d images) error = %v, want image limit", len(payloads), err)
+	}
+}
+
+func TestDecodeMessageAttachmentsCountsImageMIMEWithFileKind(t *testing.T) {
+	payloads := make([]MessageAttachment, maxChatImageAttachments+1)
+	for i := range payloads {
+		payloads[i] = MessageAttachment{
+			Kind:     "file",
+			Name:     fmt.Sprintf("image-%d.png", i+1),
+			MIMEType: "image/png",
+			Data:     base64.StdEncoding.EncodeToString([]byte{byte(i + 1)}),
+		}
+	}
+
+	decoded, history, err := decodeMessageAttachments(payloads[:maxChatImageAttachments])
+	if err != nil {
+		t.Fatalf("decodeMessageAttachments(%d file-kind images) error = %v", maxChatImageAttachments, err)
+	}
+	if decoded[0].Kind != AttachmentKindImage || history[0].Kind != AttachmentKindImage {
+		t.Fatalf("file-kind image was not normalized: decoded=%q history=%q", decoded[0].Kind, history[0].Kind)
+	}
+
+	_, _, err = decodeMessageAttachments(payloads)
+	if err == nil || !strings.Contains(err.Error(), "at most 4 image attachments") {
+		t.Fatalf("decodeMessageAttachments(%d file-kind images) error = %v, want image limit", len(payloads), err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add clipboard image paste support to the 8080 Agent Web UI composer
- cap draft/API image attachments at 4 and keep remove/re-add behavior working
- add tests for Web UI paste wiring and backend image attachment limits

## Verification
- go test ./internal/agent -run 'TestWebUI|TestDecodeMessageAttachmentsLimitsImages|TestServerHandleChatWithAudioAttachmentUsesSTT' -count=1
- node --check on the extracted embedded Web UI script

## Device smoke
- rebuilt build/bin/agent
- deployed to root@192.168.42.1:/oem/usr/bin/agent
- restarted /etc/init.d/S53agent and verified http://192.168.42.1:8080/ includes the paste-image logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pasting images directly into chat.
  * Added image attachment status messages and improved composer feedback.
  * Image selection is disabled while a response is active or when the attachment limit is reached.

* **Bug Fixes**
  * Enforced a maximum of four image attachments per message.
  * Improved image type detection and handling for pasted or uploaded files.
  * Added clearer feedback when attachments cannot be added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->