### PR TITLE
fix(agent): self-correct touch gesture arguments

### DIFF
--- a/src/agent/internal/agent/agent_loop_tool_result_test.go
+++ b/src/agent/internal/agent/agent_loop_tool_result_test.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -134,6 +136,67 @@ func toolResponseContents(t *testing.T, messages []llms.MessageContent) []string
 		t.Fatalf("no tool responses found in messages: %#v", messages)
 	}
 	return contents
+}
+
+func TestAgentLoopTouchGestureInvalidJSONSelfCorrectsBeforeAction(t *testing.T) {
+	tool := &stubTool{name: "touch_gesture", description: "Perform a gesture.", output: "ok"}
+	model := &scriptedModel{responses: []*llms.ContentResponse{
+		toolCallResponse("call_1", "touch_gesture", `{"type":"tap","point":{"x":500,500}}`),
+		toolCallResponse("call_2", "touch_gesture", `{"type":"tap","point":{"x":500,"y":500}}`),
+		contentResponse("Done"),
+	}}
+	manager, err := freshNewContextManager("system", "tap the center", nil, t.TempDir())
+	if err != nil {
+		t.Fatalf("freshNewContextManager() error = %v", err)
+	}
+	loop := NewAgentLoop(
+		model,
+		RoleProfile{Tools: []langtools.Tool{tool}},
+		nil,
+		4,
+		nil,
+		nil,
+		executor.ScreenshotPruningConfig{}.WithDefaults(),
+		manager,
+	)
+
+	answer, err := loop.Run(context.Background(), "tap the center")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if answer != "Done" {
+		t.Fatalf("Run() answer = %q, want Done", answer)
+	}
+	if len(tool.inputs) != 1 {
+		t.Fatalf("touch_gesture inputs = %#v, want only the corrected call", tool.inputs)
+	}
+	var gotInput map[string]any
+	if err := json.Unmarshal([]byte(tool.inputs[0]), &gotInput); err != nil {
+		t.Fatalf("corrected touch_gesture input is not JSON: %v", err)
+	}
+	var wantInput map[string]any
+	if err := json.Unmarshal([]byte(`{"type":"tap","point":{"x":500,"y":500}}`), &wantInput); err != nil {
+		t.Fatalf("decode wanted input: %v", err)
+	}
+	if !reflect.DeepEqual(gotInput, wantInput) {
+		t.Fatalf("touch_gesture input = %#v, want %#v", gotInput, wantInput)
+	}
+	if len(model.messages) < 2 {
+		t.Fatalf("model calls = %d, want at least 2", len(model.messages))
+	}
+	responses := toolResponseContents(t, model.messages[1])
+	if len(responses) != 1 {
+		t.Fatalf("retry context tool responses = %#v, want one", responses)
+	}
+	for _, want := range []string{
+		"no touch action was executed",
+		"Retry touch_gesture now with strict JSON",
+		`Correct: {"type":"tap","point":{"x":500,"y":500}}`,
+	} {
+		if !strings.Contains(responses[0], want) {
+			t.Fatalf("retry context missing %q:\n%s", want, responses[0])
+		}
+	}
 }
 
 func TestAgentLoopStoresLargeToolResultAsBoundedArtifact(t *testing.T) {

--- a/src/agent/internal/agent/tool_execution_test.go
+++ b/src/agent/internal/agent/tool_execution_test.go
@@ -263,6 +263,42 @@ func TestExecuteToolCallValidationFailureEmitsToolCallAndResult(t *testing.T) {
 	if recorder.results[0].Duration <= 0 {
 		t.Fatalf("expected validation failure duration to be recorded, got %s", recorder.results[0].Duration)
 	}
+	if got := recorder.results[0].Output; got != "shell input must be valid JSON after compatibility conversion" {
+		t.Fatalf("generic validation output = %q", got)
+	}
+}
+
+func TestExecuteToolCallTouchGestureValidationFailureRequestsStrictRetry(t *testing.T) {
+	tool := &stubTool{name: "touch_gesture", description: "Perform a gesture.", output: "should-not-run"}
+	result := executeToolCall(context.Background(), ToolCallExecution{
+		Specs: NewToolSpecs([]langtools.Tool{tool}),
+		Action: schema.AgentAction{
+			Tool:      "touch_gesture",
+			ToolInput: `{"type":"tap","point":{"x":500,500}}`,
+		},
+	})
+
+	if !result.Result.IsError() || result.Result.Error.Code != CodeInvalidArguments {
+		t.Fatalf("result = %#v, want invalid_arguments", result.Result)
+	}
+	if result.ActionCompleted {
+		t.Fatal("invalid touch_gesture marked action_completed=true")
+	}
+	if len(tool.inputs) != 0 {
+		t.Fatalf("touch_gesture executed with malformed input: %#v", tool.inputs)
+	}
+	for _, want := range []string{
+		"no touch action was executed",
+		"Retry touch_gesture now with strict JSON",
+		`both named keys "x" and "y"`,
+		`Invalid: {"type":"tap","point":{"x":500,500}}`,
+		`Correct: {"type":"tap","point":{"x":500,"y":500}}`,
+		"Do not continue with another action until the corrected call succeeds",
+	} {
+		if !strings.Contains(result.Result.Output, want) {
+			t.Fatalf("touch_gesture validation output missing %q:\n%s", want, result.Result.Output)
+		}
+	}
 }
 
 func TestExecuteToolCallBeforeMayRejectWithToolResult(t *testing.T) {

--- a/src/agent/internal/agent/tool_spec.go
+++ b/src/agent/internal/agent/tool_spec.go
@@ -532,6 +532,14 @@ func (spec ToolSpec) ValidateInput(input string) error {
 		return nil
 	}
 	if !json.Valid([]byte(trimmed)) {
+		if spec.Name == "touch_gesture" {
+			return fmt.Errorf(`touch_gesture arguments are invalid JSON, so no touch action was executed.
+Retry touch_gesture now with strict JSON.
+point/start/end must be JSON objects containing both named keys "x" and "y".
+Invalid: {"type":"tap","point":{"x":500,500}}
+Correct: {"type":"tap","point":{"x":500,"y":500}}
+Do not continue with another action until the corrected call succeeds.`)
+		}
 		return fmt.Errorf("%s input must be valid JSON after compatibility conversion", spec.Name)
 	}
 	return nil

--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -1182,15 +1182,15 @@ func (t *TouchGestureTool) Description() string {
 }
 
 func (t *TouchGestureTool) ArgsSchema() map[string]any {
-	typeDescription := "Gesture type."
+	typeDescription := "Gesture type. tap, double_tap, and long_press require point. swipe and drag require start and end. Directional swipe types accept optional strength, distance, and anchor."
 	if touchGestureIncludesEdgeNavigation(t.platform()) {
 		typeDescription += ` Edge aliases use real edges: back starts at x=1, home starts at y=999. For semantic home/back requests, prefer quick_action first, especially quick_action {"action":"home"} for go-home/home-screen requests; use back/home here only as fallback alternatives.`
 	}
-	return objectArgsSchema(map[string]any{
+	schema := objectArgsSchema(map[string]any{
 		"type":           stringEnumArgSchema(typeDescription, touchGestureTypesForPlatform(t.platform())...),
-		"point":          pointSchema("Point for tap, double_tap, or long_press."),
-		"start":          pointSchema("Start point for swipe or drag."),
-		"end":            pointSchema("End point for swipe or drag."),
+		"point":          pointSchema(`Required for tap, double_tap, and long_press. Must be a JSON object containing both named keys "x" and "y"; do not use an array, bare value, or positional shorthand.`),
+		"start":          pointSchema(`Required start point for swipe and drag. Must be a JSON object containing both named keys "x" and "y"; do not use an array, bare value, or positional shorthand.`),
+		"end":            pointSchema(`Required end point for swipe and drag. Must be a JSON object containing both named keys "x" and "y"; do not use an array, bare value, or positional shorthand.`),
 		"button":         stringEnumArgSchema("Mouse button for drag.", "left", "right", "middle"),
 		"duration_ms":    nonNegativeIntegerSchema("Gesture duration in milliseconds."),
 		"hold_before_ms": nonNegativeIntegerSchema("Optional dwell after pressing before a swipe begins."),
@@ -1202,6 +1202,13 @@ func (t *TouchGestureTool) ArgsSchema() map[string]any {
 		"anchor":         coordinateSchema("Directional swipe fixed-axis coordinate in 0-1000 normalized units.", 500),
 		"strength":       stringEnumArgSchema("Directional swipe preset distance.", "large", "medium", "small", "tiny"),
 	}, "type")
+	schema["description"] = `Strict JSON object for one gesture. Coordinate fields point, start, and end always use named objects containing both x and y.`
+	schema["examples"] = []map[string]any{
+		{"type": "tap", "point": map[string]any{"x": 500, "y": 500}},
+		{"type": "swipe", "start": map[string]any{"x": 500, "y": 800}, "end": map[string]any{"x": 500, "y": 200}},
+		{"type": "swipe_up", "strength": "medium"},
+	}
+	return schema
 }
 
 func touchGestureTypesForPlatform(platform string) []string {

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -3174,6 +3174,71 @@ func TestTouchGestureDescriptionDocumentsEdgeGestureAliases(t *testing.T) {
 	}
 }
 
+func TestTouchGestureSchemaRequiresNamedCoordinateObjectsAndShowsCompleteExamples(t *testing.T) {
+	schema := (&TouchGestureTool{}).ArgsSchema()
+	description, _ := schema["description"].(string)
+	for _, want := range []string{"Strict JSON object", "point", "start", "end", "both x and y"} {
+		if !strings.Contains(description, want) {
+			t.Fatalf("root schema description missing %q:\n%s", want, description)
+		}
+	}
+
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema properties = %#v", schema["properties"])
+	}
+	for _, name := range []string{"point", "start", "end"} {
+		coordinate, ok := properties[name].(map[string]any)
+		if !ok {
+			t.Fatalf("%s schema = %#v", name, properties[name])
+		}
+		if coordinate["type"] != "object" || coordinate["additionalProperties"] != false {
+			t.Fatalf("%s schema is not a strict object: %#v", name, coordinate)
+		}
+		required, ok := coordinate["required"].([]string)
+		if !ok || !slices.Equal(required, []string{"x", "y"}) {
+			t.Fatalf("%s required = %#v, want x and y", name, coordinate["required"])
+		}
+		desc, _ := coordinate["description"].(string)
+		for _, want := range []string{`named keys "x" and "y"`, "do not use an array", "bare value"} {
+			if !strings.Contains(desc, want) {
+				t.Fatalf("%s description missing %q:\n%s", name, want, desc)
+			}
+		}
+	}
+
+	examples, ok := schema["examples"].([]map[string]any)
+	if !ok || len(examples) != 3 {
+		t.Fatalf("schema examples = %#v, want three complete examples", schema["examples"])
+	}
+	encoded, err := json.Marshal(examples)
+	if err != nil || !json.Valid(encoded) {
+		t.Fatalf("schema examples are not valid JSON: encoded=%s err=%v", encoded, err)
+	}
+	for _, want := range []string{
+		`{"point":{"x":500,"y":500},"type":"tap"}`,
+		`"start":{"x":500,"y":800}`,
+		`"end":{"x":500,"y":200}`,
+		`{"strength":"medium","type":"swipe_up"}`,
+	} {
+		if !strings.Contains(string(encoded), want) {
+			t.Fatalf("schema examples missing %q: %s", want, encoded)
+		}
+	}
+
+	typeSchema, _ := properties["type"].(map[string]any)
+	typeDesc, _ := typeSchema["description"].(string)
+	for _, want := range []string{
+		"tap, double_tap, and long_press require point",
+		"swipe and drag require start and end",
+		"Directional swipe types accept optional strength, distance, and anchor",
+	} {
+		if !strings.Contains(typeDesc, want) {
+			t.Fatalf("type schema missing %q:\n%s", want, typeDesc)
+		}
+	}
+}
+
 func TestTouchGestureSchemaFiltersEdgeGesturesForDesktopPlatforms(t *testing.T) {
 	desktopTool := &TouchGestureTool{}
 	desktopTool.SetDeviceTypeFunc(func() string { return "windows" })


### PR DESCRIPTION
## Summary

- return a touch_gesture-specific strict JSON retry instruction when malformed arguments are rejected before execution
- strengthen the touch_gesture schema with required coordinate-object guidance and complete tap/swipe examples
- cover validation, retry context, single execution after correction, and schema stability

## Verification

- `go test ./internal/agent -run 'Test(ExecuteToolCall(TouchGestureValidationFailureRequestsStrictRetry|ValidationFailureEmitsToolCallAndResult)|AgentLoopTouchGestureInvalidJSONSelfCorrectsBeforeAction|TouchGestureSchemaRequiresNamedCoordinateObjectsAndShowsCompleteExamples)$'`\n- `go test ./internal/agent -skip '^TestAnthropicModelLiveRelay$'`\n- `./build.sh`\n\nThe previous permissive malformed-coordinate repair remains in `stash@{0}` and is not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for malformed touch gestures, preventing invalid actions from executing.
  - Added clear retry guidance when gesture input is not valid strict JSON.
  - Corrected touch gesture guidance to require named coordinate fields and valid gesture formats.

- **Tests**
  - Added coverage confirming invalid gestures are rejected, corrected automatically, and executed only once valid.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->