### PR TITLE
fix(agent): harden Anthropic stream diagnostics

### DIFF
--- a/src/agent/internal/agent/anthropic_model.go
+++ b/src/agent/internal/agent/anthropic_model.go
@@ -28,6 +28,7 @@ const (
 	defaultAnthropicStreamRetryDelay = 2 * time.Second
 	defaultAnthropicProtocolRetries  = 1
 	anthropicDaemonRawSSELimit       = 128 * 1024
+	anthropicRawHTTPRawSSELimit      = 4 * 1024 * 1024
 )
 
 type anthropicModel struct {
@@ -783,6 +784,15 @@ type anthropicStreamFailureDiagnostic struct {
 	ContentBlocks     []anthropicStreamBlockDiagnostic `json:"content_blocks"`
 }
 
+type anthropicSSECapture struct {
+	daemon       bytes.Buffer
+	totalBytes   int
+	rawFile      *os.File
+	rawBytes     int
+	rawWriteErr  error
+	rawFileClose bool
+}
+
 var anthropicDiagnosticResponseHeaders = map[string]struct{}{
 	"anthropic-ratelimit-input-tokens-limit":      {},
 	"anthropic-ratelimit-input-tokens-remaining":  {},
@@ -807,6 +817,83 @@ var anthropicDiagnosticResponseHeaders = map[string]struct{}{
 	"x-trace-id":                                  {},
 }
 
+func newAnthropicSSECapture(rawLoggingEnabled bool) *anthropicSSECapture {
+	capture := &anthropicSSECapture{}
+	if !rawLoggingEnabled {
+		return capture
+	}
+	rawFile, err := os.CreateTemp("", "aiden-anthropic-sse-*")
+	if err != nil {
+		capture.rawWriteErr = err
+		return capture
+	}
+	capture.rawFile = rawFile
+	return capture
+}
+
+func (c *anthropicSSECapture) Write(p []byte) (int, error) {
+	if c == nil {
+		return len(p), nil
+	}
+	c.totalBytes += len(p)
+	if remaining := anthropicDaemonRawSSELimit - c.daemon.Len(); remaining > 0 {
+		if remaining > len(p) {
+			remaining = len(p)
+		}
+		_, _ = c.daemon.Write(p[:remaining])
+	}
+	if c.rawFile == nil || c.rawWriteErr != nil || c.rawBytes >= anthropicRawHTTPRawSSELimit {
+		return len(p), nil
+	}
+	rawChunk := p
+	if remaining := anthropicRawHTTPRawSSELimit - c.rawBytes; len(rawChunk) > remaining {
+		rawChunk = rawChunk[:remaining]
+	}
+	written, err := c.rawFile.Write(rawChunk)
+	c.rawBytes += written
+	if err == nil && written != len(rawChunk) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		c.rawWriteErr = err
+	}
+	return len(p), nil
+}
+
+func (c *anthropicSSECapture) daemonBytes() []byte {
+	if c == nil {
+		return nil
+	}
+	return c.daemon.Bytes()
+}
+
+func (c *anthropicSSECapture) rawHTTPBytes() ([]byte, error) {
+	if c == nil || c.rawFile == nil {
+		if c != nil && c.rawWriteErr != nil {
+			return nil, c.rawWriteErr
+		}
+		return nil, nil
+	}
+	if c.rawWriteErr != nil {
+		return nil, c.rawWriteErr
+	}
+	raw := make([]byte, c.rawBytes)
+	if _, err := c.rawFile.ReadAt(raw, 0); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func (c *anthropicSSECapture) Close() {
+	if c == nil || c.rawFile == nil || c.rawFileClose {
+		return
+	}
+	c.rawFileClose = true
+	rawPath := c.rawFile.Name()
+	_ = c.rawFile.Close()
+	_ = os.Remove(rawPath)
+}
+
 func (d *anthropicStreamFailureDiagnostic) setRawSSE(rawSSE []byte, rawSSELimit int) {
 	rawSample := rawSSE
 	truncated := false
@@ -828,6 +915,12 @@ func (d *anthropicStreamFailureDiagnostic) setRawSSE(rawSSE []byte, rawSSELimit 
 	if !rawSSEValidUTF8 {
 		d.RawSSEBase64 = base64.StdEncoding.EncodeToString(rawSample)
 	}
+}
+
+func (d *anthropicStreamFailureDiagnostic) setCapturedRawSSE(rawSSE []byte, totalBytes int) {
+	d.setRawSSE(rawSSE, -1)
+	d.RawSSETotalBytes = totalBytes
+	d.RawSSETruncated = len(rawSSE) < totalBytes
 }
 
 func normalizeAnthropicResponseHeaders(headers http.Header) map[string]string {
@@ -900,8 +993,10 @@ func firstOpenAnthropicStreamBlock(blocks map[int]*anthropicStreamBlock) (int, b
 }
 
 func (m *anthropicModel) decodeStreamingResponse(ctx context.Context, body io.Reader, responseHeaders http.Header, model string, statusCode int, callStarted time.Time, opts *llms.CallOptions, thinkingEnabled bool) (result *llms.ContentResponse, resultErr error) {
-	var raw bytes.Buffer
-	scanner := bufio.NewScanner(io.TeeReader(body, &raw))
+	rawLoggingEnabled := m.rawLogger != nil && rawHTTPLogEnabled(ctx)
+	rawCapture := newAnthropicSSECapture(rawLoggingEnabled)
+	defer rawCapture.Close()
+	scanner := bufio.NewScanner(io.TeeReader(body, rawCapture))
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	blocks := map[int]*anthropicStreamBlock{}
 	eventTypeCounts := map[string]int{}
@@ -932,12 +1027,18 @@ func (m *anthropicModel) decodeStreamingResponse(ctx context.Context, body io.Re
 			EventTypeCounts:   eventTypeCounts,
 			ContentBlocks:     anthropicStreamBlockDiagnostics(blocks),
 		}
-		failureDiagnostic.setRawSSE(raw.Bytes(), -1)
+		failureRawSSE := rawCapture.daemonBytes()
+		if rawLoggingEnabled {
+			if captured, err := rawCapture.rawHTTPBytes(); err == nil && captured != nil {
+				failureRawSSE = captured
+			}
+		}
+		failureDiagnostic.setCapturedRawSSE(failureRawSSE, rawCapture.totalBytes)
 		failureBody, _ := json.Marshal(failureDiagnostic)
 		_ = m.logRawHTTP(ctx, model, "response", logStatusCode, string(failureBody))
 		if isAnthropicStreamProtocolFailure(resultErr) {
 			daemonDiagnostic := failureDiagnostic
-			daemonDiagnostic.setRawSSE(raw.Bytes(), anthropicDaemonRawSSELimit)
+			daemonDiagnostic.setCapturedRawSSE(rawCapture.daemonBytes(), rawCapture.totalBytes)
 			daemonBody, _ := json.Marshal(daemonDiagnostic)
 			log.Printf("[ERROR] [anthropic] stream protocol failure %s", daemonBody)
 		}
@@ -1159,7 +1260,13 @@ func (m *anthropicModel) decodeStreamingResponse(ctx context.Context, body io.Re
 	if encodeErr == nil {
 		_ = m.logRawHTTP(ctx, model, "response", statusCode, string(encodedResponse))
 	} else {
-		_ = m.logRawHTTP(ctx, model, "response", statusCode, raw.String())
+		rawSSE := rawCapture.daemonBytes()
+		if rawLoggingEnabled {
+			if captured, err := rawCapture.rawHTTPBytes(); err == nil && captured != nil {
+				rawSSE = captured
+			}
+		}
+		_ = m.logRawHTTP(ctx, model, "response", statusCode, string(rawSSE))
 	}
 	generationInfo := map[string]any{}
 	if firstContent {

--- a/src/agent/internal/agent/anthropic_model.go
+++ b/src/agent/internal/agent/anthropic_model.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/tmc/langchaingo/llms"
 )
@@ -26,6 +27,7 @@ const (
 	defaultAnthropicStreamMaxRetries = 5
 	defaultAnthropicStreamRetryDelay = 2 * time.Second
 	defaultAnthropicProtocolRetries  = 1
+	anthropicDaemonRawSSELimit       = 128 * 1024
 )
 
 type anthropicModel struct {
@@ -295,7 +297,7 @@ func (m *anthropicModel) GenerateContent(ctx context.Context, messages []llms.Me
 		}
 
 		if request.Stream {
-			result, streamErr := m.decodeStreamingResponse(ctx, response.Body, request.Model, response.StatusCode, callStarted, &callOpts, request.Thinking != nil)
+			result, streamErr := m.decodeStreamingResponse(ctx, response.Body, response.Header, request.Model, response.StatusCode, callStarted, &callOpts, request.Thinking != nil)
 			response.Body.Close()
 			if streamErr == nil {
 				return result, nil
@@ -737,6 +739,7 @@ type anthropicStreamError struct {
 	err             error
 	outputDelivered bool
 	retryable       bool
+	protocol        bool
 }
 
 func (e *anthropicStreamError) Error() string {
@@ -758,7 +761,101 @@ func newAnthropicStreamProtocolError(outputDelivered bool, format string, args .
 		err:             fmt.Errorf("Anthropic stream protocol error: "+format, args...),
 		outputDelivered: outputDelivered,
 		retryable:       true,
+		protocol:        true,
 	}
+}
+
+type anthropicStreamBlockDiagnostic struct {
+	Index int    `json:"index"`
+	Type  string `json:"type"`
+}
+
+type anthropicStreamFailureDiagnostic struct {
+	StreamError       string                           `json:"stream_error"`
+	RawSSE            string                           `json:"raw_sse"`
+	RawSSETotalBytes  int                              `json:"raw_sse_total_bytes"`
+	RawSSETruncated   bool                             `json:"raw_sse_truncated"`
+	RawSSEBase64      string                           `json:"raw_sse_base64,omitempty"`
+	ResponseID        string                           `json:"response_id"`
+	UpstreamRequestID string                           `json:"upstream_request_id"`
+	ResponseHeaders   map[string]string                `json:"response_headers"`
+	EventTypeCounts   map[string]int                   `json:"event_type_counts"`
+	ContentBlocks     []anthropicStreamBlockDiagnostic `json:"content_blocks"`
+}
+
+func (d *anthropicStreamFailureDiagnostic) setRawSSE(rawSSE []byte, rawSSELimit int) {
+	rawSample := rawSSE
+	truncated := false
+	if rawSSELimit >= 0 && len(rawSample) > rawSSELimit {
+		rawSample = rawSample[:rawSSELimit]
+		truncated = true
+	}
+	rawSSEValidUTF8 := utf8.Valid(rawSSE)
+	if rawSSEValidUTF8 {
+		for len(rawSample) > 0 && !utf8.Valid(rawSample) {
+			rawSample = rawSample[:len(rawSample)-1]
+		}
+	}
+
+	d.RawSSE = string(rawSample)
+	d.RawSSETotalBytes = len(rawSSE)
+	d.RawSSETruncated = truncated
+	d.RawSSEBase64 = ""
+	if !rawSSEValidUTF8 {
+		d.RawSSEBase64 = base64.StdEncoding.EncodeToString(rawSample)
+	}
+}
+
+func normalizeAnthropicResponseHeaders(headers http.Header) map[string]string {
+	normalized := make(map[string]string, len(headers))
+	for key, values := range headers {
+		normalized[strings.ToLower(strings.TrimSpace(key))] = strings.Join(values, ", ")
+	}
+	return normalized
+}
+
+func anthropicUpstreamRequestID(headers map[string]string) string {
+	for _, key := range []string{
+		"request-id",
+		"x-request-id",
+		"anthropic-request-id",
+		"x-amzn-requestid",
+		"x-amz-request-id",
+		"x-goog-request-id",
+		"x-trace-id",
+		"trace-id",
+	} {
+		if value := strings.TrimSpace(headers[key]); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func anthropicStreamBlockDiagnostics(blocks map[int]*anthropicStreamBlock) []anthropicStreamBlockDiagnostic {
+	indexes := make([]int, 0, len(blocks))
+	for index := range blocks {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+
+	diagnostics := make([]anthropicStreamBlockDiagnostic, 0, len(indexes))
+	for _, index := range indexes {
+		diagnostics = append(diagnostics, anthropicStreamBlockDiagnostic{
+			Index: index,
+			Type:  blocks[index].Type,
+		})
+	}
+	return diagnostics
+}
+
+func isAnthropicStreamProtocolFailure(err error) bool {
+	var streamErr *anthropicStreamError
+	if errors.As(err, &streamErr) && streamErr.protocol {
+		return true
+	}
+	var responseProtocolErr *anthropicResponseProtocolError
+	return errors.As(err, &responseProtocolErr)
 }
 
 func firstOpenAnthropicStreamBlock(blocks map[int]*anthropicStreamBlock) (int, bool) {
@@ -774,14 +871,16 @@ func firstOpenAnthropicStreamBlock(blocks map[int]*anthropicStreamBlock) (int, b
 	return openIndex, found
 }
 
-func (m *anthropicModel) decodeStreamingResponse(ctx context.Context, body io.Reader, model string, statusCode int, callStarted time.Time, opts *llms.CallOptions, thinkingEnabled bool) (result *llms.ContentResponse, resultErr error) {
-	scanner := bufio.NewScanner(body)
+func (m *anthropicModel) decodeStreamingResponse(ctx context.Context, body io.Reader, responseHeaders http.Header, model string, statusCode int, callStarted time.Time, opts *llms.CallOptions, thinkingEnabled bool) (result *llms.ContentResponse, resultErr error) {
+	var raw bytes.Buffer
+	scanner := bufio.NewScanner(io.TeeReader(body, &raw))
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	blocks := map[int]*anthropicStreamBlock{}
+	eventTypeCounts := map[string]int{}
+	normalizedResponseHeaders := normalizeAnthropicResponseHeaders(responseHeaders)
 	usage := anthropicUsage{}
 	responseID := ""
 	stopReason := ""
-	var raw strings.Builder
 	firstContent := false
 	var firstContentAt int64
 	outputDelivered := false
@@ -797,16 +896,26 @@ func (m *anthropicModel) decodeStreamingResponse(ctx context.Context, body io.Re
 		if errors.As(resultErr, &statusErr) && statusErr.HTTPStatusCode() != 0 {
 			logStatusCode = statusErr.HTTPStatusCode()
 		}
-		failureBody, _ := json.Marshal(map[string]any{
-			"stream_error": resultErr.Error(),
-			"raw_sse":      raw.String(),
-		})
+		failureDiagnostic := anthropicStreamFailureDiagnostic{
+			StreamError:       resultErr.Error(),
+			ResponseID:        responseID,
+			UpstreamRequestID: anthropicUpstreamRequestID(normalizedResponseHeaders),
+			ResponseHeaders:   normalizedResponseHeaders,
+			EventTypeCounts:   eventTypeCounts,
+			ContentBlocks:     anthropicStreamBlockDiagnostics(blocks),
+		}
+		failureDiagnostic.setRawSSE(raw.Bytes(), -1)
+		failureBody, _ := json.Marshal(failureDiagnostic)
 		_ = m.logRawHTTP(ctx, model, "response", logStatusCode, string(failureBody))
+		if isAnthropicStreamProtocolFailure(resultErr) {
+			daemonDiagnostic := failureDiagnostic
+			daemonDiagnostic.setRawSSE(raw.Bytes(), anthropicDaemonRawSSELimit)
+			daemonBody, _ := json.Marshal(daemonDiagnostic)
+			log.Printf("[ERROR] [anthropic] stream protocol failure %s", daemonBody)
+		}
 	}()
 	for scanner.Scan() {
 		line := scanner.Text()
-		raw.WriteString(line)
-		raw.WriteByte('\n')
 		trimmed := strings.TrimSpace(line)
 		if !strings.HasPrefix(trimmed, "data:") {
 			continue
@@ -827,6 +936,7 @@ func (m *anthropicModel) decodeStreamingResponse(ctx context.Context, body io.Re
 		if err := json.Unmarshal([]byte(data), &event); err != nil {
 			return nil, newAnthropicStreamProtocolError(outputDelivered, "decode event: %v", err)
 		}
+		eventTypeCounts[event.Type]++
 		if messageStopped {
 			return nil, newAnthropicStreamProtocolError(outputDelivered, "event %q received after message_stop", event.Type)
 		}
@@ -903,6 +1013,10 @@ func (m *anthropicModel) decodeStreamingResponse(ctx context.Context, body io.Re
 			case "signature_delta":
 				chunk, _ := event.Delta["signature"].(string)
 				block.Signature.WriteString(chunk)
+			case "citations_delta":
+				// Citations annotate an existing text block and do not change its text content.
+			default:
+				return nil, newAnthropicStreamProtocolError(outputDelivered, "unknown content_block_delta type %q for block %d", deltaType, event.Index)
 			}
 		case "content_block_stop":
 			if !messageStarted {
@@ -949,6 +1063,8 @@ func (m *anthropicModel) decodeStreamingResponse(ctx context.Context, body io.Re
 			encoded, _ := json.Marshal(map[string]any{"error": event.Error})
 			providerErr := newProviderHTTPError(anthropicErrorHTTPStatus(event.Error), encoded)
 			return nil, &anthropicStreamError{err: providerErr, outputDelivered: outputDelivered}
+		default:
+			return nil, newAnthropicStreamProtocolError(outputDelivered, "unknown event type %q", event.Type)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -993,7 +1109,7 @@ func (m *anthropicModel) decodeStreamingResponse(ctx context.Context, body io.Re
 	encodedResponse, encodeErr := json.Marshal(response)
 	normalized, recovery, protocolErr := normalizeAnthropicResponse(response, thinkingEnabled)
 	if protocolErr != nil {
-		return nil, &anthropicStreamError{err: protocolErr, outputDelivered: outputDelivered, retryable: true}
+		return nil, &anthropicStreamError{err: protocolErr, outputDelivered: outputDelivered, retryable: true, protocol: true}
 	}
 	response = normalized
 	if recovery != "" {

--- a/src/agent/internal/agent/anthropic_model.go
+++ b/src/agent/internal/agent/anthropic_model.go
@@ -783,6 +783,30 @@ type anthropicStreamFailureDiagnostic struct {
 	ContentBlocks     []anthropicStreamBlockDiagnostic `json:"content_blocks"`
 }
 
+var anthropicDiagnosticResponseHeaders = map[string]struct{}{
+	"anthropic-ratelimit-input-tokens-limit":      {},
+	"anthropic-ratelimit-input-tokens-remaining":  {},
+	"anthropic-ratelimit-input-tokens-reset":      {},
+	"anthropic-ratelimit-output-tokens-limit":     {},
+	"anthropic-ratelimit-output-tokens-remaining": {},
+	"anthropic-ratelimit-output-tokens-reset":     {},
+	"anthropic-ratelimit-requests-limit":          {},
+	"anthropic-ratelimit-requests-remaining":      {},
+	"anthropic-ratelimit-requests-reset":          {},
+	"anthropic-ratelimit-tokens-limit":            {},
+	"anthropic-ratelimit-tokens-remaining":        {},
+	"anthropic-ratelimit-tokens-reset":            {},
+	"anthropic-request-id":                        {},
+	"request-id":                                  {},
+	"retry-after":                                 {},
+	"trace-id":                                    {},
+	"x-amz-request-id":                            {},
+	"x-amzn-requestid":                            {},
+	"x-goog-request-id":                           {},
+	"x-request-id":                                {},
+	"x-trace-id":                                  {},
+}
+
 func (d *anthropicStreamFailureDiagnostic) setRawSSE(rawSSE []byte, rawSSELimit int) {
 	rawSample := rawSSE
 	truncated := false
@@ -807,9 +831,13 @@ func (d *anthropicStreamFailureDiagnostic) setRawSSE(rawSSE []byte, rawSSELimit 
 }
 
 func normalizeAnthropicResponseHeaders(headers http.Header) map[string]string {
-	normalized := make(map[string]string, len(headers))
+	normalized := make(map[string]string)
 	for key, values := range headers {
-		normalized[strings.ToLower(strings.TrimSpace(key))] = strings.Join(values, ", ")
+		normalizedKey := strings.ToLower(strings.TrimSpace(key))
+		if _, allowed := anthropicDiagnosticResponseHeaders[normalizedKey]; !allowed {
+			continue
+		}
+		normalized[normalizedKey] = strings.Join(values, ", ")
 	}
 	return normalized
 }

--- a/src/agent/internal/agent/anthropic_model_test.go
+++ b/src/agent/internal/agent/anthropic_model_test.go
@@ -1057,6 +1057,56 @@ func TestAnthropicModelBoundsRawSSEInDaemonProtocolFailureLog(t *testing.T) {
 	}
 }
 
+func TestAnthropicSSECaptureBoundsMemoryWithoutRawLogging(t *testing.T) {
+	capture := newAnthropicSSECapture(false)
+	t.Cleanup(capture.Close)
+
+	payload := bytes.Repeat([]byte("x"), anthropicDaemonRawSSELimit*3)
+	if n, err := capture.Write(payload); err != nil || n != len(payload) {
+		t.Fatalf("capture.Write() = (%d, %v), want (%d, nil)", n, err, len(payload))
+	}
+	if got := len(capture.daemonBytes()); got != anthropicDaemonRawSSELimit {
+		t.Fatalf("daemon capture bytes = %d, want %d", got, anthropicDaemonRawSSELimit)
+	}
+	if got := capture.totalBytes; got != len(payload) {
+		t.Fatalf("total bytes = %d, want %d", got, len(payload))
+	}
+	if capture.rawFile != nil {
+		t.Fatal("raw capture file created while raw HTTP logging is disabled")
+	}
+}
+
+func TestAnthropicSSECaptureUsesBoundedFileForRawLogging(t *testing.T) {
+	capture := newAnthropicSSECapture(true)
+	if capture.rawFile == nil {
+		t.Fatal("raw capture file was not created")
+	}
+	rawPath := capture.rawFile.Name()
+	t.Cleanup(capture.Close)
+
+	payload := bytes.Repeat([]byte("x"), anthropicRawHTTPRawSSELimit+1024)
+	if n, err := capture.Write(payload); err != nil || n != len(payload) {
+		t.Fatalf("capture.Write() = (%d, %v), want (%d, nil)", n, err, len(payload))
+	}
+	if got := len(capture.daemonBytes()); got != anthropicDaemonRawSSELimit {
+		t.Fatalf("daemon capture bytes = %d, want %d", got, anthropicDaemonRawSSELimit)
+	}
+	raw, err := capture.rawHTTPBytes()
+	if err != nil {
+		t.Fatalf("rawHTTPBytes() error = %v", err)
+	}
+	if got := len(raw); got != anthropicRawHTTPRawSSELimit {
+		t.Fatalf("raw HTTP capture bytes = %d, want %d", got, anthropicRawHTTPRawSSELimit)
+	}
+	if got := capture.totalBytes; got != len(payload) {
+		t.Fatalf("total bytes = %d, want %d", got, len(payload))
+	}
+	capture.Close()
+	if _, err := os.Stat(rawPath); !os.IsNotExist(err) {
+		t.Fatalf("raw capture file still exists after Close(): %v", err)
+	}
+}
+
 func TestAnthropicModelPreservesRawSSEBytesInProtocolFailureDiagnostic(t *testing.T) {
 	rawSSE := append([]byte(
 		"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_invalid_utf8\",\"usage\":{}}}\r\n\r\n"+

--- a/src/agent/internal/agent/anthropic_model_test.go
+++ b/src/agent/internal/agent/anthropic_model_test.go
@@ -901,6 +901,9 @@ func TestAnthropicModelLogsToolUseProtocolFailureDiagnostics(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Request-Id", "req_upstream_test")
+		w.Header().Set("Anthropic-Ratelimit-Requests-Remaining", "42")
+		w.Header().Set("Authorization", "Bearer response-secret")
+		w.Header().Set("Set-Cookie", "session=response-secret")
 		_, _ = w.Write([]byte(strings.Join([]string{
 			`data: {"type":"message_start","message":{"id":"msg_missing_tool","usage":{"input_tokens":3}}}`,
 			``,
@@ -938,6 +941,15 @@ func TestAnthropicModelLogsToolUseProtocolFailureDiagnostics(t *testing.T) {
 	headers, ok := diagnostic["response_headers"].(map[string]any)
 	if !ok || headers["request-id"] != "req_upstream_test" {
 		t.Errorf("response_headers = %#v, want preserved request-id", diagnostic["response_headers"])
+	}
+	if headers["anthropic-ratelimit-requests-remaining"] != "42" {
+		t.Errorf("response_headers = %#v, want preserved rate-limit header", headers)
+	}
+	if _, ok := headers["authorization"]; ok {
+		t.Errorf("response_headers = %#v, want authorization excluded", headers)
+	}
+	if _, ok := headers["set-cookie"]; ok {
+		t.Errorf("response_headers = %#v, want set-cookie excluded", headers)
 	}
 	eventCounts, ok := diagnostic["event_type_counts"].(map[string]any)
 	if !ok || eventCounts["message_start"] != float64(1) || eventCounts["content_block_start"] != float64(1) ||

--- a/src/agent/internal/agent/anthropic_model_test.go
+++ b/src/agent/internal/agent/anthropic_model_test.go
@@ -1,9 +1,12 @@
 package agent
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -785,6 +788,344 @@ func TestAnthropicModelAcceptsMultipleMessageDeltas(t *testing.T) {
 	if got := choice.GenerationInfo["completion_tokens"]; got != 2 {
 		t.Fatalf("completion tokens = %#v, want cumulative value 2", got)
 	}
+}
+
+func TestAnthropicModelRejectsUnknownStreamingEvent(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(strings.Join([]string{
+			`data: {"type":"message_start","message":{"id":"msg_unknown_event","usage":{}}}`,
+			``,
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"ok"}}`,
+			``,
+			`data: {"type":"content_block_stop","index":0}`,
+			``,
+			`data: {"type":"relay_metadata","backend":"pool-b"}`,
+			``,
+			`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
+			``,
+			`data: {"type":"message_stop"}`,
+			``,
+		}, "\n")))
+	}))
+	defer server.Close()
+
+	model := newAnthropicModel(server.URL, "claude-test", "test-token", server.Client(), withAnthropicStreamRetry(0, 0))
+	_, err := model.GenerateContent(context.Background(), []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "hello"),
+	}, llms.WithStreamingFunc(func(context.Context, []byte) error { return nil }))
+	if err == nil || !strings.Contains(err.Error(), `unknown event type "relay_metadata"`) {
+		t.Fatalf("GenerateContent() error = %v, want explicit unknown event protocol error", err)
+	}
+}
+
+func TestAnthropicModelRejectsUnknownContentBlockDelta(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(strings.Join([]string{
+			`data: {"type":"message_start","message":{"id":"msg_unknown_delta","usage":{}}}`,
+			``,
+			`data: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":"ok"}}`,
+			``,
+			`data: {"type":"content_block_delta","index":2,"delta":{"type":"relay_text_delta","text":"ignored"}}`,
+			``,
+			`data: {"type":"content_block_stop","index":2}`,
+			``,
+			`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
+			``,
+			`data: {"type":"message_stop"}`,
+			``,
+		}, "\n")))
+	}))
+	defer server.Close()
+
+	model := newAnthropicModel(server.URL, "claude-test", "test-token", server.Client(), withAnthropicStreamRetry(0, 0))
+	_, err := model.GenerateContent(context.Background(), []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "hello"),
+	}, llms.WithStreamingFunc(func(context.Context, []byte) error { return nil }))
+	if err == nil || !strings.Contains(err.Error(), `unknown content_block_delta type "relay_text_delta" for block 2`) {
+		t.Fatalf("GenerateContent() error = %v, want explicit unknown delta protocol error", err)
+	}
+}
+
+func TestAnthropicModelAcceptsCitationsDelta(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(strings.Join([]string{
+			`data: {"type":"message_start","message":{"id":"msg_citation","usage":{}}}`,
+			``,
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			``,
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"documented answer"}}`,
+			``,
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"citations_delta","citation":{"type":"char_location","cited_text":"source","document_index":0,"document_title":"reference","start_char_index":0,"end_char_index":6}}}`,
+			``,
+			`data: {"type":"content_block_stop","index":0}`,
+			``,
+			`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
+			``,
+			`data: {"type":"message_stop"}`,
+			``,
+		}, "\n")))
+	}))
+	defer server.Close()
+
+	var streamed strings.Builder
+	model := newAnthropicModel(server.URL, "claude-test", "test-token", server.Client(), withAnthropicStreamRetry(0, 0))
+	response, err := model.GenerateContent(context.Background(), []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "hello"),
+	}, llms.WithStreamingFunc(func(_ context.Context, chunk []byte) error {
+		streamed.Write(chunk)
+		return nil
+	}))
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v, want citations_delta to be accepted", err)
+	}
+	if got := streamed.String(); got != "documented answer" {
+		t.Fatalf("streamed text = %q, want documented answer", got)
+	}
+	if got := response.Choices[0].Content; got != "documented answer" {
+		t.Fatalf("response content = %q, want documented answer", got)
+	}
+}
+
+func TestAnthropicModelLogsToolUseProtocolFailureDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Request-Id", "req_upstream_test")
+		_, _ = w.Write([]byte(strings.Join([]string{
+			`data: {"type":"message_start","message":{"id":"msg_missing_tool","usage":{"input_tokens":3}}}`,
+			``,
+			`data: {"type":"content_block_start","index":3,"content_block":{"type":"text","text":"I will use a tool."}}`,
+			``,
+			`data: {"type":"content_block_stop","index":3}`,
+			``,
+			`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":6}}`,
+			``,
+			`data: {"type":"message_stop"}`,
+			``,
+		}, "\n")))
+	}))
+	defer server.Close()
+
+	logDir := t.TempDir()
+	model := newAnthropicModel(server.URL, "claude-test", "test-token", server.Client(),
+		withAnthropicRawHTTPLogger(newTestLLMRawHTTPLogger(logDir, "test-session")),
+		withAnthropicProtocolRetry(0, 0),
+	)
+	_, err := model.GenerateContent(contextWithRawHTTPLog(context.Background()), []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "hello"),
+	}, llms.WithStreamingFunc(func(context.Context, []byte) error { return nil }))
+	if err == nil || !strings.Contains(err.Error(), "tool_use stop_reason has no valid tool_use content") {
+		t.Fatalf("GenerateContent() error = %v, want missing tool_use protocol error", err)
+	}
+
+	diagnostic := anthropicRawHTTPResponseDiagnostic(t, readRawHTTPLog(t, logDir))
+	if got := diagnostic["response_id"]; got != "msg_missing_tool" {
+		t.Errorf("response_id = %#v, want msg_missing_tool", got)
+	}
+	if got := diagnostic["upstream_request_id"]; got != "req_upstream_test" {
+		t.Errorf("upstream_request_id = %#v, want req_upstream_test", got)
+	}
+	headers, ok := diagnostic["response_headers"].(map[string]any)
+	if !ok || headers["request-id"] != "req_upstream_test" {
+		t.Errorf("response_headers = %#v, want preserved request-id", diagnostic["response_headers"])
+	}
+	eventCounts, ok := diagnostic["event_type_counts"].(map[string]any)
+	if !ok || eventCounts["message_start"] != float64(1) || eventCounts["content_block_start"] != float64(1) ||
+		eventCounts["content_block_stop"] != float64(1) || eventCounts["message_delta"] != float64(1) ||
+		eventCounts["message_stop"] != float64(1) {
+		t.Errorf("event_type_counts = %#v, want a count for every received event type", diagnostic["event_type_counts"])
+	}
+	blocks, ok := diagnostic["content_blocks"].([]any)
+	if !ok || len(blocks) != 1 {
+		t.Fatalf("content_blocks = %#v, want one block summary", diagnostic["content_blocks"])
+	}
+	block, ok := blocks[0].(map[string]any)
+	if !ok || block["index"] != float64(3) || block["type"] != "text" {
+		t.Errorf("content block summary = %#v, want index 3 type text", blocks[0])
+	}
+}
+
+func TestAnthropicModelLogsProtocolFailureToDaemonLogWithoutRawLogger(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Request-Id", "req_daemon_log")
+		_, _ = w.Write([]byte(strings.Join([]string{
+			`data: {"type":"message_start","message":{"id":"msg_daemon_log","usage":{}}}`,
+			``,
+			`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}`,
+			``,
+			`data: {"type":"message_stop"}`,
+			``,
+		}, "\n")))
+	}))
+	defer server.Close()
+
+	var daemonLog bytes.Buffer
+	originalOutput := log.Writer()
+	log.SetOutput(&daemonLog)
+	t.Cleanup(func() { log.SetOutput(originalOutput) })
+
+	model := newAnthropicModel(server.URL, "claude-test", "test-token", server.Client(),
+		withAnthropicProtocolRetry(0, 0),
+	)
+	_, err := model.GenerateContent(context.Background(), []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "hello"),
+	}, llms.WithStreamingFunc(func(context.Context, []byte) error { return nil }))
+	if err == nil || !strings.Contains(err.Error(), "tool_use stop_reason has no valid tool_use content") {
+		t.Fatalf("GenerateContent() error = %v, want missing tool_use protocol error", err)
+	}
+
+	logged := daemonLog.String()
+	for _, want := range []string{
+		`[ERROR] [anthropic] stream protocol failure`,
+		`"response_id":"msg_daemon_log"`,
+		`"upstream_request_id":"req_daemon_log"`,
+		`"raw_sse":`,
+	} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("daemon log missing %q:\n%s", want, logged)
+		}
+	}
+}
+
+func TestAnthropicModelBoundsRawSSEInDaemonProtocolFailureLog(t *testing.T) {
+	const paddingSize = 512 * 1024
+	padding := strings.Repeat("x", paddingSize)
+	rawSSE := strings.Join([]string{
+		`data: {"type":"message_start","message":{"id":"msg_large_daemon_log","usage":{}}}`,
+		``,
+		`: ` + padding,
+		``,
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}`,
+		``,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(rawSSE))
+	}))
+	defer server.Close()
+
+	var daemonLog bytes.Buffer
+	originalOutput := log.Writer()
+	log.SetOutput(&daemonLog)
+	t.Cleanup(func() { log.SetOutput(originalOutput) })
+
+	model := newAnthropicModel(server.URL, "claude-test", "test-token", server.Client(),
+		withAnthropicProtocolRetry(0, 0),
+	)
+	_, err := model.GenerateContent(context.Background(), []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "hello"),
+	}, llms.WithStreamingFunc(func(context.Context, []byte) error { return nil }))
+	if err == nil || !strings.Contains(err.Error(), "tool_use stop_reason has no valid tool_use content") {
+		t.Fatalf("GenerateContent() error = %v, want missing tool_use protocol error", err)
+	}
+
+	diagnostic := anthropicDaemonProtocolFailureDiagnostic(t, daemonLog.String())
+	if got := diagnostic["raw_sse_total_bytes"]; got != float64(len(rawSSE)) {
+		t.Errorf("raw_sse_total_bytes = %#v, want %d", got, len(rawSSE))
+	}
+	if got := diagnostic["raw_sse_truncated"]; got != true {
+		t.Errorf("raw_sse_truncated = %#v, want true", got)
+	}
+	if got := len(daemonLog.String()); got >= paddingSize/2 {
+		t.Errorf("daemon protocol failure log is %d bytes for a %d-byte stream; want a fixed-size diagnostic cap", got, len(rawSSE))
+	}
+}
+
+func TestAnthropicModelPreservesRawSSEBytesInProtocolFailureDiagnostic(t *testing.T) {
+	rawSSE := append([]byte(
+		"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_invalid_utf8\",\"usage\":{}}}\r\n\r\n"+
+			"data: ",
+	), 0xff, 0xfe)
+	rawSSE = append(rawSSE, []byte("\r\n\r\n")...)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write(rawSSE)
+	}))
+	defer server.Close()
+
+	logDir := t.TempDir()
+	model := newAnthropicModel(server.URL, "claude-test", "test-token", server.Client(),
+		withAnthropicRawHTTPLogger(newTestLLMRawHTTPLogger(logDir, "test-session")),
+		withAnthropicStreamRetry(0, 0),
+	)
+	_, err := model.GenerateContent(contextWithRawHTTPLog(context.Background()), []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "hello"),
+	}, llms.WithStreamingFunc(func(context.Context, []byte) error { return nil }))
+	if err == nil || !strings.Contains(err.Error(), "decode event") {
+		t.Fatalf("GenerateContent() error = %v, want invalid event protocol error", err)
+	}
+
+	diagnostic := anthropicRawHTTPResponseDiagnostic(t, readRawHTTPLog(t, logDir))
+	encoded, ok := diagnostic["raw_sse_base64"].(string)
+	if !ok || encoded == "" {
+		t.Fatalf("raw_sse_base64 = %#v, want lossless raw SSE bytes", diagnostic["raw_sse_base64"])
+	}
+	decoded, decodeErr := base64.StdEncoding.DecodeString(encoded)
+	if decodeErr != nil {
+		t.Fatalf("decode raw_sse_base64: %v", decodeErr)
+	}
+	if !bytes.Equal(decoded, rawSSE) {
+		t.Fatalf("decoded raw SSE bytes differ:\n got %q\nwant %q", decoded, rawSSE)
+	}
+	if got := diagnostic["raw_sse_total_bytes"]; got != float64(len(rawSSE)) {
+		t.Errorf("raw_sse_total_bytes = %#v, want %d", got, len(rawSSE))
+	}
+	if got := diagnostic["raw_sse_truncated"]; got != false {
+		t.Errorf("raw_sse_truncated = %#v, want false", got)
+	}
+}
+
+func anthropicDaemonProtocolFailureDiagnostic(t *testing.T, logText string) map[string]any {
+	t.Helper()
+	const marker = "[ERROR] [anthropic] stream protocol failure "
+	markerIndex := strings.Index(logText, marker)
+	if markerIndex < 0 {
+		t.Fatalf("daemon log has no Anthropic protocol failure diagnostic:\n%s", logText)
+	}
+	encoded := strings.TrimSpace(logText[markerIndex+len(marker):])
+	var diagnostic map[string]any
+	if err := json.Unmarshal([]byte(encoded), &diagnostic); err != nil {
+		t.Fatalf("decode daemon protocol failure diagnostic: %v\n%s", err, encoded)
+	}
+	return diagnostic
+}
+
+func anthropicRawHTTPResponseDiagnostic(t *testing.T, logText string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(logText), "\n") {
+		var entry struct {
+			Kind string `json:"kind"`
+			Body string `json:"body"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("decode raw HTTP log entry: %v\n%s", err, line)
+		}
+		if entry.Kind != "response" {
+			continue
+		}
+		var diagnostic map[string]any
+		if err := json.Unmarshal([]byte(entry.Body), &diagnostic); err != nil {
+			t.Fatalf("decode Anthropic response diagnostic: %v\n%s", err, entry.Body)
+		}
+		return diagnostic
+	}
+	t.Fatal("raw HTTP log has no response entry")
+	return nil
 }
 
 func TestAnthropicModelLogsResponseOnEarlyStreamFailure(t *testing.T) {


### PR DESCRIPTION
## Summary

- persist structured Anthropic stream failure diagnostics with response IDs, upstream request IDs, response headers, event counts, content block summaries, and raw SSE evidence
- reject unknown stream events and delta types instead of silently ignoring protocol drift
- preserve malformed UTF-8 bytes through Base64 and bound daemon-log SSE samples to 128 KiB
- accept the standard Anthropic `citations_delta` event without altering text output

## Behavior

- full captured SSE remains available through the raw HTTP logger
- protocol failures are also written to the daemon log so benchmark workers retain evidence when storage-gated raw logging is unavailable
- provider, transport, and streaming callback failures are not mislabeled as protocol failures
- retry behavior is unchanged and no non-stream fallback is added

## Tests

- `go test ./internal/agent -run Anthropic -count=1`
- `go test ./internal/agent -count=1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Anthropic streaming responses, including citation updates and unexpected event formats.
  * Streaming failures are now identified more accurately, supporting more appropriate retry behavior.
  * Added safeguards to preserve and report useful details when responses contain malformed or invalid data.

* **Diagnostics**
  * Enhanced error reporting for interrupted or invalid streams, including bounded response details and protocol information to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->