### PR TITLE
fix(benchmark): use episode evidence for compressed memory recall

### DIFF
--- a/benchmark/runner/agent_client.py
+++ b/benchmark/runner/agent_client.py
@@ -4,6 +4,7 @@ import json
 import socket
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any
 
@@ -147,6 +148,17 @@ class AgentClient:
             raise AgentRequestError(f"history returned {status}")
         body = json.loads(body_bytes)
         return body if isinstance(body, list) else []
+
+    def get_episode(self, episode_id: str) -> dict[str, Any]:
+        encoded_id = urllib.parse.quote(str(episode_id), safe="")
+        status, body_bytes = self._get(f"/api/episodes/{encoded_id}", timeout=5)
+        if status != 200:
+            raise AgentRequestError(f"episode returned {status}")
+        body = json.loads(body_bytes)
+        episode = body.get("episode") if isinstance(body, dict) else None
+        if not isinstance(episode, dict):
+            raise AgentRequestError("episode response did not contain an episode object")
+        return episode
 
     def chat(
         self,

--- a/benchmark/runner/assertions.py
+++ b/benchmark/runner/assertions.py
@@ -20,6 +20,10 @@ PROHIBITED_ACTION_PATTERNS = {
     "cancel": re.compile(r"\bcancel\b", re.IGNORECASE),
 }
 
+MEMORY_REF_AGGREGATING_RECALL_TOOLS = frozenset(
+    {"recall_memory", "recall_device_memory"}
+)
+
 @dc.dataclass
 class AssertionOutcome:
     all_passed: bool
@@ -35,9 +39,11 @@ class ExpectedAnswerResult:
 
 @dc.dataclass
 class ExpectedRecallResult:
-    passed: bool
+    passed: bool | None
     expected_memory_ids: list[str]
     recalled_memory_ids: list[str]
+    evidence_source: str
+    recall_memory_called: bool
 
 @dc.dataclass
 class TraceObservationResult:
@@ -237,30 +243,158 @@ def evaluate_expected_answer(
 
 
 def evaluate_expected_recalled_memory_ids(
-    history: list[dict[str, Any]], expected_memory_ids: list[str]
+    history: list[dict[str, Any]],
+    expected_memory_ids: list[str],
+    *,
+    episode: dict[str, Any] | None = None,
 ) -> ExpectedRecallResult:
+    expected_ids = _unique_non_empty_strings(expected_memory_ids)
+    recall_called, result_contents, call_count = _recall_memory_result_contents(history)
+    if not recall_called:
+        return ExpectedRecallResult(
+            passed=False,
+            expected_memory_ids=expected_ids,
+            recalled_memory_ids=[],
+            evidence_source="unavailable",
+            recall_memory_called=False,
+        )
+
+    other_aggregate_recall_tools = MEMORY_REF_AGGREGATING_RECALL_TOOLS - {
+        "recall_memory"
+    }
+    episode_is_unambiguous = not _history_uses_any_tool(
+        history,
+        other_aggregate_recall_tools,
+    )
+    if episode is not None:
+        episode_recalled_ids = _unique_non_empty_strings(
+            episode.get("retrieved_memory_refs")
+            if isinstance(episode.get("retrieved_memory_refs"), list)
+            else []
+        )
+        episode_has_all_expected = all(
+            memory_id in episode_recalled_ids for memory_id in expected_ids
+        )
+        if episode_is_unambiguous or not episode_has_all_expected:
+            return ExpectedRecallResult(
+                passed=episode_has_all_expected,
+                expected_memory_ids=expected_ids,
+                recalled_memory_ids=(
+                    episode_recalled_ids if episode_is_unambiguous else []
+                ),
+                evidence_source="episode",
+                recall_memory_called=True,
+            )
+
     recalled_ids: list[str] = []
-    for message in history:
-        if message.get("type") != "tool_result" or message.get("tool_name") != "recall_memory":
+    inline_complete = bool(result_contents)
+    if call_count and len(result_contents) < call_count:
+        inline_complete = False
+    for content in result_contents:
+        payload = _parse_inline_recall_result(content)
+        if payload is None:
+            inline_complete = False
             continue
-        content = message.get("content") or ""
+        for memory_id in payload:
+            if memory_id not in recalled_ids:
+                recalled_ids.append(memory_id)
+
+    if not inline_complete:
+        return ExpectedRecallResult(
+            passed=None,
+            expected_memory_ids=expected_ids,
+            recalled_memory_ids=[],
+            evidence_source="unavailable",
+            recall_memory_called=True,
+        )
+    return ExpectedRecallResult(
+        passed=all(memory_id in recalled_ids for memory_id in expected_ids),
+        expected_memory_ids=expected_ids,
+        recalled_memory_ids=recalled_ids,
+        evidence_source="inline",
+        recall_memory_called=True,
+    )
+
+
+def _history_uses_any_tool(
+    history: list[dict[str, Any]],
+    tool_names: set[str] | frozenset[str],
+) -> bool:
+    pending_tool_name = ""
+    for message in history:
+        message_type = message.get("type")
+        if message_type == "tool_call":
+            pending_tool_name = str(message.get("tool_name") or "")
+            if pending_tool_name in tool_names:
+                return True
+            continue
+        if message_type != "tool_result":
+            continue
+        tool_name = str(message.get("tool_name") or pending_tool_name)
+        pending_tool_name = ""
+        if tool_name in tool_names:
+            return True
+    return False
+
+
+def _recall_memory_result_contents(
+    history: list[dict[str, Any]],
+) -> tuple[bool, list[Any], int]:
+    recall_called = False
+    recall_call_count = 0
+    result_contents: list[Any] = []
+    pending_tool_name = ""
+    for message in history:
+        message_type = message.get("type")
+        if message_type == "tool_call":
+            pending_tool_name = str(message.get("tool_name") or "")
+            if pending_tool_name == "recall_memory":
+                recall_called = True
+                recall_call_count += 1
+            continue
+        if message_type != "tool_result":
+            continue
+        tool_name = str(message.get("tool_name") or pending_tool_name)
+        pending_tool_name = ""
+        if tool_name != "recall_memory":
+            continue
+        recall_called = True
+        result_contents.append(message.get("content"))
+    return recall_called, result_contents, recall_call_count
+
+
+def _parse_inline_recall_result(content: Any) -> list[str] | None:
+    if isinstance(content, dict):
+        payload = content
+    else:
         try:
             payload = json.loads(content)
         except (TypeError, json.JSONDecodeError):
+            return None
+    if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
+        return None
+    recalled_ids: list[str] = []
+    for item in payload["results"]:
+        if not isinstance(item, dict):
+            return None
+        memory_id = item.get("id")
+        if not isinstance(memory_id, str) or not memory_id.strip():
+            return None
+        memory_id = memory_id.strip()
+        if memory_id not in recalled_ids:
+            recalled_ids.append(memory_id)
+    return recalled_ids
+
+
+def _unique_non_empty_strings(items: Any) -> list[str]:
+    result: list[str] = []
+    for item in items or []:
+        if not isinstance(item, str):
             continue
-        if not isinstance(payload, dict):
-            continue
-        for item in payload.get("results") or []:
-            if not isinstance(item, dict):
-                continue
-            memory_id = item.get("id")
-            if isinstance(memory_id, str) and memory_id and memory_id not in recalled_ids:
-                recalled_ids.append(memory_id)
-    return ExpectedRecallResult(
-        passed=all(memory_id in recalled_ids for memory_id in expected_memory_ids),
-        expected_memory_ids=list(expected_memory_ids),
-        recalled_memory_ids=recalled_ids,
-    )
+        value = item.strip()
+        if value and value not in result:
+            result.append(value)
+    return result
 
 
 def _normalize_option_answer(text: str) -> str | None:

--- a/benchmark/runner/assertions.py
+++ b/benchmark/runner/assertions.py
@@ -249,7 +249,10 @@ def evaluate_expected_recalled_memory_ids(
     episode: dict[str, Any] | None = None,
 ) -> ExpectedRecallResult:
     expected_ids = _unique_non_empty_strings(expected_memory_ids)
-    recall_called, result_contents, call_count = _recall_memory_result_contents(history)
+    recall_called, recalled_ids, inline_complete = _recall_tool_evidence(
+        history,
+        "recall_memory",
+    )
     if not recall_called:
         return ExpectedRecallResult(
             passed=False,
@@ -259,47 +262,16 @@ def evaluate_expected_recalled_memory_ids(
             recall_memory_called=False,
         )
 
-    other_aggregate_recall_tools = MEMORY_REF_AGGREGATING_RECALL_TOOLS - {
-        "recall_memory"
-    }
-    episode_is_unambiguous = not _history_uses_any_tool(
-        history,
-        other_aggregate_recall_tools,
-    )
-    if episode is not None:
-        episode_recalled_ids = _unique_non_empty_strings(
-            episode.get("retrieved_memory_refs")
-            if isinstance(episode.get("retrieved_memory_refs"), list)
-            else []
+    if inline_complete:
+        return ExpectedRecallResult(
+            passed=all(memory_id in recalled_ids for memory_id in expected_ids),
+            expected_memory_ids=expected_ids,
+            recalled_memory_ids=recalled_ids,
+            evidence_source="inline",
+            recall_memory_called=True,
         )
-        episode_has_all_expected = all(
-            memory_id in episode_recalled_ids for memory_id in expected_ids
-        )
-        if episode_is_unambiguous or not episode_has_all_expected:
-            return ExpectedRecallResult(
-                passed=episode_has_all_expected,
-                expected_memory_ids=expected_ids,
-                recalled_memory_ids=(
-                    episode_recalled_ids if episode_is_unambiguous else []
-                ),
-                evidence_source="episode",
-                recall_memory_called=True,
-            )
 
-    recalled_ids: list[str] = []
-    inline_complete = bool(result_contents)
-    if call_count and len(result_contents) < call_count:
-        inline_complete = False
-    for content in result_contents:
-        payload = _parse_inline_recall_result(content)
-        if payload is None:
-            inline_complete = False
-            continue
-        for memory_id in payload:
-            if memory_id not in recalled_ids:
-                recalled_ids.append(memory_id)
-
-    if not inline_complete:
+    if episode is None:
         return ExpectedRecallResult(
             passed=None,
             expected_memory_ids=expected_ids,
@@ -307,60 +279,107 @@ def evaluate_expected_recalled_memory_ids(
             evidence_source="unavailable",
             recall_memory_called=True,
         )
+
+    episode_recalled_ids = _unique_non_empty_strings(
+        episode.get("retrieved_memory_refs")
+        if isinstance(episode.get("retrieved_memory_refs"), list)
+        else []
+    )
+    episode_has_all_expected = all(
+        memory_id in episode_recalled_ids for memory_id in expected_ids
+    )
+
+    other_recalled_ids: list[str] = []
+    other_evidence_complete = True
+    for tool_name in MEMORY_REF_AGGREGATING_RECALL_TOOLS - {"recall_memory"}:
+        other_called, tool_recalled_ids, tool_evidence_complete = (
+            _recall_tool_evidence(history, tool_name)
+        )
+        if not other_called:
+            continue
+        other_evidence_complete = other_evidence_complete and tool_evidence_complete
+        for memory_id in tool_recalled_ids:
+            if memory_id not in other_recalled_ids:
+                other_recalled_ids.append(memory_id)
+
+    attributable_recalled_ids = [
+        memory_id
+        for memory_id in episode_recalled_ids
+        if memory_id not in other_recalled_ids
+    ]
+    if not episode_has_all_expected:
+        return ExpectedRecallResult(
+            passed=False,
+            expected_memory_ids=expected_ids,
+            recalled_memory_ids=(
+                attributable_recalled_ids if other_evidence_complete else []
+            ),
+            evidence_source="episode",
+            recall_memory_called=True,
+        )
+
+    expected_ids_are_attributable = all(
+        memory_id not in other_recalled_ids for memory_id in expected_ids
+    )
+    if other_evidence_complete and expected_ids_are_attributable:
+        return ExpectedRecallResult(
+            passed=True,
+            expected_memory_ids=expected_ids,
+            recalled_memory_ids=attributable_recalled_ids,
+            evidence_source="episode",
+            recall_memory_called=True,
+        )
+
     return ExpectedRecallResult(
-        passed=all(memory_id in recalled_ids for memory_id in expected_ids),
+        passed=None,
         expected_memory_ids=expected_ids,
-        recalled_memory_ids=recalled_ids,
-        evidence_source="inline",
+        recalled_memory_ids=[],
+        evidence_source="unavailable",
         recall_memory_called=True,
     )
 
 
-def _history_uses_any_tool(
+def _recall_tool_evidence(
     history: list[dict[str, Any]],
-    tool_names: set[str] | frozenset[str],
-) -> bool:
+    tool_name: str,
+) -> tuple[bool, list[str], bool]:
+    called = False
+    call_count = 0
+    result_messages: list[dict[str, Any]] = []
     pending_tool_name = ""
     for message in history:
         message_type = message.get("type")
         if message_type == "tool_call":
             pending_tool_name = str(message.get("tool_name") or "")
-            if pending_tool_name in tool_names:
-                return True
+            if pending_tool_name == tool_name:
+                called = True
+                call_count += 1
             continue
         if message_type != "tool_result":
             continue
-        tool_name = str(message.get("tool_name") or pending_tool_name)
+        result_tool_name = str(message.get("tool_name") or pending_tool_name)
         pending_tool_name = ""
-        if tool_name in tool_names:
-            return True
-    return False
+        if result_tool_name != tool_name:
+            continue
+        called = True
+        result_messages.append(message)
 
-
-def _recall_memory_result_contents(
-    history: list[dict[str, Any]],
-) -> tuple[bool, list[Any], int]:
-    recall_called = False
-    recall_call_count = 0
-    result_contents: list[Any] = []
-    pending_tool_name = ""
-    for message in history:
-        message_type = message.get("type")
-        if message_type == "tool_call":
-            pending_tool_name = str(message.get("tool_name") or "")
-            if pending_tool_name == "recall_memory":
-                recall_called = True
-                recall_call_count += 1
+    evidence_complete = bool(result_messages)
+    if call_count and len(result_messages) < call_count:
+        evidence_complete = False
+    recalled_ids: list[str] = []
+    for message in result_messages:
+        if message.get("is_error") or message.get("tool_error") is not None:
+            evidence_complete = False
             continue
-        if message_type != "tool_result":
+        payload = _parse_inline_recall_result(message.get("content"))
+        if payload is None:
+            evidence_complete = False
             continue
-        tool_name = str(message.get("tool_name") or pending_tool_name)
-        pending_tool_name = ""
-        if tool_name != "recall_memory":
-            continue
-        recall_called = True
-        result_contents.append(message.get("content"))
-    return recall_called, result_contents, recall_call_count
+        for memory_id in payload:
+            if memory_id not in recalled_ids:
+                recalled_ids.append(memory_id)
+    return called, recalled_ids, evidence_complete
 
 
 def _parse_inline_recall_result(content: Any) -> list[str] | None:

--- a/benchmark/runner/runtask.py
+++ b/benchmark/runner/runtask.py
@@ -69,6 +69,7 @@ def evaluate_task_history(
     started_at: str | None = None,
     started_mono: float | None = None,
     active_skills: list[str] | None = None,
+    episode: dict[str, Any] | None = None,
 ) -> TaskResult:
     artifact_dir.mkdir(parents=True, exist_ok=True)
     started = started_at or now_iso()
@@ -118,16 +119,36 @@ def evaluate_task_history(
         "final_response": trace.final_response,
         "total_tool_calls": trace.total_tool_calls,
     }
-    (artifact_dir / "trace.json").write_text(
-        json.dumps(trace_dict, ensure_ascii=False, indent=2), encoding="utf-8")
     last_shot_path = post_screenshot if post_screenshot is not None and post_screenshot.exists() else None
     base.metrics.update({"wall_ms": wall_ms, "tool_calls": trace.total_tool_calls,
                          "screenshots_taken": sum(1 for tc in trace.tool_calls if tc.has_screenshot),
                          "pre_screenshot_file": bool(pre_screenshot and pre_screenshot.exists()),
                          "post_screenshot_file": bool(post_screenshot and post_screenshot.exists())})
+    recall_outcome = None
+    if task.expected_recalled_memory_ids:
+        recall_outcome = evaluate_expected_recalled_memory_ids(
+            history,
+            task.expected_recalled_memory_ids,
+            episode=episode,
+        )
+        base.metrics.update({
+            "expected_recalled_memory_ids": recall_outcome.expected_memory_ids,
+            "recalled_memory_ids": recall_outcome.recalled_memory_ids,
+            "memory_recall_evidence_source": recall_outcome.evidence_source,
+            "expected_recalled_memory_match": recall_outcome.passed,
+        })
+        trace_dict.update({
+            "recalled_memory_ids": recall_outcome.recalled_memory_ids,
+            "memory_recall_evidence_source": recall_outcome.evidence_source,
+            "expected_recalled_memory_match": recall_outcome.passed,
+        })
+    (artifact_dir / "trace.json").write_text(
+        json.dumps(trace_dict, ensure_ascii=False, indent=2), encoding="utf-8")
     outcome = evaluate_hard_assertions(trace, task.hard_assertions, timed_out=timed_out)
     base.hard_assertions = outcome.results
     base.hard_assertion_failures = list(outcome.failures)
+    if recall_outcome is not None:
+        base.hard_assertions.expected_recalled_memory = recall_outcome.passed
     if not outcome.all_passed:
         base.status = "timeout" if timed_out else "failed"
         base.finished_at = now_iso()
@@ -154,29 +175,37 @@ def evaluate_task_history(
             base.status = "failed"
             base.finished_at = now_iso()
             return base
-    if task.expected_recalled_memory_ids:
-        recall_outcome = evaluate_expected_recalled_memory_ids(history, task.expected_recalled_memory_ids)
-        base.metrics.update({
-            "expected_recalled_memory_ids": recall_outcome.expected_memory_ids,
-            "recalled_memory_ids": recall_outcome.recalled_memory_ids,
-            "expected_recalled_memory_match": recall_outcome.passed,
-        })
-        base.hard_assertions.expected_recalled_memory = recall_outcome.passed
-        if not recall_outcome.passed:
+    if recall_outcome is not None:
+        if recall_outcome.passed is None:
+            base.status = "judge_error"
+            base.metrics["judge_error"] = (
+                "Memory recall evidence is unavailable: episode could not be used "
+                "and inline recall_memory results were incomplete or unparsable."
+            )
+            base.finished_at = now_iso()
+            return base
+        if recall_outcome.passed is False:
             missing_memory_ids = [
                 memory_id
                 for memory_id in recall_outcome.expected_memory_ids
                 if memory_id not in recall_outcome.recalled_memory_ids
             ]
+            if recall_outcome.recall_memory_called:
+                actual = (
+                    f"Missing: {_format_csv(missing_memory_ids)}. "
+                    f"Recalled: {_format_csv(recall_outcome.recalled_memory_ids)}."
+                )
+            else:
+                actual = (
+                    "No recall_memory call was found. "
+                    f"Missing: {_format_csv(missing_memory_ids)}. Recalled: none."
+                )
             base.hard_assertion_failures.append(
                 HardAssertionFailure(
                     id="expected_recalled_memory",
                     label="Expected Recalled Memory",
                     requirement=f"Must recall memory id(s): {_format_csv(recall_outcome.expected_memory_ids)}.",
-                    actual=(
-                        f"Missing: {_format_csv(missing_memory_ids)}. "
-                        f"Recalled: {_format_csv(recall_outcome.recalled_memory_ids)}."
-                    ),
+                    actual=actual,
                 )
             )
             base.status = "failed"
@@ -284,6 +313,8 @@ def run_one_task(
                 "environment_url is required for live screenshot capture"
             )
     timed_out = False
+    chat_completed = False
+    episode = None
     try:
         prompt = task.prompt
         if suite.prompt_prefix:
@@ -296,6 +327,7 @@ def run_one_task(
             chat_kwargs["skills"] = active_skills
         chat = client.chat(prompt, **chat_kwargs)
         history = chat.history
+        chat_completed = True
     except AgentTimeoutError:
         timed_out = True
         history = client_history_or_empty(client)
@@ -304,6 +336,18 @@ def run_one_task(
     except Exception as e:
         history = client_history_or_empty(client)
         base.metrics["agent_error"] = str(e)[:300]
+    if chat_completed:
+        episode_id = _unique_episode_id(history)
+        if episode_id is not None:
+            try:
+                episode = client.get_episode(episode_id)
+            except Exception as e:
+                base.metrics["episode_error"] = str(e)[:300]
+            else:
+                (artifact_dir / "episode.json").write_text(
+                    json.dumps(episode, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
     # Capture the final device state directly from the environment screen API.
     # The agent history no longer embeds base64 image data, so the post-screenshot
     # must be grabbed live rather than extracted from history.
@@ -339,6 +383,7 @@ def run_one_task(
         started_at=started,
         started_mono=started_mono,
         active_skills=active_skills,
+        episode=episode,
     )
 
 
@@ -352,6 +397,18 @@ def client_history_or_empty(client: AgentClient) -> list[dict]:
 
 def _format_csv(items: list[str]) -> str:
     return ", ".join(items) if items else "none"
+
+
+def _unique_episode_id(history: list[dict[str, Any]]) -> str | None:
+    episode_ids: list[str] = []
+    for message in history:
+        episode_id = message.get("episode_id")
+        if not isinstance(episode_id, str):
+            continue
+        episode_id = episode_id.strip()
+        if episode_id and episode_id not in episode_ids:
+            episode_ids.append(episode_id)
+    return episode_ids[0] if len(episode_ids) == 1 else None
 
 
 def _normalise_active_skills(skills: list[str] | None) -> list[str]:

--- a/benchmark/runner/runtask.py
+++ b/benchmark/runner/runtask.py
@@ -336,7 +336,14 @@ def run_one_task(
     except Exception as e:
         history = client_history_or_empty(client)
         base.metrics["agent_error"] = str(e)[:300]
-    if chat_completed:
+    if chat_completed and task.expected_recalled_memory_ids:
+        inline_recall_outcome = evaluate_expected_recalled_memory_ids(
+            history,
+            task.expected_recalled_memory_ids,
+        )
+    else:
+        inline_recall_outcome = None
+    if inline_recall_outcome is not None and inline_recall_outcome.passed is None:
         episode_id = _unique_episode_id(history)
         if episode_id is not None:
             try:

--- a/benchmark/tests/fixtures/personamem_204453_compressed_recall.json
+++ b/benchmark/tests/fixtures/personamem_204453_compressed_recall.json
@@ -1,0 +1,388 @@
+[
+  {
+    "task_id": "personamem_music_preference_evolution",
+    "expected_memory_ids": [
+      "personamem_music_collaboration_evolution"
+    ],
+    "history_source": "Exact history.json snapshot from full-opus5-9a2ff3f3-20260814-204453-personamem_lt_recall_v1",
+    "history": [
+      {
+        "type": "user",
+        "episode_id": "ep_1786712243814873300_3c0dc67d",
+        "request_id": "req-dkoomph4apx9",
+        "modality": "text",
+        "original_text": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: After several disagreements over the artistic direction, I felt stifled, which really discouraged me from that collaborative process.\n\nOptions:\n(a) You initially enjoyed collaborating with other musicians, but later felt stifled by disagreements and shifted toward independence.\n(b) You initially felt stifled by collaboration, then later came to enjoy collaborating with other musicians.\n(c) You first questioned your artistic abilities, then began enjoying collaboration, and finally sought collaboration more strongly.\n(d) You felt constrained at first, but over time collaboration became your preferred creative direction.",
+        "content": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: After several disagreements over the artistic direction, I felt stifled, which really discouraged me from that collaborative process.\n\nOptions:\n(a) You initially enjoyed collaborating with other musicians, but later felt stifled by disagreements and shifted toward independence.\n(b) You initially felt stifled by collaboration, then later came to enjoy collaborating with other musicians.\n(c) You first questioned your artistic abilities, then began enjoying collaboration, and finally sought collaboration more strongly.\n(d) You felt constrained at first, but over time collaboration became your preferred creative direction.",
+        "timestamp": "2026-08-14T12:57:23.814877133Z"
+      },
+      {
+        "type": "tool_call",
+        "episode_id": "ep_1786712243814873300_3c0dc67d",
+        "request_id": "req-dkoomph4apx9",
+        "content": "<tts>让我先查看一下相关的长期记忆。</tts>\n\n让我先查看一下相关的长期记忆。",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"entities\":[\"musicians\",\"collaboration\"],\"limit\":10,\"tags\":[\"collaboration\",\"artistic\",\"creative\",\"music\",\"disagreement\"]}",
+        "timestamp": "2026-08-14T12:57:28.73919826Z"
+      },
+      {
+        "type": "tool_result",
+        "episode_id": "ep_1786712243814873300_3c0dc67d",
+        "request_id": "req-dkoomph4apx9",
+        "content": "[Large tool result omitted from public history (4910 chars)]",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"entities\":[\"musicians\",\"collaboration\"],\"limit\":10,\"tags\":[\"collaboration\",\"artistic\",\"creative\",\"music\",\"disagreement\"]}",
+        "timestamp": "2026-08-14T12:57:28.74081676Z"
+      },
+      {
+        "type": "assistant",
+        "episode_id": "ep_1786712243814873300_3c0dc67d",
+        "request_id": "req-dkoomph4apx9",
+        "content": "<tts>根据长期记忆,你最初享受与其他音乐人合作,但后来因为艺术方向上的分歧感到受限,转向独立创作。答案是选项A。</tts>\n\n根据存储的长期记忆\"Collaboration preference evolved\",你最初享受与其他音乐人合作,但后来因为艺术方向上的分歧感到受限,转向了独立创作工作。\n\n<final_answer>(a)</final_answer>",
+        "timestamp": "2026-08-14T12:57:32.351037845Z"
+      }
+    ],
+    "episode_evidence_provenance": "Fixture constructed from the known structured evidence for this run; the original episode.json was unavailable.",
+    "episode": {
+      "id": "ep_1786712243814873300_3c0dc67d",
+      "retrieved_memory_refs": [
+        "personamem_music_collaboration_evolution"
+      ]
+    }
+  },
+  {
+    "task_id": "personamem_music_creative_getaway",
+    "expected_memory_ids": [
+      "personamem_music_soundscape"
+    ],
+    "history_source": "Exact history.json snapshot from full-opus5-9a2ff3f3-20260814-204453-personamem_lt_recall_v1",
+    "history": [
+      {
+        "type": "user",
+        "episode_id": "ep_1786712270159889298_3851a4a6",
+        "request_id": "req-dkoon1ktfuos",
+        "modality": "text",
+        "original_text": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: I'm planning a weekend getaway and want to try something creatively fulfilling. What would you suggest?\n\nOptions:\n(a) Spend the weekend learning traditional island cooking or tattoo design.\n(b) Set up an easel and explore visual painting with vivid colors.\n(c) Try storytelling or poetry in a cozy writing nook.\n(d) Capture forest, lake, rain, and wind sounds, then blend them into an original soundscape.",
+        "content": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: I'm planning a weekend getaway and want to try something creatively fulfilling. What would you suggest?\n\nOptions:\n(a) Spend the weekend learning traditional island cooking or tattoo design.\n(b) Set up an easel and explore visual painting with vivid colors.\n(c) Try storytelling or poetry in a cozy writing nook.\n(d) Capture forest, lake, rain, and wind sounds, then blend them into an original soundscape.",
+        "timestamp": "2026-08-14T12:57:50.15989459Z"
+      },
+      {
+        "type": "tool_call",
+        "episode_id": "ep_1786712270159889298_3851a4a6",
+        "request_id": "req-dkoon1ktfuos",
+        "content": "",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"tags\":[\"hobby\",\"creative\",\"weekend\",\"art\"]}",
+        "timestamp": "2026-08-14T12:57:53.186410841Z"
+      },
+      {
+        "type": "tool_result",
+        "episode_id": "ep_1786712270159889298_3851a4a6",
+        "request_id": "req-dkoon1ktfuos",
+        "content": "[Large tool result omitted from public history (5174 chars)]",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"tags\":[\"hobby\",\"creative\",\"weekend\",\"art\"]}",
+        "timestamp": "2026-08-14T12:57:53.187971091Z"
+      },
+      {
+        "type": "assistant",
+        "episode_id": "ep_1786712270159889298_3851a4a6",
+        "request_id": "req-dkoon1ktfuos",
+        "content": "<tts>根据你存储的记忆,你喜欢音效工程,捕捉环境声音,并将自然音频纹理转化为创意音乐项目,所以我建议选项d。</tts>\n\n根据你存储的长期记忆,你喜欢音效工程、捕捉环境声音,并将自然音频纹理转化为创意音乐项目。\n\n因此,对于这个周末创意度假,最适合你的选择是捕捉森林、湖泊、雨和风的声音,然后将它们混合成原创音景——这完全符合你对声音工程和自然音频创作的偏好。\n\n<final_answer>(d)</final_answer>",
+        "timestamp": "2026-08-14T12:57:59.691116427Z"
+      }
+    ],
+    "episode_evidence_provenance": "Fixture constructed from the known structured evidence for this run; the original episode.json was unavailable.",
+    "episode": {
+      "id": "ep_1786712270159889298_3851a4a6",
+      "retrieved_memory_refs": [
+        "personamem_music_soundscape"
+      ]
+    }
+  },
+  {
+    "task_id": "personamem_music_new_expression",
+    "expected_memory_ids": [
+      "personamem_music_expression"
+    ],
+    "history_source": "Exact history.json snapshot from full-opus5-9a2ff3f3-20260814-204453-personamem_lt_recall_v1",
+    "history": [
+      {
+        "type": "user",
+        "episode_id": "ep_1786712281942971387_abb8b45a",
+        "request_id": "req-dkoon6zos3n2",
+        "modality": "text",
+        "original_text": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: How can I find a more fulfilling way to express my love for music?\n\nOptions:\n(a) Try writing about your musical journey, experimenting with live performance in inspiring settings, and simply enjoying music without external pressures.\n(b) Focus on audio engineering and digital remixes because production is always the most fulfilling path.\n(c) Collaborate with musicians from diverse backgrounds because group efforts are always the best fit.\n(d) Get involved in music criticism by writing album reviews to shape listener perspectives.",
+        "content": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: How can I find a more fulfilling way to express my love for music?\n\nOptions:\n(a) Try writing about your musical journey, experimenting with live performance in inspiring settings, and simply enjoying music without external pressures.\n(b) Focus on audio engineering and digital remixes because production is always the most fulfilling path.\n(c) Collaborate with musicians from diverse backgrounds because group efforts are always the best fit.\n(d) Get involved in music criticism by writing album reviews to shape listener perspectives.",
+        "timestamp": "2026-08-14T12:58:01.942976845Z"
+      },
+      {
+        "type": "tool_call",
+        "episode_id": "ep_1786712281942971387_abb8b45a",
+        "request_id": "req-dkoon6zos3n2",
+        "content": "<tts>让我先查看一下相关的长期记忆。</tts>\n\n让我先查看一下相关的长期记忆。",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"entities\":[\"music\"],\"limit\":10,\"tags\":[\"music\",\"hobby\",\"passion\",\"fulfillment\",\"expression\"]}",
+        "timestamp": "2026-08-14T12:58:06.976467125Z"
+      },
+      {
+        "type": "tool_result",
+        "episode_id": "ep_1786712281942971387_abb8b45a",
+        "request_id": "req-dkoon6zos3n2",
+        "content": "[Large tool result omitted from public history (8406 chars)]",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"entities\":[\"music\"],\"limit\":10,\"tags\":[\"music\",\"hobby\",\"passion\",\"fulfillment\",\"expression\"]}",
+        "timestamp": "2026-08-14T12:58:06.978564333Z"
+      },
+      {
+        "type": "assistant",
+        "episode_id": "ep_1786712281942971387_abb8b45a",
+        "request_id": "req-dkoon6zos3n2",
+        "content": "<tts>根据您保存的长期记忆,您希望通过写作记录音乐旅程、在启发性的环境中尝试现场表演,以及单纯享受音乐而不受外部压力等方式来表达对音乐的热爱,这些方式对您来说更有个人意义。</tts>\n\n根据您保存的长期记忆,您希望通过写作记录音乐旅程、在启发性的环境中尝试现场表演,以及单纯享受音乐而不受外部压力等方式来表达对音乐的热爱,这些方式对您来说更有个人意义。\n\n记忆引用:您存储的偏好明确表示想要以个人感到满足的方式表达对音乐的热爱,包括写作音乐历程、现场表演和不带外部压力地享受音乐。\n\n<final_answer>(a)</final_answer>",
+        "timestamp": "2026-08-14T12:58:13.946294212Z"
+      }
+    ],
+    "episode_evidence_provenance": "Fixture constructed from the known structured evidence for this run; the original episode.json was unavailable.",
+    "episode": {
+      "id": "ep_1786712281942971387_abb8b45a",
+      "retrieved_memory_refs": [
+        "personamem_music_expression"
+      ]
+    }
+  },
+  {
+    "task_id": "personamem_food_fusion_cuisine",
+    "expected_memory_ids": [
+      "personamem_food_cultural_techniques"
+    ],
+    "history_source": "Exact history.json snapshot from full-opus5-9a2ff3f3-20260814-204453-personamem_lt_recall_v1",
+    "history": [
+      {
+        "type": "user",
+        "episode_id": "ep_1786712296163978088_bf32ecd7",
+        "request_id": "req-dkoondivlpj5",
+        "modality": "text",
+        "original_text": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: Can you suggest some new cooking techniques or recipes I might enjoy exploring?\n\nOptions:\n(a) Explore local farmers markets and learn farmers stories.\n(b) Start a food blog to share your culinary journey.\n(c) Delve into fusion cuisines and explore how different cultures use similar ingredients in unique ways.\n(d) Try molecular gastronomy techniques such as spherification and sous vide.",
+        "content": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: Can you suggest some new cooking techniques or recipes I might enjoy exploring?\n\nOptions:\n(a) Explore local farmers markets and learn farmers stories.\n(b) Start a food blog to share your culinary journey.\n(c) Delve into fusion cuisines and explore how different cultures use similar ingredients in unique ways.\n(d) Try molecular gastronomy techniques such as spherification and sous vide.",
+        "timestamp": "2026-08-14T12:58:16.163982963Z"
+      },
+      {
+        "type": "tool_call",
+        "episode_id": "ep_1786712296163978088_bf32ecd7",
+        "request_id": "req-dkoondivlpj5",
+        "content": "<tts>让我先查看一下你的长期记忆,看看有没有关于你烹饪偏好的信息。</tts>\n\n让我先查看一下你的长期记忆,看看有没有关于你烹饪偏好的信息。",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"entities\":[\"cooking\",\"recipes\",\"food\"],\"limit\":10,\"tags\":[\"cooking\",\"food\",\"recipe\",\"cuisine\",\"culinary\"],\"types\":[\"preference\",\"fact\",\"profile\"]}",
+        "timestamp": "2026-08-14T12:58:21.502055549Z"
+      },
+      {
+        "type": "tool_result",
+        "episode_id": "ep_1786712296163978088_bf32ecd7",
+        "request_id": "req-dkoondivlpj5",
+        "content": "[Large tool result omitted from public history (4125 chars)]",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"entities\":[\"cooking\",\"recipes\",\"food\"],\"limit\":10,\"tags\":[\"cooking\",\"food\",\"recipe\",\"cuisine\",\"culinary\"],\"types\":[\"preference\",\"fact\",\"profile\"]}",
+        "timestamp": "2026-08-14T12:58:21.504102257Z"
+      },
+      {
+        "type": "assistant",
+        "episode_id": "ep_1786712296163978088_bf32ecd7",
+        "request_id": "req-dkoondivlpj5",
+        "content": "<tts>根据你的长期记忆,你曾经喜欢过一个结合了实践技巧和食谱背后文化历史的烹饪课程。基于这个偏好,我建议选项c最适合你。</tts>\n\n根据你的长期记忆,你曾经喜欢过一个结合了实践技巧和食谱背后文化历史的烹饪课程。\n\n基于这个记忆中的偏好——你享受将实际操作技巧与食谱背后的文化历史相结合的学习方式,选项(c)最符合你的兴趣,因为它提倡深入探索融合料理,了解不同文化如何以独特方式使用相似食材,这正好结合了烹饪技巧与文化探索。\n\n<final_answer>(c)</final_answer>",
+        "timestamp": "2026-08-14T12:58:27.379833885Z"
+      }
+    ],
+    "episode_evidence_provenance": "Fixture constructed from the known structured evidence for this run; the original episode.json was unavailable.",
+    "episode": {
+      "id": "ep_1786712296163978088_bf32ecd7",
+      "retrieved_memory_refs": [
+        "personamem_food_cultural_techniques"
+      ]
+    }
+  },
+  {
+    "task_id": "personamem_therapy_games_dislike",
+    "expected_memory_ids": [
+      "personamem_therapy_rpg_dislike"
+    ],
+    "history_source": "Exact history.json snapshot from full-opus5-9a2ff3f3-20260814-204453-personamem_lt_recall_v1",
+    "history": [
+      {
+        "type": "user",
+        "episode_id": "ep_1786712326370680421_bee340ba",
+        "request_id": "req-dkoonrefw5kt",
+        "modality": "text",
+        "original_text": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: I'm planning a chill weekend at home and need some game suggestions. What would you recommend to keep things relaxed and enjoyable?\n\nOptions:\n(a) Try a serene puzzle adventure like Monument Valley because it is soothing and avoids complex character roles.\n(b) Try Stardew Valley because role-playing elements are relaxing and character progression will suit you.\n(c) Try Breath of the Wild because RPG mechanics and expansive story systems are what you enjoy.\n(d) Try a high-energy combat game like Street Fighter V for an intense challenge.",
+        "content": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: I'm planning a chill weekend at home and need some game suggestions. What would you recommend to keep things relaxed and enjoyable?\n\nOptions:\n(a) Try a serene puzzle adventure like Monument Valley because it is soothing and avoids complex character roles.\n(b) Try Stardew Valley because role-playing elements are relaxing and character progression will suit you.\n(c) Try Breath of the Wild because RPG mechanics and expansive story systems are what you enjoy.\n(d) Try a high-energy combat game like Street Fighter V for an intense challenge.",
+        "timestamp": "2026-08-14T12:58:46.370688129Z"
+      },
+      {
+        "type": "tool_call",
+        "episode_id": "ep_1786712326370680421_bee340ba",
+        "request_id": "req-dkoonrefw5kt",
+        "content": "<tts>让我先查看一下你的游戏偏好记忆。</tts>\n\n让我先查看一下你的游戏偏好记忆。",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"entities\":[\"游戏\",\"RPG\",\"角色扮演\"],\"tags\":[\"游戏\",\"偏好\",\"娱乐\",\"休闲\"],\"types\":[\"preference\",\"rule\"]}",
+        "timestamp": "2026-08-14T12:58:51.610925382Z"
+      },
+      {
+        "type": "tool_result",
+        "episode_id": "ep_1786712326370680421_bee340ba",
+        "request_id": "req-dkoonrefw5kt",
+        "content": "{\"results\":[]}",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"entities\":[\"游戏\",\"RPG\",\"角色扮演\"],\"tags\":[\"游戏\",\"偏好\",\"娱乐\",\"休闲\"],\"types\":[\"preference\",\"rule\"]}",
+        "timestamp": "2026-08-14T12:58:51.612814674Z"
+      },
+      {
+        "type": "tool_call",
+        "episode_id": "ep_1786712326370680421_bee340ba",
+        "request_id": "req-dkoonrefw5kt",
+        "content": "",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"limit\":20}",
+        "timestamp": "2026-08-14T12:58:55.193017467Z"
+      },
+      {
+        "type": "tool_result",
+        "episode_id": "ep_1786712326370680421_bee340ba",
+        "request_id": "req-dkoonrefw5kt",
+        "content": "[Large tool result omitted from public history (17728 chars)]",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"limit\":20}",
+        "timestamp": "2026-08-14T12:58:55.194040634Z"
+      },
+      {
+        "type": "tool_call",
+        "episode_id": "ep_1786712326370680421_bee340ba",
+        "request_id": "req-dkoonrefw5kt",
+        "content": "",
+        "tool_name": "shell",
+        "tool_input": "{\"command\":\"grep -io '[^\\\"]*game[^\\\"]*' /tmp/aiden-config/sessions/s_1b016e54-31aa-4260-b8d6-6e9c3a65835a/tool-results/tr_7496f6e3-d6c6-4eac-a9ec-88a3eb1a1e3a.data | head -40\"}",
+        "timestamp": "2026-08-14T12:58:59.800105761Z"
+      },
+      {
+        "type": "tool_result",
+        "episode_id": "ep_1786712326370680421_bee340ba",
+        "request_id": "req-dkoonrefw5kt",
+        "content": "Dislikes role-playing games for relaxation\nThe user tried role-playing games for relaxation but felt they were not a good fit and did not enjoy complex characters, stories, and rules.\nThe user tried role-playing games for relaxation but felt they were not a good fit and did not enjoy complex characters, stories, and rules.\ngames",
+        "tool_name": "shell",
+        "tool_input": "{\"command\":\"grep -io '[^\\\"]*game[^\\\"]*' /tmp/aiden-config/sessions/s_1b016e54-31aa-4260-b8d6-6e9c3a65835a/tool-results/tr_7496f6e3-d6c6-4eac-a9ec-88a3eb1a1e3a.data | head -40\"}",
+        "timestamp": "2026-08-14T12:58:59.805208719Z"
+      },
+      {
+        "type": "assistant",
+        "episode_id": "ep_1786712326370680421_bee340ba",
+        "request_id": "req-dkoonrefw5kt",
+        "content": "<tts>根据你之前说过的，角色扮演类游戏放松效果不好，你不喜欢复杂的角色、剧情和规则，所以推荐轻松的解谜类。</tts>\n\n记忆里记着：你试过用角色扮演游戏放松，但觉得不合适，不喜欢复杂的角色、剧情和规则。所以更适合《纪念碑谷》这类安静的解谜冒险。\n\n<final_answer>(a)</final_answer>",
+        "timestamp": "2026-08-14T12:59:04.721608013Z"
+      }
+    ],
+    "episode_evidence_provenance": "Fixture constructed from the known structured evidence for this run; the original episode.json was unavailable.",
+    "episode": {
+      "id": "ep_1786712326370680421_bee340ba",
+      "retrieved_memory_refs": [
+        "personamem_therapy_rpg_dislike"
+      ]
+    }
+  },
+  {
+    "task_id": "personamem_writing_style_discrimination",
+    "expected_memory_ids": [
+      "personamem_writing_style"
+    ],
+    "history_source": "Exact history.json snapshot from full-opus5-9a2ff3f3-20260814-204453-personamem_lt_recall_v1",
+    "history": [
+      {
+        "type": "user",
+        "episode_id": "ep_1786712346908427708_a012f20e",
+        "request_id": "req-dkooo0u3jdih",
+        "modality": "text",
+        "original_text": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: Which response style would best fit my usual writing-feedback preference?\n\nOptions:\n(a) This is beautiful and evocative; your prose sings with luminous emotion.\n(b) Good start. Cut the abstract opener, make the claim specific, and add one concrete example in paragraph two.\n(c) I cannot judge style without knowing your demographic background.\n(d) Add more ornate adjectives and longer sentences to make it sound impressive.",
+        "content": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: Which response style would best fit my usual writing-feedback preference?\n\nOptions:\n(a) This is beautiful and evocative; your prose sings with luminous emotion.\n(b) Good start. Cut the abstract opener, make the claim specific, and add one concrete example in paragraph two.\n(c) I cannot judge style without knowing your demographic background.\n(d) Add more ornate adjectives and longer sentences to make it sound impressive.",
+        "timestamp": "2026-08-14T12:59:06.908435292Z"
+      },
+      {
+        "type": "tool_call",
+        "episode_id": "ep_1786712346908427708_a012f20e",
+        "request_id": "req-dkooo0u3jdih",
+        "content": "<tts>让我先查看一下你保存的偏好记忆。</tts>\n\n让我先查看一下你保存的偏好记忆。",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"entities\":[],\"tags\":[\"writing\",\"feedback\",\"preference\",\"style\"],\"types\":[\"preference\",\"rule\"]}",
+        "timestamp": "2026-08-14T12:59:10.875693252Z"
+      },
+      {
+        "type": "tool_result",
+        "episode_id": "ep_1786712346908427708_a012f20e",
+        "request_id": "req-dkooo0u3jdih",
+        "content": "[Large tool result omitted from public history (4723 chars)]",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"entities\":[],\"tags\":[\"writing\",\"feedback\",\"preference\",\"style\"],\"types\":[\"preference\",\"rule\"]}",
+        "timestamp": "2026-08-14T12:59:10.878772627Z"
+      },
+      {
+        "type": "assistant",
+        "episode_id": "ep_1786712346908427708_a012f20e",
+        "request_id": "req-dkooo0u3jdih",
+        "content": "<tts>根据你保存的偏好，你喜欢简洁具体、能直接落地修改的反馈，而不是华丽的夸奖，所以选 b。</tts>\n\n我用到的记忆是「写作风格偏好」：你偏好简洁、具体、可执行的修改建议，而不是空泛的赞美。\n\n<final_answer>(b)</final_answer>",
+        "timestamp": "2026-08-14T12:59:15.632999629Z"
+      }
+    ],
+    "episode_evidence_provenance": "Fixture constructed from the known structured evidence for this run; the original episode.json was unavailable.",
+    "episode": {
+      "id": "ep_1786712346908427708_a012f20e",
+      "retrieved_memory_refs": [
+        "personamem_writing_style"
+      ]
+    }
+  },
+  {
+    "task_id": "personamem_study_consultation_generalization",
+    "expected_memory_ids": [
+      "personamem_flashcards"
+    ],
+    "history_source": "Exact history.json snapshot from full-opus5-9a2ff3f3-20260814-204453-personamem_lt_recall_v1",
+    "history": [
+      {
+        "type": "user",
+        "episode_id": "ep_1786712423628475008_7cc6e256",
+        "request_id": "req-dkoop02wo9wi",
+        "modality": "text",
+        "original_text": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: I'm looking for a new way to boost my study sessions for an upcoming exam. Do you have any creative ideas that could help make learning more engaging?\n\nOptions:\n(a) Create digital flashcards in an app like Anki, add visuals or audio cues, and use spaced repetition for recall practice.\n(b) Knit or fold origami during study breaks and decorate notes like a tapestry.\n(c) Watch unrelated documentaries to keep the sessions surprising.\n(d) Avoid structured recall and reread chapters passively.",
+        "content": "You are being evaluated on long-term memory. Before answering, you must call recall_memory with relevant tags/entities to inspect the preloaded memory. Do not answer from general reasoning or the option text alone.\n\nUse long-term memory if relevant. Before your final answer, briefly cite the specific stored memory you applied (1 sentence, naming the remembered fact/preference). Then end with exactly one final line like <final_answer>(a)</final_answer>.\n\nQuestion: I'm looking for a new way to boost my study sessions for an upcoming exam. Do you have any creative ideas that could help make learning more engaging?\n\nOptions:\n(a) Create digital flashcards in an app like Anki, add visuals or audio cues, and use spaced repetition for recall practice.\n(b) Knit or fold origami during study breaks and decorate notes like a tapestry.\n(c) Watch unrelated documentaries to keep the sessions surprising.\n(d) Avoid structured recall and reread chapters passively.",
+        "timestamp": "2026-08-14T13:00:23.628480591Z"
+      },
+      {
+        "type": "tool_call",
+        "episode_id": "ep_1786712423628475008_7cc6e256",
+        "request_id": "req-dkoop02wo9wi",
+        "content": "<tts>让我先查看一下我记住的关于你的学习偏好。</tts>\n\n让我先查看一下我记住的关于你的学习偏好。",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"entities\":[\"study\",\"learning\",\"exam\"],\"limit\":10,\"tags\":[\"study\",\"learning\",\"exam\",\"education\",\"preference\"]}",
+        "timestamp": "2026-08-14T13:00:28.035102093Z"
+      },
+      {
+        "type": "tool_result",
+        "episode_id": "ep_1786712423628475008_7cc6e256",
+        "request_id": "req-dkoop02wo9wi",
+        "content": "[Large tool result omitted from public history (11645 chars)]",
+        "tool_name": "recall_memory",
+        "tool_input": "{\"entities\":[\"study\",\"learning\",\"exam\"],\"limit\":10,\"tags\":[\"study\",\"learning\",\"exam\",\"education\",\"preference\"]}",
+        "timestamp": "2026-08-14T13:00:28.037965177Z"
+      },
+      {
+        "type": "assistant",
+        "episode_id": "ep_1786712423628475008_7cc6e256",
+        "request_id": "req-dkoop02wo9wi",
+        "content": "<tts>根据我记住的信息，你喜欢用抽认卡学习，考试复习时结构化的回忆练习对你效果最好，所以选 a 最合适。用 Anki 这类应用做数字卡片，加上图片或音频提示，再配合间隔重复，能把主动回忆和趣味性结合起来。</tts>\n\n我应用的记忆是：你偏好抽认卡学习方式，并且在备考时能从结构化的主动回忆练习中获益。\n\n所以推荐用 Anki 这类应用建数字卡片，加入图片和音频提示，再靠间隔重复安排复习节奏。这样既保留了你熟悉的卡片形式，又通过多感官提示和逐渐拉长的复习间隔让记忆更牢固，比被动重读章节有效得多。\n\n<final_answer>(a)</final_answer>",
+        "timestamp": "2026-08-14T13:00:34.82314443Z"
+      }
+    ],
+    "episode_evidence_provenance": "Fixture constructed from the known structured evidence for this run; the original episode.json was unavailable.",
+    "episode": {
+      "id": "ep_1786712423628475008_7cc6e256",
+      "retrieved_memory_refs": [
+        "personamem_flashcards"
+      ]
+    }
+  }
+]

--- a/benchmark/tests/test_agent_client.py
+++ b/benchmark/tests/test_agent_client.py
@@ -98,6 +98,26 @@ def test_get_history_returns_current_history():
     assert result == history
 
 
+def test_get_episode_uses_episode_id_in_path_and_unwraps_episode():
+    seen = {}
+    episode_id = "ep_1786723200000000000_0123abcd"
+    episode = {
+        "id": episode_id,
+        "retrieved_memory_refs": ["personamem_music_expression"],
+    }
+    client = AgentClient(base_url="http://test")
+
+    with patch(
+        "urllib.request.urlopen",
+        _captured(seen, body={"episode": episode}),
+    ):
+        result = client.get_episode(episode_id)
+
+    assert seen["method"] == "GET"
+    assert seen["url"].endswith(f"/api/episodes/{episode_id}")
+    assert result == episode
+
+
 def test_device_type_reads_runtime_phone_bridge_status():
     seen = {}
     client = AgentClient(base_url="http://test")

--- a/benchmark/tests/test_assertions.py
+++ b/benchmark/tests/test_assertions.py
@@ -294,7 +294,7 @@ def test_expected_recalled_memory_ids_episode_missing_expected_id_is_failure():
     assert result.evidence_source == "episode"
 
 
-def test_expected_recalled_memory_ids_episode_missing_refs_is_authoritative_empty():
+def test_expected_recalled_memory_ids_prefers_complete_inline_result_over_episode():
     history = [
         {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
         {
@@ -310,9 +310,9 @@ def test_expected_recalled_memory_ids_episode_missing_refs_is_authoritative_empt
         episode={"id": "ep-1"},
     )
 
-    assert result.passed is False
-    assert result.recalled_memory_ids == []
-    assert result.evidence_source == "episode"
+    assert result.passed is True
+    assert result.recalled_memory_ids == ["personamem_music_expression"]
+    assert result.evidence_source == "inline"
 
 
 def test_expected_recalled_memory_ids_deduplicates_multiple_recalls_and_uses_all_of():
@@ -419,6 +419,93 @@ def test_expected_recalled_memory_ids_does_not_attribute_device_recall_to_compre
             "type": "tool_result",
             "tool_name": "recall_device_memory",
             "content": '{"results":[{"id":"personamem_music_expression"}]}',
+        },
+    ]
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["personamem_music_expression"],
+        episode={"retrieved_memory_refs": ["personamem_music_expression"]},
+    )
+
+    assert result.passed is None
+    assert result.recalled_memory_ids == []
+    assert result.evidence_source == "unavailable"
+
+
+def test_expected_recalled_memory_ids_attributes_episode_when_device_recall_is_empty():
+    history = [
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": "[Large tool result omitted from public history (8406 chars)]",
+        },
+        {"type": "tool_call", "tool_name": "recall_device_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_device_memory",
+            "content": '{"results":[]}',
+        },
+    ]
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["personamem_music_expression"],
+        episode={"retrieved_memory_refs": ["personamem_music_expression"]},
+    )
+
+    assert result.passed is True
+    assert result.recalled_memory_ids == ["personamem_music_expression"]
+    assert result.evidence_source == "episode"
+
+
+def test_expected_recalled_memory_ids_attributes_episode_when_device_ids_are_unrelated():
+    history = [
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": "[Large tool result omitted from public history (8406 chars)]",
+        },
+        {"type": "tool_call", "tool_name": "recall_device_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_device_memory",
+            "content": '{"results":[{"id":"device-only"}]}',
+        },
+    ]
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["personamem_music_expression"],
+        episode={
+            "retrieved_memory_refs": [
+                "personamem_music_expression",
+                "device-only",
+            ]
+        },
+    )
+
+    assert result.passed is True
+    assert result.recalled_memory_ids == ["personamem_music_expression"]
+    assert result.evidence_source == "episode"
+
+
+def test_expected_recalled_memory_ids_keeps_episode_ambiguous_after_device_error():
+    history = [
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": "[Large tool result omitted from public history (8406 chars)]",
+        },
+        {"type": "tool_call", "tool_name": "recall_device_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_device_memory",
+            "content": "device memory unavailable",
+            "is_error": True,
         },
     ]
 

--- a/benchmark/tests/test_assertions.py
+++ b/benchmark/tests/test_assertions.py
@@ -214,6 +214,8 @@ def test_expected_recalled_memory_ids_pass_when_tool_result_contains_id():
 
     assert result.passed is True
     assert result.recalled_memory_ids == ["personamem_solo_travel"]
+    assert result.evidence_source == "inline"
+    assert result.recall_memory_called is True
 
 def test_expected_recalled_memory_ids_fail_when_expected_id_absent():
     history = [
@@ -228,6 +230,7 @@ def test_expected_recalled_memory_ids_fail_when_expected_id_absent():
 
     assert result.passed is False
     assert result.recalled_memory_ids == ["personamem_campfire_storytelling"]
+    assert result.evidence_source == "inline"
 
 def test_expected_recalled_memory_ids_ignores_non_object_json_payload():
     history = [
@@ -240,5 +243,245 @@ def test_expected_recalled_memory_ids_ignores_non_object_json_payload():
 
     result = assertions.evaluate_expected_recalled_memory_ids(history, ["personamem_solo_travel"])
 
+    assert result.passed is None
+    assert result.recalled_memory_ids == []
+    assert result.evidence_source == "unavailable"
+
+
+def test_expected_recalled_memory_ids_prefers_episode_over_compressed_history():
+    history = [
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": "[Large tool result omitted from public history (8406 chars)]",
+        },
+    ]
+    episode = {
+        "id": "ep-1",
+        "retrieved_memory_refs": ["personamem_music_expression"],
+    }
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["personamem_music_expression"],
+        episode=episode,
+    )
+
+    assert result.passed is True
+    assert result.recalled_memory_ids == ["personamem_music_expression"]
+    assert result.evidence_source == "episode"
+
+
+def test_expected_recalled_memory_ids_episode_missing_expected_id_is_failure():
+    history = [
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": "[Large tool result omitted from public history (5000 chars)]",
+        },
+    ]
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["personamem_music_expression"],
+        episode={"retrieved_memory_refs": ["personamem_music_software"]},
+    )
+
+    assert result.passed is False
+    assert result.recalled_memory_ids == ["personamem_music_software"]
+    assert result.evidence_source == "episode"
+
+
+def test_expected_recalled_memory_ids_episode_missing_refs_is_authoritative_empty():
+    history = [
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": '{"results":[{"id":"personamem_music_expression"}]}',
+        },
+    ]
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["personamem_music_expression"],
+        episode={"id": "ep-1"},
+    )
+
     assert result.passed is False
     assert result.recalled_memory_ids == []
+    assert result.evidence_source == "episode"
+
+
+def test_expected_recalled_memory_ids_deduplicates_multiple_recalls_and_uses_all_of():
+    history = [
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": '{"results":[{"id":"memory-a"},{"id":"memory-a"}]}',
+        },
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": '{"results":[{"id":"memory-b"},{"id":"memory-a"}]}',
+        },
+    ]
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["memory-a", "memory-b"],
+    )
+
+    assert result.passed is True
+    assert result.recalled_memory_ids == ["memory-a", "memory-b"]
+    assert result.evidence_source == "inline"
+
+
+def test_expected_recalled_memory_ids_does_not_use_final_answer_claim():
+    history = [
+        {"type": "assistant", "content": "I recalled personamem_music_expression."},
+    ]
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["personamem_music_expression"],
+        episode={"retrieved_memory_refs": ["personamem_music_expression"]},
+    )
+
+    assert result.passed is False
+    assert result.recalled_memory_ids == []
+    assert result.evidence_source == "unavailable"
+    assert result.recall_memory_called is False
+
+
+def test_expected_recalled_memory_ids_compressed_history_without_episode_is_unavailable():
+    history = [
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": "[Large tool result omitted from public history (8406 chars)]",
+        },
+    ]
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["personamem_music_expression"],
+    )
+
+    assert result.passed is None
+    assert result.recalled_memory_ids == []
+    assert result.evidence_source == "unavailable"
+    assert result.recall_memory_called is True
+
+
+def test_expected_recalled_memory_ids_does_not_attribute_device_recall_to_empty_memory_recall():
+    history = [
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": '{"results":[]}',
+        },
+        {"type": "tool_call", "tool_name": "recall_device_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_device_memory",
+            "content": '{"results":[{"id":"personamem_music_expression"}]}',
+        },
+    ]
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["personamem_music_expression"],
+        episode={"retrieved_memory_refs": ["personamem_music_expression"]},
+    )
+
+    assert result.passed is False
+    assert result.recalled_memory_ids == []
+    assert result.evidence_source == "inline"
+
+
+def test_expected_recalled_memory_ids_does_not_attribute_device_recall_to_compressed_memory_recall():
+    history = [
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": "[Large tool result omitted from public history (8406 chars)]",
+        },
+        {"type": "tool_call", "tool_name": "recall_device_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_device_memory",
+            "content": '{"results":[{"id":"personamem_music_expression"}]}',
+        },
+    ]
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["personamem_music_expression"],
+        episode={"retrieved_memory_refs": ["personamem_music_expression"]},
+    )
+
+    assert result.passed is None
+    assert result.recalled_memory_ids == []
+    assert result.evidence_source == "unavailable"
+
+
+def test_expected_recalled_memory_ids_uses_empty_aggregate_as_negative_episode_evidence():
+    history = [
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": "[Large tool result omitted from public history (8406 chars)]",
+        },
+        {"type": "tool_call", "tool_name": "recall_device_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_device_memory",
+            "content": '{"results":[]}',
+        },
+    ]
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["personamem_music_expression"],
+        episode={"retrieved_memory_refs": []},
+    )
+
+    assert result.passed is False
+    assert result.recalled_memory_ids == []
+    assert result.evidence_source == "episode"
+
+
+def test_expected_recalled_memory_ids_uses_partial_aggregate_as_negative_episode_evidence():
+    history = [
+        {"type": "tool_call", "tool_name": "recall_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": "[Large tool result omitted from public history (8406 chars)]",
+        },
+        {"type": "tool_call", "tool_name": "recall_device_memory", "tool_input": "{}"},
+        {
+            "type": "tool_result",
+            "tool_name": "recall_device_memory",
+            "content": '{"results":[{"id":"memory-a"}]}',
+        },
+    ]
+
+    result = assertions.evaluate_expected_recalled_memory_ids(
+        history,
+        ["memory-a", "memory-b"],
+        episode={"retrieved_memory_refs": ["memory-a"]},
+    )
+
+    assert result.passed is False
+    assert result.recalled_memory_ids == []
+    assert result.evidence_source == "episode"

