### PR TITLE
fix(benchmark): standardize runtime configuration

### DIFF
--- a/benchmark/adbandroid/README.md
+++ b/benchmark/adbandroid/README.md
@@ -62,7 +62,7 @@ uv run python -m runner start-agent-daemon \
   --environment-bridge-endpoint http://127.0.0.1:8899
 
 # 3. Run the benchmark (take --agent-url / token from step 2's output).
-#    This command enables the judge — export OPENROUTER_API_KEY first;
+#    This command enables the judge — export AIDEN_BENCHMARK_JUDGE_API_KEY first;
 #    see the "Judging" section. Append --no-judge to only exercise the pipeline.
 uv run python -m runner run \
   --suite suites/adb_android_basic.json \
@@ -111,7 +111,7 @@ a still-running bridge via its pidfile + a `/health` probe.
 
 The judge scores each task's rubric item by item using the pre/post screenshots
 and the trace (e.g. "did Settings actually open?", "was the alarm count
-correct?"), over an OpenRouter-compatible endpoint. The judge model is
+correct?"), over an OpenAI-compatible endpoint. The judge model is
 completely independent of the agent-under-test model (the agent model is set in
 `agent.toml`).
 
@@ -119,12 +119,12 @@ completely independent of the agent-under-test model (the agent model is set in
   the hard assertions (an action ran, no timeout). Good for first verifying that
   the pipeline works end to end.
 - **Judge enabled** (the default for `run`, i.e. without `--no-judge`): you must
-  provide `OPENROUTER_API_KEY`, otherwise it fails with
-  `missing env var OPENROUTER_API_KEY`.
+  provide `AIDEN_BENCHMARK_JUDGE_API_KEY`, otherwise it fails with
+  `missing env var AIDEN_BENCHMARK_JUDGE_API_KEY`.
 
 ```bash
 cd benchmark
-export OPENROUTER_API_KEY=sk-or-...
+export AIDEN_BENCHMARK_JUDGE_API_KEY=...
 
 uv run python -m runner run \
   --suite suites/adb_android_basic.json \
@@ -135,8 +135,9 @@ uv run python -m runner run \
   -v
 ```
 
-`--judge-model` can be omitted (default `anthropic/claude-sonnet-4-6`); pass an
-OpenRouter model name to use a different judge model.
+`--judge-model` can be omitted (default `anthropic/claude-sonnet-4-6`); pass the
+model name accepted by the configured OpenAI-compatible endpoint to use a
+different judge model.
 
 > The correctness of the multi-step tasks (count alarms in Clock / check WiFi /
 > open the app drawer) can only be verified by the judge; under `--no-judge`
@@ -149,7 +150,7 @@ saved in the run directory, so you can re-score **without re-running the
 device**:
 
 ```bash
-export OPENROUTER_API_KEY=sk-or-...
+export AIDEN_BENCHMARK_JUDGE_API_KEY=...
 uv run python -m runner rejudge \
   --run-dir runs/<that run's directory> \
   --judge-model anthropic/claude-sonnet-4-6

--- a/benchmark/config/agent.toml.template
+++ b/benchmark/config/agent.toml.template
@@ -1,10 +1,10 @@
 input_mode = "text"
 
 [model_providers.benchmark]
-type = "openai"
-base_url = ""
-api_key = ""
+type = "{{AIDEN_BENCHMARK_AGENT_PROVIDER}}"
+base_url = "{{AIDEN_BENCHMARK_AGENT_BASE_URL}}"
+api_key = "{{AIDEN_BENCHMARK_AGENT_API_KEY}}"
 
 [model]
 provider = "benchmark"
-model = "qwen3.6-35b"
+model = "{{AIDEN_BENCHMARK_AGENT_MODEL}}"

--- a/benchmark/manual.md
+++ b/benchmark/manual.md
@@ -42,7 +42,7 @@ full trace and screenshots without re-operating the device.
 | Runner | `benchmark/runner/main.py` | CLI entry point; runs suites and generates reports |
 | WebUI | `benchmark/runner/webui.py` | Web console; manages suites, jobs, environments, logs, reports |
 | Agent client | `benchmark/runner/agent_client.py` | Calls the Go agent's `/api/chat`, `/api/tools/*`, `/api/history` |
-| Judge | `benchmark/runner/judge.py` | Calls an OpenRouter-compatible endpoint; scores using pre/post screenshots and the trace |
+| Judge | `benchmark/runner/judge.py` | Calls an OpenAI-compatible endpoint; scores using pre/post screenshots and the trace |
 | MobileGym bridge | `benchmark/mobilegym/bridge/` | Wraps a MobileGym env as an environment bridge API |
 | ADB Android bridge | `benchmark/adbandroid/` | Wraps an Android emulator/physical device as an environment bridge API via adb (see its README) |
 | Docker daemon worker | `benchmark/docker/Dockerfile.agent-daemon` | The isolated agent daemon the WebUI starts when running a job |
@@ -388,8 +388,8 @@ Main areas on the WebUI home screen:
 
 ### 2.3 Configuring the judge
 
-The WebUI enables the judge by default. The judge is currently called over an
-OpenRouter-compatible endpoint, using the `OPENROUTER_API_KEY` API key.
+The WebUI enables the judge by default. The judge calls an OpenAI-compatible
+endpoint and uses the `AIDEN_BENCHMARK_JUDGE_API_KEY` credential.
 
 Usage:
 
@@ -439,6 +439,10 @@ The WebUI starts the MobileGym container and bridge server and records:
   `/api/setup`, `/api/providers/screenshot`, `/api/release`.
 - Task screen link: the screen link for each task worker is provided by the WebUI;
   the WebUI backend pulls the screenshot via the bridge's `/api/providers/screenshot`.
+
+MobileGym containers recovered after a WebUI restart are marked `stale`. They
+remain visible so they can be stopped or deleted, but cannot be selected for a
+new benchmark. Start a fresh MobileGym environment for every new WebUI session.
 
 ### 2.5 Running a job
 
@@ -638,7 +642,14 @@ Agent configuration notes:
   static `memory/extraction.yaml` policy is preserved when present.
 - If `--agent-config` is specified, its content is written as the worker's
   `agent.toml`; if not, the runner prefers rendering `agent.toml` from
-  `--base-config-dir/agent.toml.template`.
+  `--base-config-dir/agent.toml.template`. The built-in template reads only the
+  `AIDEN_BENCHMARK_AGENT_*` variables listed below.
+- Credential references such as `api_key = "$ANTHROPIC_AUTH_TOKEN"` are resolved
+  on the host while preparing the worker config. The resolved config is mounted
+  read-only into Docker. A missing credential fails before the daemon starts.
+- Before `--auto-agent-setup` uses a MobileGym endpoint, the runner performs a
+  short `setup` / `release` preflight. A bridge that is healthy but cannot reset
+  is rejected with instructions to start a fresh environment.
 
 Example:
 
@@ -866,8 +877,14 @@ Common environment variables:
 | --- | --- |
 | `AIDEN_AGENT_URL` | Default for CLI `--agent-url` |
 | `AIDEN_ENVIRONMENT_URL` | Default for CLI `--environment-url` |
-| `OPENROUTER_API_KEY` | Judge API key |
-| `AIDEN_MODEL` / `MODEL_NAME` / `OPENAI_MODEL` | Agent model recorded in the manifest |
+| `AIDEN_BENCHMARK_AGENT_PROVIDER` | Agent provider type rendered into the default `agent.toml` |
+| `AIDEN_BENCHMARK_AGENT_MODEL` | Agent model rendered into `agent.toml` and recorded in the manifest |
+| `AIDEN_BENCHMARK_AGENT_BASE_URL` | Agent model endpoint rendered into the default `agent.toml` |
+| `AIDEN_BENCHMARK_AGENT_API_KEY` | Agent credential rendered into the default read-only `agent.toml` |
+| `AIDEN_BENCHMARK_JUDGE_MODEL` | Default judge model for `run` and `rejudge` |
+| `AIDEN_BENCHMARK_JUDGE_BASE_URL` | Default OpenAI-compatible judge endpoint |
+| `AIDEN_BENCHMARK_JUDGE_API_KEY` | Judge API key |
+| `AIDEN_BENCHMARK_ANALYSIS_API_KEY` | Optional post-run analysis credential; defaults to the Judge key |
 | `BENCHMARK_STATE_FILE` | Default for CLI `--state-file` |
 | `MOBILEGYM_PARALLEL_ENVS` | Default parallel env count for `start_simulator.py` |
 | `AIDEN_BRIDGE_BIND_HOST` | MobileGym bridge bind host |
@@ -939,12 +956,12 @@ curl http://127.0.0.1:8080/api/tools
 
 If it is a WebUI job, look at the job's daemon log.
 
-### The judge reports missing env var OPENROUTER_API_KEY
+### The judge reports missing env var AIDEN_BENCHMARK_JUDGE_API_KEY
 
 CLI:
 
 ```bash
-export OPENROUTER_API_KEY=...
+export AIDEN_BENCHMARK_JUDGE_API_KEY=...
 ```
 
 WebUI:

--- a/benchmark/mobilegym/scripts/local_launcher.py
+++ b/benchmark/mobilegym/scripts/local_launcher.py
@@ -531,11 +531,7 @@ def summary_suite(summary: dict[str, Any]) -> str:
 
 def current_model_label(env: dict[str, str] | None = None) -> str:
     env = env or os.environ
-    for name in ("AIDEN_MODEL", "MODEL_NAME", "MODEL", "OPENAI_MODEL"):
-        value = env.get(name)
-        if value:
-            return value
-    return "aiden-go"
+    return env.get("AIDEN_BENCHMARK_AGENT_MODEL") or "aiden-go"
 
 
 def model_config_from_payload(payload: dict[str, Any]) -> dict[str, str]:
@@ -641,13 +637,13 @@ def agent_model_environment(
     api_key = model_values.get("api_key") or provider_values.get("api_key")
     env: dict[str, str] = {}
     if provider:
-        env["MODEL_PROVIDER"] = provider
+        env["AIDEN_BENCHMARK_AGENT_PROVIDER"] = provider
     if model := model_values.get("model"):
-        env["MODEL_NAME"] = model
+        env["AIDEN_BENCHMARK_AGENT_MODEL"] = model
     if base_url := provider_values.get("base_url"):
-        env["MODEL_BASE_URL"] = base_url
+        env["AIDEN_BENCHMARK_AGENT_BASE_URL"] = base_url
     if api_key:
-        env["MODEL_API_KEY"] = api_key
+        env["AIDEN_BENCHMARK_AGENT_API_KEY"] = api_key
     return env
 
 
@@ -656,12 +652,14 @@ def parse_agent_benchmark_config(text: str) -> dict[str, str]:
 
 
 def parse_agent_benchmark_assignments(text: str) -> dict[str, str]:
-    values = parse_toml_assignments(text, {"api_key", "judge_model"})
+    values = parse_toml_assignments(text, {"api_key", "judge_model", "base_url"})
     env: dict[str, str] = {}
     if values.get("api_key"):
-        env["OPENROUTER_API_KEY"] = values["api_key"]
+        env["AIDEN_BENCHMARK_JUDGE_API_KEY"] = values["api_key"]
     if values.get("judge_model"):
         env["AIDEN_BENCHMARK_JUDGE_MODEL"] = values["judge_model"]
+    if values.get("base_url"):
+        env["AIDEN_BENCHMARK_JUDGE_BASE_URL"] = values["base_url"]
     return env
 
 
@@ -703,12 +701,10 @@ def toml_section(text: str, section: str) -> str:
 
 def validate_model_environment(env: dict[str, str] | None = None) -> None:
     env = env or os.environ
-    provider = env.get("MODEL_PROVIDER") or env.get("AIDEN_MODEL_PROVIDER") or "openrouter"
-    if provider == "openrouter" and not (
-        env.get("MODEL_API_KEY") or env.get("OPENROUTER_API_KEY") or env.get("AIDEN_MODEL_API_KEY")
-    ):
+    provider = env.get("AIDEN_BENCHMARK_AGENT_PROVIDER") or "openrouter"
+    if provider == "openrouter" and not env.get("AIDEN_BENCHMARK_AGENT_API_KEY"):
         raise LauncherError(
-            "MobileGym model config missing: set MODEL_API_KEY or OPENROUTER_API_KEY "
+            "MobileGym model config missing: set AIDEN_BENCHMARK_AGENT_API_KEY "
             "before starting the Mac MobileGym launcher"
         )
 

--- a/benchmark/runner/analysis.py
+++ b/benchmark/runner/analysis.py
@@ -59,7 +59,7 @@ class AnalysisError(RuntimeError):
 
 
 SECRET_NAME_RE = re.compile(
-    r"(?i)(?P<prefix>[\"']?\b(api[_-]?key|token|password|secret|bearer|authorization|OPENROUTER_API_KEY|MODEL_API_KEY|AIDEN_MODEL_API_KEY|AIDEN_CONTROL_TOKEN)\b[\"']?\s*[:=]\s*)(?P<quote>[\"']?)(?P<value>[^\"'\s,}]+)(?P=quote)?"
+    r"(?i)(?P<prefix>[\"']?\b(api[_-]?key|token|password|secret|bearer|authorization|OPENROUTER_API_KEY|MODEL_API_KEY|AIDEN_MODEL_API_KEY|AIDEN_BENCHMARK_ANALYSIS_API_KEY|AIDEN_BENCHMARK_JUDGE_API_KEY|AIDEN_CONTROL_TOKEN)\b[\"']?\s*[:=]\s*)(?P<quote>[\"']?)(?P<value>[^\"'\s,}]+)(?P=quote)?"
 )
 BASIC_AUTH_RE = re.compile(r"(?i)authorization\s*:\s*basic\s+[A-Za-z0-9._~+/=-]{8,}")
 BEARER_RE = re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{12,}")

--- a/benchmark/runner/analysis.py
+++ b/benchmark/runner/analysis.py
@@ -110,13 +110,16 @@ def resolve_analysis_api_key(cfg: AnalysisConfig) -> tuple[str, str]:
         env_name = os.environ.get("AIDEN_BENCHMARK_ANALYSIS_API_KEY_ENV")
         if env_name:
             names.append(env_name)
-    names.extend(["OPENROUTER_API_KEY", "MODEL_API_KEY", "AIDEN_MODEL_API_KEY"])
+    names.extend(
+        ["AIDEN_BENCHMARK_ANALYSIS_API_KEY", "AIDEN_BENCHMARK_JUDGE_API_KEY"]
+    )
     for name in names:
         value = os.environ.get(name, "").strip()
         if value:
             return name, value
     raise AnalysisError(
-        "missing analysis API key: set OPENROUTER_API_KEY, MODEL_API_KEY, or AIDEN_MODEL_API_KEY"
+        "missing analysis API key: set AIDEN_BENCHMARK_ANALYSIS_API_KEY or "
+        "AIDEN_BENCHMARK_JUDGE_API_KEY"
     )
 
 
@@ -132,7 +135,13 @@ def redact_text(text: str, cfg: AnalysisConfig) -> str:
     redacted = SK_KEY_RE.sub("[REDACTED_SK_KEY]", redacted)
     redacted = JWTISH_RE.sub("[REDACTED_JWT]", redacted)
     names = [cfg.api_key_env] if cfg.api_key_env else []
-    names.extend(["OPENROUTER_API_KEY", "MODEL_API_KEY", "AIDEN_MODEL_API_KEY", "AIDEN_CONTROL_TOKEN"])
+    names.extend(
+        [
+            "AIDEN_BENCHMARK_ANALYSIS_API_KEY",
+            "AIDEN_BENCHMARK_JUDGE_API_KEY",
+            "AIDEN_CONTROL_TOKEN",
+        ]
+    )
     if cfg.api_key_value:
         redacted = redacted.replace(cfg.api_key_value, "[REDACTED_VALUE]")
     for name in names:

--- a/benchmark/runner/config.py
+++ b/benchmark/runner/config.py
@@ -200,7 +200,8 @@ def render_agent_template(text: str) -> str:
     }
     rendered = text
     for key, value in replacements.items():
-        rendered = rendered.replace("{{" + key + "}}", value.replace('"', '\\"'))
+        escaped = json.dumps(value, ensure_ascii=False)[1:-1]
+        rendered = rendered.replace("{{" + key + "}}", escaped)
     return rendered
 
 

--- a/benchmark/runner/config.py
+++ b/benchmark/runner/config.py
@@ -6,15 +6,29 @@ used by both benchmark/runner/webui.py and skillopt/webui.py.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from pathlib import Path
+from typing import Mapping
 
 
 VOICE_SIDE_EFFECT_DEFAULTS = (
     "voice_streaming_tts_enabled",
     "voice_tool_call_speech",
     "voice_progress_speech_enabled",
+)
+
+BENCHMARK_AGENT_PROVIDER_ENV = "AIDEN_BENCHMARK_AGENT_PROVIDER"
+BENCHMARK_AGENT_MODEL_ENV = "AIDEN_BENCHMARK_AGENT_MODEL"
+BENCHMARK_AGENT_BASE_URL_ENV = "AIDEN_BENCHMARK_AGENT_BASE_URL"
+BENCHMARK_AGENT_API_KEY_ENV = "AIDEN_BENCHMARK_AGENT_API_KEY"
+
+AGENT_CREDENTIAL_KEYS = ("api_key", "relay_api_key")
+_AGENT_CREDENTIAL_ENV_REFERENCE = re.compile(
+    rf"(?m)^(?P<prefix>\s*(?:{'|'.join(AGENT_CREDENTIAL_KEYS)})\s*=\s*)"
+    r"(?P<quote>['\"])(?P<reference>\$[A-Za-z_][A-Za-z0-9_]*)"
+    r"(?P=quote)(?P<suffix>\s*(?:#.*)?)$"
 )
 
 
@@ -178,29 +192,38 @@ def render_agent_template(text: str) -> str:
         Rendered text with variables substituted
     """
     replacements = {
-        "MODEL_PROVIDER": (
-            os.getenv("MODEL_PROVIDER")
-            or os.getenv("AIDEN_MODEL_PROVIDER")
-            or "fake"
-        ),
-        "MODEL_NAME": (
-            os.getenv("MODEL_NAME")
-            or os.getenv("AIDEN_MODEL")
-            or os.getenv("OPENAI_MODEL")
-            or ""
-        ),
-        "MODEL_BASE_URL": (
-            os.getenv("MODEL_BASE_URL") or os.getenv("AIDEN_MODEL_BASE_URL") or ""
-        ),
-        "MODEL_API_KEY": (
-            os.getenv("MODEL_API_KEY")
-            or os.getenv("OPENROUTER_API_KEY")
-            or os.getenv("AIDEN_MODEL_API_KEY")
-            or ""
-        ),
+        BENCHMARK_AGENT_PROVIDER_ENV: os.getenv(BENCHMARK_AGENT_PROVIDER_ENV) or "fake",
+        BENCHMARK_AGENT_MODEL_ENV: os.getenv(BENCHMARK_AGENT_MODEL_ENV) or "",
+        BENCHMARK_AGENT_BASE_URL_ENV: os.getenv(BENCHMARK_AGENT_BASE_URL_ENV) or "",
+        BENCHMARK_AGENT_API_KEY_ENV: os.getenv(BENCHMARK_AGENT_API_KEY_ENV) or "",
         "CONTROL_TOKEN_FILE": "/config/control_token",
     }
     rendered = text
     for key, value in replacements.items():
         rendered = rendered.replace("{{" + key + "}}", value.replace('"', '\\"'))
     return rendered
+
+
+def materialize_agent_config_credentials(
+    content: str,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> str:
+    """Replace credential environment references before mounting config in Docker."""
+    source_env = os.environ if env is None else env
+
+    def replace(match: re.Match[str]) -> str:
+        env_name = match.group("reference")[1:]
+        value = source_env.get(env_name)
+        if value is None or not value.strip():
+            raise ValueError(
+                "agent.toml credential references missing environment variable "
+                f"{env_name}"
+            )
+        return (
+            match.group("prefix")
+            + json.dumps(value, ensure_ascii=False)
+            + match.group("suffix")
+        )
+
+    return _AGENT_CREDENTIAL_ENV_REFERENCE.sub(replace, content)

--- a/benchmark/runner/environment.py
+++ b/benchmark/runner/environment.py
@@ -219,9 +219,12 @@ class EnvironmentManager:
         age_label = _format_container_age(created_iso) if created_iso else "age unknown"
 
         if is_healthy:
-            status = "running"
+            status = "stale"
             name = f"MobileGym (recovered, {age_label})"
-            message = "recovered from existing docker container"
+            message = (
+                "recovered from a previous WebUI session; remove it and start "
+                "a fresh environment before running benchmarks"
+            )
         else:
             status = "unhealthy"
             name = f"MobileGym (recovered, {age_label}, unhealthy)"

--- a/benchmark/runner/judge.py
+++ b/benchmark/runner/judge.py
@@ -15,12 +15,13 @@ from runner.suite import RubricItem
 
 JUDGE_PROMPT_VERSION = "v1"
 DEFAULT_JUDGE_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_JUDGE_API_KEY_ENV = "AIDEN_BENCHMARK_JUDGE_API_KEY"
 
 @dc.dataclass
 class JudgeConfig:
-    provider: str = "openrouter"
+    provider: str = "openai-compatible"
     model: str = "anthropic/claude-sonnet-4-6"
-    api_key_env: str = "OPENROUTER_API_KEY"
+    api_key_env: str = DEFAULT_JUDGE_API_KEY_ENV
     base_url: str = DEFAULT_JUDGE_BASE_URL
 
 @dc.dataclass
@@ -77,6 +78,13 @@ def _cache_key(pre: Path | None, post: Path | None, trace_json: str, rubric: lis
 
 def _chat_completions_url(base_url: str) -> str:
     return f"{(base_url or DEFAULT_JUDGE_BASE_URL).rstrip('/')}/chat/completions"
+
+
+def _resolve_judge_api_key(cfg: JudgeConfig) -> str:
+    api_key = os.environ.get(cfg.api_key_env, "").strip()
+    if not api_key:
+        raise RuntimeError(f"missing env var {cfg.api_key_env}")
+    return api_key
 
 def _judge_images(
     pre_screenshot: Path | None,
@@ -139,9 +147,7 @@ def judge_task(
         {"type": "text", "text": f"FINAL RESPONSE:\n{final_response}"},
     ]
     # Use an OpenAI-compatible chat completions endpoint.
-    api_key = os.environ.get(cfg.api_key_env, "").strip()
-    if not api_key:
-        raise RuntimeError(f"missing env var {cfg.api_key_env}")
+    api_key = _resolve_judge_api_key(cfg)
     payload = json.dumps({
         "model": cfg.model,
         "messages": [{"role": "user", "content": user_content}],

--- a/benchmark/runner/main.py
+++ b/benchmark/runner/main.py
@@ -6,11 +6,13 @@ import os
 import re
 import sys
 import time
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from runner.agent_client import AgentClient
 from runner.analysis import AnalysisConfig, _int_env, analyze_run
+from runner.config import BENCHMARK_AGENT_MODEL_ENV
 from runner.html_report import generate_report_html, upload_report
 from runner.judge import DEFAULT_JUDGE_BASE_URL, JudgeConfig
 from runner.platform import (
@@ -21,7 +23,12 @@ from runner.platform import (
 )
 from runner.report import git_sha, write_jsonl, write_manifest, write_summary, now_iso
 from runner.recovery import recover_agent_after_timeout, wait_for_agent_ready
-from runner.reset import ResetError, call_environment_release, clear_stale_adb_android_owner
+from runner.reset import (
+    ResetError,
+    call_environment_release,
+    call_environment_setup,
+    clear_stale_adb_android_owner,
+)
 from runner.runtask import run_one_task, skipped_task_result
 from runner.suite import (
     Suite,
@@ -87,13 +94,16 @@ def cli(argv: list[str] | None = None) -> int:
     p_run.add_argument("--base-config-dir", default=str(REPO_ROOT / "benchmark" / "config"))
     p_run.add_argument("--agent-config", default="")
     p_run.add_argument("--benchmark-token-file", default="")
-    p_run.add_argument("--judge-model", default="claude-sonnet-4-6")
+    p_run.add_argument(
+        "--judge-model",
+        default=os.environ.get("AIDEN_BENCHMARK_JUDGE_MODEL", "claude-sonnet-4-6"),
+    )
     p_run.add_argument(
         "--judge-base-url",
         default=os.environ.get("AIDEN_BENCHMARK_JUDGE_BASE_URL", DEFAULT_JUDGE_BASE_URL),
         help="OpenAI-compatible base URL for judge requests",
     )
-    p_run.add_argument("--agent-model", default=os.environ.get("AIDEN_MODEL") or os.environ.get("MODEL_NAME") or os.environ.get("OPENAI_MODEL") or "")
+    p_run.add_argument("--agent-model", default=os.environ.get(BENCHMARK_AGENT_MODEL_ENV, ""))
     p_run.add_argument("--no-judge", action="store_true")
     p_run.add_argument("--repeats", type=int, default=None)
     p_run.add_argument("--out", default=str(REPO_ROOT / "benchmark" / "runs"))
@@ -146,7 +156,10 @@ def cli(argv: list[str] | None = None) -> int:
                        help="Show detailed rubric results for each task")
     p_rejudge = sub.add_parser("rejudge")
     p_rejudge.add_argument("--run-dir", required=True)
-    p_rejudge.add_argument("--judge-model", default="claude-sonnet-4-6")
+    p_rejudge.add_argument(
+        "--judge-model",
+        default=os.environ.get("AIDEN_BENCHMARK_JUDGE_MODEL", "claude-sonnet-4-6"),
+    )
     p_rejudge.add_argument(
         "--judge-base-url",
         default=os.environ.get("AIDEN_BENCHMARK_JUDGE_BASE_URL", DEFAULT_JUDGE_BASE_URL),
@@ -366,6 +379,52 @@ def _resolve_target_platform_enum(
 
 def _read_environment_health(environment_url: str) -> dict:
     return read_environment_health(environment_url)
+
+
+def _preflight_mobilegym_environment(
+    environment_url: str,
+    *,
+    timeout: int = 30,
+) -> None:
+    environment_url = str(environment_url or "").strip()
+    if not environment_url:
+        return
+    health = _read_environment_health(environment_url)
+    if str(health.get("bridge_type") or "").strip().lower() != "mobilegym":
+        return
+
+    task_id = f"benchmark-preflight:{uuid.uuid4().hex}"
+    try:
+        call_environment_setup(
+            environment_url,
+            timeout=timeout,
+            task_id=task_id,
+        )
+    except ResetError as exc:
+        try:
+            call_environment_release(
+                environment_url,
+                timeout=timeout,
+                task_id=task_id,
+            )
+        except ResetError:
+            pass
+        raise RuntimeError(
+            "MobileGym environment failed setup preflight; remove it and start "
+            "a fresh MobileGym environment"
+        ) from exc
+
+    try:
+        call_environment_release(
+            environment_url,
+            timeout=timeout,
+            task_id=task_id,
+        )
+    except ResetError as exc:
+        raise RuntimeError(
+            "MobileGym environment failed release preflight; remove it and start "
+            "a fresh MobileGym environment"
+        ) from exc
 
 
 def _task_repeats(args: argparse.Namespace, task: TaskSpec) -> int:
@@ -744,7 +803,7 @@ def _cmd_run_auto_agent_setup_inner(
         "environment_url": display_environment_url or None,
         "agent_model": args.agent_model,
         "active_skills": active_skills,
-        "judge_config": {"provider": "openrouter", "model": args.judge_model, "base_url": args.judge_base_url} if judge_cfg else None,
+        "judge_config": {"provider": judge_cfg.provider, "model": args.judge_model, "base_url": args.judge_base_url} if judge_cfg else None,
         "judge_prompt_version": "v1",
         "target_platform": manifest_target_platform or None,
         "auto_agent_setup": True,
@@ -818,6 +877,11 @@ def _cmd_run(args: argparse.Namespace) -> int:
         requested_platform = str(args.target_platform or "").strip().lower()
         target_platform = "" if requested_platform == "auto" else requested_platform
     if args.auto_agent_setup:
+        try:
+            _preflight_mobilegym_environment(args.environment_url)
+        except Exception as exc:
+            print(f"Error: environment preflight failed: {exc}", file=sys.stderr)
+            return 2
         return _cmd_run_auto_agent_setup(
             args,
             suite,
@@ -1001,7 +1065,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         "environment_url": args.environment_url or None,
         "agent_model": args.agent_model,
         "active_skills": active_skills,
-        "judge_config": {"provider": "openrouter", "model": args.judge_model, "base_url": args.judge_base_url} if judge_cfg else None,
+        "judge_config": {"provider": judge_cfg.provider, "model": args.judge_model, "base_url": args.judge_base_url} if judge_cfg else None,
         "judge_prompt_version": "v1",
         "target_platform": target_platform or None,
         "mock_environment": _mock_environment_manifest(suite),

--- a/benchmark/runner/main.py
+++ b/benchmark/runner/main.py
@@ -6,7 +6,6 @@ import os
 import re
 import sys
 import time
-import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -21,12 +20,19 @@ from runner.platform import (
     resolve_daemon_platform,
     resolve_environment_platform,
 )
+from runner.preflight import (
+    MOBILEGYM_PREFLIGHT_COMPLETE_ENV,
+    preflight_mobilegym_environment,
+)
 from runner.report import git_sha, write_jsonl, write_manifest, write_summary, now_iso
-from runner.recovery import recover_agent_after_timeout, wait_for_agent_ready
+from runner.recovery import (
+    DEFAULT_ENVIRONMENT_SETUP_TIMEOUT_SEC,
+    recover_agent_after_timeout,
+    wait_for_agent_ready,
+)
 from runner.reset import (
     ResetError,
     call_environment_release,
-    call_environment_setup,
     clear_stale_adb_android_owner,
 )
 from runner.runtask import run_one_task, skipped_task_result
@@ -354,18 +360,20 @@ def _resolve_target_platform_enum(
     args: argparse.Namespace,
     *,
     required: bool = False,
+    health: dict | None = None,
 ) -> TargetPlatform | None:
     requested = str(getattr(args, "target_platform", "") or "").strip().lower()
     explicit = requested if requested and requested != "auto" else ""
     environment_url = str(getattr(args, "environment_url", "") or "").strip()
     if not environment_url:
         return None
-    try:
-        health = _read_environment_health(environment_url)
-    except Exception:
-        if required:
-            raise
-        return None
+    if health is None:
+        try:
+            health = _read_environment_health(environment_url)
+        except Exception:
+            if required:
+                raise
+            return None
     try:
         return resolve_environment_platform(
             health,
@@ -384,47 +392,14 @@ def _read_environment_health(environment_url: str) -> dict:
 def _preflight_mobilegym_environment(
     environment_url: str,
     *,
-    timeout: int = 30,
+    timeout: int = DEFAULT_ENVIRONMENT_SETUP_TIMEOUT_SEC,
+    health: dict | None = None,
 ) -> None:
-    environment_url = str(environment_url or "").strip()
-    if not environment_url:
-        return
-    health = _read_environment_health(environment_url)
-    if str(health.get("bridge_type") or "").strip().lower() != "mobilegym":
-        return
-
-    task_id = f"benchmark-preflight:{uuid.uuid4().hex}"
-    try:
-        call_environment_setup(
-            environment_url,
-            timeout=timeout,
-            task_id=task_id,
-        )
-    except ResetError as exc:
-        try:
-            call_environment_release(
-                environment_url,
-                timeout=timeout,
-                task_id=task_id,
-            )
-        except ResetError:
-            pass
-        raise RuntimeError(
-            "MobileGym environment failed setup preflight; remove it and start "
-            "a fresh MobileGym environment"
-        ) from exc
-
-    try:
-        call_environment_release(
-            environment_url,
-            timeout=timeout,
-            task_id=task_id,
-        )
-    except ResetError as exc:
-        raise RuntimeError(
-            "MobileGym environment failed release preflight; remove it and start "
-            "a fresh MobileGym environment"
-        ) from exc
+    preflight_mobilegym_environment(
+        environment_url,
+        timeout=timeout,
+        health=health,
+    )
 
 
 def _task_repeats(args: argparse.Namespace, task: TaskSpec) -> int:
@@ -855,10 +830,14 @@ def _cmd_run(args: argparse.Namespace) -> int:
     if args.auto_agent_setup and args.max_concurrency < 0:
         print("Error: max-concurrency must be non-negative", file=sys.stderr)
         return 2
+    environment_health = None
     try:
+        if args.environment_url:
+            environment_health = _read_environment_health(args.environment_url)
         resolved_platform = _resolve_target_platform_enum(
             args,
             required=bool(args.environment_url),
+            health=environment_health,
         )
         target_platform = (
             resolved_platform.value if resolved_platform is not None else ""
@@ -876,12 +855,19 @@ def _cmd_run(args: argparse.Namespace) -> int:
     if args.auto_agent_setup and _suite_has_mock_environment(suite):
         requested_platform = str(args.target_platform or "").strip().lower()
         target_platform = "" if requested_platform == "auto" else requested_platform
-    if args.auto_agent_setup:
+    if (
+        args.environment_url
+        and os.environ.get(MOBILEGYM_PREFLIGHT_COMPLETE_ENV) != "1"
+    ):
         try:
-            _preflight_mobilegym_environment(args.environment_url)
+            _preflight_mobilegym_environment(
+                args.environment_url,
+                health=environment_health,
+            )
         except Exception as exc:
             print(f"Error: environment preflight failed: {exc}", file=sys.stderr)
             return 2
+    if args.auto_agent_setup:
         return _cmd_run_auto_agent_setup(
             args,
             suite,

--- a/benchmark/runner/preflight.py
+++ b/benchmark/runner/preflight.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import concurrent.futures
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from runner.platform import read_environment_health
+from runner.recovery import DEFAULT_ENVIRONMENT_SETUP_TIMEOUT_SEC
+from runner.reset import call_environment_release, call_environment_setup
+
+
+MOBILEGYM_PREFLIGHT_COMPLETE_ENV = "AIDEN_BENCHMARK_MOBILEGYM_PREFLIGHT_COMPLETE"
+
+
+def _environment_count(health: dict[str, Any]) -> int:
+    for key in ("env_count", "concurrent"):
+        try:
+            value = int(health.get(key))
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+    return 1
+
+
+def _call_for_task_ids(
+    action: Callable[..., Any],
+    environment_url: str,
+    timeout: int,
+    task_ids: list[str],
+) -> list[tuple[str, Exception]]:
+    errors: list[tuple[str, Exception]] = []
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=len(task_ids),
+        thread_name_prefix="mobilegym-preflight",
+    ) as executor:
+        futures = {
+            executor.submit(
+                action,
+                environment_url,
+                timeout=timeout,
+                task_id=task_id,
+            ): task_id
+            for task_id in task_ids
+        }
+        for future in concurrent.futures.as_completed(futures):
+            task_id = futures[future]
+            try:
+                future.result()
+            except Exception as exc:
+                errors.append((task_id, exc))
+    return errors
+
+
+def preflight_mobilegym_environment(
+    environment_url: str,
+    *,
+    timeout: int = DEFAULT_ENVIRONMENT_SETUP_TIMEOUT_SEC,
+    health: dict[str, Any] | None = None,
+) -> None:
+    environment_url = str(environment_url or "").strip()
+    if not environment_url:
+        return
+
+    health = health if health is not None else read_environment_health(environment_url)
+    if str(health.get("bridge_type") or "").strip().lower() != "mobilegym":
+        return
+
+    task_ids = [
+        f"benchmark-preflight:{uuid.uuid4().hex}"
+        for _ in range(_environment_count(health))
+    ]
+
+    setup_errors = _call_for_task_ids(
+        call_environment_setup,
+        environment_url,
+        timeout,
+        task_ids,
+    )
+    release_errors = _call_for_task_ids(
+        call_environment_release,
+        environment_url,
+        timeout,
+        task_ids,
+    )
+
+    if setup_errors:
+        raise RuntimeError(
+            "MobileGym environment failed setup preflight; remove it and start "
+            "a fresh MobileGym environment"
+        ) from setup_errors[0][1]
+    if release_errors:
+        raise RuntimeError(
+            "MobileGym environment failed release preflight; remove it and start "
+            "a fresh MobileGym environment"
+        ) from release_errors[0][1]

--- a/benchmark/runner/webui.py
+++ b/benchmark/runner/webui.py
@@ -28,7 +28,7 @@ from runner.analysis import AnalysisResult, analyze_run, config_from_env
 from runner.capture import DEFAULT_SCREENSHOT_TIMEOUT_SEC
 from runner.environment_endpoint import EnvironmentEndpoint
 from runner.html_report import generate_report_html
-from runner.judge import JudgeConfig
+from runner.judge import DEFAULT_JUDGE_API_KEY_ENV, JudgeConfig
 from runner.platform import (
     read_environment_health,
     resolve_environment_platform,
@@ -46,6 +46,7 @@ try:
     from benchmark.runner.config import (
         AgentConfigManager,
         apply_agent_toml_runtime_defaults,
+        materialize_agent_config_credentials,
         missing_agent_config_error,
         render_agent_template,
         validate_agent_toml,
@@ -60,6 +61,7 @@ except ImportError:
     from runner.config import (
         AgentConfigManager,
         apply_agent_toml_runtime_defaults,
+        materialize_agent_config_credentials,
         missing_agent_config_error,
         render_agent_template,
         validate_agent_toml,
@@ -519,6 +521,11 @@ class BenchmarkWebApp:
         if environment_type == "mobilegym":
             mobilegym_env = self.env_manager.get(environment_id)
             if mobilegym_env is not None:
+                if mobilegym_env.status != "running":
+                    raise ValueError(
+                        "selected MobileGym environment is not fresh; remove it "
+                        "and start a fresh MobileGym environment"
+                    )
                 environment_endpoint = mobilegym_env.public_endpoint.rstrip("/")
                 environment_web_url = mobilegym_env.web_url
                 parallel_tasks = mobilegym_env.parallel_envs
@@ -1209,7 +1216,7 @@ class BenchmarkWebApp:
                 with self._lock:
                     judge_api_key = self._job_judge_api_keys.get(job.id, "")
                 if judge_api_key:
-                    env["OPENROUTER_API_KEY"] = judge_api_key
+                    env[DEFAULT_JUDGE_API_KEY_ENV] = judge_api_key
             exit_code = self._run_runner_process(
                 worker_job,
                 cmd,
@@ -1415,7 +1422,7 @@ class BenchmarkWebApp:
             with self._lock:
                 judge_api_key = self._job_judge_api_keys.get(job.id, "")
             if judge_api_key:
-                env["OPENROUTER_API_KEY"] = judge_api_key
+                env[DEFAULT_JUDGE_API_KEY_ENV] = judge_api_key
         self._raise_if_job_stop_requested(job)
         popen_kwargs: dict[str, Any] = {}
         if os.name == "posix":
@@ -1508,7 +1515,7 @@ class BenchmarkWebApp:
             with self._lock:
                 judge_api_key = self._job_judge_api_keys.get(job.id, "")
             if judge_api_key:
-                env["OPENROUTER_API_KEY"] = judge_api_key
+                env[DEFAULT_JUDGE_API_KEY_ENV] = judge_api_key
         exit_code = self._run_runner_process(job, cmd, env)
 
         result = {
@@ -1766,6 +1773,7 @@ def prepare_run_config(
             raise missing_agent_config_error(base_config_dir)
 
     content = apply_agent_toml_runtime_defaults(config.read_text(encoding="utf-8"))
+    content = materialize_agent_config_credentials(content)
     validate_agent_toml(content)
     config.write_text(content, encoding="utf-8")
 
@@ -2398,7 +2406,7 @@ def write_job_report(job: Job, *, analysis_api_key: str = "") -> str:
         "selected_task_ids": [str(row.get("task_id") or "") for row in rows],
         "agent_url": job.agent_url,
         "environment_url": job.environment_endpoint or None,
-        "judge_config": None if job.no_judge else {"provider": "openrouter", "model": job.judge_model or DEFAULT_JUDGE_MODEL, "base_url": job.judge_base_url or DEFAULT_JUDGE_BASE_URL},
+        "judge_config": None if job.no_judge else {"provider": "openai-compatible", "model": job.judge_model or DEFAULT_JUDGE_MODEL, "base_url": job.judge_base_url or DEFAULT_JUDGE_BASE_URL},
         "started_at": job.started_at,
         "finished_at": job.finished_at or now_iso(),
         "totals": totals_from_report_rows(rows),
@@ -3844,7 +3852,7 @@ INDEX_HTML = r"""<!doctype html>
             <label class="check-label"><input id="judgeEnabled" type="checkbox" checked> Enable judge</label>
             <div class="field"><label for="judgeModel">Judge model</label><input id="judgeModel" autocomplete="off" placeholder="anthropic/claude-sonnet-4-6"></div>
             <div class="field"><label for="judgeBaseUrl">Base URL</label><input id="judgeBaseUrl" autocomplete="off" placeholder="https://openrouter.ai/api/v1"></div>
-            <div class="field"><label for="judgeApiKey">API key</label><input id="judgeApiKey" type="password" autocomplete="off" placeholder="OPENROUTER_API_KEY"></div>
+            <div class="field"><label for="judgeApiKey">API key</label><input id="judgeApiKey" type="password" autocomplete="off" placeholder="AIDEN_BENCHMARK_JUDGE_API_KEY"></div>
           </div>
           <div class="run-actions">
             <button id="runBtn" class="primary">Run selected suites</button>
@@ -4062,7 +4070,7 @@ INDEX_HTML = r"""<!doctype html>
       document.getElementById('judgeBaseUrl').value = String(judge.base_url || DEFAULT_JUDGE_BASE_URL);
       const keyInput = document.getElementById('judgeApiKey');
       keyInput.value = '';
-      keyInput.placeholder = judge.has_api_key ? 'Saved; leave blank to keep' : 'OPENROUTER_API_KEY';
+      keyInput.placeholder = judge.has_api_key ? 'Saved; leave blank to keep' : 'AIDEN_BENCHMARK_JUDGE_API_KEY';
       syncJudgePanel();
       renderEnvs();
       syncRunState();

--- a/benchmark/runner/webui.py
+++ b/benchmark/runner/webui.py
@@ -33,6 +33,10 @@ from runner.platform import (
     read_environment_health,
     resolve_environment_platform,
 )
+from runner.preflight import (
+    MOBILEGYM_PREFLIGHT_COMPLETE_ENV,
+    preflight_mobilegym_environment,
+)
 from runner.reset import ResetError, call_environment_release
 from runner.suite import load_suite
 
@@ -840,6 +844,10 @@ class BenchmarkWebApp:
             if job.environment_type != "mock":
                 health = read_environment_health(job.environment_endpoint or job.endpoint)
                 resolution = resolve_environment_platform(health)
+                preflight_mobilegym_environment(
+                    job.environment_endpoint or job.endpoint,
+                    health=health,
+                )
                 self._set_job(
                     job,
                     target_platform=resolution.value,
@@ -1212,6 +1220,7 @@ class BenchmarkWebApp:
             if job.repeats:
                 cmd.extend(["--repeats", str(job.repeats)])
             env = os.environ.copy()
+            env[MOBILEGYM_PREFLIGHT_COMPLETE_ENV] = "1"
             if not job.no_judge:
                 with self._lock:
                     judge_api_key = self._job_judge_api_keys.get(job.id, "")
@@ -1418,6 +1427,7 @@ class BenchmarkWebApp:
             cmd.extend(["--repeats", str(job.repeats)])
         append_log(Path(job.runner_log), "\n$ " + " ".join(cmd))
         env = os.environ.copy()
+        env[MOBILEGYM_PREFLIGHT_COMPLETE_ENV] = "1"
         if not job.no_judge:
             with self._lock:
                 judge_api_key = self._job_judge_api_keys.get(job.id, "")

--- a/benchmark/tests/mobilegym/test_local_launcher_config.py
+++ b/benchmark/tests/mobilegym/test_local_launcher_config.py
@@ -1,0 +1,57 @@
+from mobilegym.scripts import local_launcher
+
+
+def test_current_model_label_uses_only_benchmark_agent_model():
+    assert local_launcher.current_model_label(
+        {
+            "AIDEN_BENCHMARK_AGENT_MODEL": "benchmark-model",
+            "AIDEN_MODEL": "legacy-aiden-model",
+            "MODEL_NAME": "legacy-model",
+            "OPENAI_MODEL": "legacy-openai-model",
+        }
+    ) == "benchmark-model"
+    assert local_launcher.current_model_label({"MODEL_NAME": "legacy-model"}) == "aiden-go"
+
+
+def test_agent_model_environment_uses_benchmark_agent_names():
+    assert local_launcher.agent_model_environment(
+        {"provider": "benchmark", "model": "agent-model"},
+        {
+            "type": "openai",
+            "base_url": "https://agent.example/v1",
+            "api_key": "agent-key",
+        },
+    ) == {
+        "AIDEN_BENCHMARK_AGENT_PROVIDER": "openai",
+        "AIDEN_BENCHMARK_AGENT_MODEL": "agent-model",
+        "AIDEN_BENCHMARK_AGENT_BASE_URL": "https://agent.example/v1",
+        "AIDEN_BENCHMARK_AGENT_API_KEY": "agent-key",
+    }
+
+
+def test_parse_agent_benchmark_assignments_uses_benchmark_judge_names():
+    assert local_launcher.parse_agent_benchmark_assignments(
+        'api_key = "judge-key"\njudge_model = "judge-model"\nbase_url = "https://judge.example/v1"\n'
+    ) == {
+        "AIDEN_BENCHMARK_JUDGE_API_KEY": "judge-key",
+        "AIDEN_BENCHMARK_JUDGE_MODEL": "judge-model",
+        "AIDEN_BENCHMARK_JUDGE_BASE_URL": "https://judge.example/v1",
+    }
+
+
+def test_validate_model_environment_ignores_legacy_model_credentials():
+    env = {
+        "MODEL_PROVIDER": "openrouter",
+        "MODEL_API_KEY": "legacy-model-key",
+        "OPENROUTER_API_KEY": "legacy-openrouter-key",
+    }
+
+    try:
+        local_launcher.validate_model_environment(env)
+    except local_launcher.LauncherError as exc:
+        assert str(exc) == (
+            "MobileGym model config missing: set AIDEN_BENCHMARK_AGENT_API_KEY "
+            "before starting the Mac MobileGym launcher"
+        )
+    else:
+        raise AssertionError("expected legacy model credentials to be ignored")

--- a/benchmark/tests/test_agent_config.py
+++ b/benchmark/tests/test_agent_config.py
@@ -20,6 +20,18 @@ def test_benchmark_agent_template_omits_legacy_instruction():
     assert "instruction" not in config
 
 
+def test_benchmark_agent_template_uses_benchmark_agent_environment_placeholders():
+    template = Path(__file__).resolve().parents[1] / "config" / "agent.toml.template"
+    config = tomllib.loads(template.read_text(encoding="utf-8"))
+
+    assert config["model_providers"]["benchmark"] == {
+        "type": "{{AIDEN_BENCHMARK_AGENT_PROVIDER}}",
+        "base_url": "{{AIDEN_BENCHMARK_AGENT_BASE_URL}}",
+        "api_key": "{{AIDEN_BENCHMARK_AGENT_API_KEY}}",
+    }
+    assert config["model"]["model"] == "{{AIDEN_BENCHMARK_AGENT_MODEL}}"
+
+
 def test_load_agent_model_config_reads_model_section(tmp_path: Path):
     config = tmp_path / "agent.toml"
     config.write_text(

--- a/benchmark/tests/test_agent_config.py
+++ b/benchmark/tests/test_agent_config.py
@@ -1,6 +1,7 @@
 import tomllib
 from pathlib import Path
 
+from runner import config as runner_config
 from runner import agent_config
 from runner.agent_config import (
     default_agent_config_path,
@@ -30,6 +31,17 @@ def test_benchmark_agent_template_uses_benchmark_agent_environment_placeholders(
         "api_key": "{{AIDEN_BENCHMARK_AGENT_API_KEY}}",
     }
     assert config["model"]["model"] == "{{AIDEN_BENCHMARK_AGENT_MODEL}}"
+
+
+def test_render_agent_template_escapes_complete_toml_string_content(monkeypatch):
+    api_key = 'secret\\path\nnext\t"quoted"'
+    monkeypatch.setenv(runner_config.BENCHMARK_AGENT_API_KEY_ENV, api_key)
+
+    rendered = runner_config.render_agent_template(
+        'api_key = "{{AIDEN_BENCHMARK_AGENT_API_KEY}}"\n'
+    )
+
+    assert tomllib.loads(rendered)["api_key"] == api_key
 
 
 def test_load_agent_model_config_reads_model_section(tmp_path: Path):

--- a/benchmark/tests/test_analysis.py
+++ b/benchmark/tests/test_analysis.py
@@ -24,6 +24,8 @@ def test_config_from_env_enables_analysis_and_reads_limits(monkeypatch):
 def test_resolve_analysis_api_key_uses_expected_precedence(monkeypatch):
     monkeypatch.setenv("AIDEN_BENCHMARK_ANALYSIS_API_KEY_ENV", "CUSTOM_ANALYSIS_KEY")
     monkeypatch.setenv("CUSTOM_ANALYSIS_KEY", "custom-secret")
+    monkeypatch.setenv("AIDEN_BENCHMARK_ANALYSIS_API_KEY", "analysis-secret")
+    monkeypatch.setenv("AIDEN_BENCHMARK_JUDGE_API_KEY", "judge-secret")
     monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-secret")
     monkeypatch.setenv("MODEL_API_KEY", "model-secret")
     monkeypatch.setenv("AIDEN_MODEL_API_KEY", "aiden-secret")
@@ -35,19 +37,29 @@ def test_resolve_analysis_api_key_uses_expected_precedence(monkeypatch):
     monkeypatch.delenv("AIDEN_BENCHMARK_ANALYSIS_API_KEY_ENV")
     monkeypatch.delenv("CUSTOM_ANALYSIS_KEY")
     cfg = analysis.AnalysisConfig(enabled=True)
-    assert analysis.resolve_analysis_api_key(cfg) == ("OPENROUTER_API_KEY", "openrouter-secret")
+    assert analysis.resolve_analysis_api_key(cfg) == (
+        "AIDEN_BENCHMARK_ANALYSIS_API_KEY",
+        "analysis-secret",
+    )
 
-    monkeypatch.delenv("OPENROUTER_API_KEY")
-    assert analysis.resolve_analysis_api_key(cfg) == ("MODEL_API_KEY", "model-secret")
+    monkeypatch.delenv("AIDEN_BENCHMARK_ANALYSIS_API_KEY")
+    assert analysis.resolve_analysis_api_key(cfg) == (
+        "AIDEN_BENCHMARK_JUDGE_API_KEY",
+        "judge-secret",
+    )
 
-    monkeypatch.delenv("MODEL_API_KEY")
-    assert analysis.resolve_analysis_api_key(cfg) == ("AIDEN_MODEL_API_KEY", "aiden-secret")
+    monkeypatch.delenv("AIDEN_BENCHMARK_JUDGE_API_KEY")
+    try:
+        analysis.resolve_analysis_api_key(cfg)
+    except analysis.AnalysisError as exc:
+        assert "AIDEN_BENCHMARK_ANALYSIS_API_KEY" in str(exc)
+    else:
+        raise AssertionError("expected legacy provider credentials to be ignored")
 
 
 def test_resolve_analysis_api_key_accepts_explicit_override(monkeypatch):
-    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-    monkeypatch.delenv("MODEL_API_KEY", raising=False)
-    monkeypatch.delenv("AIDEN_MODEL_API_KEY", raising=False)
+    monkeypatch.delenv("AIDEN_BENCHMARK_ANALYSIS_API_KEY", raising=False)
+    monkeypatch.delenv("AIDEN_BENCHMARK_JUDGE_API_KEY", raising=False)
 
     cfg = analysis.AnalysisConfig(enabled=True, api_key_value="ui-secret")
 
@@ -363,7 +375,7 @@ def test_analyze_run_normalizes_bridge_inactive_analysis_payload(monkeypatch, tm
             }
         )
 
-    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("AIDEN_BENCHMARK_ANALYSIS_API_KEY", "test-key")
     monkeypatch.setattr(analysis, "chat_analysis_model", fake_chat)
 
     result = analysis.analyze_run(run_dir, repo, analysis.AnalysisConfig(enabled=True))
@@ -484,7 +496,7 @@ def test_analyze_run_writes_json_and_markdown_with_mocked_llm(monkeypatch, tmp_p
             }
         )
 
-    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("AIDEN_BENCHMARK_ANALYSIS_API_KEY", "test-key")
     monkeypatch.setattr(analysis, "chat_analysis_model", fake_chat)
 
     result = analysis.analyze_run(run_dir, repo, analysis.AnalysisConfig(enabled=True))
@@ -500,9 +512,8 @@ def test_analyze_run_writes_error_artifact_without_raising(monkeypatch, tmp_path
     run_dir = repo / "benchmark" / "runs" / "run-1"
     run_dir.mkdir(parents=True)
     (run_dir / "manifest.json").write_text(json.dumps({"run_id": "run-1"}), encoding="utf-8")
-    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-    monkeypatch.delenv("MODEL_API_KEY", raising=False)
-    monkeypatch.delenv("AIDEN_MODEL_API_KEY", raising=False)
+    monkeypatch.delenv("AIDEN_BENCHMARK_ANALYSIS_API_KEY", raising=False)
+    monkeypatch.delenv("AIDEN_BENCHMARK_JUDGE_API_KEY", raising=False)
 
     result = analysis.analyze_run(run_dir, repo, analysis.AnalysisConfig(enabled=True))
 

--- a/benchmark/tests/test_analysis.py
+++ b/benchmark/tests/test_analysis.py
@@ -134,6 +134,20 @@ def test_redact_removes_known_and_custom_secrets(monkeypatch):
     assert "[REDACTED" in redacted
 
 
+def test_redact_removes_benchmark_api_key_assignments_from_captured_logs(monkeypatch):
+    monkeypatch.setenv("AIDEN_BENCHMARK_ANALYSIS_API_KEY", "current-analysis-secret")
+    monkeypatch.delenv("AIDEN_BENCHMARK_JUDGE_API_KEY", raising=False)
+    text = (
+        "AIDEN_BENCHMARK_ANALYSIS_API_KEY=captured-analysis-secret "
+        "AIDEN_BENCHMARK_JUDGE_API_KEY=captured-judge-secret"
+    )
+
+    redacted = analysis.redact_text(text, analysis.AnalysisConfig(enabled=True))
+
+    assert "captured-analysis-secret" not in redacted
+    assert "captured-judge-secret" not in redacted
+
+
 def test_render_markdown_includes_clusters_and_recommendations():
     payload = {
         "summary": "Two failures share a timeout pattern.",

--- a/benchmark/tests/test_environment.py
+++ b/benchmark/tests/test_environment.py
@@ -48,3 +48,31 @@ def test_format_container_age_accepts_docker_inspect_rfc3339nano():
 
 def test_format_container_age_returns_unknown_for_future_timestamp():
     assert environment._format_container_age("2999-01-01T00:00:00Z") == "age unknown"
+
+
+def test_recovered_mobilegym_container_is_not_reusable_for_new_runs(monkeypatch, tmp_path: Path):
+    manager = _manager_without_discovery(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        environment,
+        "_docker_published_port_safe",
+        lambda container_name, container_port: 19090 if container_port == 9090 else 18173,
+    )
+    monkeypatch.setattr(environment, "_check_endpoint_health", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        environment,
+        "_docker_inspect_created",
+        lambda container_name: "2026-08-14T00:00:00Z",
+    )
+
+    recovered = manager._build_recovered_env(
+        {
+            "name": "aiden-mobilegym-env-mg-old",
+            "id": "container-id",
+            "created_at": "2026-08-14 08:00:00 +0800 CST",
+            "image": "aiden-mobilegym-simulator:test",
+        }
+    )
+
+    assert recovered is not None
+    assert recovered.status == "stale"
+    assert "start a fresh environment" in recovered.message

--- a/benchmark/tests/test_judge.py
+++ b/benchmark/tests/test_judge.py
@@ -107,6 +107,9 @@ def test_judge_does_not_fallback_to_agent_toml_api_key(monkeypatch, tmp_path: Pa
     config.write_text('[model]\napi_key = "sk-agent"\n', encoding="utf-8")
 
     monkeypatch.setenv("AIDEN_AGENT_CONFIG", str(config))
+    monkeypatch.delenv("AIDEN_BENCHMARK_JUDGE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
 
     try:
@@ -120,6 +123,69 @@ def test_judge_does_not_fallback_to_agent_toml_api_key(monkeypatch, tmp_path: Pa
             cfg=JudgeConfig(),
         )
     except RuntimeError as e:
-        assert str(e) == "missing env var OPENROUTER_API_KEY"
+        assert "AIDEN_BENCHMARK_JUDGE_API_KEY" in str(e)
     else:
-        raise AssertionError("expected missing OPENROUTER_API_KEY error")
+        raise AssertionError("expected missing judge API key error")
+
+
+def test_default_judge_uses_benchmark_specific_api_key_env(monkeypatch):
+    seen = {}
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return json.dumps({
+                "choices": [{"message": {"content": json.dumps({
+                    "items": [{"id": "ok", "verdict": "yes", "reason": "passed"}],
+                    "overall_notes": "ok",
+                })}}]
+            }).encode("utf-8")
+
+    def fake_urlopen(req, timeout):
+        seen["authorization"] = req.headers.get("Authorization")
+        return FakeResponse()
+
+    monkeypatch.setenv("AIDEN_BENCHMARK_JUDGE_API_KEY", "sk-benchmark-judge")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    judge_task(
+        description="check",
+        rubric=[RubricItem(id="ok", check="pass")],
+        pre_screenshot=None,
+        post_screenshot=None,
+        trace={"tool_calls": []},
+        final_response="done",
+        cfg=JudgeConfig(),
+    )
+
+    assert seen["authorization"] == "Bearer sk-benchmark-judge"
+
+
+def test_default_judge_does_not_read_provider_specific_api_key_envs(monkeypatch):
+    monkeypatch.delenv("AIDEN_BENCHMARK_JUDGE_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_AUTH_TOKEN", "sk-openai-compatible")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter")
+
+    try:
+        judge_task(
+            description="check",
+            rubric=[RubricItem(id="ok", check="pass")],
+            pre_screenshot=None,
+            post_screenshot=None,
+            trace={"tool_calls": []},
+            final_response="done",
+            cfg=JudgeConfig(),
+        )
+    except RuntimeError as exc:
+        assert str(exc) == "missing env var AIDEN_BENCHMARK_JUDGE_API_KEY"
+    else:
+        raise AssertionError("expected provider-specific API key envs to be ignored")

--- a/benchmark/tests/test_main.py
+++ b/benchmark/tests/test_main.py
@@ -1,4 +1,5 @@
 import json
+import threading
 import time
 import urllib.parse
 
@@ -8,6 +9,7 @@ from runner.agent_client import ToolInvokeResult
 from runner.analysis import AnalysisResult
 from runner.models import HardAssertionFailure, HardAssertionResults, RubricVerdict, TaskResult
 import runner.main as main
+import runner.preflight as preflight_module
 import runner.suite as suite_module
 import runner.webui as webui
 
@@ -98,19 +100,19 @@ def test_resolve_target_platform_infers_mobilegym_android(monkeypatch):
 def test_preflight_mobilegym_environment_exercises_setup_and_release(monkeypatch):
     calls = []
     monkeypatch.setattr(
-        main,
-        "_read_environment_health",
+        preflight_module,
+        "read_environment_health",
         lambda environment_url: {"bridge_type": "mobilegym", "platform": "android"},
     )
     monkeypatch.setattr(
-        main,
+        preflight_module,
         "call_environment_setup",
         lambda environment_url, timeout, task_id: calls.append(
             ("setup", environment_url, timeout, task_id)
         ),
     )
     monkeypatch.setattr(
-        main,
+        preflight_module,
         "call_environment_release",
         lambda environment_url, timeout, task_id: calls.append(
             ("release", environment_url, timeout, task_id)
@@ -126,21 +128,125 @@ def test_preflight_mobilegym_environment_exercises_setup_and_release(monkeypatch
     assert calls[0][3].startswith("benchmark-preflight:")
 
 
+def test_preflight_mobilegym_environment_checks_every_pool_slot(monkeypatch):
+    calls = []
+    setup_barrier = threading.Barrier(3, timeout=1)
+    monkeypatch.setattr(
+        preflight_module,
+        "read_environment_health",
+        lambda environment_url: {
+            "bridge_type": "mobilegym",
+            "platform": "android",
+            "env_count": 3,
+        },
+    )
+
+    def setup(environment_url, timeout, task_id):
+        calls.append(("setup", environment_url, timeout, task_id))
+        setup_barrier.wait()
+
+    monkeypatch.setattr(preflight_module, "call_environment_setup", setup)
+    monkeypatch.setattr(
+        preflight_module,
+        "call_environment_release",
+        lambda environment_url, timeout, task_id: calls.append(
+            ("release", environment_url, timeout, task_id)
+        ),
+    )
+
+    main._preflight_mobilegym_environment("http://127.0.0.1:19090")
+
+    setup_calls = [call for call in calls if call[0] == "setup"]
+    release_calls = [call for call in calls if call[0] == "release"]
+    assert len(setup_calls) == 3
+    assert len({call[3] for call in setup_calls}) == 3
+    assert {call[3] for call in release_calls} == {call[3] for call in setup_calls}
+    assert all(call[2] == 180 for call in calls)
+    assert max(calls.index(call) for call in setup_calls) < min(
+        calls.index(call) for call in release_calls
+    )
+
+
 def test_preflight_mobilegym_environment_rejects_setup_failure(monkeypatch):
     monkeypatch.setattr(
-        main,
-        "_read_environment_health",
+        preflight_module,
+        "read_environment_health",
         lambda environment_url: {"bridge_type": "mobilegym", "platform": "android"},
     )
 
     def fail_setup(environment_url, timeout, task_id):
         raise main.ResetError("setup timed out")
 
-    monkeypatch.setattr(main, "call_environment_setup", fail_setup)
-    monkeypatch.setattr(main, "call_environment_release", lambda *args, **kwargs: None)
+    monkeypatch.setattr(preflight_module, "call_environment_setup", fail_setup)
+    monkeypatch.setattr(preflight_module, "call_environment_release", lambda *args, **kwargs: None)
 
     with pytest.raises(RuntimeError, match="start a fresh MobileGym environment"):
         main._preflight_mobilegym_environment("http://127.0.0.1:19090", timeout=7)
+
+
+def test_run_with_environment_url_runs_preflight_without_auto_agent_setup(
+    monkeypatch, tmp_path, capsys
+):
+    monkeypatch.delenv(main.MOBILEGYM_PREFLIGHT_COMPLETE_ENV, raising=False)
+    suite_path = tmp_path / "suite.json"
+    suite_path.write_text(
+        json.dumps(
+            {
+                "name": "suite",
+                "tasks": [
+                    {
+                        "id": "t1",
+                        "category": "diagnostic",
+                        "prompt": "test",
+                        "description_for_judge": "test",
+                        "rubric": [{"id": "ok", "check": "ok"}],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    calls = []
+
+    class FakeClient:
+        def __init__(self, base_url, benchmark_token=""):
+            pass
+
+        def health(self):
+            return False
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        main,
+        "_read_environment_health",
+        lambda environment_url: {"bridge_type": "mobilegym", "platform": "android"},
+    )
+    monkeypatch.setattr(
+        main,
+        "_preflight_mobilegym_environment",
+        lambda environment_url, health=None: calls.append(environment_url),
+    )
+    monkeypatch.setattr(main, "AgentClient", FakeClient)
+
+    argv = [
+        "run",
+        "--suite",
+        str(suite_path),
+        "--environment-url",
+        "http://127.0.0.1:19090",
+        "--no-judge",
+    ]
+    rc = main.cli(argv)
+
+    assert rc == 2
+    assert calls == ["http://127.0.0.1:19090"]
+    assert "not reachable" in capsys.readouterr().err
+
+    monkeypatch.setenv(main.MOBILEGYM_PREFLIGHT_COMPLETE_ENV, "1")
+    assert main.cli(argv) == 2
+    assert calls == ["http://127.0.0.1:19090"]
 
 
 def test_resolve_target_platform_reads_vphone_ios_health(monkeypatch):
@@ -913,7 +1019,8 @@ def test_auto_agent_setup_injects_environment_url_as_bridge_endpoint(monkeypatch
     monkeypatch.setattr(main, "wait_for_agent_clock", lambda *args, **kwargs: True)
     monkeypatch.setattr(main, "_read_environment_health", lambda url: {"bridge_type": "mobilegym"})
     monkeypatch.setattr(main, "generate_report_html", lambda run_dir: "<html></html>")
-    monkeypatch.setattr(main, "call_environment_setup", lambda *args, **kwargs: None)
+    monkeypatch.setattr(preflight_module, "call_environment_setup", lambda *args, **kwargs: None)
+    monkeypatch.setattr(preflight_module, "call_environment_release", lambda *args, **kwargs: None)
     monkeypatch.setattr(main, "call_environment_release", lambda *args, **kwargs: None)
     monkeypatch.setattr(main, "clear_stale_adb_android_owner", lambda url: stale_clears.append(url))
     monkeypatch.setattr(webui, "ensure_daemon_image", lambda *args, **kwargs: None)

--- a/benchmark/tests/test_main.py
+++ b/benchmark/tests/test_main.py
@@ -95,6 +95,54 @@ def test_resolve_target_platform_infers_mobilegym_android(monkeypatch):
     assert main._resolve_target_platform(args) == "android"
 
 
+def test_preflight_mobilegym_environment_exercises_setup_and_release(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        main,
+        "_read_environment_health",
+        lambda environment_url: {"bridge_type": "mobilegym", "platform": "android"},
+    )
+    monkeypatch.setattr(
+        main,
+        "call_environment_setup",
+        lambda environment_url, timeout, task_id: calls.append(
+            ("setup", environment_url, timeout, task_id)
+        ),
+    )
+    monkeypatch.setattr(
+        main,
+        "call_environment_release",
+        lambda environment_url, timeout, task_id: calls.append(
+            ("release", environment_url, timeout, task_id)
+        ),
+    )
+
+    main._preflight_mobilegym_environment("http://127.0.0.1:19090", timeout=7)
+
+    assert [call[0] for call in calls] == ["setup", "release"]
+    assert calls[0][1:3] == ("http://127.0.0.1:19090", 7)
+    assert calls[1][1:3] == ("http://127.0.0.1:19090", 7)
+    assert calls[0][3] == calls[1][3]
+    assert calls[0][3].startswith("benchmark-preflight:")
+
+
+def test_preflight_mobilegym_environment_rejects_setup_failure(monkeypatch):
+    monkeypatch.setattr(
+        main,
+        "_read_environment_health",
+        lambda environment_url: {"bridge_type": "mobilegym", "platform": "android"},
+    )
+
+    def fail_setup(environment_url, timeout, task_id):
+        raise main.ResetError("setup timed out")
+
+    monkeypatch.setattr(main, "call_environment_setup", fail_setup)
+    monkeypatch.setattr(main, "call_environment_release", lambda *args, **kwargs: None)
+
+    with pytest.raises(RuntimeError, match="start a fresh MobileGym environment"):
+        main._preflight_mobilegym_environment("http://127.0.0.1:19090", timeout=7)
+
+
 def test_resolve_target_platform_reads_vphone_ios_health(monkeypatch):
     args = type("Args", (), {"target_platform": "auto", "environment_url": "http://127.0.0.1:8899"})()
     monkeypatch.setattr(
@@ -304,6 +352,21 @@ def test_run_manifest_records_agent_model(monkeypatch, tmp_path):
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["agent_model"] == "qwen3.6-35b"
     assert manifest["judge_config"] is None
+
+
+def test_run_cli_defaults_use_benchmark_agent_and_judge_model_environment(monkeypatch):
+    captured = {}
+    monkeypatch.setenv("AIDEN_BENCHMARK_AGENT_MODEL", "agent-model")
+    monkeypatch.setenv("AIDEN_BENCHMARK_JUDGE_MODEL", "judge-model")
+    monkeypatch.setenv("AIDEN_MODEL", "legacy-aiden-model")
+    monkeypatch.setenv("MODEL_NAME", "legacy-model")
+    monkeypatch.setenv("OPENAI_MODEL", "legacy-openai-model")
+    monkeypatch.setattr(main, "_cmd_run", lambda args: captured.update(vars(args)) or 0)
+
+    assert main.cli(["run", "--suite", "unused.json"]) == 0
+
+    assert captured["agent_model"] == "agent-model"
+    assert captured["judge_model"] == "judge-model"
 
 
 def test_run_state_file_records_incremental_totals(monkeypatch, tmp_path):
@@ -850,6 +913,7 @@ def test_auto_agent_setup_injects_environment_url_as_bridge_endpoint(monkeypatch
     monkeypatch.setattr(main, "wait_for_agent_clock", lambda *args, **kwargs: True)
     monkeypatch.setattr(main, "_read_environment_health", lambda url: {"bridge_type": "mobilegym"})
     monkeypatch.setattr(main, "generate_report_html", lambda run_dir: "<html></html>")
+    monkeypatch.setattr(main, "call_environment_setup", lambda *args, **kwargs: None)
     monkeypatch.setattr(main, "call_environment_release", lambda *args, **kwargs: None)
     monkeypatch.setattr(main, "clear_stale_adb_android_owner", lambda url: stale_clears.append(url))
     monkeypatch.setattr(webui, "ensure_daemon_image", lambda *args, **kwargs: None)

--- a/benchmark/tests/test_webui.py
+++ b/benchmark/tests/test_webui.py
@@ -1203,6 +1203,7 @@ def test_run_suite_passes_mobilegym_environment_url(tmp_path: Path, monkeypatch)
 
     def fake_popen(cmd, **kwargs):
         captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
         return FakeProc()
 
     monkeypatch.setattr(webui.subprocess, "Popen", fake_popen)
@@ -1211,6 +1212,7 @@ def test_run_suite_passes_mobilegym_environment_url(tmp_path: Path, monkeypatch)
 
     assert "--environment-url" in captured["cmd"]
     assert captured["cmd"][captured["cmd"].index("--environment-url") + 1] == "http://127.0.0.1:19090"
+    assert captured["env"][webui.MOBILEGYM_PREFLIGHT_COMPLETE_ENV] == "1"
 
 
 def test_shared_daemon_job_uses_one_benchmark_task_id_for_daemon_and_runner(
@@ -1376,6 +1378,7 @@ def test_mobilegym_task_worker_uses_task_id_for_daemon_and_runner(tmp_path: Path
         captured["owner_job_id"] = owner_job_id
         captured["extra_owner_ids"] = extra_owner_ids
         captured["cmd"] = cmd
+        captured["env"] = env
         run_id = cmd[cmd.index("--run-id") + 1]
         run_path = raw_runs_dir / run_id
         run_path.mkdir(parents=True)
@@ -1404,6 +1407,7 @@ def test_mobilegym_task_worker_uses_task_id_for_daemon_and_runner(tmp_path: Path
         Path(job.config_dir) / "control_token"
     )
     assert captured["cmd"][captured["cmd"].index("--environment-url") + 1] == "http://127.0.0.1:19090"
+    assert captured["env"][webui.MOBILEGYM_PREFLIGHT_COMPLETE_ENV] == "1"
     assert "--target-platform" not in captured["cmd"]
     assert releases == [("http://127.0.0.1:19090", 2, "suite.json:t1")]
     assert result["exit_code"] == 0
@@ -1415,6 +1419,82 @@ def test_mobilegym_task_worker_uses_task_id_for_daemon_and_runner(tmp_path: Path
     assert task_record.agent_url == "http://127.0.0.1:18081"
     assert task_record.report_url == f"/reports/{job.id}/{result['run_id']}/report.html"
     assert task_record.screen_url == webui.webui_task_screen_url(job.id, task_record.id)
+
+
+@pytest.mark.parametrize("parallel_tasks", [1, 2])
+def test_mobilegym_webui_job_preflights_before_starting_workers(
+    tmp_path: Path, monkeypatch, parallel_tasks: int
+):
+    app = webui.BenchmarkWebApp(
+        webui.WebUIConfig(
+            suites_dir=tmp_path / "suites",
+            runs_dir=tmp_path / "runs",
+            base_config_dir=tmp_path / "base-config",
+            build_daemon_image=False,
+        )
+    )
+    job_dir = tmp_path / "runs" / "job-test"
+    (job_dir / "raw").mkdir(parents=True)
+    job = webui.Job(
+        id="job-test",
+        endpoint="http://127.0.0.1:19090",
+        docker_endpoint="http://host.docker.internal:19090",
+        environment_endpoint="http://127.0.0.1:19090",
+        suites=["suite.json"],
+        environment_type="mobilegym",
+        agent_url="http://127.0.0.1:18080",
+        config_dir=str(job_dir / "config"),
+        raw_runs_dir=str(job_dir / "raw"),
+        state_file=str(job_dir / "state.json"),
+        runner_log=str(job_dir / "runner.log"),
+        daemon_log=str(job_dir / "daemon.log"),
+        no_judge=True,
+        parallel_tasks=parallel_tasks,
+    )
+    events = []
+
+    monkeypatch.setattr(app, "get_agent_config", lambda: {"content": ""})
+    monkeypatch.setattr(webui, "prepare_run_config", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        webui,
+        "read_environment_health",
+        lambda endpoint: {
+            "bridge_type": "mobilegym",
+            "platform": "android",
+            "env_count": parallel_tasks,
+        },
+    )
+    monkeypatch.setattr(
+        webui,
+        "preflight_mobilegym_environment",
+        lambda endpoint, health=None: events.append(("preflight", endpoint, health)),
+    )
+    monkeypatch.setattr(webui, "ensure_daemon_image", lambda *args, **kwargs: None)
+    monkeypatch.setattr(app, "_refresh_job_report", lambda *args, **kwargs: None)
+    if parallel_tasks > 1:
+        monkeypatch.setattr(
+            app,
+            "_run_mobilegym_suite_parallel",
+            lambda current_job, suite_key: events.append(("parallel", suite_key)),
+        )
+    else:
+        monkeypatch.setattr(webui, "start_daemon_compose", lambda *args, **kwargs: "container-id")
+        monkeypatch.setattr(webui, "start_daemon_logs", lambda *args, **kwargs: None)
+        monkeypatch.setattr(webui, "stop_daemon_compose", lambda *args, **kwargs: None)
+        monkeypatch.setattr(app, "_wait_for_daemon", lambda *args, **kwargs: None)
+        monkeypatch.setattr(app, "_release_job_environment", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            app,
+            "_run_suite",
+            lambda current_job, suite_key: events.append(("single", suite_key)),
+        )
+
+    app._run_job(job)
+
+    assert events[0][0] == "preflight"
+    assert events[0][1] == "http://127.0.0.1:19090"
+    assert events[0][2]["env_count"] == parallel_tasks
+    assert events[1] == ("parallel" if parallel_tasks > 1 else "single", "suite.json")
 
 
 def test_read_task_log_returns_task_worker_logs(tmp_path: Path):

--- a/benchmark/tests/test_webui.py
+++ b/benchmark/tests/test_webui.py
@@ -188,17 +188,19 @@ def test_prepare_run_config_renders_template(tmp_path: Path, monkeypatch):
         '\n'.join(
             [
                 '[model]',
-                'provider = "{{MODEL_PROVIDER}}"',
-                'model = "{{MODEL_NAME}}"',
-                'api_key = "{{MODEL_API_KEY}}"',
+                'provider = "{{AIDEN_BENCHMARK_AGENT_PROVIDER}}"',
+                'model = "{{AIDEN_BENCHMARK_AGENT_MODEL}}"',
+                'base_url = "{{AIDEN_BENCHMARK_AGENT_BASE_URL}}"',
+                'api_key = "{{AIDEN_BENCHMARK_AGENT_API_KEY}}"',
                 'control = "{{CONTROL_TOKEN_FILE}}"',
             ]
         ),
         encoding="utf-8",
     )
-    monkeypatch.setenv("MODEL_PROVIDER", "openai")
-    monkeypatch.setenv("MODEL_NAME", "gpt-test")
-    monkeypatch.setenv("MODEL_API_KEY", "sk-test")
+    monkeypatch.setenv("AIDEN_BENCHMARK_AGENT_PROVIDER", "openai")
+    monkeypatch.setenv("AIDEN_BENCHMARK_AGENT_MODEL", "gpt-test")
+    monkeypatch.setenv("AIDEN_BENCHMARK_AGENT_BASE_URL", "https://agent.example/v1")
+    monkeypatch.setenv("AIDEN_BENCHMARK_AGENT_API_KEY", "sk-test")
 
     dest = tmp_path / "dest"
     webui.prepare_run_config(base, dest)
@@ -206,6 +208,7 @@ def test_prepare_run_config_renders_template(tmp_path: Path, monkeypatch):
     rendered = (dest / "agent.toml").read_text(encoding="utf-8")
     assert 'provider = "openai"' in rendered
     assert 'model = "gpt-test"' in rendered
+    assert 'base_url = "https://agent.example/v1"' in rendered
     assert 'api_key = "sk-test"' in rendered
     assert 'control = "/config/control_token"' in rendered
     assert "voice_streaming_tts_enabled = false" in rendered
@@ -214,6 +217,52 @@ def test_prepare_run_config_renders_template(tmp_path: Path, monkeypatch):
     assert (dest / "control_token").exists()
     assert (dest / "memory").is_dir()
     assert (dest / "skill-state").is_dir()
+
+
+def test_prepare_run_config_ignores_legacy_agent_model_environment(tmp_path: Path, monkeypatch):
+    base = tmp_path / "base"
+    base.mkdir()
+    (base / "agent.toml.template").write_text(
+        '\n'.join(
+            [
+                '[model]',
+                'provider = "{{AIDEN_BENCHMARK_AGENT_PROVIDER}}"',
+                'model = "{{AIDEN_BENCHMARK_AGENT_MODEL}}"',
+                'base_url = "{{AIDEN_BENCHMARK_AGENT_BASE_URL}}"',
+                'api_key = "{{AIDEN_BENCHMARK_AGENT_API_KEY}}"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    for name, value in {
+        "MODEL_PROVIDER": "legacy-provider",
+        "MODEL_NAME": "legacy-model",
+        "MODEL_BASE_URL": "https://legacy.example/v1",
+        "MODEL_API_KEY": "legacy-key",
+        "AIDEN_MODEL": "legacy-aiden-model",
+        "AIDEN_MODEL_PROVIDER": "legacy-aiden-provider",
+        "AIDEN_MODEL_BASE_URL": "https://legacy-aiden.example/v1",
+        "AIDEN_MODEL_API_KEY": "legacy-aiden-key",
+        "OPENAI_MODEL": "legacy-openai-model",
+        "OPENROUTER_API_KEY": "legacy-openrouter-key",
+    }.items():
+        monkeypatch.setenv(name, value)
+    for name in (
+        "AIDEN_BENCHMARK_AGENT_PROVIDER",
+        "AIDEN_BENCHMARK_AGENT_MODEL",
+        "AIDEN_BENCHMARK_AGENT_BASE_URL",
+        "AIDEN_BENCHMARK_AGENT_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    dest = tmp_path / "dest"
+    webui.prepare_run_config(base, dest)
+
+    rendered = (dest / "agent.toml").read_text(encoding="utf-8")
+    assert 'provider = "fake"' in rendered
+    assert 'model = ""' in rendered
+    assert 'base_url = ""' in rendered
+    assert 'api_key = ""' in rendered
 
 
 def test_prepare_run_config_uses_agent_config_text(tmp_path: Path):
@@ -233,6 +282,54 @@ def test_prepare_run_config_uses_agent_config_text(tmp_path: Path):
     assert "voice_progress_speech_enabled = false" in rendered
     assert (dest / "control_token").exists()
     assert (dest / "memory").is_dir()
+
+
+def test_prepare_run_config_materializes_agent_credential_environment_references(
+    tmp_path: Path, monkeypatch
+):
+    base = tmp_path / "base"
+    base.mkdir()
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "sk-agent-secret")
+    agent_config = """
+[model_providers.benchmark]
+type = "anthropic"
+api_key = "$ANTHROPIC_AUTH_TOKEN"
+
+[model]
+provider = "benchmark"
+model = "claude-opus-5"
+""".strip()
+
+    dest = tmp_path / "dest"
+    webui.prepare_run_config(base, dest, agent_config_text=agent_config)
+
+    rendered = (dest / "agent.toml").read_text(encoding="utf-8")
+    assert 'api_key = "sk-agent-secret"' in rendered
+    assert "$ANTHROPIC_AUTH_TOKEN" not in rendered
+
+
+def test_prepare_run_config_rejects_missing_agent_credential_environment_reference(
+    tmp_path: Path, monkeypatch
+):
+    base = tmp_path / "base"
+    base.mkdir()
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    agent_config = """
+[model_providers.benchmark]
+type = "anthropic"
+api_key = "$ANTHROPIC_AUTH_TOKEN"
+
+[model]
+provider = "benchmark"
+model = "claude-opus-5"
+""".strip()
+
+    with pytest.raises(ValueError, match="ANTHROPIC_AUTH_TOKEN"):
+        webui.prepare_run_config(
+            base,
+            tmp_path / "dest",
+            agent_config_text=agent_config,
+        )
 
 
 def test_prepare_run_config_does_not_copy_runtime_state(tmp_path: Path):
@@ -416,11 +513,11 @@ def test_webui_agent_config_persists_under_runs_dir(tmp_path: Path, monkeypatch)
     base = tmp_path / "base"
     base.mkdir()
     (base / "agent.toml.template").write_text(
-        '[model]\nprovider = "{{MODEL_PROVIDER}}"\nmodel = "{{MODEL_NAME}}"\n',
+        '[model]\nprovider = "{{AIDEN_BENCHMARK_AGENT_PROVIDER}}"\nmodel = "{{AIDEN_BENCHMARK_AGENT_MODEL}}"\n',
         encoding="utf-8",
     )
-    monkeypatch.setenv("MODEL_PROVIDER", "openai")
-    monkeypatch.setenv("MODEL_NAME", "gpt-test")
+    monkeypatch.setenv("AIDEN_BENCHMARK_AGENT_PROVIDER", "openai")
+    monkeypatch.setenv("AIDEN_BENCHMARK_AGENT_MODEL", "gpt-test")
     app = webui.BenchmarkWebApp(webui.WebUIConfig(runs_dir=tmp_path / "runs", base_config_dir=base))
 
     initial = app.get_agent_config()
@@ -598,6 +695,52 @@ def test_start_job_records_judge_settings_without_exposing_api_key(tmp_path: Pat
     assert job["judge_api_key_set"] is True
     assert "judge_api_key" not in job
     assert app._job_judge_api_keys[job["id"]] == "sk-judge-secret"
+
+
+def test_start_job_rejects_recovered_mobilegym_environment(tmp_path: Path, monkeypatch):
+    suites = tmp_path / "suites"
+    suites.mkdir()
+    (suites / "suite.json").write_text(
+        json.dumps({"name": "suite", "tasks": [{"id": "t1", "category": "diagnostic"}]}),
+        encoding="utf-8",
+    )
+    app = webui.BenchmarkWebApp(
+        webui.WebUIConfig(
+            suites_dir=suites,
+            runs_dir=tmp_path / "runs",
+            base_config_dir=tmp_path / "config",
+        )
+    )
+    recovered = webui.MobileGymEnvironment(
+        id="mg-old",
+        name="MobileGym recovered",
+        endpoint="http://host.docker.internal:19090",
+        public_endpoint="http://127.0.0.1:19090",
+        web_url="http://127.0.0.1:18173",
+        status="stale",
+        container_name="aiden-mobilegym-env-mg-old",
+    )
+    app.env_manager._environments[recovered.id] = recovered
+    monkeypatch.setattr(webui, "read_environment_bridge_concurrency", lambda endpoint: 3)
+
+    class FakeThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(webui.threading, "Thread", FakeThread)
+
+    with pytest.raises(ValueError, match="fresh MobileGym environment"):
+        app.start_job(
+            {
+                "environment_type": "mobilegym",
+                "environment_id": recovered.id,
+                "suites": ["suite.json"],
+                "no_judge": True,
+            }
+        )
 
 
 def test_start_job_persists_job_record_without_api_key(tmp_path: Path, monkeypatch):
@@ -1019,7 +1162,8 @@ def test_run_suite_passes_judge_model_and_api_key_env(tmp_path: Path, monkeypatc
     assert "--judge-base-url" in captured["cmd"]
     assert captured["cmd"][captured["cmd"].index("--judge-base-url") + 1] == "https://judge.example.com/v1"
     assert "--no-judge" not in captured["cmd"]
-    assert captured["env"]["OPENROUTER_API_KEY"] == "sk-judge-secret"
+    assert captured["env"]["AIDEN_BENCHMARK_JUDGE_API_KEY"] == "sk-judge-secret"
+    assert "OPENROUTER_API_KEY" not in captured["env"]
 
 
 def test_run_suite_passes_mobilegym_environment_url(tmp_path: Path, monkeypatch):

--- a/benchmark/vphone/start.sh
+++ b/benchmark/vphone/start.sh
@@ -17,7 +17,7 @@
 # `run` auto-discovers the running agent daemon's port and control token, so you
 # never paste --agent-url / --benchmark-token-file. Start a daemon first with
 # `./start.sh agent`. Judging is OFF by default; pass --judge-model <model> to
-# score, and --judge-key <key> to supply the judge OpenRouter key inline (no
+# score, and --judge-key <key> to supply the judge API key inline (no
 # export needed).
 #
 # The env file is picked up in this order:
@@ -258,18 +258,18 @@ case "$SUBCMD" in
       exit 1
     fi
     # Pull our own --judge-key <key> out of the args (runner does not know it) and
-    # feed it to the judge as OPENROUTER_API_KEY, so you can pass the key inline
+    # feed it to the judge, so you can pass the key inline
     # instead of exporting it. Everything else is forwarded to `runner run`.
     passthru=()
     while [ $# -gt 0 ]; do
       case "$1" in
         --judge-key)
           [ $# -ge 2 ] || { echo "error: --judge-key needs a value" >&2; exit 1; }
-          export OPENROUTER_API_KEY="$2"
+          export AIDEN_BENCHMARK_JUDGE_API_KEY="$2"
           shift 2
           ;;
         --judge-key=*)
-          export OPENROUTER_API_KEY="${1#--judge-key=}"
+          export AIDEN_BENCHMARK_JUDGE_API_KEY="${1#--judge-key=}"
           shift
           ;;
         *)
@@ -284,16 +284,16 @@ case "$SUBCMD" in
       *" --suite "*|*" --suite="*) : ;;
       *) suite_args=(--suite suites/vphone_ios_basic.json) ;;
     esac
-    # Judging is OFF by default: it needs an OpenRouter key, and forgetting it
+    # Judging is OFF by default: it needs an API key, and forgetting it
     # turns every task into JUDGE_ERROR. Opt in with --judge-model / --judge; then
-    # require the key (from --judge-key or OPENROUTER_API_KEY) up front instead of
+    # require the key up front instead of
     # failing after every task has run.
     judge_args=()
     case " ${passthru[*]:-} " in
       *" --judge-model "*|*" --judge-model="*|*" --judge "*|*" --judge="*)
-        if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+        if [ -z "${AIDEN_BENCHMARK_JUDGE_API_KEY:-}" ]; then
           echo "error: judging requested but no judge key provided." >&2
-          echo "hint: add --judge-key <judge OpenRouter key>," >&2
+          echo "hint: add --judge-key <judge API key>," >&2
           echo "      or drop --judge-model to run without scoring." >&2
           exit 1
         fi

--- a/docs/09-benchmark/README.md
+++ b/docs/09-benchmark/README.md
@@ -155,7 +155,7 @@ benchmark/
 │   ├── main.py          # CLI entry point
 │   ├── suite.py         # Suite loading
 │   ├── runtask.py       # Task execution
-│   ├── judge.py         # OpenRouter-compatible LLM judge
+│   ├── judge.py         # OpenAI-compatible LLM judge
 │   └── html_report.py   # HTML report generation
 ├── suites/              # Benchmark suites
 ├── environment_bridge.md
@@ -198,6 +198,11 @@ Suites with suite-level or task-level `mock_environment` require
 `--auto-agent-setup` and must not also pass `--environment-url`; the runner starts
 the scripted bridge itself and activates the matching fixture before each task.
 
+Auto-started Docker workers receive a host-resolved, read-only `agent.toml`.
+Credential references such as `api_key = "$AIDEN_BENCHMARK_AGENT_API_KEY"` must resolve on the
+host before the daemon starts. MobileGym endpoints also pass a functional
+`setup` / `release` preflight before workers are created.
+
 ### `rejudge`
 
 ```bash
@@ -216,7 +221,14 @@ Compare task status flips, latency, and pass-rate changes between two runs.
 
 ## Environment Variables
 
-- `OPENROUTER_API_KEY` - Required when judge is enabled.
+- `AIDEN_BENCHMARK_AGENT_PROVIDER` - Agent provider type for the default config template.
+- `AIDEN_BENCHMARK_AGENT_MODEL` - Agent model for the default config template and run manifest.
+- `AIDEN_BENCHMARK_AGENT_BASE_URL` - Agent model endpoint for the default config template.
+- `AIDEN_BENCHMARK_AGENT_API_KEY` - Agent credential embedded in the generated read-only config.
+- `AIDEN_BENCHMARK_JUDGE_MODEL` - Default judge model.
+- `AIDEN_BENCHMARK_JUDGE_BASE_URL` - Default OpenAI-compatible judge endpoint.
+- `AIDEN_BENCHMARK_JUDGE_API_KEY` - Required when judge is enabled.
+- `AIDEN_BENCHMARK_ANALYSIS_API_KEY` - Optional post-run analysis credential; defaults to the Judge key.
 - `AIDEN_AGENT_URL` - Default `--agent-url`.
 - `AIDEN_ENVIRONMENT_URL` - Default `--environment-url`.
 - `AIDEN_DAEMON_IMAGE` - Default daemon worker image for auto agent setup.

--- a/docs/09-benchmark/architecture.md
+++ b/docs/09-benchmark/architecture.md
@@ -93,9 +93,10 @@ The judge uses OpenAI-compatible chat completions. Its input is:
 The output is one yes/no verdict plus reason per rubric item. Results are
 cached by screenshots, trace, rubric, final response, and model.
 
-Agent and Judge runtime configuration use separate role-specific namespaces:
-`AIDEN_BENCHMARK_AGENT_*` and `AIDEN_BENCHMARK_JUDGE_*`. Provider-specific
-environment variable names are not part of the benchmark runtime contract.
+Agent, Judge, and Analysis runtime configuration use separate role-specific
+namespaces: `AIDEN_BENCHMARK_AGENT_*`, `AIDEN_BENCHMARK_JUDGE_*`, and
+`AIDEN_BENCHMARK_ANALYSIS_*`. Provider-specific environment variable names are
+not part of the benchmark runtime contract.
 
 ## Artifacts
 

--- a/docs/09-benchmark/architecture.md
+++ b/docs/09-benchmark/architecture.md
@@ -82,7 +82,7 @@ the HTML report.
 
 ### LLM Judge
 
-The judge uses OpenRouter-compatible chat completions. Its input is:
+The judge uses OpenAI-compatible chat completions. Its input is:
 
 - Task description.
 - Rubric.
@@ -92,6 +92,10 @@ The judge uses OpenRouter-compatible chat completions. Its input is:
 
 The output is one yes/no verdict plus reason per rubric item. Results are
 cached by screenshots, trace, rubric, final response, and model.
+
+Agent and Judge runtime configuration use separate role-specific namespaces:
+`AIDEN_BENCHMARK_AGENT_*` and `AIDEN_BENCHMARK_JUDGE_*`. Provider-specific
+environment variable names are not part of the benchmark runtime contract.
 
 ## Artifacts
 

--- a/docs/09-benchmark/quickstart.md
+++ b/docs/09-benchmark/quickstart.md
@@ -33,7 +33,17 @@ This page is a compact quickstart. The complete guide is
    export AIDEN_BENCHMARK_JUDGE_API_KEY=...
    ```
 
-4. Either an existing agent daemon, or an environment bridge plus
+4. Optional post-run Analysis settings default to the Judge model, endpoint, and
+   API key. Set role-specific overrides only when Analysis uses a different
+   runtime:
+
+   ```bash
+   export AIDEN_BENCHMARK_ANALYSIS_MODEL=your-analysis-model
+   export AIDEN_BENCHMARK_ANALYSIS_BASE_URL=https://your-analysis-endpoint.example/v1
+   export AIDEN_BENCHMARK_ANALYSIS_API_KEY=...
+   ```
+
+5. Either an existing agent daemon, or an environment bridge plus
    `--auto-agent-setup`.
 
 ## Run Against An Existing Agent

--- a/docs/09-benchmark/quickstart.md
+++ b/docs/09-benchmark/quickstart.md
@@ -16,13 +16,24 @@ This page is a compact quickstart. The complete guide is
    uv sync
    ```
 
-2. Judge API key if judge is enabled:
+2. Configure the Agent model when using the built-in config template:
 
    ```bash
-   export OPENROUTER_API_KEY=...
+   export AIDEN_BENCHMARK_AGENT_PROVIDER=openai
+   export AIDEN_BENCHMARK_AGENT_MODEL=your-agent-model
+   export AIDEN_BENCHMARK_AGENT_BASE_URL=https://your-agent-endpoint.example/v1
+   export AIDEN_BENCHMARK_AGENT_API_KEY=...
    ```
 
-3. Either an existing agent daemon, or an environment bridge plus
+3. Configure the Judge when it is enabled:
+
+   ```bash
+   export AIDEN_BENCHMARK_JUDGE_MODEL=your-judge-model
+   export AIDEN_BENCHMARK_JUDGE_BASE_URL=https://your-judge-endpoint.example/v1
+   export AIDEN_BENCHMARK_JUDGE_API_KEY=...
+   ```
+
+4. Either an existing agent daemon, or an environment bridge plus
    `--auto-agent-setup`.
 
 ## Run Against An Existing Agent

--- a/skillopt/tests/test_webui.py
+++ b/skillopt/tests/test_webui.py
@@ -269,6 +269,7 @@ def test_run_job_uses_agent_config_api_key_as_openrouter_fallback(tmp_path: Path
 
         def __init__(self, *args, **kwargs):
             observed["openrouter_api_key"] = kwargs["env"].get("OPENROUTER_API_KEY")
+            observed["judge_api_key"] = kwargs["env"].get("AIDEN_BENCHMARK_JUDGE_API_KEY")
 
         def poll(self):
             return 0
@@ -282,6 +283,7 @@ def test_run_job_uses_agent_config_api_key_as_openrouter_fallback(tmp_path: Path
     app._run_job(job)
 
     assert observed["openrouter_api_key"] == "sk-agent-fallback"
+    assert observed["judge_api_key"] == "sk-agent-fallback"
 
 
 def test_run_job_prefers_explicit_judge_api_key_over_agent_config(tmp_path: Path, monkeypatch):
@@ -307,6 +309,7 @@ def test_run_job_prefers_explicit_judge_api_key_over_agent_config(tmp_path: Path
 
         def __init__(self, *args, **kwargs):
             observed["openrouter_api_key"] = kwargs["env"].get("OPENROUTER_API_KEY")
+            observed["judge_api_key"] = kwargs["env"].get("AIDEN_BENCHMARK_JUDGE_API_KEY")
 
         def poll(self):
             return 0
@@ -319,6 +322,7 @@ def test_run_job_prefers_explicit_judge_api_key_over_agent_config(tmp_path: Path
     app._run_job(job)
 
     assert observed["openrouter_api_key"] == "sk-explicit-judge"
+    assert observed["judge_api_key"] == "sk-explicit-judge"
 
 
 def test_running_job_payload_reports_benchmark_artifact_progress(tmp_path: Path):
@@ -848,6 +852,7 @@ def test_index_html_reuses_benchmark_webui_shell():
     assert 'id="judgeEnabled"' in INDEX_HTML
     assert 'id="judgeModel"' in INDEX_HTML
     assert 'id="judgeApiKey"' in INDEX_HTML
+    assert 'placeholder="AIDEN_BENCHMARK_JUDGE_API_KEY"' in INDEX_HTML
     assert 'id="optimizerModel"' in INDEX_HTML
     assert 'id="runEnvDialog"' in INDEX_HTML
     assert 'id="skill"' not in INDEX_HTML

--- a/skillopt/webui.py
+++ b/skillopt/webui.py
@@ -22,7 +22,7 @@ from typing import Any, Mapping
 from runner.agent_config import resolve_agent_model_api_key
 from runner.environment import EnvironmentManager
 from runner.config import AgentConfigManager
-from runner.judge import JudgeConfig
+from runner.judge import DEFAULT_JUDGE_API_KEY_ENV, JudgeConfig
 from skillopt.benchmark_backend import load_benchmark_task_results
 from skillopt.phase_artifacts import latest_phase_record, load_phase_records, progress_from_phase_record
 from skillopt.score import task_result_to_rollout
@@ -517,6 +517,7 @@ class SkillOptWebApp:
             judge_api_key = agent_config_api_key_for_job(job, env=env)
         if judge_api_key:
             env["OPENROUTER_API_KEY"] = judge_api_key
+            env[DEFAULT_JUDGE_API_KEY_ENV] = judge_api_key
         env["PYTHONUNBUFFERED"] = "1"
         with Path(job.log_path).open("wb") as log:
             log.write(("$ " + " ".join(job.command) + "\n").encode("utf-8"))
@@ -1657,7 +1658,7 @@ INDEX_HTML = r"""<!doctype html>
           <div class="judge-inline">
             <label class="check-label"><input id="judgeEnabled" type="checkbox" checked> Enable judge</label>
             <div class="field"><label for="judgeModel">Judge model</label><input id="judgeModel" autocomplete="off" placeholder="agent.toml [model].model"></div>
-            <div class="field"><label for="judgeApiKey">API key</label><input id="judgeApiKey" type="password" autocomplete="off" placeholder="OPENROUTER_API_KEY"></div>
+            <div class="field"><label for="judgeApiKey">API key</label><input id="judgeApiKey" type="password" autocomplete="off" placeholder="AIDEN_BENCHMARK_JUDGE_API_KEY"></div>
           </div>
           <div class="run-actions">
             <button id="runBtn" class="primary">Run selected target</button>
@@ -2028,7 +2029,7 @@ INDEX_HTML = r"""<!doctype html>
       document.getElementById('judgeModel').value = String(judge.model || DEFAULT_JUDGE_MODEL);
       const keyInput = document.getElementById('judgeApiKey');
       keyInput.value = '';
-      keyInput.placeholder = judge.has_api_key ? 'Saved; leave blank to keep' : 'OPENROUTER_API_KEY';
+      keyInput.placeholder = judge.has_api_key ? 'Saved; leave blank to keep' : 'AIDEN_BENCHMARK_JUDGE_API_KEY';
       const so = settings.skillopt || {};
       if(so.budget) document.getElementById('budget').value = String(so.budget);
       if(so.edit_budget) document.getElementById('editBudget').value = String(so.edit_budget);


### PR DESCRIPTION
## Summary

- standardize benchmark Agent, Judge, and Analysis runtime variable names under the `AIDEN_BENCHMARK_*` namespace
- materialize Agent credential references into the generated read-only `agent.toml` before mounting it into Docker
- mark recovered MobileGym containers as stale and add a setup/release preflight to prevent benchmark runs from reusing degraded environments
- update CLI, WebUI, VPhone launcher, documentation, and tests for the new configuration contract

## Testing

- `benchmark/.venv/bin/python -m pytest -q tests/test_agent_config.py tests/test_analysis.py tests/test_environment.py tests/test_judge.py tests/test_main.py tests/test_webui.py tests/mobilegym/test_local_launcher_config.py`
- 160 passed

## Notes

- no backward compatibility is retained for the previous generic or provider-specific benchmark environment variable names
- the existing dirty state in the `pico-sdk` submodule is not included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible OpenAI-compatible judge configuration with dedicated API key, provider, model, and endpoint settings.
  * Added dedicated benchmark agent configuration for provider, model, endpoint, and credentials.
  * Added credential reference resolution with validation for missing or blank values.
  * Added preflight checks for MobileGym environments before benchmark runs.

* **Bug Fixes**
  * Recovered MobileGym environments are now marked stale and cannot be reused until refreshed.

* **Documentation**
  * Updated benchmark setup, quickstart, architecture, troubleshooting, and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->