### PR TITLE
fix(benchmark): harden MobileGym reset lifecycle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 
 [submodule "benchmark/mobilegym/vendor/mobilegym"]
 	path = benchmark/mobilegym/vendor/mobilegym
-	url = https://github.com/Purewhiter/mobilegym.git
+	url = https://github.com/AidenAI-IO/mobilegym.git

--- a/benchmark/environment_bridge.md
+++ b/benchmark/environment_bridge.md
@@ -136,8 +136,17 @@ Initializes or resets the environment route for a benchmark task.
 Optional request body:
 
 ```json
-{"episode_id": "task-episode", "setup_token": "optional-idempotency-token"}
+{
+  "episode_id": "task-episode",
+  "setup_token": "optional-idempotency-token",
+  "app_ids": ["settings"]
+}
 ```
+
+`app_ids` is optional environment metadata. MobileGym uses it to preload only
+the data loaders required by the task. An omitted or empty list skips eager app
+data loading; apps still load their own data when opened. This avoids loading
+every registered app during each task reset.
 
 For bridges that do not need setup, return success with `setup: false`.
 

--- a/benchmark/manual.md
+++ b/benchmark/manual.md
@@ -327,6 +327,7 @@ Common fields:
 | `prompt_prefix` | Prefix for every task prompt; constrains device type, tool usage, etc. |
 | `global_reset` | Suite-level reset configuration |
 | `setup` | Task-level pre-steps; currently supports `{"type": "agent_prompt", ...}` |
+| `app_ids` | Optional MobileGym app IDs to preload during environment setup; omitted tasks skip eager app data loading |
 | `rubric` | The judge model's scoring items |
 | `hard_assertions` | Deterministic checks, e.g. tool-call counts, timeout, required/forbidden tools |
 | `hard_assertions.required_tool_calls` | Requires a tool call whose input contains a specified nested subset |

--- a/benchmark/mobilegym/bridge/TOOLS_API.md
+++ b/benchmark/mobilegym/bridge/TOOLS_API.md
@@ -76,7 +76,7 @@ The benchmark runner uses this endpoint to save `pre.jpg` and `post.jpg`.
 curl -X POST http://localhost:8888/api/setup \
   -H "Content-Type: application/json" \
   -H "benchmark-task-id: suite.json:task-1" \
-  -d '{}'
+  -d '{"app_ids":["settings"]}'
 
 curl -X POST http://localhost:8888/api/release \
   -H "Content-Type: application/json" \
@@ -86,6 +86,10 @@ curl -X POST http://localhost:8888/api/release \
 
 `/api/setup` claims an env route and resets it. `/api/release` frees that route
 for later tasks.
+
+`app_ids` is optional. Missing or empty `app_ids` skips eager app data loading;
+non-empty lists preload only the named apps. The app launch path still loads an
+app's data on demand.
 
 ## Concurrency
 

--- a/benchmark/mobilegym/bridge/episode.py
+++ b/benchmark/mobilegym/bridge/episode.py
@@ -130,6 +130,7 @@ class BridgeEpisodeState:
         self.action_log: list[dict[str, Any]] = []
         self._action_counter = 0
         self._env_lock = asyncio.Lock()
+        self._pending_sync_reset: asyncio.Task[Any] | None = None
         self._restart_task: asyncio.Task[bool] | None = None
 
     async def start_episode(self, episode_id: str) -> dict[str, str]:
@@ -180,21 +181,31 @@ class BridgeEpisodeState:
         *,
         app_ids: list[str] | None,
     ) -> None:
-        async def invoke() -> None:
-            if inspect.iscoroutinefunction(reset):
-                result = reset() if app_ids is None else reset(app_ids=app_ids)
-            elif app_ids is None:
-                result = await asyncio.to_thread(reset)
-            else:
-                result = await asyncio.to_thread(reset, app_ids=app_ids)
+        async def invoke_async() -> None:
+            result = reset() if app_ids is None else reset(app_ids=app_ids)
             if inspect.isawaitable(result):
                 await result
 
+        async def invoke_sync() -> None:
+            if app_ids is None:
+                reset_task = asyncio.create_task(asyncio.to_thread(reset))
+            else:
+                reset_task = asyncio.create_task(asyncio.to_thread(reset, app_ids=app_ids))
+            self._pending_sync_reset = reset_task
+            try:
+                result = await asyncio.shield(reset_task)
+            finally:
+                if reset_task.done() and self._pending_sync_reset is reset_task:
+                    self._pending_sync_reset = None
+            if inspect.isawaitable(result):
+                await result
+
+        invoke = invoke_async if inspect.iscoroutinefunction(reset) else invoke_sync
         await asyncio.wait_for(invoke(), timeout=EPISODE_RESET_TIMEOUT_SEC)
 
     async def _restart_env_after_timeout(self, reset_error: BaseException) -> bool:
         if self._restart_task is None:
