### PR TITLE
refactor: unify phone-side Aiden app naming to companion app

### DIFF
--- a/benchmark/manual.md
+++ b/benchmark/manual.md
@@ -98,7 +98,7 @@ Notes:
   start an environment bridge automatically; if you need an environment bridge you
   must start the daemon yourself and pass the relevant daemon parameters.
 
-#### Mock Aiden App environments
+#### Mock companion app environments
 
 Phone Bridge strategy tests usually do not need a physical phone or emulator. A
 suite can declare a default `mock_environment`, and each task can override it, to

--- a/benchmark/runner/webui.py
+++ b/benchmark/runner/webui.py
@@ -524,7 +524,7 @@ class BenchmarkWebApp:
         parallel_tasks = parse_positive_int(payload.get("parallel_tasks"), default=1, field="parallel_tasks")
         if environment_type == "mock":
             environment_id = "mock-aiden-app"
-            environment_name = "Mock Aiden App environment"
+            environment_name = "Mock companion app environment"
             environment_endpoint = ""
             environment_web_url = ""
             parallel_tasks = 1
@@ -4705,7 +4705,7 @@ INDEX_HTML = r"""<!doctype html>
     function mockEnvironment(){
       return {
         id: 'mock-aiden-app',
-        name: 'Mock Aiden App environment',
+        name: 'Mock companion app environment',
         endpoint: '',
         type: 'mock',
         status: 'running'
@@ -4718,7 +4718,7 @@ INDEX_HTML = r"""<!doctype html>
       const mode = selectedSuiteEnvironmentMode();
       document.getElementById('selectedSuitesLabel').textContent = `${selectedSuites.size} suites`;
       const environmentLabel = mode === 'mock'
-        ? 'Mock Aiden App environment'
+        ? 'Mock companion app environment'
         : mode === 'mixed'
           ? 'Mixed environments - run separately'
           : env ? env.name : 'No environment';
