### PR TITLE
fix(benchmark): remove stale mouse click references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ benchmark/mobilegym/vendor/*
 # MobileGym daemon runtime state (regenerated each run)
 benchmark/mobilegym/config/agent.toml
 benchmark/mobilegym/config/agent.toml.*
+!benchmark/mobilegym/config/agent.toml.template
 benchmark/mobilegym/config/memory/
 benchmark/mobilegym/config/log/
 benchmark/mobilegym/config/control_token

--- a/benchmark/mobilegym/bridge/test_tools_api.py
+++ b/benchmark/mobilegym/bridge/test_tools_api.py
@@ -81,15 +81,15 @@ def test_get_tools_catalog(bridge_server):
 
     assert "tools" in data
     tools = {tool["name"]: tool for tool in data["tools"]}
-    assert "screenshot" not in tools
-    assert "touch_gesture" in tools
-    assert "keyboard_text" in tools
-    assert "keyboard_tap" in tools
-    assert "enter_text" in tools
-    assert "mouse_click" not in tools
-    assert "mouse_move" in tools
-    assert "mouse_scroll" in tools
-    assert "quick_action" in tools
+    assert set(tools) == {
+        "touch_gesture",
+        "keyboard_text",
+        "keyboard_tap",
+        "enter_text",
+        "mouse_move",
+        "mouse_scroll",
+        "quick_action",
+    }
 
     assert tools["touch_gesture"]["args_schema"]["additionalProperties"] is False
     touch_props = tools["touch_gesture"]["args_schema"]["properties"]

--- a/benchmark/mobilegym/config/agent.toml.template
+++ b/benchmark/mobilegym/config/agent.toml.template
@@ -1,7 +1,7 @@
 instruction = """
 Follow the normal device-control behavior for operating a visible UI through screenshots and one verified action at a time.
 
-This run targets a MobileGym simulator. Benchmark setup/reset prepares the starting screen, and the bridge exposes simulator tools such as screenshot, touch_gesture, keyboard_text, keyboard_tap, mouse_click, mouse_move, mouse_scroll, and quick_action.
+This run targets a MobileGym simulator. Benchmark setup/reset prepares the starting screen, and the bridge exposes simulator tools such as screenshot, touch_gesture, keyboard_text, keyboard_tap, mouse_move, mouse_scroll, and quick_action.
 
 If a tool result says unsupported, unavailable, unknown, or not connected, do not retry the same tool with the same arguments. Replan from the latest screenshot using available simulator tools, or stop with a concise explanation when no simulator path remains.
 """

--- a/benchmark/tests/test_agent_config.py
+++ b/benchmark/tests/test_agent_config.py
@@ -1,3 +1,5 @@
+import re
+import tomllib
 from pathlib import Path
 
 from runner import agent_config
@@ -6,6 +8,28 @@ from runner.agent_config import (
     load_agent_model_config,
     resolve_agent_model_api_key,
 )
+
+
+def test_mobilegym_agent_template_lists_current_ui_tools():
+    template = (
+        Path(__file__).resolve().parents[1]
+        / "mobilegym"
+        / "config"
+        / "agent.toml.template"
+    )
+    instruction = tomllib.loads(template.read_text(encoding="utf-8"))["instruction"]
+    match = re.search(r"tools such as (.+?)\.", instruction)
+
+    assert match is not None
+    assert [name.strip() for name in match.group(1).split(",")] == [
+        "screenshot",
+        "touch_gesture",
+        "keyboard_text",
+        "keyboard_tap",
+        "mouse_move",
+        "mouse_scroll",
+        "and quick_action",
+    ]
 
 
 def test_load_agent_model_config_reads_model_section(tmp_path: Path):

--- a/src/agent/internal/agent/tool_http_catalog_test.go
+++ b/src/agent/internal/agent/tool_http_catalog_test.go
@@ -378,16 +378,6 @@ func TestToolSpecsAgentCatalogPolicy(t *testing.T) {
 	}
 }
 
-func TestBuiltinToolCatalogOmitsMouseClick(t *testing.T) {
-	runtime := newRuntimeWithTextEntryTools()
-	if _, ok := toolNameSet(runtime.availableTools())["mouse_click"]; ok {
-		t.Fatal("conversational tool catalog unexpectedly exposes mouse_click")
-	}
-	if _, ok := runtime.ToolDescriptorByName("mouse_click"); ok {
-		t.Fatal("HTTP tool catalog unexpectedly exposes mouse_click")
-	}
-}
-
 func TestAgentToolsForPlatformFiltersPlatformSpecificTools(t *testing.T) {
 	specs := toolSpecsForNames([]string{
 		"screenshot",

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -84,6 +84,36 @@ func TestBuiltinToolSetWiresConfiguredKeyboardLayout(t *testing.T) {
 	}
 }
 
+func TestBuiltinToolSetRegistersExpectedTools(t *testing.T) {
+	tools := NewBuiltinToolSet(HIDConfig{}, AudioConfig{}, SearchConfig{}, ProxyConfig{})
+	want := []string{
+		"audio_volume",
+		"image_diff",
+		"keyboard_tap",
+		"list_scripts",
+		"mouse_move",
+		"mouse_scroll",
+		"quick_action",
+		"read_script",
+		"request_human_handoff",
+		"run_script",
+		"screenshot",
+		"shell",
+		"touch_gesture",
+		"wait_for_stable_screen",
+		"weather",
+		"web_scraper",
+		"web_search",
+		"wheel_nudge",
+		"wikipedia",
+		"write_script",
+	}
+
+	if got := tools.Names(); !slices.Equal(got, want) {
+		t.Fatalf("built-in tools = %v, want %v", got, want)
+	}
+}
+
 func TestHIDToolsExposeStructuredSchemas(t *testing.T) {
 	for name, tool := range map[string]structuredInputTool{
 		"keyboard_tap":  &KeyboardTapTool{},


### PR DESCRIPTION
## Summary

- remove the retired mouse click tool from the MobileGym agent instruction template
- keep the tracked template visible despite runtime config ignore rules
- replace one-off omission checks with exact built-in and bridge tool catalog contracts
- add coverage for the tools declared by the MobileGym agent template

## Tests

- `go test ./internal/agent`
- `uv run pytest -q tests/test_agent_config.py tests/mobilegym/test_daemon.py mobilegym/bridge/test_tools_api.py`
- `git diff --check`