### PR TITLE
fix(benchmark): align static perception with device workflow

### DIFF
--- a/benchmark/runner/agent_client.py
+++ b/benchmark/runner/agent_client.py
@@ -164,7 +164,7 @@ class AgentClient:
         self,
         message: str,
         timeout_sec: int | None = None,
-        attachments: list[dict[str, str]] | None = None,
+        attachments: list[dict[str, Any]] | None = None,
         skills: list[str] | None = None,
     ) -> ChatResponse:
         payload: dict[str, Any] = {"message": message}

--- a/benchmark/runner/main.py
+++ b/benchmark/runner/main.py
@@ -1085,6 +1085,7 @@ def _serialize_mock_environment(spec) -> dict[str, object] | None:
         return None
     return {
         "platform": spec.platform,
+        "single_frame": spec.single_frame,
         "phone_bridge": dict(spec.phone_bridge),
         "tools": sorted(spec.tools),
         "screen": spec.screen,

--- a/benchmark/runner/runtask.py
+++ b/benchmark/runner/runtask.py
@@ -6,6 +6,9 @@ import shutil
 import time
 from pathlib import Path
 from typing import Any
+
+from PIL import Image
+
 from runner.agent_client import AgentClient, AgentRequestError, AgentTimeoutError
 from runner.assertions import (
     evaluate_expected_answer,
@@ -18,7 +21,7 @@ from runner.judge import judge_task, JudgeConfig
 from runner.models import HardAssertionFailure, HardAssertionResults, RubricVerdict, TaskResult
 from runner.recovery import prepare_task_isolation, recover_agent_after_timeout
 from runner.reset import ResetError
-from runner.suite import Suite, TaskSpec
+from runner.suite import Suite, TaskSpec, effective_mock_environment
 from runner.trace import extract_trace
 from runner.report import now_iso
 
@@ -286,18 +289,53 @@ def run_one_task(
         base.finished_at = now_iso()
         return base
     pre_path = artifact_dir / "pre.jpg"
-    # Resolve input_screenshot: use static image as pre and send as attachment
     attachments = None
-    if task.input_screenshot:
-        screenshot_path = suite.source_path.parent / task.input_screenshot
-        if not screenshot_path.exists():
-            base.status = "skipped"
-            base.metrics = {"error": f"input_screenshot not found: {screenshot_path}"}
-            base.finished_at = now_iso()
-            return base
-        shutil.copy(screenshot_path, pre_path)
-        img_b64 = base64.b64encode(screenshot_path.read_bytes()).decode("ascii")
-        attachments = [{"kind": "image", "mime_type": "image/jpeg", "data": img_b64}]
+    input_screenshot_path = (
+        suite.source_path.parent / task.input_screenshot
+        if task.input_screenshot
+        else None
+    )
+    if input_screenshot_path is not None and not input_screenshot_path.exists():
+        base.status = "skipped"
+        base.metrics = {
+            "error": f"input_screenshot not found: {input_screenshot_path}"
+        }
+        base.finished_at = now_iso()
+        return base
+    mock_environment = effective_mock_environment(suite, task)
+    uses_single_frame_mock = bool(
+        mock_environment is not None and mock_environment.single_frame
+    )
+    if uses_single_frame_mock:
+        if environment_url:
+            try:
+                take_environment_screenshot(
+                    environment_url,
+                    pre_path,
+                    benchmark_task_id=benchmark_task_id,
+                )
+            except Exception as e:
+                base.metrics["pre_screenshot_error"] = str(e)[:300]
+        else:
+            base.metrics["pre_screenshot_error"] = (
+                "environment_url is required for mock screenshot capture"
+            )
+        if not pre_path.exists() and input_screenshot_path is not None:
+            shutil.copy(input_screenshot_path, pre_path)
+    elif input_screenshot_path is not None:
+        shutil.copy(input_screenshot_path, pre_path)
+        img_b64 = base64.b64encode(input_screenshot_path.read_bytes()).decode("ascii")
+        with Image.open(input_screenshot_path) as image:
+            width, height = image.size
+        attachments = [
+            {
+                "kind": "image",
+                "mime_type": "image/jpeg",
+                "width": width,
+                "height": height,
+                "data": img_b64,
+            }
+        ]
     else:
         if environment_url:
             try:
@@ -359,7 +397,9 @@ def run_one_task(
     # The agent history no longer embeds base64 image data, so the post-screenshot
     # must be grabbed live rather than extracted from history.
     post_path = artifact_dir / "post.jpg"
-    if environment_url:
+    if uses_single_frame_mock:
+        post_path = None
+    elif environment_url:
         try:
             take_environment_screenshot(
                 environment_url,

--- a/benchmark/runner/suite.py
+++ b/benchmark/runner/suite.py
@@ -60,6 +60,7 @@ class MockEnvironmentSpec:
     platform: TargetPlatform
     phone_bridge: dict[str, Any]
     tools: dict[str, list[MockToolResponseSpec]]
+    single_frame: bool = False
     screen: str | None = None
     screen_text: str = ""
     default_tool_response: MockToolResponseSpec | None = None
@@ -360,6 +361,9 @@ def _parse_mock_environment(
         return None
     if not isinstance(raw, dict):
         raise SuiteValidationError(f"{path} must be an object")
+    single_frame = raw.get("single_frame", False)
+    if not isinstance(single_frame, bool):
+        raise SuiteValidationError(f"{path}.single_frame must be boolean")
     phone_bridge = raw.get("phone_bridge") or {}
     if not isinstance(phone_bridge, dict):
         raise SuiteValidationError(f"{path}.phone_bridge must be an object")
@@ -444,6 +448,7 @@ def _parse_mock_environment(
         platform=platform,
         phone_bridge=phone_bridge,
         tools=tools,
+        single_frame=single_frame,
         screen=screen.strip() if isinstance(screen, str) else None,
         screen_text=screen_text,
         default_tool_response=default_response,

--- a/benchmark/suites/perception/perception_v1.json
+++ b/benchmark/suites/perception/perception_v1.json
@@ -2,7 +2,7 @@
   "name": "perception_v1",
   "suite_category": "Perception & Control",
   "global_reset": {},
-  "prompt_prefix": "This is an offline single-frame static perception task. Call screenshot once to observe the fixture. Use the returned width and height to convert pixel positions to normalized 0-1000 coordinates, then issue one touch_gesture. There is no post-action state, so after a successful touch do not retry or verify.",
+  "prompt_prefix": "This is an offline single-frame static perception task.",
   "tasks": [
     {
       "id": "find_settings_iphone",

--- a/benchmark/suites/perception/perception_v1.json
+++ b/benchmark/suites/perception/perception_v1.json
@@ -2,12 +2,24 @@
   "name": "perception_v1",
   "suite_category": "Perception & Control",
   "global_reset": {},
+  "prompt_prefix": "This is an offline single-frame static perception task. Call screenshot once to observe the fixture. Use the returned width and height to convert pixel positions to normalized 0-1000 coordinates, then issue one touch_gesture. There is no post-action state, so after a successful touch do not retry or verify.",
   "tasks": [
     {
       "id": "find_settings_iphone",
       "category": "perception",
       "input_screenshot": "screenshots/home_iphone.jpg",
-      "prompt": "请打开设置 app。",
+      "mock_environment": {
+        "platform": "ios",
+        "single_frame": true,
+        "phone_bridge": {},
+        "screen": "screenshots/home_iphone.jpg",
+        "tools": {
+          "touch_gesture": {
+            "output": {"ok": true}
+          }
+        }
+      },
+      "prompt": "请点击屏幕上的设置图标。",
       "description_for_judge": "Agent should identify the Settings (设置) app icon on the iPhone home screen and call touch_gesture with coordinates targeting it.",
       "rubric": [
         {
@@ -41,6 +53,17 @@
       },
       "id": "x_327",
       "input_screenshot": "screenshots/x_327.jpg",
+      "mock_environment": {
+        "platform": "ios",
+        "single_frame": true,
+        "phone_bridge": {},
+        "screen": "screenshots/x_327.jpg",
+        "tools": {
+          "touch_gesture": {
+            "output": {"ok": true}
+          }
+        }
+      },
       "prompt": "关闭广告",
       "rubric": [
         {
@@ -64,6 +87,17 @@
       },
       "id": "task_386",
       "input_screenshot": "screenshots/task_386.jpg",
+      "mock_environment": {
+        "platform": "ios",
+        "single_frame": true,
+        "phone_bridge": {},
+        "screen": "screenshots/task_386.jpg",
+        "tools": {
+          "touch_gesture": {
+            "output": {"ok": true}
+          }
+        }
+      },
       "prompt": "打开右上角的聊天详情",
       "rubric": [
         {
@@ -87,6 +121,17 @@
       },
       "id": "task_4450",
       "input_screenshot": "screenshots/task_4450.jpg",
+      "mock_environment": {
+        "platform": "ios",
+        "single_frame": true,
+        "phone_bridge": {},
+        "screen": "screenshots/task_4450.jpg",
+        "tools": {
+          "touch_gesture": {
+            "output": {"ok": true}
+          }
+        }
+      },
       "prompt": "点击刷新页面按钮",
       "rubric": [
         {
@@ -110,6 +155,17 @@
       },
       "id": "task_4606",
       "input_screenshot": "screenshots/task_4606.jpg",
+      "mock_environment": {
+        "platform": "ios",
+        "single_frame": true,
+        "phone_bridge": {},
+        "screen": "screenshots/task_4606.jpg",
+        "tools": {
+          "touch_gesture": {
+            "output": {"ok": true}
+          }
+        }
+      },
       "prompt": "点击“从相册选择”",
       "rubric": [
         {
@@ -133,6 +189,17 @@
       },
       "id": "task_4657",
       "input_screenshot": "screenshots/task_4657.jpg",
+      "mock_environment": {
+        "platform": "ios",
+        "single_frame": true,
+        "phone_bridge": {},
+        "screen": "screenshots/task_4657.jpg",
+        "tools": {
+          "touch_gesture": {
+            "output": {"ok": true}
+          }
+        }
+      },
       "prompt": "点击查找",
       "rubric": [
         {
@@ -156,6 +223,17 @@
       },
       "id": "task_4724",
       "input_screenshot": "screenshots/task_4724.jpg",
+      "mock_environment": {
+        "platform": "ios",
+        "single_frame": true,
+        "phone_bridge": {},
+        "screen": "screenshots/task_4724.jpg",
+        "tools": {
+          "touch_gesture": {
+            "output": {"ok": true}
+          }
+        }
+      },
       "prompt": "点击屏幕右上角的扫一扫图标。",
       "rubric": [
         {
@@ -179,6 +257,17 @@
       },
       "id": "task_4762",
       "input_screenshot": "screenshots/task_4762.jpg",
+      "mock_environment": {
+        "platform": "ios",
+        "single_frame": true,
+        "phone_bridge": {},
+        "screen": "screenshots/task_4762.jpg",
+        "tools": {
+          "touch_gesture": {
+            "output": {"ok": true}
+          }
+        }
+      },
       "prompt": "关闭广告",
       "rubric": [
         {
@@ -202,6 +291,17 @@
       },
       "id": "task_5022",
       "input_screenshot": "screenshots/task_5022.jpg",
+      "mock_environment": {
+        "platform": "ios",
+        "single_frame": true,
+        "phone_bridge": {},
+        "screen": "screenshots/task_5022.jpg",
+        "tools": {
+          "touch_gesture": {
+            "output": {"ok": true}
+          }
+        }
+      },
       "prompt": "点击屏幕右上角的更多聊天详情按钮",
       "rubric": [
         {
@@ -225,6 +325,17 @@
       },
       "id": "task_5097",
       "input_screenshot": "screenshots/task_5097.jpg",
+      "mock_environment": {
+        "platform": "ios",
+        "single_frame": true,
+        "phone_bridge": {},
+        "screen": "screenshots/task_5097.jpg",
+        "tools": {
+          "touch_gesture": {
+            "output": {"ok": true}
+          }
+        }
+      },
       "prompt": "选中第一幅图",
       "rubric": [
         {
@@ -248,6 +359,17 @@
       },
       "id": "task_5081",
       "input_screenshot": "screenshots/task_5081.jpg",
+      "mock_environment": {
+        "platform": "ios",
+        "single_frame": true,
+        "phone_bridge": {},
+        "screen": "screenshots/task_5081.jpg",
+        "tools": {
+          "touch_gesture": {
+            "output": {"ok": true}
+          }
+        }
+      },
       "prompt": "点击跳过广告",
       "rubric": [
         {
@@ -271,6 +393,17 @@
       },
       "id": "task_5174",
       "input_screenshot": "screenshots/task_5174.jpg",
+      "mock_environment": {
+        "platform": "ios",
+        "single_frame": true,
+        "phone_bridge": {},
+        "screen": "screenshots/task_5174.jpg",
+        "tools": {
+          "touch_gesture": {
+            "output": {"ok": true}
+          }
+        }
+      },
       "prompt": "关闭通知弹框",
       "rubric": [
         {

--- a/benchmark/tests/test_main.py
+++ b/benchmark/tests/test_main.py
@@ -1135,6 +1135,7 @@ def test_auto_agent_setup_starts_mock_environment_and_injects_phone_state(
     assert mock_spec["phone_bridge"] == {
         key: value for key, value in phone_state.items() if key != "platform"
     }
+    assert mock_spec["single_frame"] is False
     assert manifest["environment_url"].endswith("/_aiden_mock/REDACTED")
     assert manifest["target_platform"] == "ios"
 

--- a/benchmark/tests/test_mock_environment.py
+++ b/benchmark/tests/test_mock_environment.py
@@ -142,6 +142,45 @@ def test_mock_environment_returns_scripted_tool_result_and_updates_screen():
         server.stop()
 
 
+def test_perception_mock_environment_exposes_fixture_and_accepts_tap():
+    suite_path = (
+        Path(__file__).resolve().parents[1]
+        / "suites"
+        / "perception"
+        / "perception_v1.json"
+    )
+    suite = load_suite(suite_path)
+    task = next(task for task in suite.tasks if task.id == "task_4657")
+    assert task.mock_environment is not None
+    server = MockEnvironmentServer(task.mock_environment, suite_path.parent)
+    base_url = server.start()
+    try:
+        before = _json_request(
+            f"{base_url}/api/providers/screenshot",
+            "POST",
+            {"format": "jpeg", "quality": 80},
+        )
+        before_meta = before["data"]["meta"]
+        assert (before_meta["width"], before_meta["height"]) == (447, 972)
+        before_image = base64.b64decode(before["data"]["image"])
+
+        tap = _json_request(
+            f"{base_url}/api/tools/touch_gesture",
+            "POST",
+            {
+                "input": json.dumps(
+                    {"type": "tap", "point": {"x": 940, "y": 95}}
+                )
+            },
+        )
+        assert tap["is_error"] is False
+        assert json.loads(tap["output"]) == {"ok": True}
+
+        assert before_image
+    finally:
+        server.stop()
+
+
 def test_mock_environment_requires_visible_icon_click_before_text_entry():
     suite_path, spec = _task_mock_environment(
         "notes_entry_policy_v1.json",

--- a/benchmark/tests/test_runtask.py
+++ b/benchmark/tests/test_runtask.py
@@ -1,11 +1,20 @@
 import json
 from pathlib import Path
 
+from PIL import Image
+
 from runner.agent_client import AgentTimeoutError, ChatResponse
 from runner.judge import JudgeConfig, JudgeOutput
 from runner.models import RubricVerdict
 from runner.runtask import run_one_task
-from runner.suite import HardAssertions, RubricItem, Suite, TaskSpec, TraceObservationSpec
+from runner.suite import (
+    HardAssertions,
+    MockEnvironmentSpec,
+    RubricItem,
+    Suite,
+    TaskSpec,
+    TraceObservationSpec,
+)
 import runner.runtask as runtask_mod
 
 
@@ -13,6 +22,7 @@ class FakeClient:
     def __init__(self, response="ok"):
         self.response = response
         self.messages = []
+        self.attachments = []
         self.skill_requests = []
 
     def health(self):
@@ -29,11 +39,231 @@ class FakeClient:
 
     def chat(self, message, timeout_sec=None, attachments=None, skills=None):
         self.messages.append(message)
+        self.attachments.append(attachments)
         self.skill_requests.append(list(skills or []))
         return ChatResponse(
             response=self.response,
             history=[{"type": "assistant", "content": self.response}],
         )
+
+
+def test_run_one_task_includes_static_screenshot_dimensions(tmp_path: Path):
+    screenshot_dir = tmp_path / "screenshots"
+    screenshot_dir.mkdir()
+    screenshot_path = screenshot_dir / "screen.jpg"
+    Image.new("RGB", (37, 91), "white").save(screenshot_path, format="JPEG")
+
+    suite = Suite(
+        name="perception",
+        global_reset={},
+        tasks=[],
+        sha256="sha",
+        source_path=tmp_path / "suite.json",
+    )
+    task = TaskSpec(
+        id="tap_target",
+        category="perception",
+        description_for_judge="Tap the target.",
+        prompt="tap the target",
+        rubric=[],
+        hard_assertions=HardAssertions(min_tool_calls=0, max_tool_calls=0),
+        input_screenshot="screenshots/screen.jpg",
+    )
+    client = FakeClient("done")
+
+    result = run_one_task(
+        client, suite, task, 1, tmp_path / "artifacts", None, None, "run-1"
+    )
+
+    assert result.status == "passed"
+    assert client.attachments[0] is not None
+    attachment = client.attachments[0][0]
+    assert attachment["width"] == 37
+    assert attachment["height"] == 91
+
+
+def test_run_one_task_uses_mock_screenshot_without_static_attachment(
+    tmp_path: Path,
+    monkeypatch,
+):
+    screenshot_dir = tmp_path / "screenshots"
+    screenshot_dir.mkdir()
+    fixture_path = screenshot_dir / "fixture.jpg"
+    Image.new("RGB", (37, 91), "white").save(fixture_path, format="JPEG")
+    suite = Suite(
+        name="perception",
+        global_reset={},
+        tasks=[],
+        sha256="sha",
+        source_path=tmp_path / "suite.json",
+    )
+    task = TaskSpec(
+        id="tap_target",
+        category="perception",
+        description_for_judge="Tap the target.",
+        prompt="tap the target",
+        rubric=[],
+        hard_assertions=HardAssertions(min_tool_calls=0, max_tool_calls=0),
+        input_screenshot="screenshots/fixture.jpg",
+        mock_environment=MockEnvironmentSpec(
+            platform="ios",
+            phone_bridge={},
+            tools={},
+            screen="screenshots/fixture.jpg",
+            single_frame=True,
+        ),
+    )
+    capture_calls = []
+
+    def capture_fixture(environment_url, out_path, benchmark_task_id=None):
+        capture_calls.append((environment_url, benchmark_task_id))
+        out_path.write_bytes(fixture_path.read_bytes())
+        return 37, 91
+
+    monkeypatch.setattr(runtask_mod, "take_environment_screenshot", capture_fixture)
+    client = FakeClient("done")
+    artifact_dir = tmp_path / "artifacts"
+
+    result = run_one_task(
+        client,
+        suite,
+        task,
+        1,
+        artifact_dir,
+        None,
+        None,
+        "run-1",
+        environment_url="http://mock-environment.test",
+    )
+
+    assert result.status == "passed"
+    assert client.attachments == [None]
+    assert capture_calls == [("http://mock-environment.test", None)]
+    with Image.open(artifact_dir / "pre.jpg") as image:
+        assert image.size == (37, 91)
+    assert not (artifact_dir / "post.jpg").exists()
+
+
+def test_run_one_task_falls_back_to_fixture_for_mock_pre_artifact(
+    tmp_path: Path,
+    monkeypatch,
+):
+    screenshot_dir = tmp_path / "screenshots"
+    screenshot_dir.mkdir()
+    fixture_path = screenshot_dir / "fixture.jpg"
+    Image.new("RGB", (37, 91), "white").save(fixture_path, format="JPEG")
+    suite = Suite(
+        name="perception",
+        global_reset={},
+        tasks=[],
+        sha256="sha",
+        source_path=tmp_path / "suite.json",
+    )
+    task = TaskSpec(
+        id="tap_target",
+        category="perception",
+        description_for_judge="Tap the target.",
+        prompt="tap the target",
+        rubric=[],
+        hard_assertions=HardAssertions(min_tool_calls=0, max_tool_calls=0),
+        input_screenshot="screenshots/fixture.jpg",
+        mock_environment=MockEnvironmentSpec(
+            platform="ios",
+            phone_bridge={},
+            tools={},
+            screen="screenshots/fixture.jpg",
+            single_frame=True,
+        ),
+    )
+
+    def fail_capture(*args, **kwargs):
+        raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr(runtask_mod, "take_environment_screenshot", fail_capture)
+    client = FakeClient("done")
+    artifact_dir = tmp_path / "artifacts"
+
+    result = run_one_task(
+        client,
+        suite,
+        task,
+        1,
+        artifact_dir,
+        None,
+        None,
+        "run-1",
+        environment_url="http://mock-environment.test",
+    )
+
+    assert result.status == "passed"
+    assert client.attachments == [None]
+    assert result.metrics["pre_screenshot_error"] == "provider unavailable"
+    assert (artifact_dir / "pre.jpg").read_bytes() == fixture_path.read_bytes()
+    assert not (artifact_dir / "post.jpg").exists()
+
+
+def test_run_one_task_keeps_dynamic_mock_screenshot_attachment_and_post_artifact(
+    tmp_path: Path,
+    monkeypatch,
+):
+    screenshot_dir = tmp_path / "screenshots"
+    screenshot_dir.mkdir()
+    fixture_path = screenshot_dir / "fixture.jpg"
+    Image.new("RGB", (37, 91), "white").save(fixture_path, format="JPEG")
+    suite = Suite(
+        name="dynamic-mock",
+        global_reset={},
+        tasks=[],
+        sha256="sha",
+        source_path=tmp_path / "suite.json",
+    )
+    task = TaskSpec(
+        id="tap_target",
+        category="perception",
+        description_for_judge="Tap the target.",
+        prompt="tap the target",
+        rubric=[],
+        hard_assertions=HardAssertions(min_tool_calls=0, max_tool_calls=0),
+        input_screenshot="screenshots/fixture.jpg",
+        mock_environment=MockEnvironmentSpec(
+            platform="ios",
+            phone_bridge={},
+            tools={},
+            screen="screenshots/fixture.jpg",
+        ),
+    )
+    capture_calls = []
+
+    def capture_post(environment_url, out_path, benchmark_task_id=None):
+        capture_calls.append((environment_url, out_path.name, benchmark_task_id))
+        Image.new("RGB", (37, 91), "black").save(out_path, format="JPEG")
+        return 37, 91
+
+    monkeypatch.setattr(runtask_mod, "take_environment_screenshot", capture_post)
+    client = FakeClient("done")
+    artifact_dir = tmp_path / "artifacts"
+
+    result = run_one_task(
+        client,
+        suite,
+        task,
+        1,
+        artifact_dir,
+        None,
+        None,
+        "run-1",
+        environment_url="http://mock-environment.test",
+    )
+
+    assert result.status == "passed"
+    attachment = client.attachments[0][0]
+    assert attachment["width"] == 37
+    assert attachment["height"] == 91
+    assert capture_calls == [
+        ("http://mock-environment.test", "post.jpg", None),
+    ]
+    assert (artifact_dir / "pre.jpg").read_bytes() == fixture_path.read_bytes()
+    assert (artifact_dir / "post.jpg").exists()
 
 
 def test_run_one_task_passes_without_judge_when_hard_assertions_pass(tmp_path: Path):

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -41,6 +41,56 @@ def test_perception_v1_settings_rubric_uses_0_1000_normalized_coordinates():
     assert "y in [441, 560]" in check
     assert "[0.75, 0.98]" not in check
 
+
+def test_perception_v1_uses_fixture_backed_mock_environment_for_every_task():
+    suite_path = (
+        Path(__file__).resolve().parents[1]
+        / "suites"
+        / "perception"
+        / "perception_v1.json"
+    )
+    suite = load_suite(suite_path)
+
+    assert suite.mock_environment is None
+    assert suite.tasks
+    for task in suite.tasks:
+        assert task.input_screenshot
+        assert task.mock_environment is not None
+        assert task.mock_environment.platform is TargetPlatform.IOS
+        assert task.mock_environment.single_frame is True
+        assert task.mock_environment.screen == task.input_screenshot
+        assert task.mock_environment.phone_bridge == {}
+        responses = task.mock_environment.tools["touch_gesture"]
+        assert len(responses) == 1
+        assert responses[0].output == {"ok": True}
+        assert responses[0].is_error is False
+
+
+def test_perception_v1_declares_single_frame_screenshot_contract():
+    suite_path = (
+        Path(__file__).resolve().parents[1]
+        / "suites"
+        / "perception"
+        / "perception_v1.json"
+    )
+    suite = load_suite(suite_path)
+
+    assert suite.prompt_prefix.strip()
+
+
+def test_perception_v1_settings_prompt_requires_clicking_visible_icon():
+    suite_path = (
+        Path(__file__).resolve().parents[1]
+        / "suites"
+        / "perception"
+        / "perception_v1.json"
+    )
+    suite = load_suite(suite_path)
+
+    task = next(task for task in suite.tasks if task.id == "find_settings_iphone")
+    assert task.prompt == "请点击屏幕上的设置图标。"
+
+
 def test_mobilegym_basic_suite_loads_device_operation_tasks():
     suite_path = Path(__file__).resolve().parents[1] / "suites" / "mobilegym_basic.json"
     suite = load_suite(suite_path)
@@ -351,8 +401,47 @@ def test_load_suite_parses_task_level_mock_environment(tmp_path: Path):
     assert suite.mock_environment is None
     assert suite.tasks[0].mock_environment is not None
     assert suite.tasks[0].mock_environment.platform is TargetPlatform.IOS
+    assert suite.tasks[0].mock_environment.single_frame is False
     assert "platform" not in suite.tasks[0].mock_environment.phone_bridge
     assert "bridge_contacts" in suite.tasks[0].mock_environment.tools
+
+
+def test_load_suite_parses_single_frame_mock_environment(tmp_path: Path):
+    fixture = {
+        **FIXTURE,
+        "mock_environment": {
+            "platform": "ios",
+            "single_frame": True,
+            "tools": {},
+        },
+    }
+    p = tmp_path / "single-frame-mock.json"
+    p.write_text(json.dumps(fixture), encoding="utf-8")
+
+    suite = load_suite(p)
+
+    assert suite.mock_environment is not None
+    assert suite.mock_environment.single_frame is True
+
+
+@pytest.mark.parametrize("single_frame", [None, 0, 1, "true", [], {}])
+def test_load_suite_rejects_non_boolean_single_frame(
+    tmp_path: Path,
+    single_frame,
+):
+    fixture = {
+        **FIXTURE,
+        "mock_environment": {
+            "platform": "ios",
+            "single_frame": single_frame,
+            "tools": {},
+        },
+    }
+    p = tmp_path / "invalid-single-frame-mock.json"
+    p.write_text(json.dumps(fixture), encoding="utf-8")
+
+    with pytest.raises(SuiteValidationError, match="single_frame must be boolean"):
+        load_suite(p)
 
 
 def test_load_suite_normalizes_legacy_phone_bridge_platform(tmp_path: Path):

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -66,7 +66,7 @@ def test_perception_v1_uses_fixture_backed_mock_environment_for_every_task():
         assert responses[0].is_error is False
 
 
-def test_perception_v1_declares_single_frame_screenshot_contract():
+def test_perception_v1_describes_single_frame_environment_without_coaching():
     suite_path = (
         Path(__file__).resolve().parents[1]
         / "suites"
@@ -75,7 +75,18 @@ def test_perception_v1_declares_single_frame_screenshot_contract():
     )
     suite = load_suite(suite_path)
 
-    assert suite.prompt_prefix.strip()
+    prompt_prefix = suite.prompt_prefix.strip().lower()
+    assert prompt_prefix == "this is an offline single-frame static perception task."
+    for leaked_instruction in (
+        "screenshot",
+        "touch_gesture",
+        "width",
+        "height",
+        "0-1000",
+        "retry",
+        "verify",
+    ):
+        assert leaked_instruction not in prompt_prefix
 
 
 def test_perception_v1_settings_prompt_requires_clicking_visible_icon():

--- a/src/agent/internal/agent/context_manager_bridge_test.go
+++ b/src/agent/internal/agent/context_manager_bridge_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 
 	"aiden-agent/internal/agent/contextmanager"
@@ -140,5 +141,22 @@ func TestUserMessageAttachmentsRemainUnmarked(t *testing.T) {
 	}
 	if msg.Attachments[0].Source != "" {
 		t.Fatalf("user upload Source = %q, want empty", msg.Attachments[0].Source)
+	}
+}
+
+func TestUserMessageAttachmentPromptIncludesImageDimensions(t *testing.T) {
+	manager, err := InitializeContextManager("system", t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("InitializeContextManager() error = %v", err)
+	}
+	msg := userMessageFromInput(manager, "inspect", []InputAttachment{{
+		Kind:     AttachmentKindImage,
+		MIMEType: "image/jpeg",
+		Width:    447,
+		Height:   972,
+		Data:     []byte("jpeg"),
+	}})
+	if !strings.Contains(msg.Content, "width=447 height=972") {
+		t.Fatalf("content missing image dimensions: %q", msg.Content)
 	}
 }

--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -459,6 +459,9 @@ func attachmentAwarePrompt(text string, attachments []InputAttachment, descripti
 		if attachment.MIMEType != "" {
 			label += " (" + attachment.MIMEType + ")"
 		}
+		if attachment.Width > 0 && attachment.Height > 0 {
+			label += fmt.Sprintf(" width=%d height=%d", attachment.Width, attachment.Height)
+		}
 		descriptions = append(descriptions, label)
 	}
 	if len(descriptions) == 0 {

--- a/src/agent/internal/agent/input_processing.go
+++ b/src/agent/internal/agent/input_processing.go
@@ -21,6 +21,8 @@ type InputAttachment struct {
 	Kind     string
 	Name     string
 	MIMEType string
+	Width    int
+	Height   int
 	Data     []byte
 }
 

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -126,6 +126,8 @@ type MessageAttachment struct {
 	Kind       string `json:"kind"`
 	Name       string `json:"name,omitempty"`
 	MIMEType   string `json:"mime_type,omitempty"`
+	Width      int    `json:"width,omitempty"`
+	Height     int    `json:"height,omitempty"`
 	Path       string `json:"path,omitempty"`
 	Data       string `json:"data,omitempty"`
 	Size       int    `json:"size,omitempty"`
@@ -3387,6 +3389,8 @@ func decodeMessageAttachments(payloads []MessageAttachment) ([]InputAttachment, 
 			Kind:     kind,
 			Name:     payload.Name,
 			MIMEType: payload.MIMEType,
+			Width:    payload.Width,
+			Height:   payload.Height,
 			Data:     raw,
 		})
 
@@ -3394,6 +3398,8 @@ func decodeMessageAttachments(payloads []MessageAttachment) ([]InputAttachment, 
 			Kind:       kind,
 			Name:       payload.Name,
 			MIMEType:   payload.MIMEType,
+			Width:      payload.Width,
+			Height:     payload.Height,
 			Data:       payload.Data,
 			Size:       len(raw),
 			Transcript: strings.TrimSpace(payload.Transcript),

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -3147,6 +3147,27 @@ func TestDecodeMessageAttachmentsCountsImageMIMEWithFileKind(t *testing.T) {
 	}
 }
 
+func TestDecodeMessageAttachmentsPreservesImageDimensions(t *testing.T) {
+	payloads := []MessageAttachment{{
+		Kind:     AttachmentKindImage,
+		MIMEType: "image/jpeg",
+		Width:    447,
+		Height:   972,
+		Data:     base64.StdEncoding.EncodeToString([]byte("jpeg")),
+	}}
+
+	decoded, history, err := decodeMessageAttachments(payloads)
+	if err != nil {
+		t.Fatalf("decodeMessageAttachments() error = %v", err)
+	}
+	if decoded[0].Width != 447 || decoded[0].Height != 972 {
+		t.Fatalf("decoded dimensions = %dx%d", decoded[0].Width, decoded[0].Height)
+	}
+	if history[0].Width != 447 || history[0].Height != 972 {
+		t.Fatalf("history dimensions = %dx%d", history[0].Width, history[0].Height)
+	}
+}
+
 func TestServerDeviceAudioRecordingEndpointsReturnWAVAttachment(t *testing.T) {
 	stopCh := make(chan struct{})
 	var stopOnce sync.Once

--- a/src/agent/internal/agent/tools_hid.go
+++ b/src/agent/internal/agent/tools_hid.go
@@ -1109,7 +1109,7 @@ func (t *TouchGestureTool) Description() string {
 		description += `Prefer quick_action for semantic platform actions. For go-home/home-screen requests such as 回到桌面, call quick_action with {"action":"home"} first; use touch_gesture {"type":"home"} only as a fallback. `
 	}
 	return description +
-		`Base coordinates on the latest screenshot and aim at the visual center of the target using normalized 0-1000 coordinates where (500,500) is center. The tool returns a post-action screenshot. Swipe direction names describe finger movement, not content scroll. ` +
+		`Base coordinates on the latest screenshot and aim at the visual center of the target using normalized 0-1000 coordinates where (500,500) is center. Point, start, and end never accept screenshot pixels: convert a target measured at (pixel_x,pixel_y) in the latest image with x=pixel_x/max(image_width-1,1)*1000 and y=pixel_y/max(image_height-1,1)*1000 before calling. The tool returns a post-action screenshot. Swipe direction names describe finger movement, not content scroll. ` +
 		`This is a generic input tool and has no picker/wheel movement semantics. Do not tap picker rows to probe for keyboard/edit mode and do not drag picker columns with this tool; use wheel_nudge for the entire picker interaction.`
 }
 
@@ -1162,10 +1162,10 @@ func touchGestureIncludesEdgeNavigation(platform string) bool {
 
 func pointSchema(description string) map[string]any {
 	schema := objectArgsSchema(map[string]any{
-		"x": coordinateSchema("X coordinate.", 500),
-		"y": coordinateSchema("Y coordinate.", 300),
+		"x": coordinateSchema("Normalized 0-1000 X coordinate, not a screenshot pixel X value.", 500),
+		"y": coordinateSchema("Normalized 0-1000 Y coordinate, not a screenshot pixel Y value.", 300),
 	}, "x", "y")
-	schema["description"] = description
+	schema["description"] = description + ` Coordinates always use normalized 0-1000 values, never screenshot pixels.`
 	schema["examples"] = []map[string]any{{"x": 500, "y": 300}}
 	return schema
 }

--- a/src/agent/internal/agent/tools_hid_test.go
+++ b/src/agent/internal/agent/tools_hid_test.go
@@ -907,6 +907,32 @@ func TestTouchGestureSchemaRequiresNamedPointCoordinates(t *testing.T) {
 	}
 }
 
+func TestTouchGestureSchemaMakesNormalizedCoordinateContractExplicit(t *testing.T) {
+	tool := &TouchGestureTool{}
+	description := strings.ToLower(tool.Description())
+	for _, want := range []string{"normalized 0-1000", "screenshot pixels", "image_width", "image_height"} {
+		if !strings.Contains(description, want) {
+			t.Fatalf("touch_gesture description missing %q: %s", want, description)
+		}
+	}
+
+	schema := tool.ArgsSchema()
+	props := schema["properties"].(map[string]any)
+	for _, pointName := range []string{"point", "start", "end"} {
+		point := props[pointName].(map[string]any)
+		pointProps := point["properties"].(map[string]any)
+		for _, axis := range []string{"x", "y"} {
+			axisSchema := pointProps[axis].(map[string]any)
+			axisDescription := strings.ToLower(axisSchema["description"].(string))
+			for _, want := range []string{"normalized 0-1000", "screenshot pixel"} {
+				if !strings.Contains(axisDescription, want) {
+					t.Fatalf("%s.%s description missing %q: %s", pointName, axis, want, axisDescription)
+				}
+			}
+		}
+	}
+}
+
 type recordingADBRunner struct {
 	commands [][]string
 	timeouts []time.Duration


### PR DESCRIPTION
## Summary

- add an explicit single-frame fixture-backed mock environment contract for the static perception suite
- make static tasks follow the device-like screenshot-to-touch flow without fabricating post-action frames
- preserve image width and height for direct attachments and surface them in the model context
- strengthen nested touch_gesture point, start, and end coordinate schemas with the normalized 0-1000 contract and pixel conversion guidance

## Verification

- uv run pytest tests/test_main.py tests/test_mock_environment.py tests/test_runtask.py tests/test_suite.py (132 passed)
- go test ./internal/agent
- git diff --check
- verified the final native Anthropic request preserves the complete touch_gesture input_schema, including nested x/y descriptions and 0-1000 bounds

## Benchmark

Claude Opus 5 static perception rerun: 5/12, compared with 3/12 after the schema-only change. The remaining failures still reflect actual visual localization and coordinate conversion behavior rather than mocked state transitions.