### PR TITLE
fix(benchmark): remove prompt guidance and align VPhone checks

### DIFF
--- a/benchmark/config/agent.toml.template
+++ b/benchmark/config/agent.toml.template
@@ -1,4 +1,3 @@
-instruction = ""
 input_mode = "text"
 trigger_mode = "manual"
 max_iterations = -1

--- a/benchmark/mobilegym/adapter/daemon.py
+++ b/benchmark/mobilegym/adapter/daemon.py
@@ -10,7 +10,6 @@ import tempfile
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-DEFAULT_INSTRUCTION = ""
 DEFAULT_INPUT_MODE = "text"
 DEFAULT_MAX_ITERATIONS = 20
 
@@ -92,7 +91,6 @@ def create_attempt_config(
     bridge_token: str | None = None,
     control_token: str | None = None,
     template_path: str | Path | None = None,
-    instruction: str = DEFAULT_INSTRUCTION,
     input_mode: str = DEFAULT_INPUT_MODE,
     max_iterations: int = DEFAULT_MAX_ITERATIONS,
     model_provider: str | None = None,
@@ -125,7 +123,6 @@ def create_attempt_config(
         bridge_token_file=bridge_token_file,
         control_token_file=control_token_file,
         template_path=template_path,
-        instruction=instruction,
         input_mode=input_mode,
         max_iterations=max_iterations,
         model_provider=_model_value(model_provider, "AIDEN_MODEL_PROVIDER", "MODEL_PROVIDER", default="fake"),
@@ -155,7 +152,6 @@ def render_agent_toml(
     bridge_token_file: str | Path,
     control_token_file: str | Path,
     template_path: str | Path | None = None,
-    instruction: str = DEFAULT_INSTRUCTION,
     input_mode: str = DEFAULT_INPUT_MODE,
     max_iterations: int = DEFAULT_MAX_ITERATIONS,
     model_provider: str = "fake",
@@ -178,7 +174,6 @@ def render_agent_toml(
             rendered = rendered.replace("{{" + name + "}}", value)
     else:
         lines = [
-            f"instruction = {_toml_string(instruction)}",
             f"input_mode = {_toml_string(input_mode)}",
             f"max_iterations = {int(max_iterations)}",
             "",

--- a/benchmark/mobilegym/adapter/daemon.py
+++ b/benchmark/mobilegym/adapter/daemon.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-DEFAULT_INSTRUCTION = "You are controlling an Android-like MobileGym simulator. Use screenshot and touch tools."
+DEFAULT_INSTRUCTION = ""
 DEFAULT_INPUT_MODE = "text"
 DEFAULT_MAX_ITERATIONS = 20
 

--- a/benchmark/mobilegym/config/agent.toml.template
+++ b/benchmark/mobilegym/config/agent.toml.template
@@ -1,10 +1,4 @@
-instruction = """
-Follow the normal device-control behavior for operating a visible UI through screenshots and one verified action at a time.
-
-This run targets a MobileGym simulator. Benchmark setup/reset prepares the starting screen, and the bridge exposes simulator tools such as screenshot, touch_gesture, keyboard_text, keyboard_tap, mouse_move, mouse_scroll, and quick_action.
-
-If a tool result says unsupported, unavailable, unknown, or not connected, do not retry the same tool with the same arguments. Replan from the latest screenshot using available simulator tools, or stop with a concise explanation when no simulator path remains.
-"""
+instruction = ""
 input_mode = "text"
 max_iterations = 20
 voice_streaming_tts_enabled = false

--- a/benchmark/mobilegym/config/agent.toml.template
+++ b/benchmark/mobilegym/config/agent.toml.template
@@ -1,4 +1,3 @@
-instruction = ""
 input_mode = "text"
 max_iterations = 20
 voice_streaming_tts_enabled = false

--- a/benchmark/runner/config.py
+++ b/benchmark/runner/config.py
@@ -192,7 +192,6 @@ def default_agent_toml() -> str:
     """Generate default agent.toml content."""
     return "\n".join(
         [
-            'instruction = ""',
             'input_mode = "text"',
             'trigger_mode = "manual"',
             "max_iterations = -1",

--- a/benchmark/runner/webui.py
+++ b/benchmark/runner/webui.py
@@ -1877,7 +1877,6 @@ def render_agent_template(text: str) -> str:
 def default_agent_toml() -> str:
     return "\n".join(
         [
-            'instruction = ""',
             'input_mode = "text"',
             'trigger_mode = "manual"',
             "max_iterations = -1",

--- a/benchmark/suites/aiden_app/notes_entry_policy_v1.json
+++ b/benchmark/suites/aiden_app/notes_entry_policy_v1.json
@@ -1,15 +1,14 @@
 {
   "name": "aiden_app_notes_entry_policy_v1",
   "suite_category": "Aiden App / Phone Bridge Policy",
-  "description": "Prompt-conditioned Notes entry policy cases collected in one suite with task-level mock environments.",
-  "prompt_prefix": "这是 Aiden Phone Bridge 工具选择 benchmark。测试环境状态会在每个任务中直接声明；按声明状态选择最直接的 App 进入方式，不要额外猜测屏幕内容。联系人等系统数据必须通过可用的 Phone Bridge 数据工具查询。向可见编辑框写入最终内容时，根据 runtime text-entry strategy 选择输入工具。enter_text 会自行准备剪贴板，不要先调用 bridge_clipboard；写入内容必须包含查询返回的完整原始号码，但允许附带姓名标签。",
+  "description": "Notes entry policy cases collected in one suite with task-level mock environments.",
   "global_reset": {},
   "tasks": [
     {
       "id": "ios_pip_notes_already_open",
       "category": "multi_step",
       "description_for_judge": "Notes is already open. Query Biden and enter the returned number without reopening or searching for Notes.",
-      "prompt": "测试环境状态：当前已经位于 Apple 备忘录的空白编辑页，正文输入区域中心约为 normalized x=500、y=360。Aiden 在后台，iOS PiP Bridge 已开启。查询通讯录中 Biden 的手机号，直接调用 enter_text 把查询到的手机号写进当前备忘录；不要调用 bridge_clipboard、bridge_open_app 或 search_launch_app。",
+      "prompt": "测试环境状态：当前已经位于 Apple 备忘录的空白编辑页。Aiden 在后台，iOS PiP Bridge 已开启。请查询通讯录中 Biden 的手机号，并将查询到的完整号码写入当前备忘录。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {
@@ -65,7 +64,7 @@
       "id": "ios_pip_notes_icon_visible",
       "category": "multi_step",
       "description_for_judge": "The Notes icon is directly visible. Query Biden, tap the icon using object-form point coordinates, and enter the returned number without searching.",
-      "prompt": "测试环境状态：当前是 iPhone 主界面，Apple 备忘录图标清晰可见，中心为 normalized x=180、y=310。Aiden 在后台，iOS PiP Bridge 已开启。查询 Biden 的手机号，严格调用 {\"type\":\"tap\",\"point\":{\"x\":180,\"y\":310}} 进入备忘录；必须使用 point 对象，不要使用 point 数组或顶层 x/y。随后调用 enter_text 写入号码；不要调用 bridge_clipboard、bridge_open_app 或 search_launch_app。",
+      "prompt": "测试环境状态：当前是 iPhone 主界面，Apple 备忘录图标清晰可见。Aiden 在后台，iOS PiP Bridge 已开启。请查询通讯录中 Biden 的手机号，并将查询到的完整号码写入 Apple 备忘录。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {
@@ -125,7 +124,7 @@
       "id": "ios_pip_notes_icon_missing",
       "category": "multi_step",
       "description_for_judge": "Neither Notes nor its icon is visible. Query Biden, use search_launch_app, and enter the returned number.",
-      "prompt": "测试环境状态：当前是 iPhone 主界面，画面中没有打开的备忘录，也看不到备忘录图标。Aiden 在后台，iOS PiP Bridge 已开启。查询 Biden 的手机号，调用 search_launch_app 进入备忘录，再直接调用 enter_text 写入包含完整原始号码的内容；不要调用 bridge_clipboard 或 bridge_open_app。",
+      "prompt": "测试环境状态：当前是 iPhone 主界面，画面中没有打开的备忘录，也看不到备忘录图标。Aiden 在后台，iOS PiP Bridge 已开启。请查询通讯录中 Biden 的手机号，并将查询到的完整号码写入 Apple 备忘录。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {

--- a/benchmark/suites/aiden_app/phone_bridge_data_policy_v1.json
+++ b/benchmark/suites/aiden_app/phone_bridge_data_policy_v1.json
@@ -2,7 +2,6 @@
   "name": "aiden_app_phone_bridge_data_policy_v1",
   "suite_category": "Aiden App / Phone Bridge Policy",
   "description": "Policy matrix for Phone Bridge data tools across iOS Dynamic Island restore, iOS PiP background queue, and Android FGS background queue.",
-  "prompt_prefix": "这是 Aiden Phone Bridge 数据工具策略 benchmark。每个任务会直接声明平台、Aiden 前后台状态以及 PiP/FGS 状态。联系人、日历、剪贴板和通知必须使用对应的 bridge_* 数据工具，不要通过手工 UI 代替。iOS 后台且未开启 PiP 时，如果 runtime status 表明灵动岛入口可达，直接调用数据工具，由工具内部恢复 Aiden 后执行；不要先调用 bridge_open_app 或手工点击灵动岛。开启 iOS PiP 或 Android FGS 时，后台安全数据工具直接调用，但 bridge_open_app 不属于后台安全工具。",
   "global_reset": {},
   "tasks": [
     {

--- a/benchmark/suites/phone_control_v1.json
+++ b/benchmark/suites/phone_control_v1.json
@@ -9,7 +9,7 @@
       "skill_name": "device-operator"
     }
   ],
-  "prompt_prefix": "你正在操作一台通过 HDMI 采集画面的手机，不是 macOS、Linux 或桌面系统；测试环境可能是 iOS、Android 或其他移动系统。开始操作目标 UI 前，必须先调用 skill_read 读取 device-operator；读取后优先使用 quick_action 等语义工具，再根据需要使用 screenshot、touch_gesture、enter_text、keyboard_text、keyboard_tap 等手机 UI 工具。不要使用 shell、open、osascript 或桌面命令来打开目标手机上的 App；在 ADB Android benchmark 中也不要使用 bridge_open_app、search_launch_app 或 shell 排查板子服务，这些路径不属于当前手机控制环境。每次工具返回截图后，先判断页面是否变化、是否已经进入目标页面，再继续下一步；如果截图没有变化，不要反复点击同一坐标。涉及文本输入时，先从最新截图确认键盘/输入法状态；如果要输入英文或 ASCII（如 hello、Aiden、benchmark），但键盘仍是中文输入法（空格键显示“拼音”或出现候选/预编辑），必须先点地球/输入法键切到英文/Latin 键盘，再输入；不要通过中文 IME 候选词提交英文。ADB 文本工具如果返回 ok:false 但附带截图，必须先根据截图确认真实输入框内容和输入法状态，再决定是否切换键盘或重试。ADB Android 中复制、粘贴、全选优先使用长按输入框后出现的可见编辑菜单，不要依赖 Ctrl/Meta 快捷键。如需android平台打开系统设置，优先使用 quick_action，参数为 action=open_settings；iOS打开系统设置或时钟时，优先点击当前手机主屏幕上可见的图标，或使用系统搜索。",
+  "prompt_prefix": "你正在操作一台通过 HDMI 采集画面的手机，不是 macOS、Linux 或桌面系统；测试环境可能是 iOS、Android 或其他移动系统。",
   "global_reset": {},
   "tasks": [
     {

--- a/benchmark/tests/mobilegym/test_daemon.py
+++ b/benchmark/tests/mobilegym/test_daemon.py
@@ -3,6 +3,16 @@ import tomllib
 from mobilegym.adapter import daemon
 
 
+def test_render_agent_toml_uses_default_system_instruction(tmp_path):
+    rendered = daemon.render_agent_toml(
+        bridge_url="http://127.0.0.1:19090",
+        bridge_token_file=tmp_path / "bridge.token",
+        control_token_file=tmp_path / "control.token",
+    )
+
+    assert tomllib.loads(rendered)["instruction"] == ""
+
+
 def test_render_agent_toml_preserves_template_device_type(tmp_path):
     template = tmp_path / "agent.toml.template"
     template.write_text(

--- a/benchmark/tests/mobilegym/test_daemon.py
+++ b/benchmark/tests/mobilegym/test_daemon.py
@@ -3,14 +3,14 @@ import tomllib
 from mobilegym.adapter import daemon
 
 
-def test_render_agent_toml_uses_default_system_instruction(tmp_path):
+def test_render_agent_toml_omits_legacy_instruction(tmp_path):
     rendered = daemon.render_agent_toml(
         bridge_url="http://127.0.0.1:19090",
         bridge_token_file=tmp_path / "bridge.token",
         control_token_file=tmp_path / "control.token",
     )
 
-    assert tomllib.loads(rendered)["instruction"] == ""
+    assert "instruction" not in tomllib.loads(rendered)
 
 
 def test_render_agent_toml_preserves_template_device_type(tmp_path):

--- a/benchmark/tests/test_agent_config.py
+++ b/benchmark/tests/test_agent_config.py
@@ -1,4 +1,3 @@
-import re
 import tomllib
 from pathlib import Path
 
@@ -10,7 +9,7 @@ from runner.agent_config import (
 )
 
 
-def test_mobilegym_agent_template_lists_current_ui_tools():
+def test_mobilegym_agent_template_uses_default_system_instruction():
     template = (
         Path(__file__).resolve().parents[1]
         / "mobilegym"
@@ -18,18 +17,8 @@ def test_mobilegym_agent_template_lists_current_ui_tools():
         / "agent.toml.template"
     )
     instruction = tomllib.loads(template.read_text(encoding="utf-8"))["instruction"]
-    match = re.search(r"tools such as (.+?)\.", instruction)
 
-    assert match is not None
-    assert [name.strip() for name in match.group(1).split(",")] == [
-        "screenshot",
-        "touch_gesture",
-        "keyboard_text",
-        "keyboard_tap",
-        "mouse_move",
-        "mouse_scroll",
-        "and quick_action",
-    ]
+    assert instruction == ""
 
 
 def test_load_agent_model_config_reads_model_section(tmp_path: Path):

--- a/benchmark/tests/test_agent_config.py
+++ b/benchmark/tests/test_agent_config.py
@@ -9,16 +9,16 @@ from runner.agent_config import (
 )
 
 
-def test_mobilegym_agent_template_uses_default_system_instruction():
+def test_mobilegym_agent_template_omits_legacy_instruction():
     template = (
         Path(__file__).resolve().parents[1]
         / "mobilegym"
         / "config"
         / "agent.toml.template"
     )
-    instruction = tomllib.loads(template.read_text(encoding="utf-8"))["instruction"]
+    config = tomllib.loads(template.read_text(encoding="utf-8"))
 
-    assert instruction == ""
+    assert "instruction" not in config
 
 
 def test_load_agent_model_config_reads_model_section(tmp_path: Path):

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -534,21 +534,14 @@ def test_load_suite_duplicate_ids_raise(tmp_path: Path):
         load_suite(p)
 
 
-def test_phone_control_suite_constrains_agent_to_phone_ui():
+def test_phone_control_suite_only_describes_target_environment():
     suite_path = Path(__file__).resolve().parents[1] / "suites" / "phone_control_v1.json"
     suite = load_suite(suite_path)
 
-    assert "手机" in suite.prompt_prefix
-    assert "iOS" in suite.prompt_prefix
-    assert "Android" in suite.prompt_prefix
-    assert "iPhone" not in suite.prompt_prefix
-    assert "macOS" in suite.prompt_prefix
-    assert "shell" in suite.prompt_prefix
-    assert "osascript" in suite.prompt_prefix
-    assert "skill_read" in suite.prompt_prefix
-    assert "device-operator" in suite.prompt_prefix
-    assert "quick_action" in suite.prompt_prefix
-    assert "只能通过截图" not in suite.prompt_prefix
+    assert suite.prompt_prefix == (
+        "你正在操作一台通过 HDMI 采集画面的手机，不是 macOS、Linux 或桌面系统；"
+        "测试环境可能是 iOS、Android 或其他移动系统。"
+    )
 
 
 def test_mobile_text_entry_suites_prompt_for_ime_switching():
@@ -556,7 +549,6 @@ def test_mobile_text_entry_suites_prompt_for_ime_switching():
     for suite_name in (
         "adb_android_basic.json",
         "app_workflow_v1.json",
-        "phone_control_v1.json",
         "quick_action_v1.json",
         "skill_discovery_v1.json",
     ):
@@ -941,7 +933,9 @@ def test_notes_entry_policy_suite_covers_three_screen_states():
     assert "search_launch_app" in open_task.hard_assertions.forbidden_tools
     assert "bridge_open_app" in open_task.hard_assertions.forbidden_tools
     assert "enter_text" in open_task.hard_assertions.required_tools
-    assert "不要调用 bridge_clipboard、bridge_open_app 或 search_launch_app" in open_task.prompt
+    assert "enter_text" not in open_task.prompt
+    assert "bridge_clipboard" not in open_task.prompt
+    assert "search_launch_app" not in open_task.prompt
 
     icon_task = tasks["ios_pip_notes_icon_visible"]
     assert "touch_gesture" in icon_task.hard_assertions.required_tools
@@ -950,13 +944,16 @@ def test_notes_entry_policy_suite_covers_three_screen_states():
         "type": "tap",
         "point": {"x": 180, "y": 310},
     }
-    assert "必须使用 point 对象" in icon_task.prompt
-    assert "不要使用 point 数组或顶层 x/y" in icon_task.prompt
-    assert "不要调用 bridge_clipboard、bridge_open_app 或 search_launch_app" in icon_task.prompt
+    assert "point" not in icon_task.prompt
+    assert "touch_gesture" not in icon_task.prompt
+    assert "enter_text" not in icon_task.prompt
+    assert "search_launch_app" not in icon_task.prompt
 
     missing_task = tasks["ios_pip_notes_icon_missing"]
     assert "search_launch_app" in missing_task.hard_assertions.required_tools
     assert "bridge_open_app" in missing_task.hard_assertions.forbidden_tools
+    assert "search_launch_app" not in missing_task.prompt
+    assert "enter_text" not in missing_task.prompt
     text_matcher = missing_task.hard_assertions.required_tool_calls[2].input_contains["text"]
     assert text_matcher == {"$contains": "+1 202-555-0147"}
 
@@ -967,6 +964,7 @@ def test_phone_bridge_data_policy_suite_covers_tools_and_routing_modes():
     tasks = {task.id: task for task in suite.tasks}
 
     assert suite.mock_environment is None
+    assert suite.prompt_prefix == ""
     assert len(tasks) == 12
     assert all(task.mock_environment is not None for task in suite.tasks)
     assert {

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -534,16 +534,6 @@ def test_load_suite_duplicate_ids_raise(tmp_path: Path):
         load_suite(p)
 
 
-def test_phone_control_suite_only_describes_target_environment():
-    suite_path = Path(__file__).resolve().parents[1] / "suites" / "phone_control_v1.json"
-    suite = load_suite(suite_path)
-
-    assert suite.prompt_prefix == (
-        "你正在操作一台通过 HDMI 采集画面的手机，不是 macOS、Linux 或桌面系统；"
-        "测试环境可能是 iOS、Android 或其他移动系统。"
-    )
-
-
 def test_mobile_text_entry_suites_prompt_for_ime_switching():
     suites_root = Path(__file__).resolve().parents[1] / "suites"
     for suite_name in (

--- a/benchmark/tests/test_vphone_runner_integration.py
+++ b/benchmark/tests/test_vphone_runner_integration.py
@@ -70,11 +70,11 @@ def test_live_validation_flow_matches_runner_contract(tmp_path):
     assert result["checks"] == [
         "health",
         "concurrent=1",
-        "screen-jpeg",
+        "screenshot-provider",
         "setup-home",
         "ownership-429",
         "tool-catalog",
-        "screenshot-tool",
+        "touch-gesture",
         "release",
     ]
     with Image.open(screenshot) as image:

--- a/benchmark/tests/test_webui.py
+++ b/benchmark/tests/test_webui.py
@@ -218,7 +218,7 @@ def test_prepare_run_config_uses_agent_config_text(tmp_path: Path):
     base = tmp_path / "base"
     base.mkdir()
     (base / "agent.toml.template").write_text('[model]\nprovider = "template"\n', encoding="utf-8")
-    agent_config = 'instruction = "custom"\n[model]\nprovider = "saved"\n'
+    agent_config = 'custom_instruction = "custom"\n[model]\nprovider = "saved"\n'
 
     dest = tmp_path / "dest"
     webui.prepare_run_config(base, dest, agent_config_text=agent_config)
@@ -278,7 +278,7 @@ def test_default_agent_toml_uses_benchmark_defaults():
     rendered = webui.default_agent_toml()
     config = tomllib.loads(rendered)
 
-    assert 'instruction = ""' in rendered
+    assert "instruction" not in config
     assert 'trigger_mode = "manual"' in rendered
     assert "max_iterations = -1" in rendered
     assert "screenshot_keep_n = 3" in rendered
@@ -308,7 +308,7 @@ def test_agent_config_manager_migrates_saved_config_missing_voice_defaults(tmp_p
     base.mkdir()
     config_path = tmp_path / "runs" / "agent.toml"
     config_path.parent.mkdir()
-    config_path.write_text('instruction = "saved"\n[model]\nprovider = "fake"\n', encoding="utf-8")
+    config_path.write_text('custom_instruction = "saved"\n[model]\nprovider = "fake"\n', encoding="utf-8")
     manager = runner_config.AgentConfigManager(base_config_dir=base, config_path=config_path)
 
     content, source = manager.get_config()
@@ -327,7 +327,7 @@ def test_agent_config_manager_ignores_table_keys_when_migrating_voice_defaults(t
     config_path = tmp_path / "runs" / "agent.toml"
     config_path.parent.mkdir()
     config_path.write_text(
-        'instruction = "saved"\n[model]\nvoice_streaming_tts_enabled = true\nprovider = "fake"\n',
+        'custom_instruction = "saved"\n[model]\nvoice_streaming_tts_enabled = true\nprovider = "fake"\n',
         encoding="utf-8",
     )
     manager = runner_config.AgentConfigManager(base_config_dir=base, config_path=config_path)
@@ -377,11 +377,11 @@ def test_webui_agent_config_persists_under_runs_dir(tmp_path: Path, monkeypatch)
     assert initial["source"] == "generated"
     assert 'provider = "openai"' in initial["content"]
 
-    saved = 'instruction = "saved"\n[model]\nprovider = "fake"\n'
+    saved = 'custom_instruction = "saved"\n[model]\nprovider = "fake"\n'
     updated = app.save_agent_config({"content": saved})
     assert updated["source"] == "saved"
     saved_content = (tmp_path / "runs" / "agent.toml").read_text(encoding="utf-8")
-    assert 'instruction = "saved"' in saved_content
+    assert 'custom_instruction = "saved"' in saved_content
     assert "voice_streaming_tts_enabled = false" in saved_content
     assert "voice_tool_call_speech = false" in saved_content
     assert "voice_progress_speech_enabled = false" in saved_content
@@ -1759,7 +1759,7 @@ def test_run_job_uses_saved_webui_agent_config(tmp_path: Path, monkeypatch):
     base = tmp_path / "base"
     base.mkdir()
     app = webui.BenchmarkWebApp(webui.WebUIConfig(runs_dir=tmp_path / "runs", base_config_dir=base, build_daemon_image=False))
-    saved = 'instruction = "from web ui"\n[model]\nprovider = "fake"\n[device]\ndevice_type = "iOS"\n'
+    saved = 'custom_instruction = "from web ui"\n[model]\nprovider = "fake"\n[device]\ndevice_type = "iOS"\n'
     app.save_agent_config({"content": saved})
     job = webui.Job(
         id="job-test",
@@ -1803,7 +1803,7 @@ def test_run_job_uses_saved_webui_agent_config(tmp_path: Path, monkeypatch):
     app._run_job(job)
 
     saved_content = (Path(job.config_dir) / "agent.toml").read_text(encoding="utf-8")
-    assert 'instruction = "from web ui"' in saved_content
+    assert 'custom_instruction = "from web ui"' in saved_content
     assert "voice_streaming_tts_enabled = false" in saved_content
     assert "voice_tool_call_speech = false" in saved_content
     assert "voice_progress_speech_enabled = false" in saved_content

--- a/skillopt/tests/test_webui.py
+++ b/skillopt/tests/test_webui.py
@@ -10,21 +10,11 @@ from skillopt import webui
 from skillopt.webui import INDEX_HTML, SkillOptJob, SkillOptWebApp, SkillOptWebUIConfig, build_skillopt_command
 
 
-def test_mobilegym_template_instruction_adds_minimal_simulator_context():
+def test_mobilegym_template_omits_legacy_instruction():
     repo_root = Path(__file__).resolve().parents[2]
     template = repo_root / "benchmark" / "mobilegym" / "config" / "agent.toml.template"
     data = tomllib.loads(template.read_text(encoding="utf-8"))
-    instruction = data["instruction"]
-
-    assert "device-control" in instruction
-    assert "MobileGym simulator" in instruction
-    assert "screenshot" in instruction
-    assert "touch_gesture" in instruction
-    assert "unsupported" in instruction
-    assert "same tool with the same arguments" in instruction
-    assert "Do not call open_app" not in instruction
-    assert "Phone Bridge" not in instruction
-    assert "frame_service" not in instruction
+    assert "instruction" not in data
 
 
 def test_build_skillopt_command_uses_bridge_backend_options(tmp_path: Path):
@@ -651,17 +641,17 @@ def test_start_job_writes_benchmark_agent_config(tmp_path: Path, monkeypatch):
     assert 'api_key = "sk-test"' in content
 
 
-def test_start_mobilegym_job_applies_mobilegym_default_instruction(tmp_path: Path, monkeypatch):
+def test_start_mobilegym_job_does_not_inject_legacy_instruction(tmp_path: Path, monkeypatch):
     base_config_dir = tmp_path / "benchmark" / "config"
     base_config_dir.mkdir(parents=True)
     base_config_dir.joinpath("agent.toml").write_text(
-        'instruction = ""\n[model]\nprovider = "openrouter"\napi_key = "sk-test"\n',
+        '[model]\nprovider = "openrouter"\napi_key = "sk-test"\n',
         encoding="utf-8",
     )
     mobilegym_config_dir = tmp_path / "benchmark" / "mobilegym" / "config"
     mobilegym_config_dir.mkdir(parents=True)
     mobilegym_config_dir.joinpath("agent.toml").write_text(
-        'instruction = "You are controlling a MobileGym simulator."\n[model]\nprovider = "fake"\napi_key = ""\n',
+        '[model]\nprovider = "fake"\napi_key = ""\n',
         encoding="utf-8",
     )
     monkeypatch.setattr(webui, "REPO_ROOT", tmp_path)
@@ -677,7 +667,7 @@ def test_start_mobilegym_job_applies_mobilegym_default_instruction(tmp_path: Pat
     command = job["command"]
     agent_config = Path(command[command.index("--agent-config") + 1])
     content = agent_config.read_text(encoding="utf-8")
-    assert 'instruction = "You are controlling a MobileGym simulator."' in content
+    assert "instruction" not in tomllib.loads(content)
     assert 'api_key = "sk-test"' in content
 
 

--- a/skillopt/webui.py
+++ b/skillopt/webui.py
@@ -21,7 +21,7 @@ from typing import Any, Mapping
 
 from runner.agent_config import resolve_agent_model_api_key
 from runner.environment import EnvironmentManager
-from runner.config import AgentConfigManager, render_agent_template
+from runner.config import AgentConfigManager
 from runner.judge import JudgeConfig
 from skillopt.benchmark_backend import load_benchmark_task_results
 from skillopt.phase_artifacts import latest_phase_record, load_phase_records, progress_from_phase_record
@@ -228,7 +228,6 @@ class SkillOptWebApp:
                 raise ValueError("Benchmark agent.toml is unavailable. Open the Benchmark WebUI and save an agent config first.")
             if not agent_config_info.get("api_key_nonempty"):
                 raise ValueError("Benchmark agent.toml does not contain a model api_key. Open the Benchmark WebUI and save an agent config with an API key first.")
-            agent_config = apply_backend_default_instruction(agent_config, str(payload.get("backend") or "mobilegym"))
             agent_config_path = run_dir / "agent.toml"
             agent_config_path.write_text(agent_config, encoding="utf-8")
             payload["agent_config"] = str(agent_config_path)
@@ -751,22 +750,6 @@ def mobilegym_environment_url(env: dict[str, Any]) -> str:
     return str(env.get("public_endpoint") or env.get("endpoint") or "").strip()
 
 
-def default_base_config_dir_for_backend(backend: str) -> Path:
-    if str(backend or "").strip() == "mobilegym":
-        return REPO_ROOT / "benchmark" / "mobilegym" / "config"
-    return REPO_ROOT / "benchmark" / "config"
-
-
-def initial_agent_config(base_config_dir: Path) -> str:
-    config = base_config_dir / "agent.toml"
-    if config.exists():
-        return config.read_text(encoding="utf-8")
-    template = base_config_dir / "agent.toml.template"
-    if template.exists():
-        return render_agent_template(template.read_text(encoding="utf-8"))
-    return ""
-
-
 def _extract_suites_from_command(command: list[str]) -> dict[str, Any]:
     """Extract suite names from SkillOpt command for UI display."""
     suites = []
@@ -778,29 +761,6 @@ def _extract_suites_from_command(command: list[str]) -> dict[str, Any]:
             if suite_name not in suites:
                 suites.append(suite_name)
     return {"suites": suites}
-
-
-def apply_backend_default_instruction(content: str, backend: str) -> str:
-    if str(backend or "").strip() != "mobilegym":
-        return content
-    default_content = initial_agent_config(default_base_config_dir_for_backend("mobilegym"))
-    default_instruction = extract_agent_instruction(default_content).strip()
-    if not default_instruction or extract_agent_instruction(content).strip():
-        return content
-    line = f"instruction = {json.dumps(default_instruction, ensure_ascii=False)}"
-    if re.search(r"(?m)^\s*instruction\s*=.*$", content):
-        return re.sub(r"(?m)^\s*instruction\s*=.*$", lambda _: line, content, count=1)
-    return line + "\n" + content
-
-
-def extract_agent_instruction(content: str) -> str:
-    try:
-        data = tomllib.loads(content)
-    except tomllib.TOMLDecodeError:
-        match = re.search(r"(?m)^\s*instruction\s*=\s*(['\"])(.*?)\1", content)
-        return match.group(2) if match else ""
-    value = data.get("instruction")
-    return str(value or "") if isinstance(value, str) else ""
 
 
 def agent_config_has_api_key(content: str) -> bool:


### PR DESCRIPTION
## Summary

- use the production default system instruction for MobileGym instead of benchmark-only behavior guidance
- reduce the phone-control prefix to environment facts and remove tool, coordinate, and routing hints from Phone Bridge policy prompts
- keep expected execution paths in hidden benchmark assertions rather than agent-visible prompts
- align VPhone validation assertions with the screenshot provider and touch gesture checks introduced by the current bridge contract

## Testing

- benchmark/.venv/bin/pytest -q benchmark/tests (515 passed)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent configurations now support custom instructions without automatically adding backend-specific defaults.
  * Generated configurations are cleaner and omit legacy instruction settings.

* **Improvements**
  * Benchmark task prompts now focus on desired outcomes and relevant device context.
  * Updated phone-control validation checks reflect current screenshot and touch interactions.
  * Configuration persistence and migration now preserve custom instructions more reliably.

* **Tests**
  * Added coverage confirming legacy instruction fields are omitted and updated configuration behavior works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->