--- a/benchmark/tests/test_personamem_episode_regression.py
+++ b/benchmark/tests/test_personamem_episode_regression.py
@@ -1,0 +1,123 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import runner.runtask as runtask_mod
+from runner.judge import JudgeConfig, JudgeOutput
+from runner.models import RubricVerdict
+from runner.runtask import evaluate_task_history
+from runner.suite import HardAssertions, RubricItem, Suite, TaskSpec
+
+
+FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "personamem_204453_compressed_recall.json"
+)
+CASES = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+EXPECTED_HISTORY_SHAPES = {
+    "personamem_music_preference_evolution": (4, ["recall_memory"]),
+    "personamem_music_creative_getaway": (4, ["recall_memory"]),
+    "personamem_music_new_expression": (4, ["recall_memory"]),
+    "personamem_food_fusion_cuisine": (4, ["recall_memory"]),
+    "personamem_therapy_games_dislike": (
+        8,
+        ["recall_memory", "recall_memory", "shell"],
+    ),
+    "personamem_writing_style_discrimination": (4, ["recall_memory"]),
+    "personamem_study_consultation_generalization": (4, ["recall_memory"]),
+}
+
+
+def _suite_and_task(case: dict, tmp_path: Path) -> tuple[Suite, TaskSpec]:
+    suite = Suite(
+        name="personamem_lt_recall_v1",
+        global_reset={},
+        tasks=[],
+        sha256="fixture",
+        source_path=tmp_path / "suite.json",
+    )
+    task = TaskSpec(
+        id=case["task_id"],
+        category="memory",
+        description_for_judge="Use the recalled memory to answer the user.",
+        prompt="fixture",
+        rubric=[RubricItem(id="uses_memory", check="Uses the recalled memory.")],
+        hard_assertions=HardAssertions(min_tool_calls=1, max_tool_calls=50),
+        expected_recalled_memory_ids=case["expected_memory_ids"],
+    )
+    return suite, task
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case["task_id"])
+def test_204453_compressed_personamem_failures_use_episode_evidence(
+    case,
+    tmp_path: Path,
+    monkeypatch,
+):
+    suite, task = _suite_and_task(case, tmp_path)
+    artifact_dir = tmp_path / case["task_id"]
+    judge_calls = []
+    history = case["history"]
+
+    expected_message_count, expected_tool_names = EXPECTED_HISTORY_SHAPES[
+        case["task_id"]
+    ]
+    assert len(history) == expected_message_count
+    assert history[0]["type"] == "user"
+    assert history[-1]["type"] == "assistant"
+    assert history[-1]["content"]
+    tool_calls = [item for item in history if item["type"] == "tool_call"]
+    assert [item["tool_name"] for item in tool_calls] == expected_tool_names
+    assert all(
+        item["tool_input"] != "{}"
+        for item in tool_calls
+        if item["tool_name"] == "recall_memory"
+    )
+
+    def fake_judge_task(**kwargs):
+        judge_calls.append(kwargs)
+        return JudgeOutput(
+            verdicts=[RubricVerdict(id="uses_memory", verdict="yes", reason="used")],
+            overall_notes="",
+            cache_key="fixture",
+            raw_response="{}",
+        )
+
+    monkeypatch.setattr(runtask_mod, "judge_task", fake_judge_task)
+
+    result = evaluate_task_history(
+        suite=suite,
+        task=task,
+        history=history,
+        episode=case["episode"],
+        attempt=1,
+        artifact_dir=artifact_dir,
+        judge_cfg=JudgeConfig(),
+        judge_cache_dir=None,
+        run_id="full-opus5-9a2ff3f3-20260814-204453-personamem_lt_recall_v1",
+        timed_out=False,
+    )
+
+    assert result.status == "passed"
+    assert len(judge_calls) == 1
+    memory_failures = [
+        failure
+        for failure in result.hard_assertion_failures
+        if failure.id == "expected_recalled_memory"
+    ]
+    assert memory_failures == []
+    assert all(
+        "Recalled: none" not in failure.actual
+        for failure in result.hard_assertion_failures
+    )
+    assert (
+        result.metrics["recalled_memory_ids"]
+        == case["episode"]["retrieved_memory_refs"]
+    )
+    assert result.metrics["memory_recall_evidence_source"] == "episode"
+    assert result.metrics["expected_recalled_memory_match"] is True
+
+    trace = json.loads((artifact_dir / "trace.json").read_text(encoding="utf-8"))
+    assert trace["recalled_memory_ids"] == case["episode"]["retrieved_memory_refs"]
+    assert trace["memory_recall_evidence_source"] == "episode"
+    assert trace["expected_recalled_memory_match"] is True

