### PR TITLE
feat(sandbox)!: rebuild from current source on sandbox-start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all configure build clean test test-clean sandbox-start sandbox-update sandbox-logs sandbox-stop
+.PHONY: all configure build clean test test-clean sandbox-start sandbox-start-cached sandbox-update sandbox-logs sandbox-stop
 
 BUILD_DIR := build
 TEST_BUILD_DIR := build-host
@@ -29,8 +29,11 @@ clean:
 sandbox-start:
 	./scripts/start_docker_sandbox.sh
 
-sandbox-update:
-	./scripts/start_docker_sandbox.sh --build
+# Kept as an alias: sandbox-start already rebuilds from the current source.
+sandbox-update: sandbox-start
+
+sandbox-start-cached:
+	./scripts/start_docker_sandbox.sh --no-build
 
 sandbox-logs:
 	docker compose logs -f aiden

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all configure build clean test test-clean sandbox-start sandbox-start-cached sandbox-update sandbox-logs sandbox-stop
+.PHONY: all configure build clean test test-clean sandbox-start sandbox-logs sandbox-stop
 
 BUILD_DIR := build
 TEST_BUILD_DIR := build-host
@@ -28,12 +28,6 @@ clean:
 
 sandbox-start:
 	./scripts/start_docker_sandbox.sh
-
-# Kept as an alias: sandbox-start already rebuilds from the current source.
-sandbox-update: sandbox-start
-
-sandbox-start-cached:
-	./scripts/start_docker_sandbox.sh --no-build
 
 sandbox-logs:
 	docker compose logs -f aiden

--- a/docs/01-getting-started/try-aiden-on-pc.md
+++ b/docs/01-getting-started/try-aiden-on-pc.md
@@ -76,14 +76,7 @@ docker compose logs -f
 ```
 
 After changing Aiden source code, run `make sandbox-start` again to rebuild the
-image and replace the running container. `make sandbox-update` remains as an
-alias for the same behaviour.
-
-To skip the build and reuse whatever image already exists, run:
-
-```bash
-make sandbox-start-cached
-```
+image and replace the running container.
 
 Starting the sandbox preserves the `aiden-data` volume. Use `make sandbox-logs`
 to follow the Agent logs and `make sandbox-stop` to stop the sandbox.

--- a/docs/01-getting-started/try-aiden-on-pc.md
+++ b/docs/01-getting-started/try-aiden-on-pc.md
@@ -46,9 +46,10 @@ From the repository root:
 make sandbox-start
 ```
 
-The command starts the sandbox in the background and waits for both web services
-to become healthy. The first run builds the image if it does not exist; later
-runs reuse the existing image. When the services are ready, open:
+The command rebuilds the image from the current source, starts the sandbox in the
+background, and waits for both web services to become healthy. Docker layer
+caching keeps repeat runs fast when nothing changed, so the running sandbox
+always matches the working tree. When the services are ready, open:
 
 | Page | URL | Purpose |
 | --- | --- | --- |
@@ -74,15 +75,18 @@ Follow service output with:
 docker compose logs -f
 ```
 
-After changing Aiden source code, rebuild the image, replace the running
-container, and wait for both web services to become healthy with:
+After changing Aiden source code, run `make sandbox-start` again to rebuild the
+image and replace the running container. `make sandbox-update` remains as an
+alias for the same behaviour.
+
+To skip the build and reuse whatever image already exists, run:
 
 ```bash