@@ -4899,7 +4899,7 @@ INDEX_HTML = r"""<!doctype html>
     function renderActiveJob(job){
       const activeLabel = document.getElementById('activeJobLabel');
       const runtimeLabel = job.environment_type === 'mock'
-        ? (job.environment_name || 'Mock Aiden App environment')
+        ? (job.environment_name || 'Mock companion app environment')
         : job.agent_url;
       activeLabel.textContent = `${job.id} - ${runtimeLabel}`;
       const st = document.getElementById('activeJobStatus');

--- a/benchmark/suites/aiden_app/notes_entry_policy_v1.json
+++ b/benchmark/suites/aiden_app/notes_entry_policy_v1.json
@@ -8,7 +8,7 @@
       "id": "ios_pip_notes_already_open",
       "category": "multi_step",
       "description_for_judge": "Notes is already open. Query Biden and enter the returned number without reopening or searching for Notes.",
-      "prompt": "测试环境状态：当前已经位于 Apple 备忘录的空白编辑页。Aiden 在后台，iOS PiP Bridge 已开启。请查询通讯录中 Biden 的手机号，并将查询到的完整号码写入当前备忘录。",
+      "prompt": "测试环境状态：当前已经位于 Apple 备忘录的空白编辑页。companion app 在后台，iOS PiP Bridge 已开启。请查询通讯录中 Biden 的手机号，并将查询到的完整号码写入当前备忘录。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {
@@ -64,7 +64,7 @@
       "id": "ios_pip_notes_icon_visible",
       "category": "multi_step",
       "description_for_judge": "The Notes icon is directly visible. Query Biden, tap the icon using object-form point coordinates, and enter the returned number without searching.",
-      "prompt": "测试环境状态：当前是 iPhone 主界面，Apple 备忘录图标清晰可见。Aiden 在后台，iOS PiP Bridge 已开启。请查询通讯录中 Biden 的手机号，并将查询到的完整号码写入 Apple 备忘录。",
+      "prompt": "测试环境状态：当前是 iPhone 主界面，Apple 备忘录图标清晰可见。companion app 在后台，iOS PiP Bridge 已开启。请查询通讯录中 Biden 的手机号，并将查询到的完整号码写入 Apple 备忘录。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {
@@ -124,7 +124,7 @@
       "id": "ios_pip_notes_icon_missing",
       "category": "multi_step",
       "description_for_judge": "Neither Notes nor its icon is visible. Query Biden, use search_launch_app, and enter the returned number.",
-      "prompt": "测试环境状态：当前是 iPhone 主界面，画面中没有打开的备忘录，也看不到备忘录图标。Aiden 在后台，iOS PiP Bridge 已开启。请查询通讯录中 Biden 的手机号，并将查询到的完整号码写入 Apple 备忘录。",
+      "prompt": "测试环境状态：当前是 iPhone 主界面，画面中没有打开的备忘录，也看不到备忘录图标。companion app 在后台，iOS PiP Bridge 已开启。请查询通讯录中 Biden 的手机号，并将查询到的完整号码写入 Apple 备忘录。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {

--- a/benchmark/suites/aiden_app/phone_bridge_data_policy_v1.json
+++ b/benchmark/suites/aiden_app/phone_bridge_data_policy_v1.json
@@ -7,12 +7,12 @@
     {
       "id": "ios_dynamic_island_contacts_query",
       "category": "single_step",
-      "description_for_judge": "With iOS backgrounded, PiP disabled, and Dynamic Island reachable, the Agent should call bridge_contacts directly and let the tool restore Aiden internally.",
-      "prompt": "测试环境状态：iOS，Aiden 在后台，PiP Bridge 未开启，灵动岛返回入口可达。请查询通讯录里 Biden 的手机号并告诉我。",
+      "description_for_judge": "With iOS backgrounded, PiP disabled, and Dynamic Island reachable, the Agent should call bridge_contacts directly and let the tool restore the companion app internally.",
+      "prompt": "测试环境状态：iOS，companion app 在后台，PiP Bridge 未开启，灵动岛返回入口可达。请查询通讯录里 Biden 的手机号并告诉我。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {"connected": false, "phone_id": "ios-di-contacts", "app_state": "background", "return_entry": "dynamic_island", "return_entry_available": true, "pip_bridge_enabled": false, "fgs_bridge_enabled": false},
-        "screen_text": "iPhone screen with a reachable Aiden Dynamic Island return entry.",
+        "screen_text": "iPhone screen with a reachable companion app Dynamic Island return entry.",
         "tools": {
           "bridge_contacts": {
             "input_contains": {"action": "query", "query": "Biden"},
@@ -35,12 +35,12 @@
     {
       "id": "ios_dynamic_island_calendar_query",
       "category": "single_step",
-      "description_for_judge": "Query calendar through bridge_calendar; the tool restores Aiden through Dynamic Island before sending the command.",
-      "prompt": "测试环境状态：iOS，Aiden 在后台，PiP Bridge 未开启，灵动岛返回入口可达。请查询 2026-07-23 这一天的日历事件，时间范围严格使用 2026-07-23T00:00:00+08:00 到 2026-07-24T00:00:00+08:00。",
+      "description_for_judge": "Query calendar through bridge_calendar; the tool restores the companion app through Dynamic Island before sending the command.",
+      "prompt": "测试环境状态：iOS，companion app 在后台，PiP Bridge 未开启，灵动岛返回入口可达。请查询 2026-07-23 这一天的日历事件，时间范围严格使用 2026-07-23T00:00:00+08:00 到 2026-07-24T00:00:00+08:00。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {"connected": false, "phone_id": "ios-di-calendar", "app_state": "background", "return_entry": "dynamic_island", "return_entry_available": true, "pip_bridge_enabled": false, "fgs_bridge_enabled": false},
-        "screen_text": "iPhone screen with a reachable Aiden Dynamic Island return entry.",
+        "screen_text": "iPhone screen with a reachable companion app Dynamic Island return entry.",
         "tools": {
           "bridge_calendar": {
             "input_contains": {"action": "query", "from": "2026-07-23T00:00:00+08:00", "to": "2026-07-24T00:00:00+08:00"},
@@ -64,11 +64,11 @@
       "id": "ios_dynamic_island_clipboard_read",
       "category": "single_step",
       "description_for_judge": "Read the clipboard through bridge_clipboard and internal Dynamic Island restore.",
-      "prompt": "测试环境状态：iOS，Aiden 在后台，PiP Bridge 未开启，灵动岛返回入口可达。请读取当前手机剪贴板内容并告诉我。",
+      "prompt": "测试环境状态：iOS，companion app 在后台，PiP Bridge 未开启，灵动岛返回入口可达。请读取当前手机剪贴板内容并告诉我。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {"connected": false, "phone_id": "ios-di-clipboard", "app_state": "background", "return_entry": "dynamic_island", "return_entry_available": true, "pip_bridge_enabled": false, "fgs_bridge_enabled": false},
-        "screen_text": "iPhone screen with a reachable Aiden Dynamic Island return entry.",
+        "screen_text": "iPhone screen with a reachable companion app Dynamic Island return entry.",
         "tools": {
           "bridge_clipboard": {
             "input_contains": {"action": "read"},
@@ -92,11 +92,11 @@
       "id": "ios_dynamic_island_notification_send",
       "category": "single_step",
       "description_for_judge": "Send a notification through bridge_notification and internal Dynamic Island restore.",
-      "prompt": "测试环境状态：iOS，Aiden 在后台，PiP Bridge 未开启，灵动岛返回入口可达。请立即发送一条本地通知，标题为「Aiden Benchmark」，正文为「灵动岛恢复通知」，不播放声音。",
+      "prompt": "测试环境状态：iOS，companion app 在后台，PiP Bridge 未开启，灵动岛返回入口可达。请立即发送一条本地通知，标题为「Aiden Benchmark」，正文为「灵动岛恢复通知」，不播放声音。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {"connected": false, "phone_id": "ios-di-notification", "app_state": "background", "return_entry": "dynamic_island", "return_entry_available": true, "pip_bridge_enabled": false, "fgs_bridge_enabled": false},
-        "screen_text": "iPhone screen with a reachable Aiden Dynamic Island return entry.",
+        "screen_text": "iPhone screen with a reachable companion app Dynamic Island return entry.",
         "tools": {
           "bridge_notification": {
             "input_contains": {"title": "Aiden Benchmark", "body": "灵动岛恢复通知", "sound": false},
@@ -120,7 +120,7 @@
       "id": "ios_pip_contacts_query",
       "category": "single_step",
       "description_for_judge": "With iOS PiP enabled, query contacts directly through the background queue and never call bridge_open_app.",
-      "prompt": "测试环境状态：iOS，Aiden 在后台，PiP Bridge 已开启。请查询通讯录里 Alice 的手机号并告诉我。",
+      "prompt": "测试环境状态：iOS，companion app 在后台，PiP Bridge 已开启。请查询通讯录里 Alice 的手机号并告诉我。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {"connected": false, "phone_id": "ios-pip-contacts", "app_state": "background", "return_entry": "dynamic_island", "return_entry_available": true, "pip_bridge_enabled": true, "fgs_bridge_enabled": false},
@@ -148,7 +148,7 @@
       "id": "ios_pip_calendar_create",
       "category": "single_step",
       "description_for_judge": "Create a calendar event directly through the iOS PiP background queue; bridge_open_app is unavailable.",
-      "prompt": "测试环境状态：iOS，Aiden 在后台，PiP Bridge 已开启。请创建日历事件：标题「PiP 测试日程」，开始时间 2026-07-24T14:00:00+08:00，结束时间 2026-07-24T15:00:00+08:00，地点「3号会议室」。",
+      "prompt": "测试环境状态：iOS，companion app 在后台，PiP Bridge 已开启。请创建日历事件：标题「PiP 测试日程」，开始时间 2026-07-24T14:00:00+08:00，结束时间 2026-07-24T15:00:00+08:00，地点「3号会议室」。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {"connected": false, "phone_id": "ios-pip-calendar", "app_state": "background", "return_entry": "dynamic_island", "return_entry_available": true, "pip_bridge_enabled": true, "fgs_bridge_enabled": false},
@@ -176,7 +176,7 @@
       "id": "ios_pip_clipboard_write",
       "category": "single_step",
       "description_for_judge": "Write the requested standalone clipboard value through the iOS PiP background queue.",
-      "prompt": "测试环境状态：iOS，Aiden 在后台，PiP Bridge 已开启。请把文本「PiP clipboard benchmark」写入手机系统剪贴板。",
+      "prompt": "测试环境状态：iOS，companion app 在后台，PiP Bridge 已开启。请把文本「PiP clipboard benchmark」写入手机系统剪贴板。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {"connected": false, "phone_id": "ios-pip-clipboard", "app_state": "background", "return_entry": "dynamic_island", "return_entry_available": true, "pip_bridge_enabled": true, "fgs_bridge_enabled": false},
@@ -204,7 +204,7 @@
       "id": "ios_pip_notification_send",
       "category": "single_step",
       "description_for_judge": "Send a notification directly through the iOS PiP background queue.",
-      "prompt": "测试环境状态：iOS，Aiden 在后台，PiP Bridge 已开启。请立即发送本地通知，标题「PiP Benchmark」，正文「后台通知成功」，播放声音。",
+      "prompt": "测试环境状态：iOS，companion app 在后台，PiP Bridge 已开启。请立即发送本地通知，标题「PiP Benchmark」，正文「后台通知成功」，播放声音。",
       "mock_environment": {
         "platform": "ios",
         "phone_bridge": {"connected": false, "phone_id": "ios-pip-notification", "app_state": "background", "return_entry": "dynamic_island", "return_entry_available": true, "pip_bridge_enabled": true, "fgs_bridge_enabled": false},
@@ -232,7 +232,7 @@
       "id": "android_fgs_contacts_query",
       "category": "single_step",
       "description_for_judge": "Query contacts directly through the Android FGS background queue; open_app is not allowed.",
-      "prompt": "测试环境状态：Android，Aiden 在后台，FGS Bridge 已开启。请查询通讯录里 Bob 的手机号并告诉我。",
+      "prompt": "测试环境状态：Android，companion app 在后台，FGS Bridge 已开启。请查询通讯录里 Bob 的手机号并告诉我。",
       "mock_environment": {
         "platform": "android",
         "phone_bridge": {"connected": false, "phone_id": "android-fgs-contacts", "app_state": "background", "return_entry": "none", "return_entry_available": false, "pip_bridge_enabled": false, "fgs_bridge_enabled": true},
@@ -260,7 +260,7 @@
       "id": "android_fgs_calendar_query",
       "category": "single_step",
       "description_for_judge": "Query calendar directly through the Android FGS background queue.",
-      "prompt": "测试环境状态：Android，Aiden 在后台，FGS Bridge 已开启。请查询 2026-07-25 这一天的日历事件，时间范围严格使用 2026-07-25T00:00:00+08:00 到 2026-07-26T00:00:00+08:00。",
+      "prompt": "测试环境状态：Android，companion app 在后台，FGS Bridge 已开启。请查询 2026-07-25 这一天的日历事件，时间范围严格使用 2026-07-25T00:00:00+08:00 到 2026-07-26T00:00:00+08:00。",
       "mock_environment": {
         "platform": "android",
         "phone_bridge": {"connected": false, "phone_id": "android-fgs-calendar", "app_state": "background", "return_entry": "none", "return_entry_available": false, "pip_bridge_enabled": false, "fgs_bridge_enabled": true},
@@ -288,7 +288,7 @@
       "id": "android_fgs_clipboard_read",
       "category": "single_step",
       "description_for_judge": "Read the clipboard directly through the Android FGS background queue.",
-      "prompt": "测试环境状态：Android，Aiden 在后台，FGS Bridge 已开启。请读取当前手机剪贴板内容并告诉我。",
+      "prompt": "测试环境状态：Android，companion app 在后台，FGS Bridge 已开启。请读取当前手机剪贴板内容并告诉我。",
       "mock_environment": {
         "platform": "android",
         "phone_bridge": {"connected": false, "phone_id": "android-fgs-clipboard", "app_state": "background", "return_entry": "none", "return_entry_available": false, "pip_bridge_enabled": false, "fgs_bridge_enabled": true},
@@ -316,7 +316,7 @@
       "id": "android_fgs_notification_send",
       "category": "single_step",
       "description_for_judge": "Send a notification directly through the Android FGS background queue.",
-      "prompt": "测试环境状态：Android，Aiden 在后台，FGS Bridge 已开启。请立即发送本地通知，标题「FGS Benchmark」，正文「Android 后台通知成功」，不播放声音。",
+      "prompt": "测试环境状态：Android，companion app 在后台，FGS Bridge 已开启。请立即发送本地通知，标题「FGS Benchmark」，正文「Android 后台通知成功」，不播放声音。",
       "mock_environment": {
         "platform": "android",
         "phone_bridge": {"connected": false, "phone_id": "android-fgs-notification", "app_state": "background", "return_entry": "none", "return_entry_available": false, "pip_bridge_enabled": false, "fgs_bridge_enabled": true},

--- a/benchmark/tests/test_webui.py
+++ b/benchmark/tests/test_webui.py
@@ -1065,7 +1065,7 @@ def test_start_job_uses_mock_environment_without_device_endpoint(
     job = app.start_job({"suites": ["mock.json"], "no_judge": True})
 
     assert job["environment_type"] == "mock"
-    assert job["environment_name"] == "Mock Aiden App environment"
+    assert job["environment_name"] == "Mock companion app environment"
     assert job["endpoint"] == ""
     assert job["environment_endpoint"] == ""
     assert job["agent_url"] == ""
@@ -2476,7 +2476,7 @@ def test_run_mock_suite_uses_auto_agent_setup_and_updates_task_records(
         docker_endpoint="",
         suites=["aiden_app/notes_entry_policy_v1.json"],
         environment_type="mock",
-        environment_name="Mock Aiden App environment",
+        environment_name="Mock companion app environment",
         config_dir=str(config_dir),
         raw_runs_dir=str(raw_runs_dir),
         state_file=str(job_dir / "state.json"),
@@ -2557,7 +2557,7 @@ def test_run_job_mock_mode_uses_runner_platform_summary(
         docker_endpoint="",
         suites=suites,
         environment_type="mock",
-        environment_name="Mock Aiden App environment",
+        environment_name="Mock companion app environment",
         config_dir=str(job_dir / "config"),
         raw_runs_dir=str(job_dir / "raw"),
         state_file=str(job_dir / "state.json"),
@@ -2605,7 +2605,7 @@ def test_run_job_mock_mode_uses_runner_platform_summary(
 
 
 def test_webui_html_exposes_mock_environment_run_mode():
-    assert "Mock Aiden App environment" in webui.INDEX_HTML
+    assert "Mock companion app environment" in webui.INDEX_HTML
     assert "selectedSuiteEnvironmentMode" in webui.INDEX_HTML
     assert "Mock suites and external device suites must run in separate jobs" in webui.INDEX_HTML
 

--- a/docs/04-agent/live-activity.md
+++ b/docs/04-agent/live-activity.md
@@ -43,9 +43,9 @@ snapshot, so skipped intermediate Wake notifications do not lose final state.
 
 - `ready` / `connected`: Aiden is available. The app creates this standby Live
   Activity before or while entering background so Dynamic Island remains an
-  entry point back to Aiden.
+  entry point back to the companion app.
 - `running`: shows task title, current step, phase, progress, and stop state.
-- `needs_app`: asks the user to return to Aiden when an operation needs the
+- `needs_app`: asks the user to return to the companion app when an operation needs the
   foreground companion app.
 - `waiting_user` with `current_action=request_user_input`: keeps the handoff
   instruction visible after `request_human_handoff` so the user can take over

--- a/docs/04-agent/phone-bridge-protocol.md
+++ b/docs/04-agent/phone-bridge-protocol.md
@@ -93,7 +93,7 @@ The app can also actively send event messages. Events reuse the `BridgeCommandRe
 Current events:
 
 - `phone_environment`: App reports phone environment snapshot upon WebSocket connection success and returning from background to foreground.
-- `phone_app_state`: App reports the last visible app lifecycle state when it changes among `active`, `background`, and `inactive`, plus whether a Live Activity / Dynamic Island entry is available to return to Aiden and whether PiP Bridge mode is enabled. This state is for diagnostics and strategy decisions; it does not mean the app can execute permanently in iOS background.
+- `phone_app_state`: App reports the last visible app lifecycle state when it changes among `active`, `background`, and `inactive`, plus whether a Live Activity / Dynamic Island entry is available to return to the companion app and whether PiP Bridge mode is enabled. This state is for diagnostics and strategy decisions; it does not mean the app can execute permanently in iOS background.
 
 Example:
 

--- a/docs/04-agent/phone-bridge.md
+++ b/docs/04-agent/phone-bridge.md
@@ -33,7 +33,7 @@ Phone relay app -> ws://192.168.42.1:8080/api/phone-bridge
 
 The board is the WebSocket server, so it does not need to discover the phone's DHCP address and the app does not need to expose a local server. The Agent HTTP APIs use the same port, `8080`.
 
-The board also exposes `/api/phone-bridge/commands` and `/api/phone-bridge/results` HTTP queue endpoints, but React Native JS, WebSocket, and polling timers in the iOS background must not be treated as a general tool execution path. On iOS, Phone Bridge is normally a foreground fast path: if Aiden is backgrounded and the app has reported `return_entry=dynamic_island`, Agent restores Aiden through Dynamic Island, waits for foreground WebSocket bridge reconnection, then executes the requested tool command. Lock-screen Live Activity entries require visual confirmation rather than fixed-coordinate tapping.
+The board also exposes `/api/phone-bridge/commands` and `/api/phone-bridge/results` HTTP queue endpoints, but React Native JS, WebSocket, and polling timers in the iOS background must not be treated as a general tool execution path. On iOS, Phone Bridge is normally a foreground fast path: if the companion app is backgrounded and the app has reported `return_entry=dynamic_island`, Agent restores the companion app through Dynamic Island, waits for foreground WebSocket bridge reconnection, then executes the requested tool command. Lock-screen Live Activity entries require visual confirmation rather than fixed-coordinate tapping.
 
 PiP Bridge is a narrow exception. When the app reports `pip_bridge_enabled=true` while backgrounded, iOS gives PiP priority over the Dynamic Island, so the Dynamic Island return entry is not visible. The HTTP/Tool Lab catalog remains complete for direct diagnostics, while the conversational Agent catalog is filtered from live runtime capabilities before each run. `open_app` remains exposed because it can fall back to SearchLaunchApp; only executable background-safe data tools (`bridge_clipboard`, `bridge_calendar`, `bridge_contacts`, `bridge_notification`) are exposed through the HTTP queue, and unavailable App actions are omitted.
 
@@ -97,13 +97,13 @@ Android: Intent launch package name
 
 ## Key Boundaries
 
-On iOS, the relay app is not a background-resident system agent. It's more like a foreground fast-path executor; Dynamic Island can be used as the automatic entry point back to Aiden, while lock-screen Live Activity cards need visual confirmation:
+On iOS, the relay app is not a background-resident system agent. It's more like a foreground fast-path executor; Dynamic Island can be used as the automatic entry point back to the companion app, while lock-screen Live Activity cards need visual confirmation:
 
 ```text
-Aiden App foreground
+companion app foreground
 -> Receives board command
 -> openURL opens WeChat
--> Aiden App enters background
+-> companion app enters background
 -> Subsequent operations continue via hardware HDMI observation + HID operation
 ```
 
@@ -175,7 +175,7 @@ WebSocket's core value:
 
 When `app_state=background|inactive`, `return_entry=dynamic_island`,
 `return_entry_available=true`, and PiP Bridge mode is not enabled, `open_url`
-and bridge data tools can click the Aiden Dynamic Island entry, wait for Phone
+and bridge data tools can click the companion app Dynamic Island entry, wait for Phone
 Bridge recovery, then send their commands. `open_app` instead selects
 SearchLaunchApp whenever foreground Bridge app launch is unavailable.
 Lock-screen Live Activity entries are not blind-tapped because their screen

--- a/docs/09-benchmark/README.md
+++ b/docs/09-benchmark/README.md
@@ -71,7 +71,7 @@ uv run python -m runner run \
 `--auto-agent-setup` ignores `--agent-url`, reads bridge capacity from
 `/api/concurrent`, and starts one isolated agent daemon per active task worker.
 
-### Aiden App Policy Without a Phone
+### companion app Policy Without a Phone
 
 Use suite-level defaults or task-level `mock_environment` fixtures for
 deterministic Phone Bridge strategy tests. The runner simulates platform/app state
@@ -80,7 +80,7 @@ phone or emulator. Task-level fixtures let one suite hold a runtime policy matri
 without creating a JSON file for every case:
 
 In the WebUI, select one or more mock suites and click `Run selected suites`. The
-run configuration changes to `Mock Aiden App environment`, skips the device
+run configuration changes to `Mock companion app environment`, skips the device
 picker, and starts the task-level fixtures automatically. Mock and external-device
 suites must be run as separate jobs.
 
@@ -93,7 +93,7 @@ uv run python -m runner run \
   --verbose
 ```
 
-The Aiden App cases are consolidated into two suites:
+The companion app cases are consolidated into two suites:
 
 - `notes_entry_policy_v1.json`: Notes is already open, its icon is visible, or
   neither is visible. The Agent respectively enters text directly, clicks the
@@ -107,7 +107,7 @@ so they do not cover the BLE Wake-specific allowlist or runtime tool filtering.
 
 For iOS background without PiP, a reachable Dynamic Island return entry keeps the
 data tools visible. The Agent calls the requested `bridge_*` tool directly; the
-tool restores Aiden internally before executing, so the Agent must not click the
+tool restores the companion app internally before executing, so the Agent must not click the
 Dynamic Island or call `bridge_open_app`. With iOS PiP or Android FGS enabled,
 background-safe data tools execute directly through the background queue.
 `bridge_open_app` remains excluded because PiP/FGS do not provide background app

--- a/src/agent/config/skills/device-operator/SKILL.md
+++ b/src/agent/config/skills/device-operator/SKILL.md
@@ -140,7 +140,7 @@ Selecting an app:
 
 After successfully opening the switcher via a non-obvious method, call `save_memory` with the configured `[device].device_type`, method, gesture coordinates, and tags `["app-switch", "device"]`.
 
-On iOS, if Phone Bridge context says the Aiden companion app is backgrounded/inactive and `return_entry=dynamic_island`, treat Dynamic Island as the fastest way back to Aiden. Do not blind-tap lock-screen Live Activity cards; use screenshot/HID fallback or visual confirmation for those cases. Opening Aiden restores the companion app shortcut channel.
+On iOS, if Phone Bridge context says the companion app is backgrounded/inactive and `return_entry=dynamic_island`, treat Dynamic Island as the fastest way back to the companion app. Do not blind-tap lock-screen Live Activity cards; use screenshot/HID fallback or visual confirmation for those cases. Opening the companion app restores the companion app shortcut channel.
 
 ## Scrolling and Picker Controls
 

--- a/src/agent/internal/agent/phone_bridge_policy.go
+++ b/src/agent/internal/agent/phone_bridge_policy.go
@@ -10,7 +10,7 @@ const phoneBridgeBackgroundStateMaxAge = 15 * time.Second
 
 const (
 	phoneBridgeDisconnectedRecoveryGuidance = "If Phone Bridge recovery is unavailable, do not stop the task: call screenshot first to inspect the current phone state, then use visible app search or suitable HID/touch tools. Call request_human_handoff only after observation or input fallback is also unavailable, or the next step truly requires user action."
-	phoneBridgeIOSOpenAppRecoveryGuidance   = "If a Dynamic Island entry is visible, tap it to reopen Aiden, wait for Phone Bridge to reconnect, then retry. " + phoneBridgeDisconnectedRecoveryGuidance
+	phoneBridgeIOSOpenAppRecoveryGuidance   = "If a Dynamic Island entry is visible, tap it to reopen the companion app, wait for Phone Bridge to reconnect, then retry. " + phoneBridgeDisconnectedRecoveryGuidance
 )
 
 const (
@@ -251,7 +251,7 @@ func phoneBridgeHasReturnEntry(status PhoneBridgeStatus) bool {
 
 func phoneBridgeRecoveryGuidance(status PhoneBridgeStatus) string {
 	if phoneBridgeCanRestoreFromReturnEntry(status) {
-		return "Retry the companion app tool; it can reopen Aiden through the Dynamic Island entry, wait for Phone Bridge to reconnect, then send the command. Use home-screen search or HID fallback only if restore fails."
+		return "Retry the companion app tool; it can reopen the companion app through the Dynamic Island entry, wait for Phone Bridge to reconnect, then send the command. Use home-screen search or HID fallback only if restore fails."
 	}
 	if phoneBridgeIsAndroid(status) {
 		return "Use screenshot plus HID/touch fallback; Android FGS Bridge mode only supports background-safe data tools."
@@ -293,7 +293,7 @@ func phoneBridgeRestoreUnavailableError(status PhoneBridgeStatus) error {
 			return fmt.Errorf("phone bridge is connected but not ready for foreground command")
 		}
 		if phoneBridgeIsAndroid(status) {
-			return fmt.Errorf("phone bridge app is %s; Android bridge commands require a connected foreground Aiden app", state)
+			return fmt.Errorf("phone bridge app is %s; Android bridge commands require a connected foreground companion app", state)
 		}
 		if !phoneBridgeIsIOS(status) {
 			return fmt.Errorf("phone bridge app is %s and no supported foreground return entry is available", state)


### PR DESCRIPTION
## 改动概览

将代码、文档、测试用例中所有指代**手机端 Aiden 应用**的名称统一为 `companion app`，与 system prompt 和工具描述中的已有命名保持一致。

### 改动范围

| 分类 | 文件 | 说明 |
|------|------|------|
| Go 源码 | `phone_bridge_policy.go` | `reopen Aiden` → `reopen the companion app`（3 处） |
| Skill | `device-operator/SKILL.md` | `back to Aiden` → `back to the companion app`、`Opening Aiden` → `Opening the companion app` |
| 文档 | `phone-bridge.md`、`phone-bridge-protocol.md`、`live-activity.md`、`benchmark/README.md` | 共 8 处 |
| WebUI | `webui.py` | `Mock Aiden App environment` → `Mock companion app environment`（4 处） |
| 测试 | `test_webui.py` | 同上（4 处） |
| 手册 | `manual.md` | 同上（2 处） |
| 测试用例 | `aiden_app/*.json` | `Aiden 在后台` 等 → `companion app 在后台`（15 处） |

### 不改动的

以下名称是产品/品牌/硬件指称，不属于手机端 App 代称，保留不变：
- `Aiden Agent`
- `Aiden hardware controller` / `Aiden controller` / `Aiden 控制器`
- `Aiden Firmware` / `Aiden hardware`

### 验证

- 128 个 Python 单元测试通过（2 个预存失败与本次无关）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology throughout documentation to refer to the “companion app” instead of the former product name.
  * Clarified Live Activity, Dynamic Island, foreground recovery, and phone bridge guidance.

* **User Experience**
  * Updated benchmark interfaces, labels, prompts, and recovery messages with consistent companion app terminology.

* **Tests**
  * Updated WebUI and job-record expectations to reflect the revised environment name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->