--- a/benchmark/tests/test_runtask.py
+++ b/benchmark/tests/test_runtask.py
@@ -376,7 +376,7 @@ def test_ambiguous_episode_empty_memory_refs_is_real_failure(tmp_path: Path):
     assert result.metrics["expected_recalled_memory_match"] is False
 
 
-def test_ambiguous_episode_missing_one_expected_memory_is_real_failure(tmp_path: Path):
+def test_episode_missing_one_expected_memory_reports_attributable_recall(tmp_path: Path):
     from runner.runtask import evaluate_task_history
 
     suite, task = _memory_suite_and_task(tmp_path)
@@ -395,7 +395,7 @@ def test_ambiguous_episode_missing_one_expected_memory_is_real_failure(tmp_path:
     )
 
     assert result.status == "failed"
-    assert result.metrics["recalled_memory_ids"] == []
+    assert result.metrics["recalled_memory_ids"] == ["memory-a"]
     assert result.metrics["memory_recall_evidence_source"] == "episode"
     assert result.metrics["expected_recalled_memory_match"] is False
 
@@ -522,7 +522,7 @@ def test_run_one_task_fetches_unique_episode_and_saves_it(tmp_path: Path):
     assert result.metrics["memory_recall_evidence_source"] == "episode"
 
 
-def test_run_one_task_episode_fetch_failure_uses_complete_inline_result(tmp_path: Path):
+def test_run_one_task_complete_inline_result_does_not_fetch_episode(tmp_path: Path):
     suite, task = _memory_suite_and_task(tmp_path)
     client = EpisodeClient(
         inline_content=json.dumps(
@@ -544,7 +544,34 @@ def test_run_one_task_episode_fetch_failure_uses_complete_inline_result(tmp_path
 
     assert result.status == "passed"
     assert result.metrics["memory_recall_evidence_source"] == "inline"
-    assert "episode unavailable" in result.metrics["episode_error"]
+    assert client.episode_requests == []
+    assert "episode_error" not in result.metrics
+    assert not (tmp_path / "artifacts" / "episode.json").exists()
+
+
+def test_run_one_task_without_memory_id_assertion_does_not_fetch_episode(
+    tmp_path: Path,
+):
+    suite, task = _memory_suite_and_task(tmp_path)
+    task.expected_recalled_memory_ids = []
+    client = EpisodeClient(
+        inline_content="[Large tool result omitted from public history (8406 chars)]",
+        episode={"id": "ep/one", "retrieved_memory_refs": []},
+    )
+
+    result = run_one_task(
+        client,
+        suite,
+        task,
+        1,
+        tmp_path / "artifacts",
+        None,
+        None,
+        "run-1",
+    )
+
+    assert result.status == "passed"
+    assert client.episode_requests == []
     assert not (tmp_path / "artifacts" / "episode.json").exists()
 
 

--- a/benchmark/tests/test_runtask.py
+++ b/benchmark/tests/test_runtask.py
@@ -200,6 +200,380 @@ def test_evaluate_task_history_records_expected_memory_failure_details(tmp_path:
     )
 
 
+def _memory_suite_and_task(tmp_path: Path):
+    suite = Suite(
+        name="persona",
+        global_reset={},
+        tasks=[],
+        sha256="sha",
+        source_path=tmp_path / "suite.json",
+    )
+    task = TaskSpec(
+        id="personamem_case",
+        category="memory",
+        description_for_judge="Recall the expected memory.",
+        prompt="What do I prefer?",
+        rubric=[RubricItem(id="uses_memory", check="Uses the memory.")],
+        hard_assertions=HardAssertions(min_tool_calls=1, max_tool_calls=3),
+        expected_recalled_memory_ids=["personamem_music_expression"],
+    )
+    return suite, task
+
+
+def _compressed_recall_history(episode_id: str = "ep-1"):
+    return [
+        {
+            "type": "tool_call",
+            "tool_name": "recall_memory",
+            "tool_input": "{}",
+            "episode_id": episode_id,
+        },
+        {
+            "type": "tool_result",
+            "tool_name": "recall_memory",
+            "content": "[Large tool result omitted from public history (8406 chars)]",
+            "episode_id": episode_id,
+        },
+        {
+            "type": "assistant",
+            "content": "I used the stored preference.",
+            "episode_id": episode_id,
+        },
+    ]
+
+
+def _compressed_recall_and_device_history(episode_id: str = "ep-1"):
+    recall_history = _compressed_recall_history(episode_id)
+    return recall_history[:-1] + [
+        {
+            "type": "tool_call",
+            "tool_name": "recall_device_memory",
+            "tool_input": "{}",
+            "episode_id": episode_id,
+        },
+        {
+            "type": "tool_result",
+            "tool_name": "recall_device_memory",
+            "content": '{"results":[]}',
+            "episode_id": episode_id,
+        },
+        recall_history[-1],
+    ]
+
+
+def test_compressed_recall_with_episode_continues_to_judge_and_persists_evidence(
+    tmp_path: Path,
+    monkeypatch,
+):
+    from runner.runtask import evaluate_task_history
+
+    suite, task = _memory_suite_and_task(tmp_path)
+    judge_called = []
+
+    def fake_judge_task(**kwargs):
+        judge_called.append(kwargs)
+        return JudgeOutput(
+            verdicts=[RubricVerdict(id="uses_memory", verdict="yes", reason="used")],
+            overall_notes="",
+            cache_key="k",
+            raw_response="{}",
+        )
+
+    monkeypatch.setattr(runtask_mod, "judge_task", fake_judge_task)
+
+    result = evaluate_task_history(
+        suite=suite,
+        task=task,
+        history=_compressed_recall_history(),
+        episode={
+            "id": "ep-1",
+            "retrieved_memory_refs": ["personamem_music_expression"],
+        },
+        attempt=1,
+        artifact_dir=tmp_path / "artifacts",
+        judge_cfg=JudgeConfig(),
+        judge_cache_dir=None,
+        run_id="run-1",
+        timed_out=False,
+    )
+
+    assert result.status == "passed"
+    assert len(judge_called) == 1
+    assert result.metrics["recalled_memory_ids"] == ["personamem_music_expression"]
+    assert result.metrics["memory_recall_evidence_source"] == "episode"
+    assert result.metrics["expected_recalled_memory_match"] is True
+    trace = json.loads((tmp_path / "artifacts" / "trace.json").read_text())
+    assert trace["recalled_memory_ids"] == ["personamem_music_expression"]
+    assert trace["memory_recall_evidence_source"] == "episode"
+    assert trace["expected_recalled_memory_match"] is True
+
+
+def test_episode_missing_expected_memory_is_real_failure(tmp_path: Path):
+    from runner.runtask import evaluate_task_history
+
+    suite, task = _memory_suite_and_task(tmp_path)
+    result = evaluate_task_history(
+        suite=suite,
+        task=task,
+        history=_compressed_recall_history(),
+        episode={"id": "ep-1", "retrieved_memory_refs": ["other-memory"]},
+        attempt=1,
+        artifact_dir=tmp_path / "artifacts",
+        judge_cfg=None,
+        judge_cache_dir=None,
+        run_id="run-1",
+        timed_out=False,
+    )
+
+    assert result.status == "failed"
+    assert result.metrics["memory_recall_evidence_source"] == "episode"
+    assert result.metrics["expected_recalled_memory_match"] is False
+
+
+def test_episode_authoritative_empty_memory_refs_is_real_failure(tmp_path: Path):
+    from runner.runtask import evaluate_task_history
+
+    suite, task = _memory_suite_and_task(tmp_path)
+    result = evaluate_task_history(
+        suite=suite,
+        task=task,
+        history=_compressed_recall_history(),
+        episode={"id": "ep-1"},
+        attempt=1,
+        artifact_dir=tmp_path / "artifacts",
+        judge_cfg=None,
+        judge_cache_dir=None,
+        run_id="run-1",
+        timed_out=False,
+    )
+
+    assert result.status == "failed"
+    assert result.metrics["recalled_memory_ids"] == []
+    assert result.metrics["memory_recall_evidence_source"] == "episode"
+    assert result.metrics["expected_recalled_memory_match"] is False
+
+
+def test_ambiguous_episode_empty_memory_refs_is_real_failure(tmp_path: Path):
+    from runner.runtask import evaluate_task_history
+
+    suite, task = _memory_suite_and_task(tmp_path)
+    result = evaluate_task_history(
+        suite=suite,
+        task=task,
+        history=_compressed_recall_and_device_history(),
+        episode={"id": "ep-1", "retrieved_memory_refs": []},
+        attempt=1,
+        artifact_dir=tmp_path / "artifacts",
+        judge_cfg=None,
+        judge_cache_dir=None,
+        run_id="run-1",
+        timed_out=False,
+    )
+
+    assert result.status == "failed"
+    assert result.metrics["recalled_memory_ids"] == []
+    assert result.metrics["memory_recall_evidence_source"] == "episode"
+    assert result.metrics["expected_recalled_memory_match"] is False
+
+
+def test_ambiguous_episode_missing_one_expected_memory_is_real_failure(tmp_path: Path):
+    from runner.runtask import evaluate_task_history
+
+    suite, task = _memory_suite_and_task(tmp_path)
+    task.expected_recalled_memory_ids = ["memory-a", "memory-b"]
+    result = evaluate_task_history(
+        suite=suite,
+        task=task,
+        history=_compressed_recall_and_device_history(),
+        episode={"id": "ep-1", "retrieved_memory_refs": ["memory-a"]},
+        attempt=1,
+        artifact_dir=tmp_path / "artifacts",
+        judge_cfg=None,
+        judge_cache_dir=None,
+        run_id="run-1",
+        timed_out=False,
+    )
+
+    assert result.status == "failed"
+    assert result.metrics["recalled_memory_ids"] == []
+    assert result.metrics["memory_recall_evidence_source"] == "episode"
+    assert result.metrics["expected_recalled_memory_match"] is False
+
+
+def test_compressed_recall_without_episode_is_judge_error(tmp_path: Path):
+    from runner.runtask import evaluate_task_history
+
+    suite, task = _memory_suite_and_task(tmp_path)
+    result = evaluate_task_history(
+        suite=suite,
+        task=task,
+        history=_compressed_recall_history(),
+        episode=None,
+        attempt=1,
+        artifact_dir=tmp_path / "artifacts",
+        judge_cfg=None,
+        judge_cache_dir=None,
+        run_id="run-1",
+        timed_out=False,
+    )
+
+    assert result.status == "judge_error"
+    assert result.hard_assertions.expected_recalled_memory is None
+    assert result.metrics["memory_recall_evidence_source"] == "unavailable"
+    assert result.metrics["expected_recalled_memory_match"] is None
+    trace = json.loads((tmp_path / "artifacts" / "trace.json").read_text())
+    assert trace["recalled_memory_ids"] == []
+    assert trace["memory_recall_evidence_source"] == "unavailable"
+    assert trace["expected_recalled_memory_match"] is None
+
+
+def test_missing_recall_call_fails_even_when_episode_contains_expected_id(tmp_path: Path):
+    from runner.runtask import evaluate_task_history
+
+    suite, task = _memory_suite_and_task(tmp_path)
+    task.hard_assertions.min_tool_calls = 0
+    history = [
+        {
+            "type": "assistant",
+            "content": "I recalled personamem_music_expression.",
+            "episode_id": "ep-1",
+        }
+    ]
+    result = evaluate_task_history(
+        suite=suite,
+        task=task,
+        history=history,
+        episode={"retrieved_memory_refs": ["personamem_music_expression"]},
+        attempt=1,
+        artifact_dir=tmp_path / "artifacts",
+        judge_cfg=None,
+        judge_cache_dir=None,
+        run_id="run-1",
+        timed_out=False,
+    )
+
+    assert result.status == "failed"
+    assert result.metrics["recalled_memory_ids"] == []
+    assert result.metrics["expected_recalled_memory_match"] is False
+    assert "No recall_memory call" in result.hard_assertion_failures[-1].actual
+
+
+class EpisodeClient(FakeClient):
+    def __init__(self, *, inline_content, episode=None, episode_error=None):
+        super().__init__("done")
+        self.inline_content = inline_content
+        self.episode = episode
+        self.episode_error = episode_error
+        self.episode_requests = []
+
+    def chat(self, message, timeout_sec=None, attachments=None, skills=None):
+        self.messages.append(message)
+        return ChatResponse(
+            response="done",
+            history=[
+                {
+                    "type": "tool_call",
+                    "tool_name": "recall_memory",
+                    "tool_input": "{}",
+                    "episode_id": "ep/one",
+                },
+                {
+                    "type": "tool_result",
+                    "tool_name": "recall_memory",
+                    "content": self.inline_content,
+                    "episode_id": "ep/one",
+                },
+                {"type": "assistant", "content": "done", "episode_id": "ep/one"},
+            ],
+        )
+
+    def get_episode(self, episode_id):
+        self.episode_requests.append(episode_id)
+        if self.episode_error is not None:
+            raise self.episode_error
+        return self.episode
+
+
+def test_run_one_task_fetches_unique_episode_and_saves_it(tmp_path: Path):
+    suite, task = _memory_suite_and_task(tmp_path)
+    episode = {
+        "id": "ep/one",
+        "retrieved_memory_refs": ["personamem_music_expression"],
+    }
+    client = EpisodeClient(
+        inline_content="[Large tool result omitted from public history (8406 chars)]",
+        episode=episode,
+    )
+
+    result = run_one_task(
+        client,
+        suite,
+        task,
+        1,
+        tmp_path / "artifacts",
+        None,
+        None,
+        "run-1",
+    )
+
+    assert result.status == "passed"
+    assert client.episode_requests == ["ep/one"]
+    assert json.loads((tmp_path / "artifacts" / "episode.json").read_text()) == episode
+    assert result.metrics["memory_recall_evidence_source"] == "episode"
+
+
+def test_run_one_task_episode_fetch_failure_uses_complete_inline_result(tmp_path: Path):
+    suite, task = _memory_suite_and_task(tmp_path)
+    client = EpisodeClient(
+        inline_content=json.dumps(
+            {"results": [{"id": "personamem_music_expression"}]}
+        ),
+        episode_error=RuntimeError("episode unavailable"),
+    )
+
+    result = run_one_task(
+        client,
+        suite,
+        task,
+        1,
+        tmp_path / "artifacts",
+        None,
+        None,
+        "run-1",
+    )
+
+    assert result.status == "passed"
+    assert result.metrics["memory_recall_evidence_source"] == "inline"
+    assert "episode unavailable" in result.metrics["episode_error"]
+    assert not (tmp_path / "artifacts" / "episode.json").exists()
+
+
+def test_run_one_task_episode_fetch_failure_with_compressed_result_is_judge_error(
+    tmp_path: Path,
+):
+    suite, task = _memory_suite_and_task(tmp_path)
+    client = EpisodeClient(
+        inline_content="[Large tool result omitted from public history (8406 chars)]",
+        episode_error=RuntimeError("episode unavailable"),
+    )
+
+    result = run_one_task(
+        client,
+        suite,
+        task,
+        1,
+        tmp_path / "artifacts",
+        None,
+        None,
+        "run-1",
+    )
+
+    assert result.status == "judge_error"
+    assert result.metrics["memory_recall_evidence_source"] == "unavailable"
+    assert result.metrics["expected_recalled_memory_match"] is None
+    assert "episode unavailable" in result.metrics["episode_error"]
+
+
 def test_run_one_task_applies_suite_prompt_prefix(tmp_path: Path):
     suite = Suite(
         name="persona",


### PR DESCRIPTION
## Summary
- fetch task episodes only when compressed public history cannot prove expected memory recall
- prefer complete inline recall_memory evidence and disambiguate aggregate episode refs using other recall results
- preserve unavailable evidence as judge_error and cover the original PersonaMem regressions

## Testing
- uv run --group dev pytest -q
- 546 passed