-make sandbox-update
+make sandbox-start-cached
 ```
 
-The update preserves the `aiden-data` volume. Use `make sandbox-logs` to follow
-the Agent logs and `make sandbox-stop` to stop the sandbox.
+Starting the sandbox preserves the `aiden-data` volume. Use `make sandbox-logs`
+to follow the Agent logs and `make sandbox-stop` to stop the sandbox.
 
 ## Connect an Environment Bridge
 

--- a/scripts/start_docker_sandbox.sh
+++ b/scripts/start_docker_sandbox.sh
@@ -5,14 +5,10 @@ ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 WAIT_TIMEOUT="${AIDEN_SANDBOX_WAIT_TIMEOUT:-180}"
 CONFIG_WEB_PORT="${AIDEN_CONFIG_WEB_PORT:-8000}"
 AGENT_WEB_PORT="${AIDEN_AGENT_WEB_PORT:-8080}"
-BUILD_IMAGE=true
 
-if [[ $# -gt 1 ]] || [[ $# -eq 1 && "$1" != "--no-build" ]]; then
-    echo "Usage: $0 [--no-build]" >&2
+if [[ $# -gt 0 ]]; then
+    echo "Usage: $0" >&2
     exit 2
-fi
-if [[ ${1:-} == "--no-build" ]]; then
-    BUILD_IMAGE=false
 fi
 
 cd "$ROOT_DIR"
@@ -41,13 +37,10 @@ compose_args=(
     --detach
     --wait
     --wait-timeout "$WAIT_TIMEOUT"
+    --build
 )
-if [[ "$BUILD_IMAGE" == true ]]; then
-    echo "Building the current source and starting the Aiden Docker sandbox..."
-    compose_args+=(--build)
-else
-    echo "Starting the Aiden Docker sandbox from the existing image..."
-fi
+
+echo "Building the current source and starting the Aiden Docker sandbox..."
 
 if ! docker compose up "${compose_args[@]}" aiden; then
     echo "The sandbox did not become healthy. Recent logs:" >&2

--- a/scripts/start_docker_sandbox.sh
+++ b/scripts/start_docker_sandbox.sh
@@ -5,14 +5,14 @@ ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 WAIT_TIMEOUT="${AIDEN_SANDBOX_WAIT_TIMEOUT:-180}"
 CONFIG_WEB_PORT="${AIDEN_CONFIG_WEB_PORT:-8000}"
 AGENT_WEB_PORT="${AIDEN_AGENT_WEB_PORT:-8080}"
-BUILD_IMAGE=false
+BUILD_IMAGE=true
 
-if [[ $# -gt 1 ]] || [[ $# -eq 1 && "$1" != "--build" ]]; then
-    echo "Usage: $0 [--build]" >&2
+if [[ $# -gt 1 ]] || [[ $# -eq 1 && "$1" != "--no-build" ]]; then
+    echo "Usage: $0 [--no-build]" >&2
     exit 2
 fi
-if [[ ${1:-} == "--build" ]]; then
-    BUILD_IMAGE=true
+if [[ ${1:-} == "--no-build" ]]; then
+    BUILD_IMAGE=false
 fi
 
 cd "$ROOT_DIR"
@@ -43,10 +43,10 @@ compose_args=(
     --wait-timeout "$WAIT_TIMEOUT"
 )
 if [[ "$BUILD_IMAGE" == true ]]; then
-    echo "Rebuilding and updating the Aiden Docker sandbox..."
+    echo "Building the current source and starting the Aiden Docker sandbox..."
     compose_args+=(--build)
 else
-    echo "Starting the Aiden Docker sandbox..."
+    echo "Starting the Aiden Docker sandbox from the existing image..."
 fi
 
 if ! docker compose up "${compose_args[@]}" aiden; then

--- a/tests/benchmark/test_docker_sandbox.py
+++ b/tests/benchmark/test_docker_sandbox.py
@@ -60,7 +60,7 @@ class DockerSandboxContractTest(unittest.TestCase):
         self.assertIn('device_type = "iOS"', config)
         self.assertNotIn("api_key", config)
 
-    def test_start_and_update_targets_share_health_checked_startup(self):
+    def test_start_target_has_health_checked_startup(self):
         start_script = read_repo_file("scripts/start_docker_sandbox.sh")
         makefile = read_repo_file("Makefile")
 
@@ -71,11 +71,9 @@ class DockerSandboxContractTest(unittest.TestCase):
         self.assertIn("sandbox-start:", makefile)
         self.assertIn("./scripts/start_docker_sandbox.sh", makefile)
         self.assertNotIn("down -v", start_script)
-        self.assertIn("sandbox-update:", makefile)
-        self.assertIn("./scripts/start_docker_sandbox.sh --no-build", makefile)
 
-    def run_start_script(self, *arguments: str) -> list[str]:
-        """Run the start script against a fake docker and return its `up` args."""
+    def test_starting_the_sandbox_always_rebuilds_the_image(self):
+        """The started sandbox must run the working tree, never a stale image."""
 
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_path = Path(temporary_directory)
@@ -97,7 +95,7 @@ class DockerSandboxContractTest(unittest.TestCase):
             environment["PATH"] = f"{temporary_path}{os.pathsep}{environment['PATH']}"
             environment["AIDEN_FAKE_DOCKER_LOG"] = str(invocations)
             completed = subprocess.run(
-                [str(REPO_ROOT / "scripts/start_docker_sandbox.sh"), *arguments],
+                [str(REPO_ROOT / "scripts/start_docker_sandbox.sh")],
                 env=environment,
                 capture_output=True,
                 text=True,
@@ -110,23 +108,7 @@ class DockerSandboxContractTest(unittest.TestCase):
                 if line.startswith("compose up")
             ]
             self.assertEqual(len(up_commands), 1, invocations.read_text())
-            return up_commands[0].split()
-
-    def test_starting_the_sandbox_rebuilds_the_image_by_default(self):
-        self.assertIn("--build", self.run_start_script())
-
-    def test_no_build_reuses_the_existing_sandbox_image(self):
-        self.assertNotIn("--build", self.run_start_script("--no-build"))
-
-    def test_start_script_rejects_unknown_arguments(self):
-        completed = subprocess.run(
-            [str(REPO_ROOT / "scripts/start_docker_sandbox.sh"), "--build"],
-            capture_output=True,
-            text=True,
-        )
-
-        self.assertEqual(completed.returncode, 2)
-        self.assertIn("--no-build", completed.stderr)
+            self.assertIn("--build", up_commands[0].split())
 
     def test_try_aiden_on_pc_is_the_hardware_free_sandbox_entrypoint(self):
         guide = read_repo_file("docs/01-getting-started/try-aiden-on-pc.md")
@@ -134,7 +116,7 @@ class DockerSandboxContractTest(unittest.TestCase):
 
         self.assertIn("docker compose up --build", guide)
         self.assertIn("make sandbox-start", guide)
-        self.assertIn("make sandbox-update", guide)
+        self.assertNotIn("make sandbox-update", guide)
         self.assertIn(
             "AIDEN_BRIDGE_EPISODE_ID=my-sandbox-session", guide
         )

--- a/tests/benchmark/test_docker_sandbox.py
+++ b/tests/benchmark/test_docker_sandbox.py
@@ -72,7 +72,61 @@ class DockerSandboxContractTest(unittest.TestCase):
         self.assertIn("./scripts/start_docker_sandbox.sh", makefile)
         self.assertNotIn("down -v", start_script)
         self.assertIn("sandbox-update:", makefile)
-        self.assertIn("./scripts/start_docker_sandbox.sh --build", makefile)
+        self.assertIn("./scripts/start_docker_sandbox.sh --no-build", makefile)
+
+    def run_start_script(self, *arguments: str) -> list[str]:
+        """Run the start script against a fake docker and return its `up` args."""
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            invocations = temporary_path / "docker-invocations"
+            docker = temporary_path / "docker"
+            docker.write_text(
+                "#!/bin/sh\n"
+                'if [ "$1" = compose ] && [ "$2" = up ] && [ "$3" = --help ]; then\n'
+                "    printf '  --build\\n  --wait\\n  --wait-timeout duration\\n'\n"
+                "    exit 0\n"
+                "fi\n"
+                'printf \'%s\\n\' "$*" >>"$AIDEN_FAKE_DOCKER_LOG"\n'
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            docker.chmod(0o755)
+
+            environment = os.environ.copy()
+            environment["PATH"] = f"{temporary_path}{os.pathsep}{environment['PATH']}"
+            environment["AIDEN_FAKE_DOCKER_LOG"] = str(invocations)
+            completed = subprocess.run(
+                [str(REPO_ROOT / "scripts/start_docker_sandbox.sh"), *arguments],
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+
+            up_commands = [
+                line
+                for line in invocations.read_text(encoding="utf-8").splitlines()
+                if line.startswith("compose up")
+            ]
+            self.assertEqual(len(up_commands), 1, invocations.read_text())
+            return up_commands[0].split()
+
+    def test_starting_the_sandbox_rebuilds_the_image_by_default(self):
+        self.assertIn("--build", self.run_start_script())
+
+    def test_no_build_reuses_the_existing_sandbox_image(self):
+        self.assertNotIn("--build", self.run_start_script("--no-build"))
+
+    def test_start_script_rejects_unknown_arguments(self):
+        completed = subprocess.run(
+            [str(REPO_ROOT / "scripts/start_docker_sandbox.sh"), "--build"],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("--no-build", completed.stderr)
 
     def test_try_aiden_on_pc_is_the_hardware_free_sandbox_entrypoint(self):
         guide = read_repo_file("docs/01-getting-started/try-aiden-on-pc.md")


### PR DESCRIPTION
## Summary

`make sandbox-start` reused whatever image already existed, so a sandbox started after editing source kept running the previously built `agent` and `config_web` binaries. Picking up code changes required remembering to run `make sandbox-update` instead.

`make sandbox-start` now always rebuilds, and is the only sandbox start entry point:

- `scripts/start_docker_sandbox.sh` — always passes `--build`; takes no arguments.
- `Makefile` — `sandbox-update` removed. It would have been an exact duplicate of `sandbox-start`.
- `docs/01-getting-started/try-aiden-on-pc.md` — updated accordingly.

The `aiden-data` volume is untouched, so Config Web settings and Agent state persist across restarts.

## Breaking change

`make sandbox-update` and `scripts/start_docker_sandbox.sh --build` are removed. Use `make sandbox-start`, which always rebuilds. The script now exits 2 on any argument.

## Build cost with a warm cache

Measured locally (arm64, warm buildx cache):

| Scenario | Wall time |
| --- | --- |
| No source change | 1.8s — every layer `CACHED`, container not even restarted |
| One-line change in `src/agent/cmd/daemon/main.go` | 13s — only `go build` re-runs (10.9s) |

The layer order in `docker/dev/Dockerfile` is what keeps this cheap: `go.mod`/`go.sum` are copied and `go mod download` runs before `COPY src/agent/`, and `runtime-tools-builder` depends only on `TARGETARCH`, so editing source never re-downloads Go modules or the fq/rg/yq release archives.

Known inefficiency, not addressed here: `config-web-builder` does `COPY src/ ./src/`, so a Go-only edit also invalidates the C++ layer and recompiles `config_web`. The two builder stages run in parallel, so it is hidden inside the 13s above. Narrowing that COPY would mean maintaining a second file list next to the existing compile list and risking drift between them.

## Test plan

- `python3 -m unittest tests.benchmark.test_docker_sandbox.DockerSandboxContractTest` — 9 tests pass.
- `test_starting_the_sandbox_always_rebuilds_the_image` puts a fake `docker` ahead of `PATH`, runs the real script, and asserts `--build` reaches `docker compose up` — a behavioural check rather than a grep over the script text.
- `bash -n scripts/start_docker_sandbox.sh`; `make -n sandbox-start`; `./scripts/start_docker_sandbox.sh --build` exits 2.
- Ran the real `make sandbox-start` end to end: image built, container reached the Compose healthcheck, both Config Web and Agent Web served.

CI's `scripts/test_docker_sandbox.sh` issues its own `compose up -d --build` and does not call this script, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)