### PR TITLE
fix(build): enable Python readline for interactive editing

### DIFF
--- a/fix-python-readline.patch
+++ b/fix-python-readline.patch
@@ -1,0 +1,60 @@
+From: Jacob <cookiejlim@gmail.com>
+Subject: [PATCH] build: enable Python readline module for interactive editing
+
+Problem:
+--------
+After pip integration (SDK commit a40899f), Python REPL arrow keys print
+escape sequences like ^[[A^[[B instead of navigating command history.
+
+Root cause:
+-----------
+- Buildroot bash package selects BR2_PACKAGE_READLINE (luckfox_pico_defconfig:74)
+- libreadline.so exists in firmware for bash
+- Python3 compiled with --disable-readline (missing BR2_PACKAGE_PYTHON3_READLINE)
+- readline.cpython-*.so module not built
+- Python REPL falls back to raw input mode
+
+Fix:
+----
+Enable BR2_PACKAGE_PYTHON3_READLINE=y in both defconfigs so Python can use
+the existing readline library already present for bash.
+
+Affected files in pico-sdk (sysdrv/tools/board/buildroot/):
+- luckfox_pico_defconfig
+- luckfox_pico_w_defconfig
+
+--- a/sysdrv/tools/board/buildroot/luckfox_pico_defconfig
++++ b/sysdrv/tools/board/buildroot/luckfox_pico_defconfig
+@@ -27,6 +27,7 @@ BR2_PACKAGE_E2FSPROGS=y
+ BR2_PACKAGE_E2FSPROGS_RESIZE2FS=y
+ BR2_PACKAGE_EVTEST=y
+ BR2_PACKAGE_PYTHON3=y
++BR2_PACKAGE_PYTHON3_READLINE=y
+ BR2_PACKAGE_PYTHON3_SSL=y
+ BR2_PACKAGE_PYTHON_AIOHTTP=y
+ BR2_PACKAGE_PYTHON_CHARSET_NORMALIZER=y
+
+--- a/sysdrv/tools/board/buildroot/luckfox_pico_w_defconfig
++++ b/sysdrv/tools/board/buildroot/luckfox_pico_w_defconfig
+@@ -54,6 +54,7 @@ BR2_PACKAGE_DBUS_TRIGGERD=y
+ BR2_PACKAGE_EVTEST=y
+ BR2_PACKAGE_NODEJS=y
+ BR2_PACKAGE_NODEJS_MODULES_ADDITIONAL="--omit=optional wetty@2.5.0 sass@1.69.7"
++BR2_PACKAGE_PYTHON3_READLINE=y
+ BR2_PACKAGE_PYTHON3_SSL=y
+ BR2_PACKAGE_PYTHON_AIOHTTP=y
+ BR2_PACKAGE_PYTHON_CHARSET_NORMALIZER=y
+
+Verification:
+-------------
+After rebuilding firmware with this change:
+1. SSH to device
+2. Run: python3
+3. Press arrow keys → should navigate history instead of printing ^[[A^[[B
+4. Confirm readline module: python3 -c "import readline; print(readline.__file__)"
+
+Dependencies:
+-------------
+BR2_PACKAGE_PYTHON3_READLINE selects BR2_PACKAGE_READLINE (already satisfied by bash)
+BR2_PACKAGE_READLINE selects BR2_PACKAGE_NCURSES (already in both defconfigs)
+No additional package overhead; only adds ~100KB readline.cpython-*.so module.


### PR DESCRIPTION
## Problem

After pip integration (SDK a40899f), Python REPL arrow keys print escape sequences like `^[[A^[[B` instead of navigating command history.

## Root Cause

- Buildroot bash package already pulls in libreadline.so
- Python3 compiled with `--disable-readline` (missing `BR2_PACKAGE_PYTHON3_READLINE=y`)
- readline.cpython-*.so module not built
- Python REPL falls back to raw input mode

## Solution

Enable `BR2_PACKAGE_PYTHON3_READLINE=y` in both luckfox defconfigs.

Adds ~100KB Python readline module, no new system libraries (readline/ncurses already present for bash).

## Testing

After firmware rebuild with this patch applied to pico-sdk:
1. SSH to device
2. Run `python3`
3. Arrow keys navigate history correctly
4. Ctrl+A/E, Ctrl+R work as expected

## Files Changed in pico-sdk

- `sysdrv/tools/board/buildroot/luckfox_pico_defconfig`
- `sysdrv/tools/board/buildroot/luckfox_pico_w_defconfig`

See `fix-python-readline.patch` for detailed analysis and the exact defconfig changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled interactive history navigation and line editing in the Python 3 command-line interpreter on Luckfox Pico builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->