### PR TITLE
refactor(agent): share model runtime bindings

### DIFF
--- a/src/agent/internal/agent/anthropic_model.go
+++ b/src/agent/internal/agent/anthropic_model.go
@@ -34,7 +34,7 @@ type anthropicModel struct {
 	token            string
 	useBearerAuth    bool
 	httpClient       *http.Client
-	rawLogger        *llmRawHTTPLogger
+	rawLogger        RawHTTPLogger
 	temperature      *float64
 	reasoningEffort  string
 	streamMaxRetries int
@@ -45,7 +45,7 @@ type anthropicModel struct {
 
 type anthropicModelOption func(*anthropicModel)
 
-func withAnthropicRawHTTPLogger(logger *llmRawHTTPLogger) anthropicModelOption {
+func withAnthropicRawHTTPLogger(logger RawHTTPLogger) anthropicModelOption {
 	return func(m *anthropicModel) { m.rawLogger = logger }
 }
 
@@ -1094,31 +1094,25 @@ func (m *anthropicModel) withRawHTTPLogScope(ctx context.Context) context.Contex
 	if m == nil || m.rawLogger == nil || !rawHTTPLogEnabled(ctx) {
 		return ctx
 	}
-	if _, ok := rawHTTPLogFileTime(ctx); !ok {
-		ctx = contextWithRawHTTPLogFileTime(ctx, m.rawLogger.currentTime())
-	}
-	if _, ok := rawHTTPLogFileSessionID(ctx); !ok {
-		ctx = contextWithRawHTTPLogFileSessionID(ctx, m.rawLogger.currentSessionID())
-	}
-	return ctx
+	return m.rawLogger.BeginScope(ctx)
 }
 
 func (m *anthropicModel) logRawHTTP(ctx context.Context, model, kind string, statusCode int, raw string) error {
 	if m == nil || m.rawLogger == nil || !rawHTTPLogEnabled(ctx) {
 		return nil
 	}
-	fileTime, _ := rawHTTPLogFileTime(ctx)
-	sessionID, _ := rawHTTPLogFileSessionID(ctx)
-	return m.rawLogger.LogWithFileScope(model, kind, statusCode, raw, fileTime, sessionID)
+	return m.rawLogger.Log(ctx, RawHTTPLogEntry{
+		Model:      model,
+		Kind:       kind,
+		StatusCode: statusCode,
+		Raw:        raw,
+	})
 }
 
-func buildAnthropicModelOptions(m *ModelManager, cfg ModelConfig) []anthropicModelOption {
+func buildAnthropicModelOptions(ctx ModelBuildContext, cfg ModelConfig) []anthropicModelOption {
 	var options []anthropicModelOption
-	if cfg.LogRawHTTP && strings.TrimSpace(m.rawHTTPLogDir) != "" {
-		logger := newLLMRawHTTPLogger(m.rawHTTPLogDir, "")
-		logger.SetSessionIDProvider(m.rawHTTPLogSessionID)
-		logger.SetStorageMonitor(m.currentStorageMonitor())
-		options = append(options, withAnthropicRawHTTPLogger(logger))
+	if ctx.RawHTTPLogger != nil {
+		options = append(options, withAnthropicRawHTTPLogger(ctx.RawHTTPLogger))
 	}
 	if cfg.Temperature != nil {
 		options = append(options, withAnthropicTemperature(cfg.Temperature))

--- a/src/agent/internal/agent/anthropic_model_test.go
+++ b/src/agent/internal/agent/anthropic_model_test.go
@@ -803,7 +803,7 @@ func TestAnthropicModelLogsResponseOnEarlyStreamFailure(t *testing.T) {
 
 	logDir := t.TempDir()
 	model := newAnthropicModel(server.URL, "claude-test", "test-token", server.Client(),
-		withAnthropicRawHTTPLogger(newLLMRawHTTPLogger(logDir, "test-session")),
+		withAnthropicRawHTTPLogger(newTestLLMRawHTTPLogger(logDir, "test-session")),
 		withAnthropicStreamRetry(0, time.Second),
 	)
 	_, err := model.GenerateContent(contextWithRawHTTPLog(context.Background()), []llms.MessageContent{
@@ -829,7 +829,7 @@ func TestAnthropicProviderUsesEnvironmentFallbacks(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
 
 	manager := NewModelManager(ModelConfig{Provider: "anthropic", Model: "claude-test"}, ProxyConfig{})
-	built, err := manager.build(manager.config)
+	built, err := manager.build()
 	if err != nil {
 		t.Fatalf("build() error = %v", err)
 	}
@@ -870,7 +870,7 @@ func TestAnthropicProviderAuthTokenReferenceUsesBearer(t *testing.T) {
 		Model:    "claude-test",
 		APIKey:   "$ANTHROPIC_AUTH_TOKEN",
 	}, ProxyConfig{})
-	built, err := manager.build(manager.config)
+	built, err := manager.build()
 	if err != nil {
 		t.Fatalf("build() error = %v", err)
 	}

--- a/src/agent/internal/agent/model_provider_registry.go
+++ b/src/agent/internal/agent/model_provider_registry.go
@@ -1,64 +1,130 @@
 package agent
 
 import (
+	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/tmc/langchaingo/llms"
 	fakellm "github.com/tmc/langchaingo/llms/fake"
+	"github.com/tmc/langchaingo/llms/ollama"
 )
+
+type ModelBuildContext struct {
+	HTTPClient        *http.Client
+	OllamaHTTPClient  *http.Client
+	RawHTTPLogger     RawHTTPLogger
+	SessionIDProvider func() string
+	PromptCachePolicy PromptCachePolicy
+}
+
+type ModelProviderBuilder func(ModelBuildContext, ModelConfig) (llms.Model, error)
 
 type modelProviderDefinition struct {
 	providerType        string
 	allowsCustomBaseURL bool
-	build               func(*ModelManager, ModelConfig) (llms.Model, error)
+	build               ModelProviderBuilder
 }
 
 var modelProviderDefinitions = []modelProviderDefinition{
 	{
 		providerType: "openrouter",
-		build:        (*ModelManager).buildOpenRouterModel,
+		build:        buildOpenRouterModel,
 	},
 	{
 		providerType:        "openai",
 		allowsCustomBaseURL: true,
-		build: func(m *ModelManager, cfg ModelConfig) (llms.Model, error) {
-			return m.buildOpenAICompatibleModel(cfg, "https://api.openai.com/v1"), nil
+		build: func(ctx ModelBuildContext, cfg ModelConfig) (llms.Model, error) {
+			return buildOpenAICompatibleModel(ctx, cfg, "https://api.openai.com/v1"), nil
 		},
 	},
 	{
 		providerType:        "anthropic",
 		allowsCustomBaseURL: true,
-		build:               (*ModelManager).buildAnthropicModel,
+		build:               buildAnthropicModel,
 	},
 	{
 		providerType: "kimi",
-		build: func(m *ModelManager, cfg ModelConfig) (llms.Model, error) {
-			return m.buildOpenAICompatibleModel(cfg, moonshotGlobalBaseURL), nil
+		build: func(ctx ModelBuildContext, cfg ModelConfig) (llms.Model, error) {
+			return buildOpenAICompatibleModel(ctx, cfg, moonshotGlobalBaseURL), nil
 		},
 	},
 	{
 		providerType: "kimi-cn",
-		build: func(m *ModelManager, cfg ModelConfig) (llms.Model, error) {
-			return m.buildOpenAICompatibleModel(cfg, moonshotCNBaseURL), nil
+		build: func(ctx ModelBuildContext, cfg ModelConfig) (llms.Model, error) {
+			return buildOpenAICompatibleModel(ctx, cfg, moonshotCNBaseURL), nil
 		},
 	},
 	{
 		providerType: "volcengine",
-		build: func(m *ModelManager, cfg ModelConfig) (llms.Model, error) {
-			return m.buildOpenAICompatibleModel(cfg, arkBeijingBaseURL), nil
+		build: func(ctx ModelBuildContext, cfg ModelConfig) (llms.Model, error) {
+			return buildOpenAICompatibleModel(ctx, cfg, arkBeijingBaseURL), nil
 		},
 	},
 	{
 		providerType:        "ollama",
 		allowsCustomBaseURL: true,
-		build:               (*ModelManager).buildOllamaModel,
+		build:               buildOllamaModel,
 	},
 	{
 		providerType: "fake",
-		build: func(_ *ModelManager, cfg ModelConfig) (llms.Model, error) {
+		build: func(_ ModelBuildContext, cfg ModelConfig) (llms.Model, error) {
 			return fakellm.NewFakeLLM(cfg.Responses), nil
 		},
 	},
+}
+
+func buildOpenAICompatibleModel(ctx ModelBuildContext, cfg ModelConfig, defaultBaseURL string) llms.Model {
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	return newOpenAICompatibleModel(baseURL, cfg.Model, resolveToken(cfg), ctx.HTTPClient, openAICompatibleOptions(ctx, cfg)...)
+}
+
+func buildOpenRouterModel(ctx ModelBuildContext, cfg ModelConfig) (llms.Model, error) {
+	token := resolveToken(cfg)
+	if token == "" {
+		if env, ok := providerAPIKeyEnv(cfg.APIKey); ok && env != "" {
+			return nil, fmt.Errorf("missing the OpenRouter API key, set it in the %s environment variable", env)
+		}
+		return nil, fmt.Errorf("missing the OpenRouter API key, set api_key on the provider record")
+	}
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "https://openrouter.ai/api/v1"
+	}
+	opts := append(openAICompatibleOptions(ctx, cfg),
+		withOpenAICompatibleSessionSticky(ctx.SessionIDProvider),
+		withOpenAICompatibleRouterMetadata(),
+		withOpenAICompatibleOpenRouterReasoning())
+	if ctx.PromptCachePolicy.UsesExplicitCacheControl() {
+		opts = append(opts, withOpenAICompatibleExplicitPromptCache())
+	}
+	return newOpenAICompatibleModel(baseURL, cfg.Model, token, ctx.HTTPClient, opts...), nil
+}
+
+func buildAnthropicModel(ctx ModelBuildContext, cfg ModelConfig) (llms.Model, error) {
+	token, useBearerAuth := resolveAnthropicToken(cfg.APIKey)
+	if token == "" {
+		if env, ok := providerAPIKeyEnv(cfg.APIKey); ok && env != "" {
+			return nil, fmt.Errorf("missing the Anthropic API key, set it in the %s environment variable", env)
+		}
+		return nil, fmt.Errorf("missing the Anthropic API key, set api_key on the provider record, ANTHROPIC_AUTH_TOKEN, or ANTHROPIC_API_KEY")
+	}
+	options := buildAnthropicModelOptions(ctx, cfg)
+	if useBearerAuth {
+		options = append(options, withAnthropicBearerAuth())
+	}
+	return newAnthropicModel(resolveAnthropicBaseURL(cfg.BaseURL), cfg.Model, token, ctx.HTTPClient, options...), nil
+}
+
+func buildOllamaModel(ctx ModelBuildContext, cfg ModelConfig) (llms.Model, error) {
+	options := []ollama.Option{ollama.WithModel(cfg.Model), ollama.WithHTTPClient(ctx.OllamaHTTPClient)}
+	if cfg.BaseURL != "" {
+		options = append(options, ollama.WithServerURL(cfg.BaseURL))
+	}
+	return ollama.New(options...)
 }
 
 func lookupModelProviderDefinition(providerType string) (modelProviderDefinition, bool) {

--- a/src/agent/internal/agent/model_runtime_bindings.go
+++ b/src/agent/internal/agent/model_runtime_bindings.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+)
+
+type StorageWriteGate interface {
+	AllowWrite(StorageCapability) bool
+	HandleWriteError(error) bool
+}
+
+type ModelRuntimeBindings struct {
+	mu               sync.RWMutex
+	sessionID        func() string
+	storageWriteGate StorageWriteGate
+}
+
+func NewModelRuntimeBindings() *ModelRuntimeBindings {
+	return &ModelRuntimeBindings{}
+}
+
+func (b *ModelRuntimeBindings) SetSessionIDProvider(provider func() string) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	b.sessionID = provider
+	b.mu.Unlock()
+}
+
+func (b *ModelRuntimeBindings) CurrentSessionID() string {
+	if b == nil {
+		return ""
+	}
+	b.mu.RLock()
+	provider := b.sessionID
+	b.mu.RUnlock()
+	if provider == nil {
+		return ""
+	}
+	return strings.TrimSpace(provider())
+}
+
+func (b *ModelRuntimeBindings) SetStorageWriteGate(gate StorageWriteGate) {
+	if b == nil {
+		return
+	}
+	if gate != nil {
+		value := reflect.ValueOf(gate)
+		switch value.Kind() {
+		case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+			if value.IsNil() {
+				gate = nil
+			}
+		}
+	}
+	b.mu.Lock()
+	b.storageWriteGate = gate
+	b.mu.Unlock()
+}
+
+func (b *ModelRuntimeBindings) StorageWriteGate() StorageWriteGate {
+	if b == nil {
+		return nil
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.storageWriteGate
+}

--- a/src/agent/internal/agent/model_runtime_bindings_test.go
+++ b/src/agent/internal/agent/model_runtime_bindings_test.go
@@ -1,0 +1,210 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+type recordingStorageWriteGate struct {
+	allow bool
+}
+
+func newTestLLMRawHTTPLogger(logDir, sessionID string) *llmRawHTTPLogger {
+	bindings := NewModelRuntimeBindings()
+	bindings.SetSessionIDProvider(func() string { return sessionID })
+	return newLLMRawHTTPLogger(logDir, bindings)
+}
+
+func (g *recordingStorageWriteGate) AllowWrite(StorageCapability) bool {
+	return g.allow
+}
+
+func (g *recordingStorageWriteGate) HandleWriteError(error) bool {
+	return false
+}
+
+func TestModelRuntimeBindingsCanReplaceDependencies(t *testing.T) {
+	bindings := NewModelRuntimeBindings()
+	bindings.SetSessionIDProvider(func() string { return "session-a" })
+	firstGate := &recordingStorageWriteGate{allow: false}
+	bindings.SetStorageWriteGate(firstGate)
+
+	if got := bindings.CurrentSessionID(); got != "session-a" {
+		t.Fatalf("CurrentSessionID() = %q, want session-a", got)
+	}
+	if got := bindings.StorageWriteGate(); got != firstGate {
+		t.Fatalf("StorageWriteGate() = %T %p, want first gate %p", got, got, firstGate)
+	}
+
+	bindings.SetSessionIDProvider(func() string { return "session-b" })
+	secondGate := &recordingStorageWriteGate{allow: true}
+	bindings.SetStorageWriteGate(secondGate)
+
+	if got := bindings.CurrentSessionID(); got != "session-b" {
+		t.Fatalf("CurrentSessionID() after replacement = %q, want session-b", got)
+	}
+	if got := bindings.StorageWriteGate(); got != secondGate {
+		t.Fatalf("StorageWriteGate() after replacement = %T %p, want second gate %p", got, got, secondGate)
+	}
+}
+
+func TestModelRuntimeBindingsNormalizesTypedNilStorageWriteGate(t *testing.T) {
+	bindings := NewModelRuntimeBindings()
+	var monitor *StorageMonitor
+	bindings.SetStorageWriteGate(monitor)
+	if gate := bindings.StorageWriteGate(); gate != nil {
+		t.Fatalf("StorageWriteGate() = %T, want nil", gate)
+	}
+}
+
+func TestLLMRawHTTPLoggerUsesStableRuntimeBindings(t *testing.T) {
+	dir := t.TempDir()
+	bindings := NewModelRuntimeBindings()
+	bindings.SetSessionIDProvider(func() string { return "session-a" })
+	bindings.SetStorageWriteGate(&recordingStorageWriteGate{allow: false})
+	logger := newLLMRawHTTPLogger(dir, bindings)
+
+	ctx := logger.BeginScope(context.Background())
+	if err := logger.Log(ctx, RawHTTPLogEntry{Model: "model", Kind: "request", StatusCode: http.StatusOK, Raw: `{}`}); err != nil {
+		t.Fatalf("Log() while writes disabled error = %v", err)
+	}
+	if matches, err := filepath.Glob(filepath.Join(dir, "llm-http-*.log")); err != nil || len(matches) != 0 {
+		t.Fatalf("logs while writes disabled = %#v, err = %v", matches, err)
+	}
+
+	bindings.SetStorageWriteGate(&recordingStorageWriteGate{allow: true})
+	bindings.SetSessionIDProvider(func() string { return "session-b" })
+	ctx = logger.BeginScope(context.Background())
+	if err := logger.Log(ctx, RawHTTPLogEntry{Model: "model", Kind: "request", StatusCode: http.StatusOK, Raw: `{}`}); err != nil {
+		t.Fatalf("Log() after bindings replacement error = %v", err)
+	}
+	if matches, err := filepath.Glob(filepath.Join(dir, "llm-http-session-b.log")); err != nil || len(matches) != 1 {
+		t.Fatalf("session-b logs = %#v, err = %v", matches, err)
+	}
+}
+
+func TestProviderModelsShareManagerRuntimeBindingsWithRawLogger(t *testing.T) {
+	for _, cfg := range []ModelConfig{
+		{Provider: "openai", Model: "test-model", APIKey: "test-key", LogRawHTTP: true},
+		{Provider: "anthropic", Model: "test-model", APIKey: "test-key", LogRawHTTP: true},
+	} {
+		t.Run(cfg.Provider, func(t *testing.T) {
+			manager := NewModelManager(cfg, ProxyConfig{}, WithLLMRawHTTPLogDir(t.TempDir()))
+			model, err := manager.get()
+			if err != nil {
+				t.Fatalf("get() error = %v", err)
+			}
+
+			var rawLogger RawHTTPLogger
+			switch model := model.(type) {
+			case *openAICompatibleModel:
+				rawLogger = model.rawLogger
+			case *anthropicModel:
+				rawLogger = model.rawLogger
+			default:
+				t.Fatalf("model = %T, want provider model", model)
+			}
+			logger, ok := rawLogger.(*llmRawHTTPLogger)
+			if !ok {
+				t.Fatalf("raw logger = %T, want *llmRawHTTPLogger", rawLogger)
+			}
+			if logger.bindings != manager.bindings() {
+				t.Fatal("provider logger does not share the manager runtime bindings")
+			}
+		})
+	}
+}
+
+func TestModelManagerSetSessionIDProviderAfterBuildUpdatesOpenRouter(t *testing.T) {
+	var gotHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("x-session-id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	manager := NewModelManager(ModelConfig{
+		Provider: "openrouter",
+		Model:    "test-model",
+		APIKey:   "test-key",
+		BaseURL:  server.URL,
+	}, ProxyConfig{})
+	model, err := manager.get()
+	if err != nil {
+		t.Fatalf("get() error = %v", err)
+	}
+	manager.SetSessionIDProvider(func() string { return "session-after-build" })
+
+	if _, err := model.GenerateContent(context.Background(), []llms.MessageContent{{
+		Role:  llms.ChatMessageTypeHuman,
+		Parts: []llms.ContentPart{llms.TextPart("hello")},
+	}}); err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+	if gotHeader != "session-after-build" {
+		t.Fatalf("x-session-id = %q, want session-after-build", gotHeader)
+	}
+}
+
+func TestModelManagerUpdatesRawLoggerDependenciesAfterBuild(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	logDir := t.TempDir()
+	manager := NewModelManager(ModelConfig{
+		Provider:   "openai",
+		Model:      "test-model",
+		BaseURL:    server.URL,
+		LogRawHTTP: true,
+	}, ProxyConfig{}, WithLLMRawHTTPLogDir(logDir))
+	model, err := manager.get()
+	if err != nil {
+		t.Fatalf("get() error = %v", err)
+	}
+
+	manager.SetSessionIDProvider(func() string { return "session-a" })
+	storageConfig := DefaultStorageConfig()
+	storageConfig.Cleanup.Enabled = false
+	monitor := NewStorageMonitor(storageConfig, &sequenceStorageSampler{
+		samples: []StorageSample{storageSampleWithAvailableMB(8)},
+	}, nil, nil, nil)
+	manager.SetStorageMonitor(monitor)
+	if _, err := monitor.CheckAndRemediate(context.Background(), StorageCheckRequest{Reason: CheckReasonPeriodic}); err != nil {
+		t.Fatalf("CheckAndRemediate() error = %v", err)
+	}
+	callModel := func() {
+		t.Helper()
+		if _, err := model.GenerateContent(contextWithRawHTTPLog(context.Background()), []llms.MessageContent{{
+			Role:  llms.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextPart("hello")},
+		}}); err != nil {
+			t.Fatalf("GenerateContent() error = %v", err)
+		}
+	}
+
+	callModel()
+	if matches, err := filepath.Glob(filepath.Join(logDir, "llm-http-*.log")); err != nil || len(matches) != 0 {
+		t.Fatalf("logs while writes disabled = %#v, err = %v", matches, err)
+	}
+
+	manager.SetStorageMonitor(nil)
+	callModel()
+	if matches, err := filepath.Glob(filepath.Join(logDir, "llm-http-session-a.log")); err != nil || len(matches) != 1 {
+		t.Fatalf("session-a logs after clearing gate = %#v, err = %v", matches, err)
+	}
+
+	manager.SetSessionIDProvider(func() string { return "session-b" })
+	callModel()
+	if matches, err := filepath.Glob(filepath.Join(logDir, "llm-http-session-b.log")); err != nil || len(matches) != 1 {
+		t.Fatalf("session-b logs after provider replacement = %#v, err = %v", matches, err)
+	}
+}

--- a/src/agent/internal/agent/models.go
+++ b/src/agent/internal/agent/models.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/tmc/langchaingo/chains"
 	"github.com/tmc/langchaingo/llms"
-	"github.com/tmc/langchaingo/llms/ollama"
 )
 
 // Moonshot Kimi OpenAI-compatible endpoints. "kimi" targets the global site and
@@ -34,9 +33,12 @@ const (
 const arkBeijingBaseURL = "https://ark.cn-beijing.volces.com/api/v3"
 
 type ModelManager struct {
-	config ModelConfig
-	proxy  ProxyConfig
-	model  llms.Model
+	config          ModelConfig
+	proxy           ProxyConfig
+	model           llms.Model
+	modelMu         sync.Mutex
+	bindingsMu      sync.Mutex
+	runtimeBindings *ModelRuntimeBindings
 
 	specMu                    sync.Mutex
 	providerSpec              model.ModelSpec
@@ -45,33 +47,17 @@ type ModelManager struct {
 	metadataHTTPClient        *http.Client
 	providerMetadataCachePath string
 	rawHTTPLogDir             string
-	rawHTTPLogSessionID       func() string
-	storageMu                 sync.RWMutex
-	storageMonitor            *StorageMonitor
 }
 
 func (m *ModelManager) SetStorageMonitor(monitor *StorageMonitor) {
 	if m == nil {
 		return
 	}
-	m.storageMu.Lock()
-	m.storageMonitor = monitor
-	m.storageMu.Unlock()
-	if model, ok := m.model.(*openAICompatibleModel); ok && model.rawLogger != nil {
-		model.rawLogger.SetStorageMonitor(monitor)
+	if monitor == nil {
+		m.bindings().SetStorageWriteGate(nil)
+		return
 	}
-	if model, ok := m.model.(*anthropicModel); ok && model.rawLogger != nil {
-		model.rawLogger.SetStorageMonitor(monitor)
-	}
-}
-
-func (m *ModelManager) currentStorageMonitor() *StorageMonitor {
-	if m == nil {
-		return nil
-	}
-	m.storageMu.RLock()
-	defer m.storageMu.RUnlock()
-	return m.storageMonitor
+	m.bindings().SetStorageWriteGate(monitor)
 }
 
 type ModelManagerOption func(*ModelManager)
@@ -89,7 +75,11 @@ func WithLLMRawHTTPLogDir(path string) ModelManagerOption {
 }
 
 func NewModelManager(config ModelConfig, proxy ProxyConfig, opts ...ModelManagerOption) *ModelManager {
-	m := &ModelManager{config: config, proxy: proxy}
+	m := &ModelManager{
+		config:          config,
+		proxy:           proxy,
+		runtimeBindings: NewModelRuntimeBindings(),
+	}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(m)
@@ -98,32 +88,30 @@ func NewModelManager(config ModelConfig, proxy ProxyConfig, opts ...ModelManager
 	return m
 }
 
-func (m *ModelManager) SetRawHTTPLogSessionIDProvider(provider func() string) {
-	m.rawHTTPLogSessionID = provider
-	if model, ok := m.model.(*openAICompatibleModel); ok && model.rawLogger != nil {
-		model.rawLogger.SetSessionIDProvider(provider)
+func (m *ModelManager) SetSessionIDProvider(provider func() string) {
+	if m == nil {
+		return
 	}
-	if model, ok := m.model.(*anthropicModel); ok && model.rawLogger != nil {
-		model.rawLogger.SetSessionIDProvider(provider)
-	}
+	m.bindings().SetSessionIDProvider(provider)
 }
 
-// activeSessionID resolves the current session id via the configured provider.
-// It reads m.rawHTTPLogSessionID at call time so the value is picked up even
-// when the provider is set after the model is built.
-func (m *ModelManager) activeSessionID() string {
-	if m.rawHTTPLogSessionID == nil {
-		return ""
+func (m *ModelManager) bindings() *ModelRuntimeBindings {
+	m.bindingsMu.Lock()
+	defer m.bindingsMu.Unlock()
+	if m.runtimeBindings == nil {
+		m.runtimeBindings = NewModelRuntimeBindings()
 	}
-	return m.rawHTTPLogSessionID()
+	return m.runtimeBindings
 }
 
 func (m *ModelManager) get() (llms.Model, error) {
+	m.modelMu.Lock()
+	defer m.modelMu.Unlock()
 	if m.model != nil {
 		return m.model, nil
 	}
 
-	built, err := m.build(m.config)
+	built, err := m.build()
 	if err != nil {
 		return nil, fmt.Errorf("build model: %w", err)
 	}
@@ -189,71 +177,26 @@ func (m *ModelManager) Spec() model.ModelSpec {
 	return spec
 }
 
-func (m *ModelManager) build(cfg ModelConfig) (llms.Model, error) {
-	definition, ok := lookupModelProviderDefinition(cfg.Provider)
+func (m *ModelManager) build() (llms.Model, error) {
+	definition, ok := lookupModelProviderDefinition(m.config.Provider)
 	if !ok {
-		return nil, fmt.Errorf("unsupported provider %q", cfg.Provider)
+		return nil, fmt.Errorf("unsupported provider %q", m.config.Provider)
 	}
-	return definition.build(m, cfg)
+	return definition.build(m.buildContext(), m.config)
 }
 
-func (m *ModelManager) buildOpenAICompatibleModel(cfg ModelConfig, defaultBaseURL string) llms.Model {
-	baseURL := cfg.BaseURL
-	if baseURL == "" {
-		baseURL = defaultBaseURL
+func (m *ModelManager) buildContext() ModelBuildContext {
+	var logger RawHTTPLogger
+	if m.config.LogRawHTTP && strings.TrimSpace(m.rawHTTPLogDir) != "" {
+		logger = newLLMRawHTTPLogger(m.rawHTTPLogDir, m.bindings())
 	}
-	return newOpenAICompatibleModel(baseURL, cfg.Model, resolveToken(cfg), newRetryHTTPClient(m.proxy), m.openAICompatibleOptions(cfg)...)
-}
-
-func (m *ModelManager) buildAnthropicModel(cfg ModelConfig) (llms.Model, error) {
-	token, useBearerAuth := resolveAnthropicToken(cfg.APIKey)
-	if token == "" {
-		if env, ok := providerAPIKeyEnv(cfg.APIKey); ok && env != "" {
-			return nil, fmt.Errorf("missing the Anthropic API key, set it in the %s environment variable", env)
-		}
-		return nil, fmt.Errorf("missing the Anthropic API key, set api_key on the provider record, ANTHROPIC_AUTH_TOKEN, or ANTHROPIC_API_KEY")
+	return ModelBuildContext{
+		HTTPClient:        newRetryHTTPClient(m.proxy),
+		OllamaHTTPClient:  newProxyHTTPClient(m.proxy),
+		RawHTTPLogger:     logger,
+		SessionIDProvider: m.bindings().CurrentSessionID,
+		PromptCachePolicy: m.cachedOpenRouterPromptCachePolicy(),
 	}
-	options := buildAnthropicModelOptions(m, cfg)
-	if useBearerAuth {
-		options = append(options, withAnthropicBearerAuth())
-	}
-	return newAnthropicModel(
-		resolveAnthropicBaseURL(cfg.BaseURL),
-		cfg.Model,
-		token,
-		newRetryHTTPClient(m.proxy),
-		options...,
-	), nil
-}
-
-func (m *ModelManager) buildOpenRouterModel(cfg ModelConfig) (llms.Model, error) {
-	token := resolveToken(cfg)
-	if token == "" {
-		if env, ok := providerAPIKeyEnv(cfg.APIKey); ok && env != "" {
-			return nil, fmt.Errorf("missing the OpenRouter API key, set it in the %s environment variable", env)
-		}
-		return nil, fmt.Errorf("missing the OpenRouter API key, set api_key on the provider record")
-	}
-	baseURL := cfg.BaseURL
-	if baseURL == "" {
-		baseURL = "https://openrouter.ai/api/v1"
-	}
-	opts := append(m.openAICompatibleOptions(cfg),
-		withOpenAICompatibleSessionSticky(m.activeSessionID),
-		withOpenAICompatibleRouterMetadata(),
-		withOpenAICompatibleOpenRouterReasoning())
-	if m.cachedOpenRouterPromptCachePolicy().UsesExplicitCacheControl() {
-		opts = append(opts, withOpenAICompatibleExplicitPromptCache())
-	}
-	return newOpenAICompatibleModel(baseURL, cfg.Model, token, newRetryHTTPClient(m.proxy), opts...), nil
-}
-
-func (m *ModelManager) buildOllamaModel(cfg ModelConfig) (llms.Model, error) {
-	options := []ollama.Option{ollama.WithModel(cfg.Model), ollama.WithHTTPClient(newProxyHTTPClient(m.proxy))}
-	if cfg.BaseURL != "" {
-		options = append(options, ollama.WithServerURL(cfg.BaseURL))
-	}
-	return ollama.New(options...)
 }
 
 func openRouterExplicitPromptCacheSupported(model string) bool {
@@ -279,13 +222,10 @@ func openRouterExplicitPromptCacheSupported(model string) bool {
 	}
 }
 
-func (m *ModelManager) openAICompatibleOptions(cfg ModelConfig) []openAICompatibleModelOption {
+func openAICompatibleOptions(ctx ModelBuildContext, cfg ModelConfig) []openAICompatibleModelOption {
 	var opts []openAICompatibleModelOption
-	if cfg.LogRawHTTP && strings.TrimSpace(m.rawHTTPLogDir) != "" {
-		logger := newLLMRawHTTPLogger(m.rawHTTPLogDir, "")
-		logger.SetSessionIDProvider(m.rawHTTPLogSessionID)
-		logger.SetStorageMonitor(m.currentStorageMonitor())
-		opts = append(opts, withOpenAICompatibleRawHTTPLogger(logger))
+	if ctx.RawHTTPLogger != nil {
+		opts = append(opts, withOpenAICompatibleRawHTTPLogger(ctx.RawHTTPLogger))
 	}
 	if cfg.ReasoningEffort != "" {
 		opts = append(opts, withOpenAICompatibleReasoningEffort(cfg.ReasoningEffort))

--- a/src/agent/internal/agent/models_test.go
+++ b/src/agent/internal/agent/models_test.go
@@ -146,7 +146,7 @@ func TestBuildKimiProvidersResolveBaseURL(t *testing.T) {
 				BaseURL:  tt.baseURL,
 			}, ProxyConfig{})
 
-			model, err := mgr.build(mgr.config)
+			model, err := mgr.build()
 			if err != nil {
 				t.Fatalf("build: %v", err)
 			}
@@ -180,7 +180,7 @@ func TestBuildVolcengineProviderResolvesBaseURL(t *testing.T) {
 				BaseURL:  tt.baseURL,
 			}, ProxyConfig{})
 
-			model, err := mgr.build(mgr.config)
+			model, err := mgr.build()
 			if err != nil {
 				t.Fatalf("build: %v", err)
 			}
@@ -207,7 +207,7 @@ func TestBuildOpenRouterEnablesNestedReasoning(t *testing.T) {
 		APIKey:   "test-key",
 	}, ProxyConfig{})
 
-	model, err := mgr.build(mgr.config)
+	model, err := mgr.build()
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestBuildOpenRouterMissingAPIKeyError(t *testing.T) {
 			APIKey:   "$" + tokenEnv,
 		}, ProxyConfig{})
 
-		_, err := mgr.build(mgr.config)
+		_, err := mgr.build()
 		if err == nil {
 			t.Fatal("build succeeded without an API key")
 		}
@@ -246,7 +246,7 @@ func TestBuildOpenRouterMissingAPIKeyError(t *testing.T) {
 			Model:    "google/gemini-3.5-flash",
 		}, ProxyConfig{})
 
-		_, err := mgr.build(mgr.config)
+		_, err := mgr.build()
 		if err == nil {
 			t.Fatal("build succeeded without an API key")
 		}

--- a/src/agent/internal/agent/openai_compatible_model.go
+++ b/src/agent/internal/agent/openai_compatible_model.go
@@ -25,7 +25,7 @@ type openAICompatibleModel struct {
 	model               string
 	token               string
 	httpClient          *http.Client
-	rawLogger           *llmRawHTTPLogger
+	rawLogger           RawHTTPLogger
 	explicitPromptCache bool
 	routerMetadata      bool
 	reasoningEffort     string
@@ -85,7 +85,7 @@ func rawHTTPLogFileSessionID(ctx context.Context) (string, bool) {
 	return strings.TrimSpace(sessionID), ok
 }
 
-func withOpenAICompatibleRawHTTPLogger(logger *llmRawHTTPLogger) openAICompatibleModelOption {
+func withOpenAICompatibleRawHTTPLogger(logger RawHTTPLogger) openAICompatibleModelOption {
 	return func(m *openAICompatibleModel) {
 		m.rawLogger = logger
 	}
@@ -138,90 +138,93 @@ func withOpenAICompatibleTemperature(temp *float64) openAICompatibleModelOption 
 const openRouterSessionIDMaxLen = 256
 
 type llmRawHTTPLogger struct {
-	dir               string
-	sessionID         string
-	sessionIDProvider func() string
-	storageMonitor    *StorageMonitor
-	now               func() time.Time
-	mu                sync.Mutex
+	dir      string
+	bindings *ModelRuntimeBindings
+	now      func() time.Time
+	mu       sync.Mutex
 }
 
-func newLLMRawHTTPLogger(logDir, sessionID string) *llmRawHTTPLogger {
+type RawHTTPLogEntry struct {
+	Model      string
+	Kind       string
+	StatusCode int
+	Raw        string
+}
+
+type RawHTTPLogger interface {
+	BeginScope(context.Context) context.Context
+	Log(context.Context, RawHTTPLogEntry) error
+}
+
+func newLLMRawHTTPLogger(logDir string, bindings *ModelRuntimeBindings) *llmRawHTTPLogger {
 	logDir = strings.TrimSpace(logDir)
 	if logDir == "" {
 		return nil
 	}
+	if bindings == nil {
+		bindings = NewModelRuntimeBindings()
+	}
 	return &llmRawHTTPLogger{
-		dir:       logDir,
-		sessionID: strings.TrimSpace(sessionID),
-		now:       time.Now,
+		dir:      logDir,
+		bindings: bindings,
+		now:      time.Now,
 	}
 }
 
-func (l *llmRawHTTPLogger) SetSessionIDProvider(provider func() string) {
+func (l *llmRawHTTPLogger) BeginScope(ctx context.Context) context.Context {
 	if l == nil {
-		return
+		return ctx
 	}
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.sessionIDProvider = provider
-}
-
-func (l *llmRawHTTPLogger) SetStorageMonitor(monitor *StorageMonitor) {
-	if l == nil {
-		return
+	if _, ok := rawHTTPLogFileTime(ctx); !ok {
+		ctx = contextWithRawHTTPLogFileTime(ctx, l.currentTime())
 	}
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.storageMonitor = monitor
+	if _, ok := rawHTTPLogFileSessionID(ctx); !ok {
+		ctx = contextWithRawHTTPLogFileSessionID(ctx, l.bindings.CurrentSessionID())
+	}
+	return ctx
 }
 
-func (l *llmRawHTTPLogger) Log(model, kind string, statusCode int, raw string) error {
-	return l.LogWithFileTime(model, kind, statusCode, raw, time.Time{})
-}
-
-func (l *llmRawHTTPLogger) LogWithFileTime(model, kind string, statusCode int, raw string, fileTime time.Time) error {
-	return l.LogWithFileScope(model, kind, statusCode, raw, fileTime, l.currentSessionID())
-}
-
-func (l *llmRawHTTPLogger) LogWithFileScope(model, kind string, statusCode int, raw string, fileTime time.Time, sessionID string) error {
+func (l *llmRawHTTPLogger) Log(ctx context.Context, entry RawHTTPLogEntry) error {
 	if l == nil || strings.TrimSpace(l.dir) == "" {
 		return nil
 	}
-	l.mu.Lock()
-	storageMonitor := l.storageMonitor
-	l.mu.Unlock()
-	if storageMonitor != nil && !storageMonitor.AllowWrite(StorageCapabilityLLMHTTPLog) {
+	gate := l.bindings.StorageWriteGate()
+	if gate != nil && !gate.AllowWrite(StorageCapabilityLLMHTTPLog) {
 		return nil
 	}
 	now := l.currentTime()
+	fileTime, _ := rawHTTPLogFileTime(ctx)
 	if fileTime.IsZero() {
 		fileTime = now
+	}
+	sessionID, ok := rawHTTPLogFileSessionID(ctx)
+	if !ok {
+		sessionID = l.bindings.CurrentSessionID()
 	}
 
 	// Compact JSON bodies to single line if possible
 	compacted := new(bytes.Buffer)
-	if err := json.Compact(compacted, []byte(raw)); err == nil {
-		raw = compacted.String()
+	if err := json.Compact(compacted, []byte(entry.Raw)); err == nil {
+		entry.Raw = compacted.String()
 	} else {
 		// Not JSON or malformed, escape newlines
-		raw = strings.ReplaceAll(raw, "\n", "\\n")
-		raw = strings.ReplaceAll(raw, "\r", "\\r")
+		entry.Raw = strings.ReplaceAll(entry.Raw, "\n", "\\n")
+		entry.Raw = strings.ReplaceAll(entry.Raw, "\r", "\\r")
 	}
 
 	// Create JSONL entry with ordered fields
-	entry := struct {
+	logEntry := struct {
 		TS     string `json:"ts"`
 		Kind   string `json:"kind"`
 		Status int    `json:"status"`
 		Body   string `json:"body"`
 	}{
 		TS:     now.Format("15:04:05"),
-		Kind:   strings.TrimSpace(kind),
-		Status: statusCode,
-		Body:   raw,
+		Kind:   strings.TrimSpace(entry.Kind),
+		Status: entry.StatusCode,
+		Body:   entry.Raw,
 	}
-	entryBytes, err := json.Marshal(entry)
+	entryBytes, err := json.Marshal(logEntry)
 	if err != nil {
 		return fmt.Errorf("marshal log entry: %w", err)
 	}
@@ -229,7 +232,7 @@ func (l *llmRawHTTPLogger) LogWithFileScope(model, kind string, statusCode int, 
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if err := os.MkdirAll(l.dir, 0755); err != nil {
-		if storageMonitor != nil && storageMonitor.HandleWriteError(err) {
+		if gate != nil && gate.HandleWriteError(err) {
 			return nil
 		}
 		return err
@@ -245,14 +248,14 @@ func (l *llmRawHTTPLogger) LogWithFileScope(model, kind string, statusCode int, 
 	path := filepath.Join(l.dir, fileName)
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
-		if storageMonitor != nil && storageMonitor.HandleWriteError(err) {
+		if gate != nil && gate.HandleWriteError(err) {
 			return nil
 		}
 		return err
 	}
 	defer file.Close()
 	_, err = file.Write(append(entryBytes, '\n'))
-	if err != nil && storageMonitor != nil && storageMonitor.HandleWriteError(err) {
+	if err != nil && gate != nil && gate.HandleWriteError(err) {
 		return nil
 	}
 	return err
@@ -263,22 +266,6 @@ func (l *llmRawHTTPLogger) currentTime() time.Time {
 		return time.Now()
 	}
 	return l.now()
-}
-
-func (l *llmRawHTTPLogger) currentSessionID() string {
-	if l == nil {
-		return ""
-	}
-	l.mu.Lock()
-	provider := l.sessionIDProvider
-	fallback := l.sessionID
-	l.mu.Unlock()
-	if provider != nil {
-		if sessionID := strings.TrimSpace(provider()); sessionID != "" {
-			return sessionID
-		}
-	}
-	return strings.TrimSpace(fallback)
 }
 
 type compatibleChatRequest struct {
@@ -945,25 +932,19 @@ func (m *openAICompatibleModel) logRawHTTP(ctx context.Context, modelName, kind 
 	if !rawHTTPLogEnabled(ctx) {
 		return nil
 	}
-	if fileTime, ok := rawHTTPLogFileTime(ctx); ok {
-		sessionID, _ := rawHTTPLogFileSessionID(ctx)
-		return m.rawLogger.LogWithFileScope(modelName, kind, statusCode, raw, fileTime, sessionID)
-	}
-	return m.rawLogger.Log(modelName, kind, statusCode, raw)
+	return m.rawLogger.Log(ctx, RawHTTPLogEntry{
+		Model:      modelName,
+		Kind:       kind,
+		StatusCode: statusCode,
+		Raw:        raw,
+	})
 }
 
 func (m *openAICompatibleModel) withRawHTTPLogFileTime(ctx context.Context) context.Context {
 	if m == nil || m.rawLogger == nil || !rawHTTPLogEnabled(ctx) {
 		return ctx
 	}
-	if _, ok := rawHTTPLogFileTime(ctx); ok {
-		if _, hasSessionID := rawHTTPLogFileSessionID(ctx); hasSessionID {
-			return ctx
-		}
-		return contextWithRawHTTPLogFileSessionID(ctx, m.rawLogger.currentSessionID())
-	}
-	ctx = contextWithRawHTTPLogFileTime(ctx, m.rawLogger.currentTime())
-	return contextWithRawHTTPLogFileSessionID(ctx, m.rawLogger.currentSessionID())
+	return m.rawLogger.BeginScope(ctx)
 }
 
 func convertMessageContent(message llms.MessageContent, explicitPromptCache bool) (compatibleMessage, error) {

--- a/src/agent/internal/agent/openai_compatible_model_test.go
+++ b/src/agent/internal/agent/openai_compatible_model_test.go
@@ -280,7 +280,7 @@ func TestOpenAICompatibleModelLogsRawHTTPWhenEnabled(t *testing.T) {
 		"test-model",
 		"",
 		server.Client(),
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir, "test-session-1")),
+		withOpenAICompatibleRawHTTPLogger(newTestLLMRawHTTPLogger(logDir, "test-session-1")),
 	)
 	_, err := model.GenerateContent(contextWithRawHTTPLog(context.Background()), []llms.MessageContent{{
 		Role:  llms.ChatMessageTypeHuman,
@@ -338,7 +338,7 @@ func TestOpenAICompatibleModelRawHTTPLogUsesEffectiveRequestModel(t *testing.T) 
 		"configured-model",
 		"",
 		server.Client(),
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir, "test-session-1")),
+		withOpenAICompatibleRawHTTPLogger(newTestLLMRawHTTPLogger(logDir, "test-session-1")),
 	)
 	_, err := model.GenerateContent(
 		contextWithRawHTTPLog(context.Background()),
@@ -433,7 +433,7 @@ func TestOpenAICompatibleModelLogsRawStreamingHTTPWhenEnabled(t *testing.T) {
 		"test-model",
 		"",
 		server.Client(),
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir, "test-session-1")),
+		withOpenAICompatibleRawHTTPLogger(newTestLLMRawHTTPLogger(logDir, "test-session-1")),
 	)
 	_, err := model.GenerateContent(
 		contextWithRawHTTPLog(context.Background()),
@@ -518,7 +518,7 @@ func TestOpenAICompatibleModelLogsRawStreamingHTTPOnDecodeError(t *testing.T) {
 		"test-model",
 		"",
 		server.Client(),
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir, "test-session-1")),
+		withOpenAICompatibleRawHTTPLogger(newTestLLMRawHTTPLogger(logDir, "test-session-1")),
 	)
 	_, err := model.GenerateContent(
 		contextWithRawHTTPLog(context.Background()),
@@ -586,8 +586,8 @@ func TestOpenAICompatibleModelRawHTTPLogKeepsRunInInitialSessionFile(t *testing.
 	defer server.Close()
 
 	logDir := t.TempDir()
-	logger := newLLMRawHTTPLogger(logDir, "")
-	logger.SetSessionIDProvider(func() string {
+	logger := newLLMRawHTTPLogger(logDir, NewModelRuntimeBindings())
+	logger.bindings.SetSessionIDProvider(func() string {
 		sessionMu.Lock()
 		defer sessionMu.Unlock()
 		return sessionID
@@ -644,11 +644,13 @@ func TestOpenAICompatibleModelRawHTTPLogKeepsRunInInitialSessionFile(t *testing.
 
 func TestLLMRawHTTPLoggerFallsBackToTimestampForUnsafeSessionID(t *testing.T) {
 	logDir := t.TempDir()
-	logger := newLLMRawHTTPLogger(logDir, "")
+	logger := newLLMRawHTTPLogger(logDir, NewModelRuntimeBindings())
 	fileTime := time.Date(2026, 6, 21, 9, 4, 59, 0, time.UTC)
 
-	if err := logger.LogWithFileScope("test-model", "request", http.StatusOK, `{"ok":true}`, fileTime, "..evil"); err != nil {
-		t.Fatalf("LogWithFileScope() error = %v", err)
+	ctx := contextWithRawHTTPLogFileTime(context.Background(), fileTime)
+	ctx = contextWithRawHTTPLogFileSessionID(ctx, "..evil")
+	if err := logger.Log(ctx, RawHTTPLogEntry{Model: "test-model", Kind: "request", StatusCode: http.StatusOK, Raw: `{"ok":true}`}); err != nil {
+		t.Fatalf("Log() error = %v", err)
 	}
 
 	matches, err := filepath.Glob(filepath.Join(logDir, "llm-http-*.log"))
@@ -691,7 +693,7 @@ func TestRuntimeConfiguresRawHTTPLogWithActiveMemorySessionID(t *testing.T) {
 	if !ok {
 		t.Fatalf("model = %T, want *openAICompatibleModel", model)
 	}
-	compatible.rawLogger.now = func() time.Time {
+	compatible.rawLogger.(*llmRawHTTPLogger).now = func() time.Time {
 		return time.Date(2026, 6, 21, 9, 4, 59, 0, time.UTC)
 	}
 
@@ -762,7 +764,7 @@ func TestRuntimeRawHTTPLogUsesSessionIDForFileName(t *testing.T) {
 		t.Fatalf("model = %T, want *openAICompatibleModel", model)
 	}
 	current := time.Date(2026, 6, 21, 9, 4, 59, 0, time.UTC)
-	compatible.rawLogger.now = func() time.Time { return current }
+	compatible.rawLogger.(*llmRawHTTPLogger).now = func() time.Time { return current }
 
 	runLLM := func(prompt string) {
 		t.Helper()
@@ -824,7 +826,7 @@ func TestRuntimeRawHTTPLogSwitchesSessionFileAfterRotation(t *testing.T) {
 	if !ok {
 		t.Fatalf("model = %T, want *openAICompatibleModel", model)
 	}
-	compatible.rawLogger.now = func() time.Time {
+	compatible.rawLogger.(*llmRawHTTPLogger).now = func() time.Time {
 		return time.Date(2026, 6, 21, 9, 4, 59, 0, time.UTC)
 	}
 
@@ -919,7 +921,7 @@ func TestOpenAICompatibleModelLogsResponseOnTransportError(t *testing.T) {
 		"test-model",
 		"",
 		client,
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir, "test-session-1")),
+		withOpenAICompatibleRawHTTPLogger(newTestLLMRawHTTPLogger(logDir, "test-session-1")),
 	)
 	_, err := model.GenerateContent(contextWithRawHTTPLog(context.Background()), []llms.MessageContent{{
 		Role:  llms.ChatMessageTypeHuman,
@@ -962,7 +964,7 @@ func TestOpenAICompatibleModelSkipsRawHTTPLogWithoutContextMarker(t *testing.T) 
 		"test-model",
 		"",
 		server.Client(),
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(logDir, "test-session-1")),
+		withOpenAICompatibleRawHTTPLogger(newTestLLMRawHTTPLogger(logDir, "test-session-1")),
 	)
 	// Plain context, no contextWithRawHTTPLog marker.
 	_, err := model.GenerateContent(context.Background(), []llms.MessageContent{{
@@ -1000,7 +1002,7 @@ func TestOpenAICompatibleModelDoesNotBufferRawHTTPResponseWithoutContextMarker(t
 		"test-model",
 		"",
 		client,
-		withOpenAICompatibleRawHTTPLogger(newLLMRawHTTPLogger(t.TempDir(), "test-session-1")),
+		withOpenAICompatibleRawHTTPLogger(newTestLLMRawHTTPLogger(t.TempDir(), "test-session-1")),
 	)
 
 	resp, err := model.GenerateContent(context.Background(), []llms.MessageContent{{
@@ -1612,7 +1614,7 @@ func TestModelManagerSendsSessionHeaderOnlyForOpenRouter(t *testing.T) {
 			defer server.Close()
 
 			mgr := NewModelManager(ModelConfig{Provider: tc.provider, Model: "m", APIKey: "k", BaseURL: server.URL}, ProxyConfig{})
-			mgr.SetRawHTTPLogSessionIDProvider(func() string { return "sess-123" })
+			mgr.SetSessionIDProvider(func() string { return "sess-123" })
 			model, err := mgr.get()
 			if err != nil {
 				t.Fatalf("Get() error = %v", err)

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -580,7 +580,7 @@ func NewRuntimeWithDeps(cfg Config, models model.Model, memories *MemoryManager,
 	}
 	// Use the active memory session ID for raw HTTP log partitioning.
 	if modelManager, ok := models.(*ModelManager); ok {
-		modelManager.SetRawHTTPLogSessionIDProvider(func() string {
+		modelManager.SetSessionIDProvider(func() string {
 			if memories == nil {
 				return ""
 			}

--- a/src/agent/internal/agent/storage_write_gate_test.go
+++ b/src/agent/internal/agent/storage_write_gate_test.go
@@ -43,13 +43,15 @@ func TestLLMRawHTTPLoggerHonorsStorageCapability(t *testing.T) {
 	config := DefaultStorageConfig()
 	config.Cleanup.Enabled = false
 	monitor := NewStorageMonitor(config, sampler, nil, nil, nil)
-	logger := newLLMRawHTTPLogger(dir, "session")
-	logger.SetStorageMonitor(monitor)
+	bindings := NewModelRuntimeBindings()
+	bindings.SetSessionIDProvider(func() string { return "session" })
+	bindings.SetStorageWriteGate(monitor)
+	logger := newLLMRawHTTPLogger(dir, bindings)
 
 	if _, err := monitor.CheckAndRemediate(context.Background(), StorageCheckRequest{Reason: CheckReasonPeriodic}); err != nil {
 		t.Fatalf("critical CheckAndRemediate() error = %v", err)
 	}
-	if err := logger.Log("model", "request", 200, `{}`); err != nil {
+	if err := logger.Log(context.Background(), RawHTTPLogEntry{Model: "model", Kind: "request", StatusCode: 200, Raw: `{}`}); err != nil {
 		t.Fatalf("Log() at critical error = %v", err)
 	}
 	entries, err := os.ReadDir(dir)
@@ -63,7 +65,7 @@ func TestLLMRawHTTPLoggerHonorsStorageCapability(t *testing.T) {
 	if _, err := monitor.CheckAndRemediate(context.Background(), StorageCheckRequest{Reason: CheckReasonPeriodic}); err != nil {
 		t.Fatalf("recovery CheckAndRemediate() error = %v", err)
 	}
-	if err := logger.Log("model", "request", 200, `{}`); err != nil {
+	if err := logger.Log(context.Background(), RawHTTPLogEntry{Model: "model", Kind: "request", StatusCode: 200, Raw: `{}`}); err != nil {
 		t.Fatalf("Log() after recovery error = %v", err)
 	}
 	entries, err = os.ReadDir(dir)

--- a/src/config_web/web/assets/js/llm-logs.js
+++ b/src/config_web/web/assets/js/llm-logs.js
@@ -600,7 +600,16 @@ function extractResponseMessage(body) {
       const m = obj.choices[0].message || {};
       return {role: m.role || 'assistant', content: m.content || '', tool_calls: m.tool_calls || []};
     }
-    if (obj && Array.isArray(obj.content) && !Array.isArray(obj.choices)) {
+    if (obj && obj.error) {
+      const errStr = typeof obj.error === 'string' ? obj.error : JSON.stringify(obj.error, null, 2);
+      return {role: 'assistant', content: 'Error: ' + errStr};
+    }
+    const isAnthropicMessage = obj && Array.isArray(obj.content) && (
+      obj.type === 'message' ||
+      (typeof obj.id === 'string' && typeof obj.model === 'string' &&
+       Object.prototype.hasOwnProperty.call(obj, 'stop_reason') && obj.usage && typeof obj.usage === 'object')
+    );
+    if (isAnthropicMessage) {
       let content = '';
       const toolCalls = [];
       for (const block of obj.content) {
@@ -613,10 +622,6 @@ function extractResponseMessage(body) {
         }
       }
       return {role: obj.role || 'assistant', content: content, tool_calls: toolCalls};
-    }
-    if (obj && obj.error) {
-      const errStr = typeof obj.error === 'string' ? obj.error : JSON.stringify(obj.error, null, 2);
-      return {role: 'assistant', content: 'Error: ' + errStr};
     }
   } catch(e) {}
   // Try SSE stream — accumulate content and tool_calls across `data:` events.

--- a/src/config_web/web/assets/js/llm-logs.js
+++ b/src/config_web/web/assets/js/llm-logs.js
@@ -38,6 +38,11 @@ function formatBytes(bytes) {
   if (value < 1024 * 1024) return (value / 1024).toFixed(value < 10 * 1024 ? 1 : 0) + ' KB';
   return (value / (1024 * 1024)).toFixed(value < 10 * 1024 * 1024 ? 1 : 0) + ' MB';
 }
+function formatLogTimestamp(timestamp) {
+  const value = String(timestamp || '');
+  const match = value.match(/(?:^|T)(\d{2}:\d{2}:\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?$/);
+  return match ? match[1] : value;
+}
 function pauseForUi() {
   return new Promise(resolve => setTimeout(resolve, 0));
 }
@@ -278,8 +283,7 @@ function renderRequestItem(g, idx) {
   html += '<div class="request-item-head">';
   html += '<span class="request-item-index">#' + (idx + 1) + '</span>';
   html += '<span class="' + badgeClass + '">' + esc(badgeText) + '</span>';
-  const requestTs=String(g.request.ts||'');
-  html += '<span style="font-size:11px;color:#9ca3af;margin-left:auto">' + esc(requestTs.substring(11, 19)) + '</span>';
+  html += '<span style="font-size:11px;color:#9ca3af;margin-left:auto">' + esc(formatLogTimestamp(g.request.ts)) + '</span>';
   html += '</div>';
   html += '<div class="request-item-preview">' + esc(preview) + '</div>';
   html += '</button>';
@@ -596,7 +600,7 @@ function extractResponseMessage(body) {
       const m = obj.choices[0].message || {};
       return {role: m.role || 'assistant', content: m.content || '', tool_calls: m.tool_calls || []};
     }
-    if (obj && obj.type === 'message' && Array.isArray(obj.content)) {
+    if (obj && Array.isArray(obj.content) && !Array.isArray(obj.choices)) {
       let content = '';
       const toolCalls = [];
       for (const block of obj.content) {

--- a/tests/config_web_source_test.cpp
+++ b/tests/config_web_source_test.cpp
@@ -491,8 +491,9 @@ TEST_CASE("config web exposes the LLM HTTP log viewer") {
     CHECK(llm_html.find("Import Raw") != std::string::npos);
     CHECK(llm_html.find("function streamLogEntries") != std::string::npos);
     CHECK(llm_html.find("function processLogChunk") != std::string::npos);
-    CHECK(llm_html.find("const requestTs=String(g.request.ts||'');") != std::string::npos);
-    CHECK(llm_html.find("g.request.ts.substring(11, 19)") == std::string::npos);
+    CHECK(llm_html.find("function formatLogTimestamp") != std::string::npos);
+    CHECK(llm_html.find("formatLogTimestamp(g.request.ts)") != std::string::npos);
+    CHECK(llm_html.find("substring(11, 19)") == std::string::npos);
     CHECK(llm_html.find("response.body.getReader()") != std::string::npos);
     CHECK(llm_html.find("new TextDecoder()") != std::string::npos);
     CHECK(llm_html.find("fetch('/api/llm-logs/export/' + encodeURIComponent(name))") != std::string::npos);

--- a/tests/llm_logs_anthropic_test.mjs
+++ b/tests/llm_logs_anthropic_test.mjs
@@ -179,6 +179,36 @@ assert.deepEqual(
   'Anthropic JSON responses should preserve text and tool calls',
 );
 
+assert.deepEqual(
+  extract(JSON.stringify({
+    id: 'msg_live',
+    model: 'claude-sonnet-4-6',
+    role: '',
+    content: [
+      {type: 'text', text: 'Live response'},
+      {type: 'tool_use', id: 'tool-live', name: 'echo', input: {value: 'ok'}},
+    ],
+    stop_reason: 'tool_use',
+    usage: {input_tokens: 10, output_tokens: 4},
+  })),
+  {
+    role: 'assistant',
+    content: 'Live response',
+    tool_calls: [
+      {
+        id: 'tool-live',
+        type: 'function',
+        function: {name: 'echo', arguments: '{"value":"ok"}'},
+      },
+    ],
+  },
+  'Aggregated Anthropic streaming responses should render as assistant messages',
+);
+
+assert.equal(context.formatLogTimestamp('12:34:56'), '12:34:56');
+assert.equal(context.formatLogTimestamp('2026-08-12T12:34:56Z'), '12:34:56');
+assert.equal(context.formatLogTimestamp(''), '');
+
 const anthropicSse = [
   'event: message_start',
   'data: {"type":"message_start","message":{"role":"assistant"}}',

--- a/tests/llm_logs_anthropic_test.mjs
+++ b/tests/llm_logs_anthropic_test.mjs
@@ -205,6 +205,27 @@ assert.deepEqual(
   'Aggregated Anthropic streaming responses should render as assistant messages',
 );
 
+assert.deepEqual(
+  extract(JSON.stringify({
+    error: {type: 'upstream_error', message: 'Provider failed'},
+    content: [],
+  })),
+  {
+    role: 'assistant',
+    content: 'Error: {\n  "type": "upstream_error",\n  "message": "Provider failed"\n}',
+  },
+  'Error responses should take precedence over content arrays',
+);
+
+assert.equal(
+  context.extractResponseMessage(JSON.stringify({
+    content: [{type: 'text', text: 'Provider diagnostic'}],
+    error_code: 123,
+  })),
+  null,
+  'Unrecognized content-array envelopes should remain raw diagnostics',
+);
+
 assert.equal(context.formatLogTimestamp('12:34:56'), '12:34:56');
 assert.equal(context.formatLogTimestamp('2026-08-12T12:34:56Z'), '12:34:56');
 assert.equal(context.formatLogTimestamp(''), '');


### PR DESCRIPTION
## Summary

- add a stable `ModelRuntimeBindings` container shared by `ModelManager`, provider models, and the raw HTTP logger
- replace dependency propagation with dynamic session provider and storage write gate lookups
- introduce explicit `ModelBuildContext`/`ModelProviderBuilder` APIs and make providers depend on the `RawHTTPLogger` interface
- rename `SetRawHTTPLogSessionIDProvider` to `SetSessionIDProvider` and cover post-build dependency replacement

## Testing

- `go test ./... -count=1`
- `go test -race ./internal/agent -run 'TestModelRuntimeBindings|TestModelManagerUpdatesRawLoggerDependenciesAfterBuild|TestProviderModelsShareManagerRuntimeBindingsWithRawLogger|TestModelManagerSetSessionIDProviderAfterBuildUpdatesOpenRouter|TestOpenAICompatibleModelRawHTTPLogKeepsRunInInitialSessionFile|TestModelManagerSendsSessionHeaderOnlyForOpenRouter' -count=1`
- `go vet ./internal/agent`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved LLM log display with consistent `HH:MM:SS` timestamps.
  - Added support for Anthropic responses containing combined text and tool-use content.
  - Improved handling of Anthropic responses with missing or empty roles.

- **Bug Fixes**
  - LLM logs now better preserve valid timestamps, including ISO-formatted values.
  - Improved runtime updates for session-aware logging and storage permissions.
  - Enhanced provider configuration and shared request handling across supported models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->