-            self._restart_task = asyncio.create_task(self._restart_env_if_supported())
+            self._restart_task = asyncio.create_task(self._restart_env_when_idle())
         restart_task = self._restart_task
         try:
             result = await asyncio.wait_for(
@@ -227,8 +238,23 @@ class BridgeEpisodeState:
         self._restart_task = None
         return result
 
+    async def _restart_env_when_idle(self) -> bool:
+        await self._await_pending_sync_reset()
+        return await self._restart_env_if_supported()
+
+    async def _await_pending_sync_reset(self) -> None:
+        reset_task = self._pending_sync_reset
+        if reset_task is None:
+            return
+        try:
+            await asyncio.gather(asyncio.shield(reset_task), return_exceptions=True)
+        finally:
+            if reset_task.done() and self._pending_sync_reset is reset_task:
+                self._pending_sync_reset = None
+
     async def _await_pending_restart(self) -> None:
         if self._restart_task is None:
+            await self._await_pending_sync_reset()
             return
         await self._restart_env_after_timeout(
             TimeoutError("previous environment restart is still in progress")
@@ -237,11 +263,7 @@ class BridgeEpisodeState:
     async def _restart_env_if_supported(self) -> bool:
         restart = getattr(self.env, "restart", None)
         if restart is not None:
-            restart_result = restart()
-            if asyncio.iscoroutine(restart_result) or isinstance(restart_result, Awaitable):
-                started_env = await restart_result
-            else:
-                started_env = restart_result
+            started_env = await self._invoke_env_callable(restart)
             if started_env is not None:
                 self.env = started_env
             return True
@@ -250,17 +272,20 @@ class BridgeEpisodeState:
         start = getattr(self.env, "start", None)
         if close is None or start is None:
             return False
-        close_result = close()
-        if asyncio.iscoroutine(close_result) or isinstance(close_result, Awaitable):
-            await close_result
-        start_result = start()
-        if asyncio.iscoroutine(start_result) or isinstance(start_result, Awaitable):
-            started_env = await start_result
-        else:
-            started_env = start_result
+        await self._invoke_env_callable(close)
+        started_env = await self._invoke_env_callable(start)
         if started_env is not None:
             self.env = started_env
         return True
+
+    async def _invoke_env_callable(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        if inspect.iscoroutinefunction(fn):
+            result = fn(*args, **kwargs)
+        else:
+            result = await asyncio.to_thread(fn, *args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
 
     async def end_episode(self, episode_id: str) -> dict[str, Any]:
         episode_id = self.require_active(episode_id)

--- a/benchmark/mobilegym/bridge/episode.py
+++ b/benchmark/mobilegym/bridge/episode.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import threading
 from collections.abc import Awaitable, Callable
 from typing import Any
-
 
 BENCHMARK_TASK_ID_HEADER = "benchmark-task-id"
 EPISODE_RESET_TIMEOUT_SEC = 45
@@ -162,7 +162,7 @@ class BridgeEpisodeState:
                     await self._run_reset(reset, app_ids=app_ids)
                     reset_ran = True
                     break
-                except asyncio.TimeoutError as exc:
+                except (asyncio.TimeoutError, TimeoutError) as exc:
                     restarted = await self._restart_env_after_timeout(exc)
                     if attempt == 0 and restarted:
                         continue
@@ -180,9 +180,17 @@ class BridgeEpisodeState:
         *,
         app_ids: list[str] | None,
     ) -> None:
-        result = reset() if app_ids is None else reset(app_ids=app_ids)
-        if asyncio.iscoroutine(result) or isinstance(result, Awaitable):
-            await asyncio.wait_for(result, timeout=EPISODE_RESET_TIMEOUT_SEC)
+        async def invoke() -> None:
+            if inspect.iscoroutinefunction(reset):
+                result = reset() if app_ids is None else reset(app_ids=app_ids)
+            elif app_ids is None:
+                result = await asyncio.to_thread(reset)
+            else:
+                result = await asyncio.to_thread(reset, app_ids=app_ids)
+            if inspect.isawaitable(result):
+                await result
+
+        await asyncio.wait_for(invoke(), timeout=EPISODE_RESET_TIMEOUT_SEC)
 
     async def _restart_env_after_timeout(self, reset_error: BaseException) -> bool:
         if self._restart_task is None:

--- a/benchmark/mobilegym/bridge/episode.py
+++ b/benchmark/mobilegym/bridge/episode.py
@@ -8,6 +8,7 @@ from typing import Any
 
 BENCHMARK_TASK_ID_HEADER = "benchmark-task-id"
 EPISODE_RESET_TIMEOUT_SEC = 45
+EPISODE_RESTART_TIMEOUT_SEC = 30
 
 
 class BridgeEpisodeError(RuntimeError):
@@ -129,49 +130,114 @@ class BridgeEpisodeState:
         self.action_log: list[dict[str, Any]] = []
         self._action_counter = 0
         self._env_lock = asyncio.Lock()
+        self._restart_task: asyncio.Task[bool] | None = None
 
     async def start_episode(self, episode_id: str) -> dict[str, str]:
         episode_id = str(episode_id or "").strip()
         if not episode_id:
             raise ValueError("episode_id is required")
         async with self._env_lock:
+            await self._await_pending_restart()
             self.active_episode_id = episode_id
             self.action_log = []
             self._action_counter = 0
         return {"episode_id": episode_id}
 
-    async def reset_episode(self, episode_id: str) -> dict[str, Any]:
+    async def reset_episode(
+        self,
+        episode_id: str,
+        app_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
         episode_id = str(episode_id or "").strip()
         if not episode_id:
             raise ValueError("episode_id is required")
         async with self._env_lock:
+            await self._await_pending_restart()
             reset_ran = False
             for attempt in range(2):
-                restarted = await self._restart_env_if_supported()
                 reset = getattr(self.env, "reset", None)
                 if reset is None:
                     break
                 try:
-                    await self._run_reset(reset)
+                    await self._run_reset(reset, app_ids=app_ids)
                     reset_ran = True
                     break
                 except asyncio.TimeoutError as exc:
+                    restarted = await self._restart_env_after_timeout(exc)
                     if attempt == 0 and restarted:
                         continue
                     raise TimeoutError(
-                        f"environment reset timed out after {EPISODE_RESET_TIMEOUT_SEC}s"
+                        f"environment reset timed out after {EPISODE_RESET_TIMEOUT_SEC}s: {exc}"
                     ) from exc
             self.active_episode_id = episode_id
             self.action_log = []
             self._action_counter = 0
         return {"episode_id": episode_id, "reset": reset_ran}
 
-    async def _run_reset(self, reset: Callable[[], Any | Awaitable[Any]]) -> None:
-        result = reset()
+    async def _run_reset(
+        self,
+        reset: Callable[..., Any | Awaitable[Any]],
+        *,
+        app_ids: list[str] | None,
+    ) -> None:
+        result = reset() if app_ids is None else reset(app_ids=app_ids)
         if asyncio.iscoroutine(result) or isinstance(result, Awaitable):
             await asyncio.wait_for(result, timeout=EPISODE_RESET_TIMEOUT_SEC)
 
+    async def _restart_env_after_timeout(self, reset_error: BaseException) -> bool:
+        if self._restart_task is None:
+            self._restart_task = asyncio.create_task(self._restart_env_if_supported())
+        restart_task = self._restart_task
+        try:
+            result = await asyncio.wait_for(
+                asyncio.shield(restart_task),
+                timeout=EPISODE_RESTART_TIMEOUT_SEC,
+            )
+        except asyncio.TimeoutError as exc:
+            if restart_task.done():
+                try:
+                    result = restart_task.result()
+                except Exception as restart_exc:
+                    self._restart_task = None
+                    raise TimeoutError(
+                        "environment restart failed while recovering from reset timeout: "
+                        f"{type(restart_exc).__name__}: {restart_exc}; reset error: {reset_error}"
+                    ) from restart_exc
+                self._restart_task = None
+                return result
+            raise TimeoutError(
+                f"environment restart timed out after {EPISODE_RESTART_TIMEOUT_SEC}s "
+                f"while recovering from reset timeout: {reset_error}"
+            ) from exc
+        except Exception as exc:
+            if restart_task.done():
+                self._restart_task = None
+            raise TimeoutError(
+                f"environment restart failed while recovering from reset timeout: "
+                f"{type(exc).__name__}: {exc}; reset error: {reset_error}"
+            ) from exc
+        self._restart_task = None
+        return result
+
+    async def _await_pending_restart(self) -> None:
+        if self._restart_task is None:
+            return
+        await self._restart_env_after_timeout(
+            TimeoutError("previous environment restart is still in progress")
+        )
+
     async def _restart_env_if_supported(self) -> bool:
+        restart = getattr(self.env, "restart", None)
+        if restart is not None:
+            restart_result = restart()
+            if asyncio.iscoroutine(restart_result) or isinstance(restart_result, Awaitable):
+                started_env = await restart_result
+            else:
+                started_env = restart_result
+            if started_env is not None:
+                self.env = started_env
+            return True
+
         close = getattr(self.env, "close", None)
         start = getattr(self.env, "start", None)
         if close is None or start is None:
@@ -208,6 +274,7 @@ class BridgeEpisodeState:
         if running_loop is not self.owner_loop:
             raise RuntimeError("env work must run on the MobileGym owner loop")
         async with self._env_lock:
+            await self._await_pending_restart()
             result = fn(self.env)
             if asyncio.iscoroutine(result) or isinstance(result, Awaitable):
                 return await result

--- a/benchmark/mobilegym/bridge/server.py
+++ b/benchmark/mobilegym/bridge/server.py
@@ -49,6 +49,15 @@ DEFAULT_BRIDGE_REQUEST_TIMEOUT_SEC = 180
 SCREENSHOT_PROVIDER_TIMEOUT_SEC = 30
 
 
+def _setup_app_ids(payload: dict[str, Any]) -> list[str]:
+    value = payload.get("app_ids", [])
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) and item.strip() for item in value
+    ):
+        raise ValueError("app_ids must be a list of non-empty strings")
+    return list(dict.fromkeys(item.strip() for item in value))
+
+
 class BridgeServer:
     def __init__(
         self,
@@ -165,8 +174,8 @@ def _handler_for(bridge: BridgeServer):
                 self._send_error(429, "no_bridge_env_available", str(exc))
             except ValueError as exc:
                 self._send_error(400, "bad_request", str(exc))
-            except TimeoutError:
-                self._send_error(504, "timeout", "bridge request timed out")
+            except TimeoutError as exc:
+                self._send_error(504, "timeout", str(exc) or "bridge request timed out")
             except Exception as exc:
                 self._send_error(500, "bridge_error", str(exc))
 
@@ -189,13 +198,20 @@ def _handler_for(bridge: BridgeServer):
                 episode_id = f"reset-{uuid.uuid4().hex}"
             task_id = benchmark_task_id_from_headers(self.headers)
             setup_token = setup_token_from_payload(payload)
+            app_ids = _setup_app_ids(payload)
 
             def setup() -> dict[str, Any]:
                 state = bridge.router.state_for_task_id(task_id)
-                return bridge.submit_to_state(state, state.reset_episode(episode_id))
+                return bridge.submit_to_state(
+                    state,
+                    state.reset_episode(episode_id, app_ids=app_ids),
+                )
 
             if setup_token:
-                result = bridge.setup_tokens.run((task_id, setup_token), setup)
+                result = bridge.setup_tokens.run(
+                    (task_id, setup_token, tuple(app_ids)),
+                    setup,
+                )
             else:
                 result = setup()
             self._send_json(200, bridge_ok(result))

--- a/benchmark/mobilegym/bridge/server.py
+++ b/benchmark/mobilegym/bridge/server.py
@@ -50,7 +50,9 @@ SCREENSHOT_PROVIDER_TIMEOUT_SEC = 30
 
 
 def _setup_app_ids(payload: dict[str, Any]) -> list[str]:
-    value = payload.get("app_ids", [])
+    value = payload.get("app_ids")
+    if value is None:
+        return []
     if not isinstance(value, list) or not all(
         isinstance(item, str) and item.strip() for item in value
     ):

--- a/benchmark/mobilegym/bridge/test_tools_api.py
+++ b/benchmark/mobilegym/bridge/test_tools_api.py
@@ -780,6 +780,59 @@ def test_reset_episode_reuses_env_when_reset_succeeds():
     asyncio.run(run())
 
 
+def test_run_reset_bounds_synchronous_reset(monkeypatch):
+    import asyncio
+    import time
+
+    from . import episode as episode_mod
+
+    monkeypatch.setattr(episode_mod, "EPISODE_RESET_TIMEOUT_SEC", 0.01)
+
+    def reset(app_ids=None):
+        time.sleep(0.1)
+
+    async def run():
+        state = BridgeEpisodeState(object(), asyncio.get_running_loop())
+        started = time.monotonic()
+        with pytest.raises(asyncio.TimeoutError):
+            await state._run_reset(reset, app_ids=[])
+        return time.monotonic() - started
+
+    assert asyncio.run(run()) < 0.05
+
+
+def test_reset_episode_catches_builtin_timeout_error(monkeypatch):
+    import asyncio
+
+    from . import episode as episode_mod
+
+    class DistinctAsyncioTimeoutError(Exception):
+        pass
+
+    monkeypatch.setattr(episode_mod.asyncio, "TimeoutError", DistinctAsyncioTimeoutError)
+
+    class TimeoutEnv:
+        def __init__(self):
+            self.restart_calls = 0
+
+        async def reset(self, app_ids=None):
+            raise TimeoutError("phase=waitForData timeout")
+
+        async def restart(self):
+            self.restart_calls += 1
+
+    async def run():
+        env = TimeoutEnv()
+        state = BridgeEpisodeState(env, asyncio.get_running_loop())
+
+        with pytest.raises(TimeoutError, match="environment reset timed out"):
+            await state.reset_episode("episode-1", app_ids=[])
+
+        assert env.restart_calls == 2
+
+    asyncio.run(run())
+
+
 def test_reset_episode_retries_after_reset_timeout(monkeypatch):
     import asyncio
     from . import episode as episode_mod
@@ -866,7 +919,7 @@ def test_reset_episode_bounds_environment_restart(monkeypatch):
     import asyncio
     from . import episode as episode_mod
 
-    monkeypatch.setattr(episode_mod, "EPISODE_RESTART_TIMEOUT_SEC", 0.01, raising=False)
+    monkeypatch.setattr(episode_mod, "EPISODE_RESTART_TIMEOUT_SEC", 0.01)
 
     class HangingRestartEnv:
         async def reset(self, app_ids=None):
@@ -891,7 +944,7 @@ def test_reset_episode_keeps_timed_out_restart_isolated_until_it_finishes(monkey
     import asyncio
     from . import episode as episode_mod
 
-    monkeypatch.setattr(episode_mod, "EPISODE_RESTART_TIMEOUT_SEC", 0.01, raising=False)
+    monkeypatch.setattr(episode_mod, "EPISODE_RESTART_TIMEOUT_SEC", 0.01)
 
     class SlowRestartEnv:
         def __init__(self):

--- a/benchmark/mobilegym/bridge/test_tools_api.py
+++ b/benchmark/mobilegym/bridge/test_tools_api.py
@@ -751,35 +751,31 @@ def test_multi_env_tools_require_benchmark_task_id_header():
         loop.close()
 
 
-def test_reset_episode_restarts_env_before_reset_when_supported():
+def test_reset_episode_reuses_env_when_reset_succeeds():
     import asyncio
 
     class RestartableEnv:
         def __init__(self):
             self.calls = []
-            self.restarted = False
 
         async def close(self):
             self.calls.append("close")
 
         async def start(self):
             self.calls.append("start")
-            self.restarted = True
             return self
 
-        async def reset(self):
-            self.calls.append("reset")
-            if not self.restarted:
-                raise RuntimeError("second reset would hang without page restart")
+        async def reset(self, app_ids=None):
+            self.calls.append(("reset", app_ids))
 
     async def run():
         env = RestartableEnv()
         state = BridgeEpisodeState(env, asyncio.get_running_loop())
 
-        result = await state.reset_episode("episode-1")
+        result = await state.reset_episode("episode-1", app_ids=[])
 
         assert result == {"episode_id": "episode-1", "reset": True}
-        assert env.calls == ["close", "start", "reset"]
+        assert env.calls == [("reset", [])]
 
     asyncio.run(run())
 
@@ -802,8 +798,8 @@ def test_reset_episode_retries_after_reset_timeout(monkeypatch):
             self.calls.append("start")
             return self
 
-        async def reset(self):
-            self.calls.append("reset")
+        async def reset(self, app_ids=None):
+            self.calls.append(("reset", app_ids))
             self.reset_calls += 1
             if self.reset_calls == 1:
                 await asyncio.sleep(10)
@@ -812,10 +808,138 @@ def test_reset_episode_retries_after_reset_timeout(monkeypatch):
         env = TimeoutThenSuccessEnv()
         state = BridgeEpisodeState(env, asyncio.get_running_loop())
 
-        result = await state.reset_episode("episode-1")
+        result = await state.reset_episode("episode-1", app_ids=["settings"])
 
         assert result == {"episode_id": "episode-1", "reset": True}
-        assert env.calls == ["close", "start", "reset", "close", "start", "reset"]
+        assert env.calls == [
+            ("reset", ["settings"]),
+            "close",
+            "start",
+            ("reset", ["settings"]),
+        ]
+
+    asyncio.run(run())
+
+
+def test_reset_episode_recreates_env_after_final_timeout(monkeypatch):
+    import asyncio
+    from . import episode as episode_mod
+
+    monkeypatch.setattr(episode_mod, "EPISODE_RESET_TIMEOUT_SEC", 0.01)
+
+    class AlwaysTimeoutEnv:
+        def __init__(self):
+            self.calls = []
+
+        async def close(self):
+            self.calls.append("close")
+
+        async def start(self):
+            self.calls.append("start")
+            return self
+
+        async def reset(self, app_ids=None):
+            self.calls.append(("reset", app_ids))
+            await asyncio.sleep(10)
+
+    async def run():
+        env = AlwaysTimeoutEnv()
+        state = BridgeEpisodeState(env, asyncio.get_running_loop())
+
+        with pytest.raises(TimeoutError, match="reset timed out"):
+            await state.reset_episode("episode-1", app_ids=[])
+
+        assert env.calls == [
+            ("reset", []),
+            "close",
+            "start",
+            ("reset", []),
+            "close",
+            "start",
+        ]
+        assert state.active_episode_id is None
+
+    asyncio.run(run())
+
+
+def test_reset_episode_bounds_environment_restart(monkeypatch):
+    import asyncio
+    from . import episode as episode_mod
+
+    monkeypatch.setattr(episode_mod, "EPISODE_RESTART_TIMEOUT_SEC", 0.01, raising=False)
+
+    class HangingRestartEnv:
+        async def reset(self, app_ids=None):
+            raise TimeoutError("phase=__OS__ timeout")
+
+        async def close(self):
+            await asyncio.sleep(10)
+
+        async def start(self):
+            return self
+
+    async def run():
+        state = BridgeEpisodeState(HangingRestartEnv(), asyncio.get_running_loop())
+
+        with pytest.raises(TimeoutError, match="restart timed out"):
+            await state.reset_episode("episode-1", app_ids=[])
+
+    asyncio.run(run())
+
+
+def test_reset_episode_keeps_timed_out_restart_isolated_until_it_finishes(monkeypatch):
+    import asyncio
+    from . import episode as episode_mod
+
+    monkeypatch.setattr(episode_mod, "EPISODE_RESTART_TIMEOUT_SEC", 0.01, raising=False)
+
+    class SlowRestartEnv:
+        def __init__(self):
+            self.allow_start = asyncio.Event()
+            self.started = False
+            self.closed = False
+            self.reset_calls = 0
+            self.read_calls = 0
+
+        async def reset(self, app_ids=None):
+            self.reset_calls += 1
+            if self.closed:
+                raise RuntimeError("Call start() first")
+            if not self.started:
+                raise TimeoutError("phase=__OS__ timeout")
+
+        async def close(self):
+            self.closed = True
+
+        async def start(self):
+            await self.allow_start.wait()
+            self.started = True
+            self.closed = False
+            return self
+
+        async def read(self):
+            self.read_calls += 1
+            if self.closed:
+                raise RuntimeError("read raced with restart")
+            return "ready"
+
+    async def run():
+        env = SlowRestartEnv()
+        state = BridgeEpisodeState(env, asyncio.get_running_loop())
+
+        with pytest.raises(TimeoutError, match="restart timed out"):
+            await state.reset_episode("episode-1", app_ids=[])
+
+        read_task = asyncio.create_task(state.run_env(lambda current: current.read()))
+        await asyncio.sleep(0)
+        assert env.read_calls == 0
+
+        env.allow_start.set()
+        assert await read_task == "ready"
+        result = await state.reset_episode("episode-2", app_ids=[])
+
+        assert result == {"episode_id": "episode-2", "reset": True}
+        assert env.reset_calls == 2
 
     asyncio.run(run())
 
@@ -829,7 +953,7 @@ def test_setup_token_deduplicates_concurrent_and_completed_requests():
             self.reset_entered = Event()
             self.allow_reset = Event()
 
-        def reset(self):
+        def reset(self, app_ids=None):
             self.reset_calls += 1
             self.reset_entered.set()
             self.allow_reset.wait(timeout=5)

--- a/benchmark/mobilegym/bridge/test_tools_api.py
+++ b/benchmark/mobilegym/bridge/test_tools_api.py
@@ -801,6 +801,117 @@ def test_run_reset_bounds_synchronous_reset(monkeypatch):
     assert asyncio.run(run()) < 0.05
 
 
+def test_reset_episode_isolates_timed_out_synchronous_reset(monkeypatch):
+    import asyncio
+
+    from . import episode as episode_mod
+
+    monkeypatch.setattr(episode_mod, "EPISODE_RESET_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr(episode_mod, "EPISODE_RESTART_TIMEOUT_SEC", 0.01)
+
+    class BlockingResetEnv:
+        def __init__(self):
+            self.allow_reset = Event()
+            self.restart_calls = 0
+            self.read_calls = 0
+
+        def reset(self, app_ids=None):
+            self.allow_reset.wait(timeout=1)
+
+        async def restart(self):
+            self.restart_calls += 1
+
+        async def read(self):
+            self.read_calls += 1
+            return "ready"
+
+    async def run():
+        env = BlockingResetEnv()
+        state = BridgeEpisodeState(env, asyncio.get_running_loop())
+
+        with pytest.raises(TimeoutError):
+            await state.reset_episode("episode-1", app_ids=[])
+
+        restart_calls_before_release = env.restart_calls
+        read_task = asyncio.create_task(state.run_env(lambda current: current.read()))
+        await asyncio.sleep(0)
+        read_finished_before_release = read_task.done()
+
+        env.allow_reset.set()
+        result = await read_task
+        return (
+            restart_calls_before_release,
+            read_finished_before_release,
+            env.restart_calls,
+            result,
+        )
+
+    assert asyncio.run(run()) == (0, False, 1, "ready")
+
+
+def test_cancelled_synchronous_reset_stays_isolated():
+    import asyncio
+
+    class BlockingResetEnv:
+        def __init__(self):
+            self.allow_reset = Event()
+            self.reset_started = Event()
+            self.read_calls = 0
+
+        def reset(self, app_ids=None):
+            self.reset_started.set()
+            self.allow_reset.wait(timeout=1)
+
+        async def read(self):
+            self.read_calls += 1
+            return "ready"
+
+    async def run():
+        env = BlockingResetEnv()
+        state = BridgeEpisodeState(env, asyncio.get_running_loop())
+        reset_task = asyncio.create_task(state._run_reset(env.reset, app_ids=[]))
+
+        await asyncio.to_thread(env.reset_started.wait, 1)
+        reset_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await reset_task
+
+        read_task = asyncio.create_task(state.run_env(lambda current: current.read()))
+        await asyncio.sleep(0)
+        read_finished_before_release = read_task.done()
+
+        env.allow_reset.set()
+        result = await read_task
+        return read_finished_before_release, env.read_calls, result
+
+    assert asyncio.run(run()) == (False, 1, "ready")
+
+
+def test_reset_episode_bounds_synchronous_restart(monkeypatch):
+    import asyncio
+    import time
+
+    from . import episode as episode_mod
+
+    monkeypatch.setattr(episode_mod, "EPISODE_RESTART_TIMEOUT_SEC", 0.01)
+
+    class BlockingRestartEnv:
+        async def reset(self, app_ids=None):
+            raise TimeoutError("phase=__OS__ timeout")
+
+        def restart(self):
+            time.sleep(0.1)
+
+    async def run():
+        state = BridgeEpisodeState(BlockingRestartEnv(), asyncio.get_running_loop())
+        started = time.monotonic()
+        with pytest.raises(TimeoutError, match="restart timed out"):
+            await state.reset_episode("episode-1", app_ids=[])
+        return time.monotonic() - started
+
+    assert asyncio.run(run()) < 0.05
+
+
 def test_reset_episode_catches_builtin_timeout_error(monkeypatch):
     import asyncio
 

--- a/benchmark/mobilegym/docker/Dockerfile
+++ b/benchmark/mobilegym/docker/Dockerfile
@@ -45,12 +45,22 @@ RUN apt-get update && apt-get install -y \
     libasound2 \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone MobileGym (用 cp -a 保留 dotfiles)
-ARG MOBILEGYM_REPO=https://github.com/Purewhiter/mobilegym.git
-ARG MOBILEGYM_BRANCH=main
-RUN git clone --depth 1 --branch ${MOBILEGYM_BRANCH} ${MOBILEGYM_REPO} /tmp/mobilegym && \
+# Clone the exact MobileGym commit pinned by the firmware submodule.
+ARG MOBILEGYM_REPO=https://github.com/AidenAI-IO/mobilegym.git
+ARG MOBILEGYM_COMMIT
+RUN test -n "${MOBILEGYM_COMMIT}" && \
+    git init /tmp/mobilegym && \
+    git -C /tmp/mobilegym remote add origin "${MOBILEGYM_REPO}" && \
+    git -C /tmp/mobilegym \
+        -c http.version=HTTP/1.1 \
+        -c http.lowSpeedLimit=1024 \
+        -c http.lowSpeedTime=60 \
+        fetch --depth 1 --progress origin "${MOBILEGYM_COMMIT}" && \
+    git -C /tmp/mobilegym checkout --detach FETCH_HEAD && \
+    test "$(git -C /tmp/mobilegym rev-parse HEAD)" = "${MOBILEGYM_COMMIT}" && \
     cp -a /tmp/mobilegym/. /mobilegym/ && \
     rm -rf /tmp/mobilegym
+LABEL io.aiden.mobilegym.commit="${MOBILEGYM_COMMIT}"
 
 # Install Python dependencies
 RUN cd /mobilegym && \

--- a/benchmark/mobilegym/docker/README.md
+++ b/benchmark/mobilegym/docker/README.md
@@ -11,10 +11,13 @@ uv run python -m runner webui
 uv run python -m runner start-mobilegym-env
 ```
 
-Both paths build `benchmark/mobilegym/docker/Dockerfile` with the
-`mobilegym-base` target when the MobileGym simulator image is missing. The
-runner and daemon orchestration lives in `benchmark/runner/webui.py`,
-`benchmark/runner/services.py`, and `benchmark/docker/`.
+Both paths resolve the MobileGym repository from `.gitmodules` and the exact
+commit from the firmware repository's MobileGym gitlink. They reuse the local
+image only when its `io.aiden.mobilegym.commit` label matches that commit;
+otherwise they build `benchmark/mobilegym/docker/Dockerfile` with the
+`mobilegym-base` target. The runner and daemon orchestration lives in
+`benchmark/runner/webui.py`, `benchmark/runner/services.py`, and
+`benchmark/docker/`.
 
 Standalone MobileGym compose/test-runner files were removed because they used
 the old `run_aiden.py` flow and were no longer part of the WebUI or benchmark

--- a/benchmark/mobilegym/scripts/start_simulator.py
+++ b/benchmark/mobilegym/scripts/start_simulator.py
@@ -13,12 +13,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import inspect
 import logging
 import os
 import signal
 import sys
-from pathlib import Path
 from collections.abc import Awaitable
+from pathlib import Path
 from typing import Any
 
 SCRIPT_PATH = Path(__file__).resolve()
@@ -34,6 +35,35 @@ class SimulatorError(RuntimeError):
     pass
 
 
+def _supports_app_ids(reset: Any) -> bool:
+    try:
+        parameters = inspect.signature(reset).parameters.values()
+    except (TypeError, ValueError):
+        return True
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        or (
+            parameter.name == "app_ids"
+            and parameter.kind
+            in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        )
+        for parameter in parameters
+    )
+
+
+async def _await_reset_result(result: Any) -> None:
+    if inspect.isawaitable(result):
+        await result
+
+
+async def _reset_mobilegym_env(env: Any, *, app_ids: list[str]) -> None:
+    reset = env.reset
+    if _supports_app_ids(reset):
+        await _await_reset_result(reset(app_ids=app_ids))
+    else:
+        await _await_reset_result(reset())
+
+
 def install_resilient_mobilegym_reset(mobilegym_env_cls: type[Any]) -> None:
     """Patch MobileGymEnv.reset to recover from a crashed Playwright page.
 
@@ -44,6 +74,17 @@ def install_resilient_mobilegym_reset(mobilegym_env_cls: type[Any]) -> None:
     if getattr(mobilegym_env_cls, "_aiden_resilient_reset_installed", False):
         return
     original_reset = mobilegym_env_cls.reset
+    original_supports_app_ids = _supports_app_ids(original_reset)
+
+    async def call_original_reset(
+        self: Any,
+        app_ids: list[str] | None,
+        reset_kwargs: dict[str, Any],
+    ) -> None:
+        kwargs = dict(reset_kwargs)
+        if original_supports_app_ids:
+            kwargs["app_ids"] = app_ids
+        await _await_reset_result(original_reset(self, **kwargs))
 
     async def resilient_reset(
         self: Any,
@@ -51,14 +92,14 @@ def install_resilient_mobilegym_reset(mobilegym_env_cls: type[Any]) -> None:
         **reset_kwargs: Any,
     ) -> None:
         try:
-            await original_reset(self, app_ids=app_ids, **reset_kwargs)
+            await call_original_reset(self, app_ids, reset_kwargs)
             return
         except Exception as exc:
             if not _is_recoverable_page_crash(exc):
                 raise
             logger.warning("MobileGym reset recovered by recreating page after: %s", exc)
             await _restart_mobilegym_env(self)
-            await original_reset(self, app_ids=app_ids, **reset_kwargs)
+            await call_original_reset(self, app_ids, reset_kwargs)
 
     mobilegym_env_cls._aiden_original_reset = original_reset
     mobilegym_env_cls.reset = resilient_reset
@@ -175,7 +216,7 @@ async def create_mobilegym_env(env_url: str, headless: bool, device: str = "sim"
         )
         install_resilient_mobilegym_reset(MobileGymEnv)
         await env.start()
-        await env.reset(app_ids=[])
+        await _reset_mobilegym_env(env, app_ids=[])
         return env, config
     else:
         config = EnvConfig(
@@ -234,10 +275,7 @@ async def create_mobilegym_env_pool(
     await pool.__aenter__()
     envs = list(pool.envs)
     for env in envs:
-        try:
-            await env.reset(app_ids=[])
-        except TypeError:
-            await env.reset()
+        await _reset_mobilegym_env(env, app_ids=[])
     config = {
         "env_url": env_url,
         "headless": headless,

--- a/benchmark/mobilegym/scripts/start_simulator.py
+++ b/benchmark/mobilegym/scripts/start_simulator.py
@@ -45,16 +45,20 @@ def install_resilient_mobilegym_reset(mobilegym_env_cls: type[Any]) -> None:
         return
     original_reset = mobilegym_env_cls.reset
 
-    async def resilient_reset(self: Any, app_ids: list[str] | None = None) -> None:
+    async def resilient_reset(
+        self: Any,
+        app_ids: list[str] | None = None,
+        **reset_kwargs: Any,
+    ) -> None:
         try:
-            await original_reset(self, app_ids=app_ids)
+            await original_reset(self, app_ids=app_ids, **reset_kwargs)
             return
         except Exception as exc:
             if not _is_recoverable_page_crash(exc):
                 raise
             logger.warning("MobileGym reset recovered by recreating page after: %s", exc)
             await _restart_mobilegym_env(self)
-            await original_reset(self, app_ids=app_ids)
+            await original_reset(self, app_ids=app_ids, **reset_kwargs)
 
     mobilegym_env_cls._aiden_original_reset = original_reset
     mobilegym_env_cls.reset = resilient_reset
@@ -70,12 +74,19 @@ def _is_recoverable_page_crash(exc: Exception) -> bool:
             "target crashed",
             "target closed",
             "browser closed",
-            "page.goto",
+            "has been closed",
         )
     )
 
 
 async def _restart_mobilegym_env(env: Any) -> None:
+    restart = getattr(env, "restart", None)
+    if restart is not None:
+        result = restart()
+        if asyncio.iscoroutine(result) or isinstance(result, Awaitable):
+            await result
+        return
+
     close = getattr(env, "close", None)
     if close is not None:
         result = close()
@@ -164,7 +175,7 @@ async def create_mobilegym_env(env_url: str, headless: bool, device: str = "sim"
         )
         install_resilient_mobilegym_reset(MobileGymEnv)
         await env.start()
-        await env.reset()
+        await env.reset(app_ids=[])
         return env, config
     else:
         config = EnvConfig(
@@ -224,7 +235,7 @@ async def create_mobilegym_env_pool(
     envs = list(pool.envs)
     for env in envs:
         try:
-            await env.reset()
+            await env.reset(app_ids=[])
         except TypeError:
             await env.reset()
     config = {

--- a/benchmark/runner/agent_client.py
+++ b/benchmark/runner/agent_client.py
@@ -6,15 +6,20 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from typing import Any
 
 
 class AgentTimeoutError(TimeoutError):
-    pass
+    def __init__(self, message: str = "", *, request_id: str | None = None):
+        super().__init__(message)
+        self.request_id = request_id
 
 
 class AgentRequestError(RuntimeError):
-    pass
+    def __init__(self, message: str = "", *, request_id: str | None = None):
+        super().__init__(message)
+        self.request_id = request_id
 
 
 @dc.dataclass
@@ -40,6 +45,7 @@ class AgentClient:
         self.base_url = base_url.rstrip("/")
         self._default_timeout = default_timeout_sec
         self._benchmark_token = str(benchmark_token or "").strip()
+        self._pending_chat_request_ids: set[str] = set()
 
     def _post(
         self,
@@ -167,22 +173,28 @@ class AgentClient:
         attachments: list[dict[str, Any]] | None = None,
         skills: list[str] | None = None,
     ) -> ChatResponse:
-        payload: dict[str, Any] = {"message": message}
+        request_id = f"benchmark-{uuid.uuid4().hex}"
+        payload: dict[str, Any] = {"message": message, "request_id": request_id}
         if attachments:
             payload["attachments"] = attachments
         if skills:
             payload["skills"] = skills
-        status, body_bytes = self._post(
-            "/api/chat", payload, timeout=timeout_sec or self._default_timeout
-        )
+        try:
+            status, body_bytes = self._post(
+                "/api/chat", payload, timeout=timeout_sec or self._default_timeout
+            )
+        except (AgentTimeoutError, AgentRequestError) as exc:
+            exc.request_id = request_id
+            self._pending_chat_request_ids.add(request_id)
+            raise
         if status != 200:
             raise AgentRequestError(f"chat returned {status}")
         body = json.loads(body_bytes)
 
         # Async mode: agent returns request_id, long poll for completion.
-        request_id = body.get("request_id")
-        if request_id:
-            return self._wait_for_chat_result(request_id, timeout_sec)
+        response_request_id = str(body.get("request_id") or "").strip()
+        if response_request_id:
+            return self._wait_for_chat_result(response_request_id, timeout_sec)
 
         return ChatResponse(
             response=body.get("response", ""),
@@ -194,12 +206,20 @@ class AgentClient:
     ) -> ChatResponse:
         """Long poll /api/chat/result?wait=true until the task completes."""
         timeout = timeout_sec or self._default_timeout
-        status, body_bytes = self._get(
-            f"/api/chat/result?request_id={request_id}&wait=true",
-            timeout=timeout,
-        )
+        encoded_id = urllib.parse.quote(request_id, safe="")
+        try:
+            status, body_bytes = self._get(
+                f"/api/chat/result?request_id={encoded_id}&wait=true",
+                timeout=timeout,
+            )
+        except (AgentTimeoutError, AgentRequestError) as exc:
+            exc.request_id = request_id
+            self._pending_chat_request_ids.add(request_id)
+            raise
         if status != 200:
-            raise AgentRequestError(f"chat/result returned {status}")
+            raise AgentRequestError(
+                f"chat/result returned {status}", request_id=request_id
+            )
         body = json.loads(body_bytes)
 
         result_status = body.get("status")
@@ -216,6 +236,31 @@ class AgentClient:
             response=body.get("response", ""),
             history=body.get("history", []),
         )
+
+    def cancel_chat(self, request_id: str, timeout: int = 15) -> str:
+        status, body_bytes = self._post(
+            "/api/chat/cancel",
+            {"request_id": request_id},
+            timeout=timeout,
+        )
+        if status != 200:
+            raise AgentRequestError(
+                f"chat/cancel returned {status}", request_id=request_id
+            )
+        body = json.loads(body_bytes)
+        return str(body.get("status") or "") if isinstance(body, dict) else ""
+
+    def chat_result_status(self, request_id: str, timeout: int = 5) -> str:
+        encoded_id = urllib.parse.quote(request_id, safe="")
+        status, body_bytes = self._get(
+            f"/api/chat/result?request_id={encoded_id}", timeout=timeout
+        )
+        if status != 200:
+            raise AgentRequestError(
+                f"chat/result returned {status}", request_id=request_id
+            )
+        body = json.loads(body_bytes)
+        return str(body.get("status") or "") if isinstance(body, dict) else ""
 
     def invoke_tool(
         self,
@@ -244,14 +289,45 @@ class AgentClient:
         timeout_sec: int = 90,
         poll_sec: float = 3.0,
     ) -> bool:
-        """Wait until the agent accepts clear/history again after a timed-out chat."""
+        """Cancel timed-out chats, wait for terminal state, then clear history."""
         deadline = time.monotonic() + max(0, timeout_sec)
-        while True:
-            if not self.health():
+        pending_request_ids = list(
+            getattr(self, "_pending_chat_request_ids", set())
+        )
+        for request_id in pending_request_ids:
+            cancel_sent = False
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                if not cancel_sent:
+                    try:
+                        self.cancel_chat(
+                            request_id,
+                            timeout=min(15, max(1, int(remaining))),
+                        )
+                        cancel_sent = True
+                    except (AgentTimeoutError, AgentRequestError):
+                        time.sleep(min(poll_sec, max(0, deadline - time.monotonic())))
+                        continue
+                try:
+                    result_status = self.chat_result_status(
+                        request_id,
+                        timeout=min(5, max(1, int(remaining))),
+                    )
+                except (AgentTimeoutError, AgentRequestError):
+                    if time.monotonic() >= deadline:
+                        return False
+                    time.sleep(min(poll_sec, max(0, deadline - time.monotonic())))
+                    continue
+                if result_status in {"complete", "error", "canceled", "not_found"}:
+                    self._pending_chat_request_ids.discard(request_id)
+                    break
                 if time.monotonic() >= deadline:
                     return False
                 time.sleep(min(poll_sec, max(0, deadline - time.monotonic())))
-                continue
+
+        while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 return False

--- a/benchmark/runner/agent_client.py
+++ b/benchmark/runner/agent_client.py
@@ -22,6 +22,20 @@ class AgentRequestError(RuntimeError):
         self.request_id = request_id
 
 
+def _parse_json_response(
+    body_bytes: bytes,
+    endpoint: str,
+    *,
+    request_id: str | None = None,
+) -> Any:
+    try:
+        return json.loads(body_bytes)
+    except json.JSONDecodeError as exc:
+        raise AgentRequestError(
+            f"{endpoint} returned invalid JSON: {exc}", request_id=request_id
+        ) from exc
+
+
 @dc.dataclass
 class ChatResponse:
     response: str
@@ -142,10 +156,7 @@ class AgentClient:
         )
         if status != 200:
             raise AgentRequestError(f"phone_bridge_state returned {status}")
-        try:
-            body = json.loads(body_bytes)
-        except json.JSONDecodeError as exc:
-            raise AgentRequestError(f"phone_bridge_state returned invalid JSON: {exc}") from exc
+        body = _parse_json_response(body_bytes, "phone_bridge_state")
         return body if isinstance(body, dict) else {}
 
     def get_history(self) -> list[dict[str, Any]]:
@@ -188,7 +199,7 @@ class AgentClient:
             self._pending_chat_request_ids.add(request_id)
             raise
         if status != 200:
-            raise AgentRequestError(f"chat returned {status}")
+            raise AgentRequestError(f"chat returned {status}", request_id=request_id)
         body = json.loads(body_bytes)
 
         # Async mode: agent returns request_id, long poll for completion.
@@ -247,7 +258,9 @@ class AgentClient:
             raise AgentRequestError(
                 f"chat/cancel returned {status}", request_id=request_id
             )
-        body = json.loads(body_bytes)
+        body = _parse_json_response(
+            body_bytes, "chat/cancel", request_id=request_id
+        )
         return str(body.get("status") or "") if isinstance(body, dict) else ""
 
     def chat_result_status(self, request_id: str, timeout: int = 5) -> str:
@@ -259,7 +272,9 @@ class AgentClient:
             raise AgentRequestError(
                 f"chat/result returned {status}", request_id=request_id
             )
-        body = json.loads(body_bytes)
+        body = _parse_json_response(
+            body_bytes, "chat/result", request_id=request_id
+        )
         return str(body.get("status") or "") if isinstance(body, dict) else ""
 
     def invoke_tool(

--- a/benchmark/runner/environment.py
+++ b/benchmark/runner/environment.py
@@ -6,8 +6,11 @@ used by both benchmark/runner/webui.py and skillopt/webui.py.
 
 from __future__ import annotations
 
+import configparser
 import dataclasses as dc
+import json
 import os
+import re
 import subprocess
 import threading
 import time
@@ -15,16 +18,25 @@ import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Mapping
 
 
 DEFAULT_MOBILEGYM_IMAGE = "aiden-mobilegym-simulator:py311"
 DEFAULT_MOBILEGYM_READY_TIMEOUT_SEC = 120
 DEFAULT_MOBILEGYM_PARALLEL_ENVS = 5
+MOBILEGYM_SUBMODULE_PATH = "benchmark/mobilegym/vendor/mobilegym"
+MOBILEGYM_SUBMODULE_SECTION = f'submodule "{MOBILEGYM_SUBMODULE_PATH}"'
+MOBILEGYM_COMMIT_LABEL = "io.aiden.mobilegym.commit"
 LOG_TAIL_BYTES = 96 * 1024
 # WebUI polls list_all every 5s; cache the docker-sync result briefly so multiple
 # concurrent requests within a single poll window don't each fork docker.
 DOCKER_SYNC_CACHE_TTL_SEC = 2.0
+
+
+@dc.dataclass(frozen=True)
+class MobileGymSource:
+    repo: str
+    commit: str
 
 
 @dc.dataclass
@@ -292,6 +304,7 @@ class EnvironmentManager:
                 self.mobilegym_image,
                 self.build_mobilegym_image,
                 Path(env.log_path),
+                repo_root=self.repo_root,
             )
             self._set_environment(env, status="starting", message="starting container")
 
@@ -685,9 +698,55 @@ def docker_no_proxy(endpoint: str) -> str:
     return ",".join(base)
 
 
-def ensure_mobilegym_image(image: str, build_missing: bool, log_path: Path) -> None:
-    """Ensure MobileGym Docker image exists."""
-    ensure_docker_image(image, build_missing, log_path, "mobilegym-base")
+def resolve_mobilegym_source(repo_root: Path) -> MobileGymSource:
+    """Resolve the MobileGym repository and pinned commit from the firmware tree."""
+    gitmodules = configparser.ConfigParser()
+    gitmodules_path = repo_root / ".gitmodules"
+    if not gitmodules.read(gitmodules_path, encoding="utf-8"):
+        raise RuntimeError(f"Unable to read submodule configuration: {gitmodules_path}")
+    try:
+        mobilegym_repo = gitmodules[MOBILEGYM_SUBMODULE_SECTION]["url"].strip()
+    except KeyError as exc:
+        raise RuntimeError(
+            f"MobileGym submodule URL not found in {gitmodules_path}"
+        ) from exc
+
+    try:
+        mobilegym_commit = subprocess.check_output(
+            ["git", "rev-parse", f"HEAD:{MOBILEGYM_SUBMODULE_PATH}"],
+            cwd=repo_root,
+            text=True,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError("Unable to resolve the MobileGym submodule commit from HEAD") from exc
+    if not re.fullmatch(r"[0-9a-f]{40}", mobilegym_commit):
+        raise RuntimeError(f"Invalid MobileGym submodule commit in HEAD: {mobilegym_commit!r}")
+
+    return MobileGymSource(repo=mobilegym_repo, commit=mobilegym_commit)
+
+
+def ensure_mobilegym_image(
+    image: str,
+    build_missing: bool,
+    log_path: Path,
+    *,
+    repo_root: Path | None = None,
+) -> None:
+    """Ensure the MobileGym image matches the commit pinned by the firmware tree."""
+    repo_root = repo_root or Path(__file__).resolve().parents[2]
+    source = resolve_mobilegym_source(repo_root)
+    ensure_docker_image(
+        image,
+        build_missing,
+        log_path,
+        "mobilegym-base",
+        repo_root=repo_root,
+        build_args={
+            "MOBILEGYM_REPO": source.repo,
+            "MOBILEGYM_COMMIT": source.commit,
+        },
+        required_labels={MOBILEGYM_COMMIT_LABEL: source.commit},
+    )
 
 
 def ensure_docker_image(
@@ -697,20 +756,47 @@ def ensure_docker_image(
     target: str,
     *,
     stop_requested: Callable[[], bool] | None = None,
+    repo_root: Path | None = None,
+    build_args: Mapping[str, str] | None = None,
+    required_labels: Mapping[str, str] | None = None,
 ) -> None:
     """Ensure Docker image exists, optionally building it."""
-    repo_root = Path(__file__).resolve().parents[2]
+    repo_root = repo_root or Path(__file__).resolve().parents[2]
 
     inspect = subprocess.run(
-        ["docker", "image", "inspect", image],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        ["docker", "image", "inspect", "--format", "{{json .Config.Labels}}", image],
+        capture_output=True,
+        text=True,
         check=False,
     )
-    if inspect.returncode == 0:
-        return
+    image_exists = inspect.returncode == 0
+    labels: dict[str, str] = {}
+    if image_exists:
+        try:
+            parsed_labels = json.loads(inspect.stdout) if inspect.stdout.strip() else None
+        except json.JSONDecodeError:
+            parsed_labels = None
+        if isinstance(parsed_labels, dict):
+            labels = {str(key): str(value) for key, value in parsed_labels.items()}
+
+        mismatched_labels = {
+            key: (labels.get(key), expected)
+            for key, expected in (required_labels or {}).items()
+            if labels.get(key) != expected
+        }
+        if not mismatched_labels:
+            return
+    else:
+        mismatched_labels = {}
+
     if not build_missing:
-        raise RuntimeError(f"Docker image not found: {image}")
+        if not image_exists:
+            raise RuntimeError(f"Docker image not found: {image}")
+        details = ", ".join(
+            f"{key} is {actual or 'unset'}, expected {expected}"
+            for key, (actual, expected) in mismatched_labels.items()
+        )
+        raise RuntimeError(f"Docker image {image} is stale: {details}")
 
     cmd = [
         "docker",
@@ -719,10 +805,10 @@ def ensure_docker_image(
         str(repo_root / "benchmark" / "mobilegym" / "docker" / "Dockerfile"),
         "--target",
         target,
-        "-t",
-        image,
-        str(repo_root),
     ]
+    for key, value in (build_args or {}).items():
+        cmd.extend(["--build-arg", f"{key}={value}"])
+    cmd.extend(["-t", image, str(repo_root)])
     append_log(log_path, "$ " + " ".join(cmd))
 
     popen_kwargs: dict[str, Any] = {}

--- a/benchmark/runner/recovery.py
+++ b/benchmark/runner/recovery.py
@@ -51,18 +51,35 @@ def prepare_task_isolation(
     if not recover_agent_after_timeout(client, timeout_sec=min(30, ready_timeout_sec)):
         raise ResetError("agent did not recover before task isolation")
 
+    environment_setup_required = bool(environment_url and not task.input_screenshot)
+    environment_setup_done = not environment_setup_required
     last_error: Exception | None = None
     for attempt in range(1, setup_attempts + 1):
         try:
             client.clear_history()
-            if environment_url and not task.input_screenshot:
+        except (AgentTimeoutError, AgentRequestError) as e:
+            last_error = e
+            if attempt >= setup_attempts:
+                break
+            per_attempt_timeout = max(15, ready_timeout_sec // setup_attempts)
+            wait_for_agent_ready(client, timeout_sec=per_attempt_timeout)
+            time.sleep(1)
+            continue
+
+        if environment_setup_required and not environment_setup_done:
+            try:
                 call_environment_setup(
                     environment_url,
                     task_id=benchmark_task_id or task.id,
                     timeout=DEFAULT_ENVIRONMENT_SETUP_TIMEOUT_SEC,
+                    app_ids=task.app_ids,
                 )
-                per_task_setup(client, task.setup, prompt_prefix=suite.prompt_prefix)
-            elif not task.input_screenshot:
+            except (ResetError, AgentTimeoutError, AgentRequestError):
+                raise
+            environment_setup_done = True
+
+        try:
+            if not task.input_screenshot:
                 per_task_setup(client, task.setup, prompt_prefix=suite.prompt_prefix)
             return
         except (ResetError, AgentTimeoutError, AgentRequestError) as e:

--- a/benchmark/runner/recovery.py
+++ b/benchmark/runner/recovery.py
@@ -87,7 +87,13 @@ def prepare_task_isolation(
             if attempt >= setup_attempts:
                 break
             per_attempt_timeout = max(15, ready_timeout_sec // setup_attempts)
-            wait_for_agent_ready(client, timeout_sec=per_attempt_timeout)
+            if not recover_agent_after_timeout(
+                client, timeout_sec=per_attempt_timeout
+            ):
+                raise ResetError(
+                    "agent did not recover after per-task setup failure"
+                ) from e
+            environment_setup_done = not environment_setup_required
             time.sleep(1)
 
     if last_error is None:

--- a/benchmark/runner/reset.py
+++ b/benchmark/runner/reset.py
@@ -29,10 +29,17 @@ def _environment_headers(task_id: str | None = None) -> dict[str, str]:
     return headers
 
 
-def _post_environment(endpoint: str, *, timeout: int, headers: dict[str, str], action: str) -> dict[str, Any]:
+def _post_environment(
+    endpoint: str,
+    *,
+    timeout: int,
+    headers: dict[str, str],
+    action: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     req = urllib.request.Request(
         endpoint,
-        data=b"{}",
+        data=json.dumps(payload or {}, ensure_ascii=False).encode("utf-8"),
         headers=headers,
         method="POST",
     )
@@ -58,12 +65,18 @@ def _post_environment(endpoint: str, *, timeout: int, headers: dict[str, str], a
     return payload if isinstance(payload, dict) else {}
 
 
-def call_environment_setup(environment_url: str, timeout: int = 30, task_id: str | None = None) -> dict[str, Any]:
+def call_environment_setup(
+    environment_url: str,
+    timeout: int = 30,
+    task_id: str | None = None,
+    app_ids: list[str] | None = None,
+) -> dict[str, Any]:
     return _post_environment(
         _environment_endpoint(environment_url).setup,
         timeout=timeout,
         headers=_environment_headers(task_id),
         action="setup",
+        payload={"app_ids": list(app_ids or [])},
     )
 
 

--- a/benchmark/runner/suite.py
+++ b/benchmark/runner/suite.py
@@ -81,6 +81,7 @@ class TaskSpec:
     answer_format: str | None = None
     platforms: list[str] = dc.field(default_factory=list)
     expected_recalled_memory_ids: list[str] = dc.field(default_factory=list)
+    app_ids: list[str] = dc.field(default_factory=list)
 
 @dc.dataclass
 class Suite:
@@ -211,6 +212,12 @@ def load_suite(path: Path) -> Suite:
             isinstance(item, str) and item.strip() for item in expected_recalled_memory_ids
         ):
             raise SuiteValidationError(f"task {tid}: expected_recalled_memory_ids must be a list of non-empty strings")
+        raw_app_ids = raw.get("app_ids", [])
+        if not isinstance(raw_app_ids, list) or not all(
+            isinstance(item, str) and item.strip() for item in raw_app_ids
+        ):
+            raise SuiteValidationError(f"task {tid}: app_ids must be a list of non-empty strings")
+        app_ids = list(dict.fromkeys(item.strip() for item in raw_app_ids))
         platforms = _platform_list(raw.get("platforms", []), tid)
         task_mock_environment = _parse_mock_environment(
             raw.get("mock_environment"),
@@ -229,6 +236,7 @@ def load_suite(path: Path) -> Suite:
             answer_format=answer_format,
             platforms=platforms,
             expected_recalled_memory_ids=expected_recalled_memory_ids,
+            app_ids=app_ids,
         ))
     prompt_prefix = data.get("prompt_prefix", "")
     if not isinstance(prompt_prefix, str):

--- a/benchmark/runner/webui.py
+++ b/benchmark/runner/webui.py
@@ -41,7 +41,11 @@ from runner.reset import ResetError, call_environment_release
 from runner.suite import load_suite
 
 try:
-    from benchmark.runner.environment import EnvironmentManager, MobileGymEnvironment
+    from benchmark.runner.environment import (
+        EnvironmentManager,
+        MobileGymEnvironment,
+        ensure_mobilegym_image,
+    )
     from benchmark.runner.adb_android_environment import (
         ADBAndroidEnvironment,
         ADBAndroidEnvironmentManager,
@@ -56,7 +60,11 @@ try:
         validate_agent_toml,
     )
 except ImportError:
-    from runner.environment import EnvironmentManager, MobileGymEnvironment
+    from runner.environment import (
+        EnvironmentManager,
+        MobileGymEnvironment,
+        ensure_mobilegym_image,
+    )
     from runner.adb_android_environment import (
         ADBAndroidEnvironment,
         ADBAndroidEnvironmentManager,
@@ -2093,10 +2101,6 @@ def ensure_daemon_image(
         env=env,
         stop_requested=stop_requested,
     )
-
-
-def ensure_mobilegym_image(image: str, build_missing: bool, log_path: Path) -> None:
-    ensure_docker_image(image, build_missing, log_path, "mobilegym-base")
 
 
 def ensure_docker_image(

--- a/benchmark/tests/mobilegym/test_bridge_server.py
+++ b/benchmark/tests/mobilegym/test_bridge_server.py
@@ -349,6 +349,20 @@ def test_setup_rejects_invalid_app_ids():
         assert bridge.env.reset_calls == 0
 
 
+def test_setup_treats_null_app_ids_as_empty():
+    with RunningBridge() as bridge:
+        status, body = request_json(
+            bridge.base_url,
+            "POST",
+            "/api/setup",
+            {"app_ids": None},
+        )
+
+        assert status == 200
+        assert body["data"]["reset"] is True
+        assert bridge.env.reset_app_ids == [[]]
+
+
 def test_setup_timeout_preserves_mobilegym_phase_diagnostic():
     with RunningBridge() as bridge:
         async def timeout_reset(app_ids=None):

--- a/benchmark/tests/mobilegym/test_bridge_server.py
+++ b/benchmark/tests/mobilegym/test_bridge_server.py
@@ -104,6 +104,7 @@ class FakeEnv:
         self.state = {"os": {}, "apps": {}}
         self.route = {"app": "launcher", "path": "/"}
         self.reset_calls = 0
+        self.reset_app_ids = []
         self.calls = []
         self.loop_matches = []
         self.threads = []
@@ -141,9 +142,10 @@ class FakeEnv:
         self._record("get_route")
         return self.route
 
-    async def reset(self):
+    async def reset(self, app_ids=None):
         self._record("reset")
         self.reset_calls += 1
+        self.reset_app_ids.append(app_ids)
         return FakeObservation()
 
 
@@ -294,6 +296,17 @@ def test_health_and_runner_endpoints_do_not_require_authentication():
         assert body["data"] == {"episode_id": "reset-ep1", "reset": True}
         assert bridge.state.active_episode_id == "reset-ep1"
         assert bridge.env.reset_calls == 1
+        assert bridge.env.reset_app_ids == [[]]
+
+        status, body = request_json(
+            bridge.base_url,
+            "POST",
+            "/api/setup",
+            {"episode_id": "reset-ep2", "app_ids": ["settings"]},
+        )
+        assert status == 200
+        assert body["data"] == {"episode_id": "reset-ep2", "reset": True}
+        assert bridge.env.reset_app_ids == [[], ["settings"]]
 
         status, body = request_json(
             bridge.base_url,
@@ -315,11 +328,44 @@ def test_health_and_runner_endpoints_do_not_require_authentication():
         assert status == 200
         assert body["data"] == bridge.env.route
 
-        status, _ = request_json(bridge.base_url, "POST", "/episode/end", {"episode_id": "reset-ep1"})
+        status, _ = request_json(bridge.base_url, "POST", "/episode/end", {"episode_id": "reset-ep2"})
         assert status == 200
 
         assert bridge.env.loop_matches and all(bridge.env.loop_matches)
         assert bridge.env.threads and set(bridge.env.threads) == {"mobilegym-owner-loop"}
+
+
+def test_setup_rejects_invalid_app_ids():
+    with RunningBridge() as bridge:
+        status, body = request_json(
+            bridge.base_url,
+            "POST",
+            "/api/setup",
+            {"app_ids": "settings"},
+        )
+
+        assert status == 400
+        assert body["error"]["code"] == "bad_request"
+        assert bridge.env.reset_calls == 0
+
+
+def test_setup_timeout_preserves_mobilegym_phase_diagnostic():
+    with RunningBridge() as bridge:
+        async def timeout_reset(app_ids=None):
+            raise TimeoutError("phase=waitForData timeout after 40000ms")
+
+        bridge.env.reset = timeout_reset
+
+        status, body = request_json(
+            bridge.base_url,
+            "POST",
+            "/api/setup",
+            {"app_ids": []},
+        )
+
+        assert status == 504
+        assert body["error"]["code"] == "timeout"
+        assert "phase=waitForData" in body["error"]["message"]
 
 
 def test_api_screen_is_removed():

--- a/benchmark/tests/mobilegym/test_start_simulator.py
+++ b/benchmark/tests/mobilegym/test_start_simulator.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 import types
 
+import pytest
 from mobilegym.scripts import start_simulator
 
 
@@ -100,6 +101,54 @@ def test_create_mobilegym_env_pool_uses_envpool(monkeypatch):
     assert captured["pool_kwargs"]["isolation"] == "contexts"
     assert captured["pool_kwargs"]["num_browsers"] == 1
     assert config["parallel_envs"] == 2
+
+
+def test_reset_mobilegym_env_supports_legacy_reset_signature():
+    class LegacyEnv:
+        def __init__(self):
+            self.reset_calls = 0
+
+        async def reset(self):
+            self.reset_calls += 1
+
+    env = LegacyEnv()
+
+    asyncio.run(start_simulator._reset_mobilegym_env(env, app_ids=[]))
+
+    assert env.reset_calls == 1
+
+
+def test_reset_mobilegym_env_does_not_retry_internal_type_error():
+    class BrokenEnv:
+        def __init__(self):
+            self.reset_calls = 0
+
+        async def reset(self, app_ids=None):
+            self.reset_calls += 1
+            raise TypeError("reset implementation failed")
+
+    env = BrokenEnv()
+
+    with pytest.raises(TypeError, match="reset implementation failed"):
+        asyncio.run(start_simulator._reset_mobilegym_env(env, app_ids=[]))
+
+    assert env.reset_calls == 1
+
+
+def test_resilient_mobilegym_reset_supports_legacy_reset_signature():
+    class LegacyMobileGymEnv:
+        def __init__(self):
+            self.reset_calls = 0
+
+        async def reset(self):
+            self.reset_calls += 1
+
+    start_simulator.install_resilient_mobilegym_reset(LegacyMobileGymEnv)
+
+    env = LegacyMobileGymEnv()
+    asyncio.run(env.reset(app_ids=[]))
+
+    assert env.reset_calls == 1
 
 
 def test_resilient_mobilegym_reset_restarts_after_crashed_page():

--- a/benchmark/tests/mobilegym/test_start_simulator.py
+++ b/benchmark/tests/mobilegym/test_start_simulator.py
@@ -95,7 +95,7 @@ def test_create_mobilegym_env_pool_uses_envpool(monkeypatch):
     assert len(envs) == 2
     assert all(env.reset_called for env in envs)
     assert captured["entered"] is True
-    assert captured["reset_app_ids"] == [None, None]
+    assert captured["reset_app_ids"] == [[], []]
     assert captured["pool_kwargs"]["n"] == 2
     assert captured["pool_kwargs"]["isolation"] == "contexts"
     assert captured["pool_kwargs"]["num_browsers"] == 1
@@ -109,8 +109,8 @@ def test_resilient_mobilegym_reset_restarts_after_crashed_page():
             self.close_calls = 0
             self.start_calls = 0
 
-        async def reset(self, app_ids=None):
-            self.original_reset_calls.append(app_ids)
+        async def reset(self, app_ids=None, timeout_ms=40000):
+            self.original_reset_calls.append((app_ids, timeout_ms))
             if len(self.original_reset_calls) == 1:
                 raise RuntimeError("Page.goto: Page crashed")
 
@@ -124,11 +124,68 @@ def test_resilient_mobilegym_reset_restarts_after_crashed_page():
     start_simulator.install_resilient_mobilegym_reset(FakeMobileGymEnv)
 
     env = FakeMobileGymEnv()
-    asyncio.run(env.reset(app_ids=[]))
+    asyncio.run(env.reset(app_ids=[], timeout_ms=1234))
 
-    assert env.original_reset_calls == [[], []]
+    assert env.original_reset_calls == [([], 1234), ([], 1234)]
     assert env.close_calls == 1
     assert env.start_calls == 1
+
+
+def test_resilient_mobilegym_reset_does_not_restart_after_navigation_timeout():
+    class FakeMobileGymEnv:
+        def __init__(self):
+            self.close_calls = 0
+            self.start_calls = 0
+
+        async def reset(self, app_ids=None, timeout_ms=40000):
+            raise TimeoutError("Page.goto: Timeout 40000ms exceeded")
+
+        async def close(self):
+            self.close_calls += 1
+
+        async def start(self):
+            self.start_calls += 1
+            return self
+
+    start_simulator.install_resilient_mobilegym_reset(FakeMobileGymEnv)
+
+    env = FakeMobileGymEnv()
+    try:
+        asyncio.run(env.reset(app_ids=[], timeout_ms=1234))
+    except TimeoutError as exc:
+        assert "Page.goto: Timeout" in str(exc)
+    else:
+        raise AssertionError("navigation timeout should propagate")
+
+    assert env.close_calls == 0
+    assert env.start_calls == 0
+
+
+def test_resilient_mobilegym_reset_restarts_after_target_closed_error():
+    class FakeMobileGymEnv:
+        def __init__(self):
+            self.reset_calls = 0
+            self.restart_calls = 0
+
+        async def reset(self, app_ids=None, timeout_ms=40000):
+            self.reset_calls += 1
+            if self.reset_calls == 1:
+                raise RuntimeError(
+                    "TargetClosedError: Page.goto: "
+                    "Target page, context or browser has been closed"
+                )
+
+        async def restart(self):
+            self.restart_calls += 1
+            return self
+
+    start_simulator.install_resilient_mobilegym_reset(FakeMobileGymEnv)
+
+    env = FakeMobileGymEnv()
+    asyncio.run(env.reset(app_ids=[], timeout_ms=1234))
+
+    assert env.reset_calls == 2
+    assert env.restart_calls == 1
 
 
 def test_bridge_request_timeout_default_covers_mobilegym_reset_retries():

--- a/benchmark/tests/test_agent_client.py
+++ b/benchmark/tests/test_agent_client.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from runner.agent_client import AgentClient, AgentTimeoutError
+from runner.agent_client import AgentClient, AgentRequestError, AgentTimeoutError
 
 
 class FakeResponse:
@@ -140,6 +140,39 @@ def test_chat_includes_skills_when_provided():
         client.chat("请打开设置", skills=["device-operator"])
     body = json.loads(seen["body"])
     assert body["skills"] == ["device-operator"]
+
+
+def test_chat_non_200_error_preserves_request_id():
+    seen = {}
+    client = AgentClient(base_url="http://test")
+
+    with patch("urllib.request.urlopen", _captured(seen, status=503)), \
+         pytest.raises(AgentRequestError) as exc_info:
+        client.chat("prepare device")
+
+    request_id = json.loads(seen["body"])["request_id"]
+    assert request_id.startswith("benchmark-")
+    assert exc_info.value.request_id == request_id
+
+
+@pytest.mark.parametrize(
+    ("method_name", "transport_name", "expected_message"),
+    [
+        ("cancel_chat", "_post", "chat/cancel returned invalid JSON"),
+        ("chat_result_status", "_get", "chat/result returned invalid JSON"),
+    ],
+)
+def test_chat_recovery_rejects_invalid_json(
+    method_name, transport_name, expected_message
+):
+    client = AgentClient(base_url="http://test")
+
+    with patch.object(client, transport_name, return_value=(200, b"not-json")), \
+         pytest.raises(AgentRequestError) as exc_info:
+        getattr(client, method_name)("req-1")
+
+    assert expected_message in str(exc_info.value)
+    assert exc_info.value.request_id == "req-1"
 
 
 def test_recover_after_timeout_waits_until_clear_succeeds(monkeypatch):

--- a/benchmark/tests/test_agent_client.py
+++ b/benchmark/tests/test_agent_client.py
@@ -164,6 +164,40 @@ def test_recover_after_timeout_waits_until_clear_succeeds(monkeypatch):
     assert sleeps == [1]
 
 
+def test_recover_after_timeout_cancels_timed_out_chat_before_clear(monkeypatch):
+    seen = []
+    responses = [
+        FakeResponse(200, {"request_id": "req-1"}),
+        socket.timeout("read timed out"),
+        FakeResponse(200, {"request_id": "req-1", "status": "canceled"}),
+        FakeResponse(200, {"status": "running"}),
+        FakeResponse(200, {"status": "error", "error": "request canceled"}),
+        FakeResponse(200, {"status": "ok"}),
+    ]
+
+    def fake_urlopen(req, timeout=None):
+        seen.append((req.full_url, req.get_method(), timeout))
+        response = responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+    client = AgentClient(base_url="http://test")
+    with patch("urllib.request.urlopen", fake_urlopen):
+        with pytest.raises(AgentTimeoutError) as exc_info:
+            client.chat("prepare device", timeout_sec=1)
+
+        assert exc_info.value.request_id == "req-1"
+        assert client.recover_after_timeout(timeout_sec=10, poll_sec=1) is True
+
+    assert [entry[1] for entry in seen] == ["POST", "GET", "POST", "GET", "GET", "POST"]
+    assert seen[2][0].endswith("/api/chat/cancel")
+    assert seen[3][0].endswith("/api/chat/result?request_id=req-1")
+    assert seen[4][0].endswith("/api/chat/result?request_id=req-1")
+    assert seen[5][0].endswith("/api/clear")
+
+
 def test_chat_timeout_raises():
     def fake_urlopen(req, timeout=None):
         raise socket.timeout("read timed out")

--- a/benchmark/tests/test_environment.py
+++ b/benchmark/tests/test_environment.py
@@ -1,9 +1,16 @@
+import json
 import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 from runner import environment
+
+
+MOBILEGYM_COMMIT = "1896e744cc33fcc77ebf645ff54584f83b5c6aec"
+MOBILEGYM_REPO = "https://github.com/AidenAI-IO/mobilegym.git"
 
 
 def _manager_without_discovery(monkeypatch, tmp_path: Path) -> environment.EnvironmentManager:
@@ -76,3 +83,154 @@ def test_recovered_mobilegym_container_is_not_reusable_for_new_runs(monkeypatch,
     assert recovered is not None
     assert recovered.status == "stale"
     assert "start a fresh environment" in recovered.message
+
+
+def test_resolve_mobilegym_source_uses_head_gitlink_and_gitmodules(monkeypatch, tmp_path: Path):
+    (tmp_path / ".gitmodules").write_text(
+        """[submodule \"benchmark/mobilegym/vendor/mobilegym\"]
+\tpath = benchmark/mobilegym/vendor/mobilegym
+\turl = https://github.com/AidenAI-IO/mobilegym.git
+""",
+        encoding="utf-8",
+    )
+    captured = {}
+
+    def fake_check_output(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["cwd"] = kwargs.get("cwd")
+        return f"{MOBILEGYM_COMMIT}\n"
+
+    monkeypatch.setattr(environment.subprocess, "check_output", fake_check_output)
+
+    source = environment.resolve_mobilegym_source(tmp_path)
+
+    assert source.repo == MOBILEGYM_REPO
+    assert source.commit == MOBILEGYM_COMMIT
+    assert captured["cmd"] == [
+        "git",
+        "rev-parse",
+        "HEAD:benchmark/mobilegym/vendor/mobilegym",
+    ]
+    assert captured["cwd"] == tmp_path
+
+
+def test_ensure_mobilegym_image_reuses_matching_commit(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(
+        environment,
+        "resolve_mobilegym_source",
+        lambda repo_root: environment.MobileGymSource(MOBILEGYM_REPO, MOBILEGYM_COMMIT),
+    )
+
+    def fake_run(cmd, **kwargs):
+        return environment.subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps({environment.MOBILEGYM_COMMIT_LABEL: MOBILEGYM_COMMIT}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(environment.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        environment.subprocess,
+        "Popen",
+        lambda *args, **kwargs: pytest.fail("matching image should not be rebuilt"),
+    )
+
+    environment.ensure_mobilegym_image(
+        "aiden-mobilegym-simulator:test",
+        True,
+        tmp_path / "build.log",
+        repo_root=tmp_path,
+    )
+
+
+@pytest.mark.parametrize(
+    ("inspect_returncode", "labels"),
+    [
+        (1, None),
+        (0, {"io.aiden.mobilegym.commit": "0" * 40}),
+    ],
+)
+def test_ensure_mobilegym_image_builds_missing_or_stale_image(
+    monkeypatch,
+    tmp_path: Path,
+    inspect_returncode: int,
+    labels: dict[str, str] | None,
+):
+    monkeypatch.setattr(
+        environment,
+        "resolve_mobilegym_source",
+        lambda repo_root: environment.MobileGymSource(MOBILEGYM_REPO, MOBILEGYM_COMMIT),
+    )
+
+    def fake_run(cmd, **kwargs):
+        return environment.subprocess.CompletedProcess(
+            cmd,
+            inspect_returncode,
+            stdout=json.dumps(labels) if labels is not None else "",
+            stderr="",
+        )
+
+    class FakeProc:
+        returncode = 0
+
+        def poll(self):
+            return self.returncode
+
+    captured = {}
+    monkeypatch.setattr(environment.subprocess, "run", fake_run)
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return FakeProc()
+
+    monkeypatch.setattr(environment.subprocess, "Popen", fake_popen)
+
+    environment.ensure_mobilegym_image(
+        "aiden-mobilegym-simulator:test",
+        True,
+        tmp_path / "build.log",
+        repo_root=tmp_path,
+    )
+
+    assert captured["cmd"] == [
+        "docker",
+        "build",
+        "-f",
+        str(tmp_path / "benchmark" / "mobilegym" / "docker" / "Dockerfile"),
+        "--target",
+        "mobilegym-base",
+        "--build-arg",
+        f"MOBILEGYM_REPO={MOBILEGYM_REPO}",
+        "--build-arg",
+        f"MOBILEGYM_COMMIT={MOBILEGYM_COMMIT}",
+        "-t",
+        "aiden-mobilegym-simulator:test",
+        str(tmp_path),
+    ]
+
+
+def test_ensure_mobilegym_image_rejects_stale_image_when_build_disabled(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(
+        environment,
+        "resolve_mobilegym_source",
+        lambda repo_root: environment.MobileGymSource(MOBILEGYM_REPO, MOBILEGYM_COMMIT),
+    )
+    monkeypatch.setattr(
+        environment.subprocess,
+        "run",
+        lambda cmd, **kwargs: environment.subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps({environment.MOBILEGYM_COMMIT_LABEL: "0" * 40}),
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match=f"expected {MOBILEGYM_COMMIT}"):
+        environment.ensure_mobilegym_image(
+            "aiden-mobilegym-simulator:test",
+            False,
+            tmp_path / "build.log",
+            repo_root=tmp_path,
+        )

--- a/benchmark/tests/test_recovery.py
+++ b/benchmark/tests/test_recovery.py
@@ -183,6 +183,77 @@ def test_prepare_task_isolation_runs_agent_prompt_after_environment_setup(monkey
     assert client.clears == 2
 
 
+def test_prepare_task_isolation_rebuilds_environment_after_agent_prompt_timeout(monkeypatch):
+    events = []
+
+    def fake_environment_setup(environment_url, task_id=None, timeout=30, app_ids=None):
+        events.append(("environment_setup", task_id))
+
+    class TimeoutThenSuccessClient(SetupClient):
+        def __init__(self):
+            super().__init__()
+            self.chat_attempts = 0
+
+        def recover_after_timeout(self, timeout_sec=90, poll_sec=3.0):
+            events.append(("recover", timeout_sec))
+            return True
+
+        def clear_history(self, timeout=30):
+            super().clear_history(timeout=timeout)
+            events.append(("clear_history", self.clears))
+
+        def chat(self, message, timeout_sec=None):
+            self.chat_attempts += 1
+            events.append(("chat", self.chat_attempts))
+            if self.chat_attempts == 1:
+                error = AgentTimeoutError("setup timed out")
+                error.request_id = "setup-req-1"
+                raise error
+            self.chats.append((message, timeout_sec))
+
+    monkeypatch.setattr("runner.recovery.call_environment_setup", fake_environment_setup)
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+    client = TimeoutThenSuccessClient()
+    suite = Suite(
+        name="phone",
+        global_reset={},
+        tasks=[],
+        sha256="sha",
+        source_path=__import__("pathlib").Path("suite.json"),
+    )
+    task = TaskSpec(
+        id="open_settings",
+        category="single_step",
+        description_for_judge="Open settings.",
+        prompt="open settings",
+        rubric=[RubricItem(id="ok", check="ok")],
+        hard_assertions=HardAssertions(min_tool_calls=1, max_tool_calls=3),
+        setup={"type": "agent_prompt", "prompt": "open a settings sub-page"},
+    )
+
+    prepare_task_isolation(
+        client,
+        suite,
+        task,
+        environment_url="http://127.0.0.1:9090",
+        benchmark_task_id="suite.json:open_settings",
+        ready_timeout_sec=10,
+        setup_attempts=2,
+    )
+
+    assert events == [
+        ("recover", 10),
+        ("clear_history", 1),
+        ("environment_setup", "suite.json:open_settings"),
+        ("chat", 1),
+        ("recover", 15),
+        ("clear_history", 2),
+        ("environment_setup", "suite.json:open_settings"),
+        ("chat", 2),
+        ("clear_history", 3),
+    ]
+
+
 def test_prepare_task_isolation_runs_seed_memory_with_environment_setup(monkeypatch):
     setup_calls = []
 

--- a/benchmark/tests/test_recovery.py
+++ b/benchmark/tests/test_recovery.py
@@ -99,11 +99,48 @@ def test_prepare_task_isolation_retries_clear(monkeypatch):
     assert client.clears == 2
 
 
+def test_prepare_task_isolation_retries_clear_before_environment_setup(monkeypatch):
+    setup_calls = []
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        "runner.recovery.call_environment_setup",
+        lambda *args, **kwargs: setup_calls.append((args, kwargs)),
+    )
+    client = SetupClient(fail_clears=1)
+    suite = Suite(
+        name="phone",
+        global_reset={},
+        tasks=[],
+        sha256="sha",
+        source_path=__import__("pathlib").Path("suite.json"),
+    )
+    task = TaskSpec(
+        id="open_settings",
+        category="single_step",
+        description_for_judge="Open settings.",
+        prompt="open settings",
+        rubric=[RubricItem(id="ok", check="ok")],
+        hard_assertions=HardAssertions(min_tool_calls=1, max_tool_calls=3),
+    )
+
+    prepare_task_isolation(
+        client,
+        suite,
+        task,
+        environment_url="http://127.0.0.1:9090",
+        ready_timeout_sec=10,
+        setup_attempts=3,
+    )
+
+    assert client.clears == 2
+    assert len(setup_calls) == 1
+
+
 def test_prepare_task_isolation_runs_agent_prompt_after_environment_setup(monkeypatch):
     setup_calls = []
 
-    def fake_environment_setup(environment_url, task_id=None, timeout=30):
-        setup_calls.append((environment_url, task_id, timeout))
+    def fake_environment_setup(environment_url, task_id=None, timeout=30, app_ids=None):
+        setup_calls.append((environment_url, task_id, timeout, app_ids))
 
     monkeypatch.setattr(
         "runner.recovery.call_environment_setup",
@@ -126,6 +163,7 @@ def test_prepare_task_isolation_runs_agent_prompt_after_environment_setup(monkey
         rubric=[RubricItem(id="ok", check="ok")],
         hard_assertions=HardAssertions(min_tool_calls=1, max_tool_calls=3),
         setup={"type": "agent_prompt", "prompt": "open a settings sub-page", "timeout_sec": 45},
+        app_ids=["settings"],
     )
 
     prepare_task_isolation(
@@ -138,7 +176,9 @@ def test_prepare_task_isolation_runs_agent_prompt_after_environment_setup(monkey
         setup_attempts=1,
     )
 
-    assert setup_calls == [("http://127.0.0.1:9090", "suite.json:open_settings", 180)]
+    assert setup_calls == [
+        ("http://127.0.0.1:9090", "suite.json:open_settings", 180, ["settings"])
+    ]
     assert client.chats == [("ADB benchmark rules\n\nopen a settings sub-page", 45)]
     assert client.clears == 2
 
@@ -146,8 +186,8 @@ def test_prepare_task_isolation_runs_agent_prompt_after_environment_setup(monkey
 def test_prepare_task_isolation_runs_seed_memory_with_environment_setup(monkeypatch):
     setup_calls = []
 
-    def fake_environment_setup(environment_url, task_id=None, timeout=30):
-        setup_calls.append((environment_url, task_id, timeout))
+    def fake_environment_setup(environment_url, task_id=None, timeout=30, app_ids=None):
+        setup_calls.append((environment_url, task_id, timeout, app_ids))
 
     monkeypatch.setattr(
         "runner.recovery.call_environment_setup",
@@ -191,7 +231,9 @@ def test_prepare_task_isolation_runs_seed_memory_with_environment_setup(monkeypa
         setup_attempts=1,
     )
 
-    assert setup_calls == [("http://127.0.0.1:9090", "personamem.json:recall_fact", 180)]
+    assert setup_calls == [
+        ("http://127.0.0.1:9090", "personamem.json:recall_fact", 180, [])
+    ]
     assert client.seeded_memories == [
         ({"id": "mem-1", "content": "The user likes flashcards.", "tags": ["study"]}, 7)
     ]
@@ -218,6 +260,46 @@ def test_prepare_task_isolation_raises_after_exhausting_retries(monkeypatch):
 
     with pytest.raises(AgentTimeoutError, match="clear timed out"):
         prepare_task_isolation(client, suite, task, ready_timeout_sec=10, setup_attempts=2)
+
+
+def test_prepare_task_isolation_does_not_repeat_failed_environment_setup(monkeypatch):
+    setup_calls = 0
+
+    def fail_environment_setup(environment_url, task_id=None, timeout=30, app_ids=None):
+        nonlocal setup_calls
+        setup_calls += 1
+        raise ResetError("environment reset failed")
+
+    monkeypatch.setattr("runner.recovery.call_environment_setup", fail_environment_setup)
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+    client = SetupClient()
+    suite = Suite(
+        name="phone",
+        global_reset={},
+        tasks=[],
+        sha256="sha",
+        source_path=__import__("pathlib").Path("suite.json"),
+    )
+    task = TaskSpec(
+        id="open_settings",
+        category="single_step",
+        description_for_judge="Open settings.",
+        prompt="open settings",
+        rubric=[RubricItem(id="ok", check="ok")],
+        hard_assertions=HardAssertions(min_tool_calls=1, max_tool_calls=3),
+    )
+
+    with pytest.raises(ResetError, match="environment reset failed"):
+        prepare_task_isolation(
+            client,
+            suite,
+            task,
+            environment_url="http://127.0.0.1:9090",
+            ready_timeout_sec=10,
+            setup_attempts=3,
+        )
+
+    assert setup_calls == 1
 
 
 def test_prepare_task_isolation_raises_when_agent_never_ready(monkeypatch):

--- a/benchmark/tests/test_reset.py
+++ b/benchmark/tests/test_reset.py
@@ -124,12 +124,16 @@ def test_call_environment_setup_posts_to_api_setup(monkeypatch):
 
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
-    result = call_environment_setup("http://127.0.0.1:9090", timeout=12)
+    result = call_environment_setup(
+        "http://127.0.0.1:9090",
+        timeout=12,
+        app_ids=["settings"],
+    )
 
     assert seen == {
         "url": "http://127.0.0.1:9090/api/setup",
         "method": "POST",
-        "body": b"{}",
+        "body": b'{"app_ids": ["settings"]}',
         "task_id": None,
         "timeout": 12,
     }

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -235,6 +235,41 @@ def test_load_suite_parses_expected_recalled_memory_ids(tmp_path: Path):
 
     assert suite.tasks[0].expected_recalled_memory_ids == ["mem_expected"]
 
+
+def test_load_suite_parses_task_app_ids(tmp_path: Path):
+    fixture = {
+        **FIXTURE,
+        "tasks": [
+            {
+                **FIXTURE["tasks"][0],
+                "app_ids": ["settings"],
+            }
+        ],
+    }
+    path = tmp_path / "s.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    suite = load_suite(path)
+
+    assert suite.tasks[0].app_ids == ["settings"]
+
+
+def test_load_suite_rejects_invalid_task_app_ids(tmp_path: Path):
+    fixture = {
+        **FIXTURE,
+        "tasks": [
+            {
+                **FIXTURE["tasks"][0],
+                "app_ids": "settings",
+            }
+        ],
+    }
+    path = tmp_path / "s.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    with pytest.raises(SuiteValidationError, match="app_ids"):
+        load_suite(path)
+
 def test_load_suite_parses_task_platforms(tmp_path: Path):
     fixture = {
         **FIXTURE,

--- a/docs/01-getting-started/build.md
+++ b/docs/01-getting-started/build.md
@@ -11,9 +11,10 @@ git clone --recursive git@github.com:AidenAI-IO/aiden-firmware.git
 cd aiden-firmware
 ```
 
-The project includes the `pico-sdk` submodule. It's recommended to use `--recursive` on the first clone. If you've already cloned but the submodule is missing:
+The project includes Git submodules such as `pico-sdk` and MobileGym. It's recommended to use `--recursive` on the first clone. For an existing checkout, synchronize submodule URLs before initializing or updating them:
 
 ```bash
+git submodule sync --recursive
 git submodule update --init --recursive
 ```
 


### PR DESCRIPTION
## Summary

- reuse healthy MobileGym pages during setup and rebuild only after bounded timeout or confirmed page crash
- propagate task app IDs through runner, bridge, and MobileGym so setup skips unrelated heavy data loaders
- share one reset/readiness deadline, preserve phase diagnostics in HTTP 504 responses, and isolate pending restarts from concurrent environment operations
- stop runner-level retries from multiplying failed environment setup work while retaining agent recovery retries

## Dependency

Depends on AidenAI-IO/mobilegym#1. Merge the MobileGym PR first so commit 90a5616 is available from the configured submodule remote.

## Validation

- 139 related aiden-firmware tests passed
- 14 MobileGym Python tests passed
- 4 MobileGym TypeScript tests passed
- npm run build passed
- full three-worker phone_control_v1 benchmark produced 0 HTTP 504 and 0 environment setup errors; all final five tasks completed MobileGym setup
- final-code Chromium pressure test completed 60 concurrent setup/release operations with 0 errors, p50 500 ms, max 648 ms

Benchmark artifacts: benchmark/runs/mobilegym-reset-fix-reviewed-20260815

## Test note

A broader local benchmark/tests invocation still exposes five WebUI environment lifecycle tests whose monkeypatches target a different runner module alias and therefore reach real Docker or health checks. The changed-path regression suites above pass, and the failing WebUI paths are not modified by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tasks can select apps to preload during environment setup, reducing unnecessary loading.
  - Chat requests now support cancellation, status tracking, and clearer request-related errors.
- **Bug Fixes**
  - Improved recovery after crashes, closures, reset timeouts, and interrupted chat requests.
  - Restart attempts have bounded timeouts and clearer diagnostics.
  - Task isolation avoids repeating completed setup.
- **Documentation**
  - Updated setup and API guidance for app preloading and MobileGym setup.
- **Chores**
  - MobileGym builds use pinned source versions and detect stale images.
- **Tests**
  - Expanded coverage for validation, retries, restarts, cancellation, and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->