### PR TITLE
fix(model): set Qwen3.8-27B default reasoning_effort to medium

### DIFF
--- a/src/agent/internal/agent/model_specs.go
+++ b/src/agent/internal/agent/model_specs.go
@@ -71,6 +71,13 @@ var modelSpecRegistry = map[string]model.ModelSpec{
 	// Other dated releases need their own entry, keyed by the exact Ark model id.
 	"doubao-seed-2-1-pro-260628": {ContextWindow: 262_144, MaxOutput: 131_072, DefaultReasoningEffort: stringPtr("low")},
 
+	// Qwen3.8-27B on OpenRouter (vision + tool calling). Context window is
+	// 256K per the Qwen3 published model card. Default reasoning_effort is
+	// "medium" because Qwen3.8 includes native reasoning and performs best
+	// with medium-level reasoning effort out of the box.
+	"qwen/qwen3.8-27b": {ContextWindow: 262_144, MaxOutput: 32_768, DefaultReasoningEffort: stringPtr("medium")},
+	"qwen3.8-27b":      {ContextWindow: 262_144, MaxOutput: 32_768, DefaultReasoningEffort: stringPtr("medium")},
+
 	// Existing entries retained for back-compat with dev/staging configs.
 	"anthropic/claude-3.5-sonnet":  {ContextWindow: 200_000, MaxOutput: 8_192},
 	"anthropic/claude-3.7-sonnet":  {ContextWindow: 200_000, MaxOutput: 8_192},


### PR DESCRIPTION
## 改动

在 `model_specs.go` 的模型注册表中新增 `qwen/qwen3.8-27b` 条目，设置 `DefaultReasoningEffort = "medium"`。

当用户配置 `model = "qwen3.8-27b"` 且未显式设置 `reasoning_effort` 时，运行时自动填入 `"medium"`。用户显式配置的 `reasoning_effort` 仍然优先。

双注册 key：`qwen/qwen3.8-27b` + `qwen3.8-27b`，带 provider prefix 和不带都能解析。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Qwen3.8-27B model.
  * Configured a 262,144-token context window, 32,768-token output limit, and medium reasoning effort by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->