### PR TITLE
fix(benchmark): resolve mock platform per task

### DIFF
--- a/benchmark/runner/main.py
+++ b/benchmark/runner/main.py
@@ -18,7 +18,6 @@ from runner.platform import (
     read_environment_health,
     resolve_daemon_platform,
     resolve_environment_platform,
-    summarize_target_platforms,
 )
 from runner.report import git_sha, write_jsonl, write_manifest, write_summary, now_iso
 from runner.recovery import recover_agent_after_timeout, wait_for_agent_ready
@@ -416,6 +415,15 @@ def _build_task_units(
     return units
 
 
+def _run_target_platform(units: list[TaskRunUnit], fallback: str = "") -> str:
+    platforms = {unit.target_platform for unit in units if unit.target_platform}
+    if not platforms:
+        return fallback
+    if len(platforms) == 1:
+        return next(iter(platforms))
+    return "mixed"
+
+
 def _cmd_run_auto_agent_setup(
     args: argparse.Namespace,
     suite: Suite,
@@ -499,13 +507,14 @@ def _cmd_run_auto_agent_setup_inner(
     setup_log = run_dir / "auto-agent-setup.log"
 
     units = _build_task_units(args, suite, target_platform)
-    manifest_target_platform = target_platform
-    if mock_server is not None:
-        manifest_target_platform = summarize_target_platforms(
-            unit.target_platform for unit in units
-        )
-        if not manifest_target_platform and suite.mock_environment is not None:
-            manifest_target_platform = suite.mock_environment.platform
+    mock_platform_fallback = target_platform
+    if not mock_platform_fallback and suite.mock_environment is not None:
+        mock_platform_fallback = suite.mock_environment.platform.value
+    manifest_target_platform = (
+        _run_target_platform(units, mock_platform_fallback)
+        if mock_server is not None
+        else target_platform
+    )
     total_runs = len(units)
     has_runnable_units = any(not unit.skip_reason for unit in units)
     if has_runnable_units:
@@ -542,20 +551,26 @@ def _cmd_run_auto_agent_setup_inner(
     if args.agent_config:
         agent_config_text = Path(args.agent_config).read_text(encoding="utf-8")
 
-    def run_unit(
-        index: int,
-        task: TaskSpec,
-        attempt: int,
-        repeats: int,
-        skip_reason: str,
-        task_target_platform: str,
-    ):
-        progress = f"{index}/{total_runs}"
-        art_dir = run_dir / "tasks" / task.id / (f"attempt_{attempt}" if repeats > 1 else "")
-        if skip_reason:
-            print(f"[{progress}] SKIPPED    {task.id} attempt={attempt} ({skip_reason})", flush=True)
-            return skipped_task_result(suite, task, attempt, art_dir, run_id, skip_reason)
-        token = worker_token(str(suite.source_path), f"{task.id}-{attempt}")
+    def run_unit(unit: TaskRunUnit):
+        progress = f"{unit.index}/{total_runs}"
+        art_dir = run_dir / "tasks" / unit.task.id / (
+            f"attempt_{unit.attempt}" if unit.repeats > 1 else ""
+        )
+        if unit.skip_reason:
+            print(
+                f"[{progress}] SKIPPED    {unit.task.id} attempt={unit.attempt} "
+                f"({unit.skip_reason})",
+                flush=True,
+            )
+            return skipped_task_result(
+                suite,
+                unit.task,
+                unit.attempt,
+                art_dir,
+                run_id,
+                unit.skip_reason,
+            )
+        token = worker_token(str(suite.source_path), f"{unit.task.id}-{unit.attempt}")
         worker_dir = workers_dir / token
         config_dir = worker_dir / "config"
         runner_log = worker_dir / "runner.log"
@@ -569,7 +584,13 @@ def _cmd_run_auto_agent_setup_inner(
         benchmark_token = _read_optional_token(config_dir / "control_token")
         host_port = 0
         agent_url = f"http://127.0.0.1:{host_port}"
-        route_id = _task_route_id(args, suite, task.id, attempt, repeats)
+        route_id = _task_route_id(
+            args,
+            suite,
+            unit.task.id,
+            unit.attempt,
+            unit.repeats,
+        )
         job = Job(
             id=f"{run_id}-{token}",
             endpoint=args.environment_url.rstrip("/"),
@@ -585,14 +606,17 @@ def _cmd_run_auto_agent_setup_inner(
         log_proc = None
         client = None
         try:
-            print(f"[{progress}] STARTING   {task.id} attempt={attempt}", flush=True)
-            task_mock_environment = effective_mock_environment(suite, task)
+            print(
+                f"[{progress}] STARTING   {unit.task.id} attempt={unit.attempt}",
+                flush=True,
+            )
+            task_mock_environment = effective_mock_environment(suite, unit.task)
             if mock_server is not None:
                 if task_mock_environment is None:
                     return skipped_task_result(
                         suite,
-                        task,
-                        attempt,
+                        unit.task,
+                        unit.attempt,
                         art_dir,
                         run_id,
                         "task has no mock_environment and the suite has no default",
@@ -605,7 +629,7 @@ def _cmd_run_auto_agent_setup_inner(
                 config_dir=config_dir,
                 environment_bridge_endpoint=docker_environment_url,
                 benchmark_task_id=route_id,
-                device_type=task_target_platform,
+                device_type=unit.target_platform,
                 environment_bridge_mode=True,
                 log_path=runner_log,
             )
@@ -617,22 +641,35 @@ def _cmd_run_auto_agent_setup_inner(
             if not wait_for_agent_ready(client, timeout_sec=args.agent_ready_timeout_sec):
                 return skipped_task_result(
                     suite,
-                    task,
-                    attempt,
+                    unit.task,
+                    unit.attempt,
                     art_dir,
                     run_id,
                     f"agent not ready within {args.agent_ready_timeout_sec}s",
                 )
             if task_mock_environment is not None:
                 client.set_phone_bridge_state(task_mock_environment.phone_bridge)
-            if not args.skip_clock_wait and not wait_for_agent_clock(client, timeout_sec=args.clock_timeout_sec):
-                return skipped_task_result(suite, task, attempt, art_dir, run_id, "agent board clock did not sync before benchmark start")
-            print(f"[{progress}] RUNNING    {task.id} attempt={attempt}", flush=True)
+            if not args.skip_clock_wait and not wait_for_agent_clock(
+                client,
+                timeout_sec=args.clock_timeout_sec,
+            ):
+                return skipped_task_result(
+                    suite,
+                    unit.task,
+                    unit.attempt,
+                    art_dir,
+                    run_id,
+                    "agent board clock did not sync before benchmark start",
+                )
+            print(
+                f"[{progress}] RUNNING    {unit.task.id} attempt={unit.attempt}",
+                flush=True,
+            )
             return run_one_task(
                 client,
                 suite,
-                task,
-                attempt,
+                unit.task,
+                unit.attempt,
                 art_dir,
                 judge_cfg,
                 judge_cache,
@@ -643,7 +680,14 @@ def _cmd_run_auto_agent_setup_inner(
             )
         except Exception as exc:
             append_log(runner_log, f"ERROR: {exc}")
-            return skipped_task_result(suite, task, attempt, art_dir, run_id, str(exc))
+            return skipped_task_result(
+                suite,
+                unit.task,
+                unit.attempt,
+                art_dir,
+                run_id,
+                str(exc),
+            )
         finally:
             if args.environment_url:
                 try:
@@ -666,29 +710,27 @@ def _cmd_run_auto_agent_setup_inner(
     )
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix=f"bench-cli-{run_id}") as executor:
         future_to_unit = {
-            executor.submit(
-                run_unit,
-                unit.index,
-                unit.task,
-                unit.attempt,
-                unit.repeats,
-                unit.skip_reason,
-                unit.target_platform,
-            ): (unit.index, unit.task, unit.attempt)
+            executor.submit(run_unit, unit): unit
             for unit in units
         }
         for future in concurrent.futures.as_completed(future_to_unit):
-            index, task, attempt = future_to_unit[future]
+            unit = future_to_unit[future]
             result = future.result()
-            _log_task_result(task.id, attempt, result, verbose=args.verbose, progress=f"{index}/{total_runs}")
+            _log_task_result(
+                unit.task.id,
+                unit.attempt,
+                result,
+                verbose=args.verbose,
+                progress=f"{unit.index}/{total_runs}",
+            )
             results.append(result)
             completed += 1
             _write_state(args.state_file, {
                 **base_state,
                 "completed": completed,
-                "current": index,
-                "current_task": task.id,
-                "current_attempt": attempt,
+                "current": unit.index,
+                "current_task": unit.task.id,
+                "current_attempt": unit.attempt,
                 "last_result": result.status,
                 "totals": _result_totals(results, total_runs),
             })

--- a/benchmark/runner/main.py
+++ b/benchmark/runner/main.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from runner.agent_client import AgentClient
@@ -17,15 +18,30 @@ from runner.platform import (
     read_environment_health,
     resolve_daemon_platform,
     resolve_environment_platform,
-    resolve_mock_platform,
 )
 from runner.report import git_sha, write_jsonl, write_manifest, write_summary, now_iso
 from runner.recovery import recover_agent_after_timeout, wait_for_agent_ready
 from runner.reset import ResetError, call_environment_release, clear_stale_adb_android_owner
 from runner.runtask import run_one_task, skipped_task_result
-from runner.suite import Suite, TaskSpec, load_suite
+from runner.suite import (
+    Suite,
+    TaskSpec,
+    effective_mock_environment,
+    load_suite,
+    resolve_mock_task_platform,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class TaskRunUnit:
+    index: int
+    task: TaskSpec
+    attempt: int
+    repeats: int
+    skip_reason: str
+    target_platform: str
 
 
 def wait_for_agent_clock(
@@ -348,22 +364,6 @@ def _resolve_target_platform_enum(
         return None
 
 
-def _mock_environment_platform(suite: Suite) -> str:
-    platforms: set[str] = (
-        {resolve_mock_platform(suite.mock_environment.platform).value}
-        if suite.mock_environment is not None and not suite.tasks
-        else set()
-    )
-    for task in suite.tasks:
-        spec = _task_mock_environment(suite, task)
-        if spec is None:
-            continue
-        platforms.add(resolve_mock_platform(spec.platform).value)
-    if len(platforms) != 1:
-        raise ValueError("mock environment suite must declare exactly one target platform")
-    return next(iter(platforms))
-
-
 def _read_environment_health(environment_url: str) -> dict:
     return read_environment_health(environment_url)
 
@@ -383,13 +383,35 @@ def _build_task_units(
     args: argparse.Namespace,
     suite: Suite,
     target_platform: str,
-) -> list[tuple[int, TaskSpec, int, int, str]]:
-    units: list[tuple[int, TaskSpec, int, int, str]] = []
+) -> list[TaskRunUnit]:
+    units: list[TaskRunUnit] = []
+    uses_mock_environment = _suite_has_mock_environment(suite)
     for task in suite.tasks:
         repeats = _task_repeats(args, task)
-        skip_reason = _task_platform_skip_reason(task, target_platform)
+        task_target_platform = target_platform
+        skip_reason = ""
+        if uses_mock_environment:
+            try:
+                task_target_platform = resolve_mock_task_platform(
+                    suite,
+                    task,
+                    constraint=target_platform or None,
+                ).value
+            except ValueError as exc:
+                skip_reason = str(exc)
+        if not skip_reason:
+            skip_reason = _task_platform_skip_reason(task, task_target_platform)
         for attempt in range(1, repeats + 1):
-            units.append((len(units) + 1, task, attempt, repeats, skip_reason))
+            units.append(
+                TaskRunUnit(
+                    index=len(units) + 1,
+                    task=task,
+                    attempt=attempt,
+                    repeats=repeats,
+                    skip_reason=skip_reason,
+                    target_platform=task_target_platform,
+                )
+            )
     return units
 
 
@@ -477,7 +499,7 @@ def _cmd_run_auto_agent_setup_inner(
 
     units = _build_task_units(args, suite, target_platform)
     total_runs = len(units)
-    has_runnable_units = any(not unit[4] for unit in units)
+    has_runnable_units = any(not unit.skip_reason for unit in units)
     if has_runnable_units:
         clear_stale_adb_android_owner(args.environment_url)
         ensure_daemon_image(args.daemon_image, not args.no_build_daemon_image, setup_log)
@@ -512,7 +534,14 @@ def _cmd_run_auto_agent_setup_inner(
     if args.agent_config:
         agent_config_text = Path(args.agent_config).read_text(encoding="utf-8")
 
-    def run_unit(index: int, task: TaskSpec, attempt: int, repeats: int, skip_reason: str):
+    def run_unit(
+        index: int,
+        task: TaskSpec,
+        attempt: int,
+        repeats: int,
+        skip_reason: str,
+        task_target_platform: str,
+    ):
         progress = f"{index}/{total_runs}"
         art_dir = run_dir / "tasks" / task.id / (f"attempt_{attempt}" if repeats > 1 else "")
         if skip_reason:
@@ -549,7 +578,7 @@ def _cmd_run_auto_agent_setup_inner(
         client = None
         try:
             print(f"[{progress}] STARTING   {task.id} attempt={attempt}", flush=True)
-            task_mock_environment = _task_mock_environment(suite, task)
+            task_mock_environment = effective_mock_environment(suite, task)
             if mock_server is not None:
                 if task_mock_environment is None:
                     return skipped_task_result(
@@ -568,7 +597,7 @@ def _cmd_run_auto_agent_setup_inner(
                 config_dir=config_dir,
                 environment_bridge_endpoint=docker_environment_url,
                 benchmark_task_id=route_id,
-                device_type=target_platform,
+                device_type=task_target_platform,
                 environment_bridge_mode=True,
                 log_path=runner_log,
             )
@@ -629,8 +658,16 @@ def _cmd_run_auto_agent_setup_inner(
     )
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix=f"bench-cli-{run_id}") as executor:
         future_to_unit = {
-            executor.submit(run_unit, index, task, attempt, repeats, skip_reason): (index, task, attempt)
-            for index, task, attempt, repeats, skip_reason in units
+            executor.submit(
+                run_unit,
+                unit.index,
+                unit.task,
+                unit.attempt,
+                unit.repeats,
+                unit.skip_reason,
+                unit.target_platform,
+            ): (unit.index, unit.task, unit.attempt)
+            for unit in units
         }
         for future in concurrent.futures.as_completed(future_to_unit):
             index, task, attempt = future_to_unit[future]
@@ -728,17 +765,8 @@ def _cmd_run(args: argparse.Namespace) -> int:
         )
         return 2
     if args.auto_agent_setup and _suite_has_mock_environment(suite):
-        try:
-            declared_mock_platform = _mock_environment_platform(suite)
-            requested_platform = str(args.target_platform or "").strip().lower()
-            resolved_mock_platform = resolve_mock_platform(
-                declared_mock_platform,
-                constraint=requested_platform or None,
-            )
-            target_platform = resolved_mock_platform.value
-        except ValueError as exc:
-            print(f"Error: failed to resolve target platform: {exc}", file=sys.stderr)
-            return 2
+        requested_platform = str(args.target_platform or "").strip().lower()
+        target_platform = "" if requested_platform == "auto" else requested_platform
     if args.auto_agent_setup:
         return _cmd_run_auto_agent_setup(
             args,
@@ -752,7 +780,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         print(f"Error: --repeats must be positive, got {args.repeats}", file=sys.stderr)
         return 2
     units = _build_task_units(args, suite, target_platform)
-    has_runnable_units = any(not unit[4] for unit in units)
+    has_runnable_units = any(not unit.skip_reason for unit in units)
     if args.environment_url:
         clear_stale_adb_android_owner(args.environment_url)
     client = _new_agent_client(args.agent_url, _read_optional_token(args.benchmark_token_file))
@@ -780,7 +808,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
     if not args.environment_url:
         target_platform = daemon_platform.value
         units = _build_task_units(args, suite, target_platform)
-        has_runnable_units = any(not unit[4] for unit in units)
+        has_runnable_units = any(not unit.skip_reason for unit in units)
     if (
         has_runnable_units
         and not args.skip_clock_wait
@@ -809,7 +837,12 @@ def _cmd_run(args: argparse.Namespace) -> int:
     }
     _write_state(args.state_file, base_state)
     try:
-        for current_index, task, attempt, n, skip_reason in units:
+        for unit in units:
+            current_index = unit.index
+            task = unit.task
+            attempt = unit.attempt
+            n = unit.repeats
+            skip_reason = unit.skip_reason
             if skip_reason:
                 art_dir = run_dir / "tasks" / task.id / (f"attempt_{attempt}" if n > 1 else "")
                 r = skipped_task_result(suite, task, attempt, art_dir, run_id, skip_reason)
@@ -1007,10 +1040,6 @@ def _serialize_mock_environment(spec) -> dict[str, object] | None:
         "screen": spec.screen,
         "screen_text": spec.screen_text,
     }
-
-
-def _task_mock_environment(suite: Suite, task: TaskSpec):
-    return task.mock_environment or suite.mock_environment
 
 
 def _suite_has_mock_environment(suite: Suite) -> bool:

--- a/benchmark/runner/main.py
+++ b/benchmark/runner/main.py
@@ -18,6 +18,7 @@ from runner.platform import (
     read_environment_health,
     resolve_daemon_platform,
     resolve_environment_platform,
+    summarize_target_platforms,
 )
 from runner.report import git_sha, write_jsonl, write_manifest, write_summary, now_iso
 from runner.recovery import recover_agent_after_timeout, wait_for_agent_ready
@@ -498,6 +499,13 @@ def _cmd_run_auto_agent_setup_inner(
     setup_log = run_dir / "auto-agent-setup.log"
 
     units = _build_task_units(args, suite, target_platform)
+    manifest_target_platform = target_platform
+    if mock_server is not None:
+        manifest_target_platform = summarize_target_platforms(
+            unit.target_platform for unit in units
+        )
+        if not manifest_target_platform and suite.mock_environment is not None:
+            manifest_target_platform = suite.mock_environment.platform
     total_runs = len(units)
     has_runnable_units = any(not unit.skip_reason for unit in units)
     if has_runnable_units:
@@ -696,7 +704,7 @@ def _cmd_run_auto_agent_setup_inner(
         "active_skills": active_skills,
         "judge_config": {"provider": "openrouter", "model": args.judge_model, "base_url": args.judge_base_url} if judge_cfg else None,
         "judge_prompt_version": "v1",
-        "target_platform": target_platform or None,
+        "target_platform": manifest_target_platform or None,
         "auto_agent_setup": True,
         "concurrency": max_workers,
         "mock_environment": _mock_environment_manifest(suite),

--- a/benchmark/runner/platform.py
+++ b/benchmark/runner/platform.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import urllib.request
-from collections.abc import Iterable
 from enum import Enum
 from typing import Any
 
@@ -18,21 +17,6 @@ class TargetPlatform(str, Enum):
 
 
 VALID_TARGET_PLATFORMS = {platform.value for platform in TargetPlatform}
-
-
-def summarize_target_platforms(platforms: Iterable[Any]) -> str:
-    values = sorted(
-        {
-            normalize_target_platform(platform).value
-            for platform in platforms
-            if str(platform or "").strip()
-        }
-    )
-    if not values:
-        return ""
-    if len(values) == 1:
-        return values[0]
-    return "mixed"
 
 
 def normalize_target_platform(

--- a/benchmark/runner/platform.py
+++ b/benchmark/runner/platform.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import urllib.request
+from collections.abc import Iterable
 from enum import Enum
 from typing import Any
 
@@ -17,6 +18,21 @@ class TargetPlatform(str, Enum):
 
 
 VALID_TARGET_PLATFORMS = {platform.value for platform in TargetPlatform}
+
+
+def summarize_target_platforms(platforms: Iterable[Any]) -> str:
+    values = sorted(
+        {
+            normalize_target_platform(platform).value
+            for platform in platforms
+            if str(platform or "").strip()
+        }
+    )
+    if not values:
+        return ""
+    if len(values) == 1:
+        return values[0]
+    return "mixed"
 
 
 def normalize_target_platform(

--- a/benchmark/runner/suite.py
+++ b/benchmark/runner/suite.py
@@ -6,7 +6,11 @@ import re
 from pathlib import Path
 from typing import Any
 
-from runner.platform import TargetPlatform, normalize_target_platform
+from runner.platform import (
+    TargetPlatform,
+    normalize_target_platform,
+    resolve_mock_platform,
+)
 
 VALID_CATEGORIES = {"diagnostic", "single_step", "multi_step", "memory", "perception", "device_operation"}
 
@@ -87,6 +91,46 @@ class Suite:
     prompt_prefix: str = ""
     trace_observations: list[TraceObservationSpec] = dc.field(default_factory=list)
     mock_environment: MockEnvironmentSpec | None = None
+
+
+def effective_mock_environment(
+    suite: Suite,
+    task: TaskSpec,
+) -> MockEnvironmentSpec | None:
+    return task.mock_environment or suite.mock_environment
+
+
+def resolve_mock_task_platform(
+    suite: Suite,
+    task: TaskSpec,
+    *,
+    constraint: str | TargetPlatform | None = None,
+) -> TargetPlatform:
+    spec = effective_mock_environment(suite, task)
+    if spec is None:
+        raise ValueError(
+            f"mock environment task {task.id!r} has no mock environment"
+        )
+    return resolve_mock_platform(spec.platform, constraint=constraint)
+
+
+def resolve_mock_suite_platforms(
+    suite: Suite,
+    *,
+    constraint: str | TargetPlatform | None = None,
+) -> tuple[TargetPlatform, ...]:
+    if suite.tasks:
+        platforms = {
+            resolve_mock_task_platform(suite, task, constraint=constraint)
+            for task in suite.tasks
+        }
+    elif suite.mock_environment is not None:
+        platforms = {
+            resolve_mock_platform(suite.mock_environment.platform, constraint=constraint)
+        }
+    else:
+        platforms = set()
+    return tuple(sorted(platforms, key=lambda platform: platform.value))
 
 def load_suite(path: Path) -> Suite:
     raw_bytes = Path(path).read_bytes()

--- a/benchmark/runner/suite.py
+++ b/benchmark/runner/suite.py
@@ -113,25 +113,6 @@ def resolve_mock_task_platform(
         )
     return resolve_mock_platform(spec.platform, constraint=constraint)
 
-
-def resolve_mock_suite_platforms(
-    suite: Suite,
-    *,
-    constraint: str | TargetPlatform | None = None,
-) -> tuple[TargetPlatform, ...]:
-    if suite.tasks:
-        platforms = {
-            resolve_mock_task_platform(suite, task, constraint=constraint)
-            for task in suite.tasks
-        }
-    elif suite.mock_environment is not None:
-        platforms = {
-            resolve_mock_platform(suite.mock_environment.platform, constraint=constraint)
-        }
-    else:
-        platforms = set()
-    return tuple(sorted(platforms, key=lambda platform: platform.value))
-
 def load_suite(path: Path) -> Suite:
     raw_bytes = Path(path).read_bytes()
     sha = hashlib.sha256(raw_bytes).hexdigest()

--- a/benchmark/runner/webui.py
+++ b/benchmark/runner/webui.py
@@ -31,6 +31,7 @@ from runner.judge import JudgeConfig
 from runner.platform import (
     read_environment_health,
     resolve_environment_platform,
+    summarize_target_platforms,
 )
 from runner.reset import ResetError, call_environment_release
 from runner.suite import load_suite, resolve_mock_suite_platforms
@@ -824,13 +825,7 @@ class BenchmarkWebApp:
                 )
                 self._set_job(
                     job,
-                    target_platform=(
-                        platforms[0].value
-                        if len(platforms) == 1
-                        else "mixed"
-                        if platforms
-                        else ""
-                    ),
+                    target_platform=summarize_target_platforms(platforms),
                 )
             else:
                 health = read_environment_health(job.environment_endpoint or job.endpoint)

--- a/benchmark/runner/webui.py
+++ b/benchmark/runner/webui.py
@@ -31,10 +31,9 @@ from runner.judge import JudgeConfig
 from runner.platform import (
     read_environment_health,
     resolve_environment_platform,
-    summarize_target_platforms,
 )
 from runner.reset import ResetError, call_environment_release
-from runner.suite import load_suite, resolve_mock_suite_platforms
+from runner.suite import load_suite
 
 try:
     from benchmark.runner.environment import EnvironmentManager, MobileGymEnvironment
@@ -818,16 +817,7 @@ class BenchmarkWebApp:
             self._raise_if_job_stop_requested(job)
             self._set_job(job, status="preparing", started_at=now_iso(), message="preparing config")
             agent_config_text = self.get_agent_config()["content"]
-            if job.environment_type == "mock":
-                platforms = resolve_mock_suites_platforms(
-                    self.config.suites_dir,
-                    job.suites,
-                )
-                self._set_job(
-                    job,
-                    target_platform=summarize_target_platforms(platforms),
-                )
-            else:
+            if job.environment_type != "mock":
                 health = read_environment_health(job.environment_endpoint or job.endpoint)
                 resolution = resolve_environment_platform(health)
                 self._set_job(
@@ -849,6 +839,10 @@ class BenchmarkWebApp:
                 for suite_key in job.suites:
                     self._raise_if_job_stop_requested(job)
                     self._run_mock_suite(job, suite_key)
+                self._set_job(
+                    job,
+                    target_platform=_mock_job_target_platform(job.suite_results),
+                )
                 self._raise_if_job_stop_requested(job)
                 self._refresh_job_report(job)
                 final_status = (
@@ -1630,12 +1624,17 @@ def suite_uses_mock_environment(path: Path) -> bool:
     return isinstance(data, dict) and suite_data_uses_mock_environment(data)
 
 
-def resolve_mock_suites_platforms(suites_dir: Path, suite_keys: list[str]):
-    platforms = set()
-    for suite_key in suite_keys:
-        suite = load_suite(resolve_suite_path(suites_dir, suite_key))
-        platforms.update(resolve_mock_suite_platforms(suite))
-    return tuple(sorted(platforms, key=lambda platform: platform.value))
+def _mock_job_target_platform(suite_results: list[dict[str, Any]]) -> str:
+    platforms = {
+        str((result.get("manifest") or {}).get("target_platform") or "").strip()
+        for result in suite_results
+    }
+    platforms.discard("")
+    if not platforms:
+        return ""
+    if len(platforms) == 1:
+        return next(iter(platforms))
+    return "mixed"
 
 
 def resolve_suite_path(suites_dir: Path, key: str) -> Path:

--- a/benchmark/runner/webui.py
+++ b/benchmark/runner/webui.py
@@ -31,10 +31,9 @@ from runner.judge import JudgeConfig
 from runner.platform import (
     read_environment_health,
     resolve_environment_platform,
-    resolve_mock_platform,
 )
 from runner.reset import ResetError, call_environment_release
-from runner.suite import load_suite
+from runner.suite import load_suite, resolve_mock_suite_platforms
 
 try:
     from benchmark.runner.environment import EnvironmentManager, MobileGymEnvironment
@@ -819,13 +818,19 @@ class BenchmarkWebApp:
             self._set_job(job, status="preparing", started_at=now_iso(), message="preparing config")
             agent_config_text = self.get_agent_config()["content"]
             if job.environment_type == "mock":
-                resolution = resolve_mock_suites_platform(
+                platforms = resolve_mock_suites_platforms(
                     self.config.suites_dir,
                     job.suites,
                 )
                 self._set_job(
                     job,
-                    target_platform=resolution.value,
+                    target_platform=(
+                        platforms[0].value
+                        if len(platforms) == 1
+                        else "mixed"
+                        if platforms
+                        else ""
+                    ),
                 )
             else:
                 health = read_environment_health(job.environment_endpoint or job.endpoint)
@@ -1630,22 +1635,12 @@ def suite_uses_mock_environment(path: Path) -> bool:
     return isinstance(data, dict) and suite_data_uses_mock_environment(data)
 
 
-def resolve_mock_suites_platform(suites_dir: Path, suite_keys: list[str]):
+def resolve_mock_suites_platforms(suites_dir: Path, suite_keys: list[str]):
     platforms = set()
     for suite_key in suite_keys:
         suite = load_suite(resolve_suite_path(suites_dir, suite_key))
-        if suite.mock_environment is not None and not suite.tasks:
-            platforms.add(suite.mock_environment.platform)
-        for task in suite.tasks:
-            spec = task.mock_environment or suite.mock_environment
-            if spec is None:
-                raise ValueError(
-                    f"mock environment suite {suite_key!r} task {task.id!r} has no mock environment"
-                )
-            platforms.add(spec.platform)
-    if len(platforms) != 1:
-        raise ValueError("mock environment suites must declare exactly one target platform")
-    return resolve_mock_platform(next(iter(platforms)))
+        platforms.update(resolve_mock_suite_platforms(suite))
+    return tuple(sorted(platforms, key=lambda platform: platform.value))
 
 
 def resolve_suite_path(suites_dir: Path, key: str) -> Path:

--- a/benchmark/tests/test_main.py
+++ b/benchmark/tests/test_main.py
@@ -1289,7 +1289,7 @@ def test_auto_agent_setup_resolves_mock_platform_per_task(monkeypatch, tmp_path)
     assert manifest["target_platform"] == "mixed"
 
 
-def test_mock_suite_platforms_use_each_task_effective_override(tmp_path):
+def test_mock_task_platform_uses_task_override(tmp_path):
     suite_path = tmp_path / "mock-suite.json"
     suite_path.write_text(
         json.dumps(
@@ -1318,31 +1318,12 @@ def test_mock_suite_platforms_use_each_task_effective_override(tmp_path):
         encoding="utf-8",
     )
 
-    assert suite_module.resolve_mock_suite_platforms(main.load_suite(suite_path)) == (
-        suite_module.TargetPlatform.IOS,
-    )
+    suite = main.load_suite(suite_path)
 
-
-def test_mock_suite_platforms_support_empty_suite_default(tmp_path):
-    suite_path = tmp_path / "mock-suite.json"
-    suite_path.write_text(
-        json.dumps(
-            {
-                "name": "mock_suite",
-                "mock_environment": {
-                    "platform": "ios",
-                    "phone_bridge": {},
-                    "tools": {},
-                },
-                "tasks": [],
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    assert suite_module.resolve_mock_suite_platforms(main.load_suite(suite_path)) == (
-        suite_module.TargetPlatform.IOS,
-    )
+    assert {
+        suite_module.resolve_mock_task_platform(suite, task)
+        for task in suite.tasks
+    } == {suite_module.TargetPlatform.IOS}
 
 
 def test_mock_suite_loading_rejects_effective_spec_without_platform(tmp_path):

--- a/benchmark/tests/test_main.py
+++ b/benchmark/tests/test_main.py
@@ -1136,6 +1136,7 @@ def test_auto_agent_setup_starts_mock_environment_and_injects_phone_state(
         key: value for key, value in phone_state.items() if key != "platform"
     }
     assert manifest["environment_url"].endswith("/_aiden_mock/REDACTED")
+    assert manifest["target_platform"] == "ios"
 
 
 def test_auto_agent_setup_filters_mock_tasks_by_target_platform(tmp_path, capsys):
@@ -1280,6 +1281,12 @@ def test_auto_agent_setup_resolves_mock_platform_per_task(monkeypatch, tmp_path)
 
     assert rc == 0
     assert daemon_platforms == {"ios": "ios", "android": "android"}
+    manifest = json.loads(
+        (tmp_path / "runs" / "mixed-run" / "manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["target_platform"] == "mixed"
 
 
 def test_mock_suite_platforms_use_each_task_effective_override(tmp_path):

--- a/benchmark/tests/test_main.py
+++ b/benchmark/tests/test_main.py
@@ -8,6 +8,7 @@ from runner.agent_client import ToolInvokeResult
 from runner.analysis import AnalysisResult
 from runner.models import HardAssertionFailure, HardAssertionResults, RubricVerdict, TaskResult
 import runner.main as main
+import runner.suite as suite_module
 import runner.webui as webui
 
 
@@ -1137,7 +1138,7 @@ def test_auto_agent_setup_starts_mock_environment_and_injects_phone_state(
     assert manifest["environment_url"].endswith("/_aiden_mock/REDACTED")
 
 
-def test_auto_agent_setup_rejects_mock_target_platform_mismatch(tmp_path, capsys):
+def test_auto_agent_setup_filters_mock_tasks_by_target_platform(tmp_path, capsys):
     suite_path = tmp_path / "mock-suite.json"
     suite_path.write_text(
         json.dumps(
@@ -1168,6 +1169,8 @@ def test_auto_agent_setup_rejects_mock_target_platform_mismatch(tmp_path, capsys
             str(suite_path),
             "--out",
             str(tmp_path / "runs"),
+            "--run-id",
+            "filtered-run",
             "--auto-agent-setup",
             "--target-platform",
             "ios",
@@ -1175,11 +1178,111 @@ def test_auto_agent_setup_rejects_mock_target_platform_mismatch(tmp_path, capsys
         ]
     )
 
-    assert rc == 2
-    assert "does not match" in capsys.readouterr().err
+    assert rc == 0
+    assert "does not match" not in capsys.readouterr().err
+    manifest = json.loads(
+        (tmp_path / "runs" / "filtered-run" / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["target_platform"] == "ios"
+    assert manifest["totals"]["skipped"] == 1
 
 
-def test_mock_environment_platform_uses_each_task_effective_override(tmp_path):
+def test_auto_agent_setup_resolves_mock_platform_per_task(monkeypatch, tmp_path):
+    suite_path = tmp_path / "mock-suite.json"
+    suite_path.write_text(
+        json.dumps(
+            {
+                "name": "mixed_mock_suite",
+                "tasks": [
+                    {
+                        "id": platform,
+                        "category": "diagnostic",
+                        "prompt": f"test {platform}",
+                        "description_for_judge": f"test {platform}",
+                        "rubric": [{"id": "done", "check": "done"}],
+                        "mock_environment": {
+                            "platform": platform,
+                            "phone_bridge": {},
+                            "tools": {"screenshot": {"output": {"ok": True}}},
+                        },
+                    }
+                    for platform in ("ios", "android")
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    daemon_platforms = {}
+
+    class FakeClient:
+        def __init__(self, base_url, benchmark_token=""):
+            pass
+
+        def set_phone_bridge_state(self, state):
+            return {"ok": True}
+
+        def close(self):
+            pass
+
+    def fake_prepare_run_config(base_config_dir, config_dir, **kwargs):
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "control_token").write_text("mock-token", encoding="utf-8")
+
+    def fake_start_daemon_compose(job, **kwargs):
+        task_id = kwargs["benchmark_task_id"].rsplit(":", 1)[-1]
+        daemon_platforms[task_id] = kwargs["device_type"]
+        return f"container-{task_id}"
+
+    monkeypatch.setattr(main, "AgentClient", FakeClient)
+    monkeypatch.setattr(main, "wait_for_agent_ready", lambda *args, **kwargs: True)
+    monkeypatch.setattr(main, "wait_for_agent_clock", lambda *args, **kwargs: True)
+    monkeypatch.setattr(main, "generate_report_html", lambda run_dir: "<html></html>")
+    monkeypatch.setattr(webui, "ensure_daemon_image", lambda *args, **kwargs: None)
+    monkeypatch.setattr(webui, "prepare_run_config", fake_prepare_run_config)
+    monkeypatch.setattr(
+        webui, "docker_published_port", lambda container_id, container_port: 18081
+    )
+    monkeypatch.setattr(webui, "start_daemon_compose", fake_start_daemon_compose)
+    monkeypatch.setattr(webui, "start_daemon_logs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(webui, "stop_daemon_compose", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        main,
+        "run_one_task",
+        lambda client, suite, task, attempt, artifact_dir, *args, **kwargs: TaskResult(
+            suite=suite.name,
+            run_id="mixed-run",
+            task_id=task.id,
+            category=task.category,
+            attempt=attempt,
+            status="passed",
+            rubric=[],
+            rubric_pass_count=0,
+            rubric_total=0,
+            artifact_dir=str(artifact_dir),
+        ),
+    )
+
+    rc = main.cli(
+        [
+            "run",
+            "--suite",
+            str(suite_path),
+            "--out",
+            str(tmp_path / "runs"),
+            "--run-id",
+            "mixed-run",
+            "--auto-agent-setup",
+            "--max-concurrency",
+            "1",
+            "--no-judge",
+        ]
+    )
+
+    assert rc == 0
+    assert daemon_platforms == {"ios": "ios", "android": "android"}
+
+
+def test_mock_suite_platforms_use_each_task_effective_override(tmp_path):
     suite_path = tmp_path / "mock-suite.json"
     suite_path.write_text(
         json.dumps(
@@ -1208,10 +1311,12 @@ def test_mock_environment_platform_uses_each_task_effective_override(tmp_path):
         encoding="utf-8",
     )
 
-    assert main._mock_environment_platform(main.load_suite(suite_path)) == "ios"
+    assert suite_module.resolve_mock_suite_platforms(main.load_suite(suite_path)) == (
+        suite_module.TargetPlatform.IOS,
+    )
 
 
-def test_mock_environment_platform_supports_empty_suite_default(tmp_path):
+def test_mock_suite_platforms_support_empty_suite_default(tmp_path):
     suite_path = tmp_path / "mock-suite.json"
     suite_path.write_text(
         json.dumps(
@@ -1228,10 +1333,12 @@ def test_mock_environment_platform_supports_empty_suite_default(tmp_path):
         encoding="utf-8",
     )
 
-    assert main._mock_environment_platform(main.load_suite(suite_path)) == "ios"
+    assert suite_module.resolve_mock_suite_platforms(main.load_suite(suite_path)) == (
+        suite_module.TargetPlatform.IOS,
+    )
 
 
-def test_mock_environment_platform_rejects_effective_spec_without_platform(tmp_path):
+def test_mock_suite_loading_rejects_effective_spec_without_platform(tmp_path):
     suite_path = tmp_path / "mock-suite.json"
     suite_path.write_text(
         json.dumps(
@@ -1267,7 +1374,7 @@ def test_mock_environment_platform_rejects_effective_spec_without_platform(tmp_p
     )
 
     with pytest.raises(ValueError, match="declare a target platform"):
-        main._mock_environment_platform(main.load_suite(suite_path))
+        main.load_suite(suite_path)
 
 
 def test_auto_agent_setup_caps_environment_concurrency(monkeypatch, tmp_path):

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from pathlib import Path
 from runner.platform import TargetPlatform
-from runner.suite import load_suite, SuiteValidationError
+from runner.suite import load_suite, resolve_mock_suite_platforms, SuiteValidationError
 
 FIXTURE = {
     "name": "test_suite",
@@ -969,6 +969,10 @@ def test_phone_bridge_data_policy_suite_covers_tools_and_routing_modes():
     assert suite.mock_environment is None
     assert len(tasks) == 12
     assert all(task.mock_environment is not None for task in suite.tasks)
+    assert resolve_mock_suite_platforms(suite) == (
+        TargetPlatform.ANDROID,
+        TargetPlatform.IOS,
+    )
     assert {
         tool
         for task in suite.tasks

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from pathlib import Path
 from runner.platform import TargetPlatform
-from runner.suite import load_suite, resolve_mock_suite_platforms, SuiteValidationError
+from runner.suite import load_suite, SuiteValidationError
 
 FIXTURE = {
     "name": "test_suite",
@@ -969,10 +969,11 @@ def test_phone_bridge_data_policy_suite_covers_tools_and_routing_modes():
     assert suite.mock_environment is None
     assert len(tasks) == 12
     assert all(task.mock_environment is not None for task in suite.tasks)
-    assert resolve_mock_suite_platforms(suite) == (
-        TargetPlatform.ANDROID,
-        TargetPlatform.IOS,
-    )
+    assert {
+        task.mock_environment.platform
+        for task in suite.tasks
+        if task.mock_environment is not None
+    } == {TargetPlatform.ANDROID, TargetPlatform.IOS}
     assert {
         tool
         for task in suite.tasks

--- a/benchmark/tests/test_webui.py
+++ b/benchmark/tests/test_webui.py
@@ -2250,7 +2250,19 @@ def test_run_mock_suite_uses_auto_agent_setup_and_updates_task_records(
     assert job.suite_results[0]["run_id"].startswith("job-mock-")
 
 
-def test_run_job_mock_mode_skips_shared_agent_daemon(tmp_path: Path, monkeypatch):
+@pytest.mark.parametrize(
+    ("platforms", "expected_platform"),
+    [
+        (["ios"], "ios"),
+        (["ios", "android"], "mixed"),
+    ],
+)
+def test_run_job_mock_mode_uses_runner_platform_summary(
+    tmp_path: Path,
+    monkeypatch,
+    platforms,
+    expected_platform,
+):
     app = webui.BenchmarkWebApp(
         webui.WebUIConfig(
             suites_dir=tmp_path,
@@ -2260,34 +2272,12 @@ def test_run_job_mock_mode_skips_shared_agent_daemon(tmp_path: Path, monkeypatch
     )
     job_dir = tmp_path / "runs" / "job-mock"
     job_dir.mkdir(parents=True)
-    suite_path = tmp_path / "mock.json"
-    suite_path.write_text(
-        json.dumps(
-            {
-                "name": "mock",
-                "mock_environment": {
-                    "platform": "ios",
-                    "phone_bridge": {},
-                    "tools": {},
-                },
-                "tasks": [
-                    {
-                        "id": "task",
-                        "category": "diagnostic",
-                        "prompt": "test",
-                        "description_for_judge": "test",
-                        "rubric": [{"id": "done", "check": "done"}],
-                    }
-                ],
-            }
-        ),
-        encoding="utf-8",
-    )
+    suites = [f"{platform}.json" for platform in platforms]
     job = webui.Job(
         id="job-mock",
         endpoint="",
         docker_endpoint="",
-        suites=["mock.json"],
+        suites=suites,
         environment_type="mock",
         environment_name="Mock Aiden App environment",
         config_dir=str(job_dir / "config"),
@@ -2315,85 +2305,25 @@ def test_run_job_mock_mode_skips_shared_agent_daemon(tmp_path: Path, monkeypatch
 
     def fake_run_mock_suite(run_job, suite_key):
         calls.append(suite_key)
-        run_job.suite_results.append({"suite": suite_key, "exit_code": 0})
+        platform = Path(suite_key).stem
+        run_job.suite_results.append(
+            {
+                "suite": suite_key,
+                "exit_code": 0,
+                "manifest": {"target_platform": platform},
+            }
+        )
 
     monkeypatch.setattr(app, "_run_mock_suite", fake_run_mock_suite)
     monkeypatch.setattr(app, "_refresh_job_report", lambda run_job: None)
 
     app._run_job(job)
 
-    assert calls == ["mock.json"]
+    assert calls == suites
     assert job.status == "passed"
-    assert job.target_platform == "ios"
+    assert job.target_platform == expected_platform
     persisted = json.loads((job_dir / "job.json").read_text(encoding="utf-8"))
-    assert persisted["target_platform"] == "ios"
-
-
-def test_run_job_mock_mode_accepts_mixed_task_platforms(tmp_path: Path, monkeypatch):
-    app = webui.BenchmarkWebApp(
-        webui.WebUIConfig(
-            suites_dir=tmp_path,
-            runs_dir=tmp_path / "runs",
-            base_config_dir=tmp_path / "config",
-        )
-    )
-    job_dir = tmp_path / "runs" / "job-mixed-mock"
-    job_dir.mkdir(parents=True)
-    suite_path = tmp_path / "mixed-mock.json"
-    suite_path.write_text(
-        json.dumps(
-            {
-                "name": "mixed mock",
-                "tasks": [
-                    {
-                        "id": platform,
-                        "category": "diagnostic",
-                        "prompt": "test",
-                        "description_for_judge": "test",
-                        "rubric": [{"id": "done", "check": "done"}],
-                        "mock_environment": {
-                            "platform": platform,
-                            "phone_bridge": {},
-                            "tools": {},
-                        },
-                    }
-                    for platform in ("ios", "android")
-                ],
-            }
-        ),
-        encoding="utf-8",
-    )
-    job = webui.Job(
-        id="job-mixed-mock",
-        endpoint="",
-        docker_endpoint="",
-        suites=["mixed-mock.json"],
-        environment_type="mock",
-        environment_name="Mock Aiden App environment",
-        config_dir=str(job_dir / "config"),
-        raw_runs_dir=str(job_dir / "raw"),
-        state_file=str(job_dir / "state.json"),
-        runner_log=str(job_dir / "runner.log"),
-        daemon_log=str(job_dir / "daemon.log"),
-        no_judge=True,
-    )
-    app._jobs[job.id] = job
-
-    monkeypatch.setattr(app, "get_agent_config", lambda: {"content": ""})
-    monkeypatch.setattr(webui, "prepare_run_config", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        app,
-        "_run_mock_suite",
-        lambda run_job, suite_key: run_job.suite_results.append(
-            {"suite": suite_key, "exit_code": 0}
-        ),
-    )
-    monkeypatch.setattr(app, "_refresh_job_report", lambda run_job: None)
-
-    app._run_job(job)
-
-    assert job.status == "passed"
-    assert job.target_platform == "mixed"
+    assert persisted["target_platform"] == expected_platform
 
 
 def test_webui_html_exposes_mock_environment_run_mode():

--- a/benchmark/tests/test_webui.py
+++ b/benchmark/tests/test_webui.py
@@ -2329,6 +2329,73 @@ def test_run_job_mock_mode_skips_shared_agent_daemon(tmp_path: Path, monkeypatch
     assert persisted["target_platform"] == "ios"
 
 
+def test_run_job_mock_mode_accepts_mixed_task_platforms(tmp_path: Path, monkeypatch):
+    app = webui.BenchmarkWebApp(
+        webui.WebUIConfig(
+            suites_dir=tmp_path,
+            runs_dir=tmp_path / "runs",
+            base_config_dir=tmp_path / "config",
+        )
+    )
+    job_dir = tmp_path / "runs" / "job-mixed-mock"
+    job_dir.mkdir(parents=True)
+    suite_path = tmp_path / "mixed-mock.json"
+    suite_path.write_text(
+        json.dumps(
+            {
+                "name": "mixed mock",
+                "tasks": [
+                    {
+                        "id": platform,
+                        "category": "diagnostic",
+                        "prompt": "test",
+                        "description_for_judge": "test",
+                        "rubric": [{"id": "done", "check": "done"}],
+                        "mock_environment": {
+                            "platform": platform,
+                            "phone_bridge": {},
+                            "tools": {},
+                        },
+                    }
+                    for platform in ("ios", "android")
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    job = webui.Job(
+        id="job-mixed-mock",
+        endpoint="",
+        docker_endpoint="",
+        suites=["mixed-mock.json"],
+        environment_type="mock",
+        environment_name="Mock Aiden App environment",
+        config_dir=str(job_dir / "config"),
+        raw_runs_dir=str(job_dir / "raw"),
+        state_file=str(job_dir / "state.json"),
+        runner_log=str(job_dir / "runner.log"),
+        daemon_log=str(job_dir / "daemon.log"),
+        no_judge=True,
+    )
+    app._jobs[job.id] = job
+
+    monkeypatch.setattr(app, "get_agent_config", lambda: {"content": ""})
+    monkeypatch.setattr(webui, "prepare_run_config", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        app,
+        "_run_mock_suite",
+        lambda run_job, suite_key: run_job.suite_results.append(
+            {"suite": suite_key, "exit_code": 0}
+        ),
+    )
+    monkeypatch.setattr(app, "_refresh_job_report", lambda run_job: None)
+
+    app._run_job(job)
+
+    assert job.status == "passed"
+    assert job.target_platform == "mixed"
+
+
 def test_webui_html_exposes_mock_environment_run_mode():
     assert "Mock Aiden App environment" in webui.INDEX_HTML
     assert "selectedSuiteEnvironmentMode" in webui.INDEX_HTML


### PR DESCRIPTION
## Summary

- resolve each mock task platform from its effective task or suite-default specification
- treat the CLI target platform as a per-task constraint and pass the resolved device type to each isolated daemon
- share mock platform resolution between the CLI and WebUI, allowing mixed iOS and Android suites

## Testing

- `cd benchmark && .venv/bin/pytest -q`
- 505 passed