### PR TITLE
fix(agent): recover malformed Anthropic stream responses

### DIFF
--- a/src/agent/internal/agent/anthropic_model.go
+++ b/src/agent/internal/agent/anthropic_model.go
@@ -26,7 +26,7 @@ const (
 	anthropicAPIVersion              = "2023-06-01"
 	defaultAnthropicStreamMaxRetries = 5
 	defaultAnthropicStreamRetryDelay = 2 * time.Second
-	defaultAnthropicProtocolRetries  = 1
+	defaultAnthropicProtocolRetries  = 3
 	anthropicDaemonRawSSELimit       = 128 * 1024
 	anthropicRawHTTPRawSSELimit      = 4 * 1024 * 1024
 )

--- a/src/agent/internal/agent/anthropic_model.go
+++ b/src/agent/internal/agent/anthropic_model.go
@@ -29,6 +29,7 @@ const (
 	defaultAnthropicProtocolRetries  = 3
 	anthropicDaemonRawSSELimit       = 128 * 1024
 	anthropicRawHTTPRawSSELimit      = 4 * 1024 * 1024
+	anthropicEmptyEndTurnMessage     = "end_turn response has no text or tool_use content"
 )
 
 type anthropicModel struct {
@@ -269,13 +270,22 @@ func (m *anthropicModel) GenerateContent(ctx context.Context, messages []llms.Me
 	ctx = m.withRawHTTPLogScope(ctx)
 	streamRetries := 0
 	protocolRetries := 0
+	nonStreamingFallback := false
+	var streamFallbackCause error
+	fail := func(err error) error {
+		if streamFallbackCause == nil {
+			return err
+		}
+		log.Printf("[WARN] [anthropic] non-streaming fallback failed: %v", err)
+		return streamFallbackCause
+	}
 	for {
 		_ = m.logRawHTTP(ctx, request.Model, "request", 0, string(payload))
 
 		httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, m.baseURL+"/messages", bytes.NewReader(payload))
 		if err != nil {
 			_ = m.logRawHTTP(ctx, request.Model, "response", 0, "create request error: "+err.Error())
-			return nil, fmt.Errorf("create Anthropic request: %w", err)
+			return nil, fail(fmt.Errorf("create Anthropic request: %w", err))
 		}
 		httpRequest.Header.Set("Content-Type", "application/json")
 		httpRequest.Header.Set("anthropic-version", anthropicAPIVersion)
@@ -288,13 +298,13 @@ func (m *anthropicModel) GenerateContent(ctx context.Context, messages []llms.Me
 		response, err := m.httpClient.Do(httpRequest)
 		if err != nil {
 			_ = m.logRawHTTP(ctx, request.Model, "response", 0, "transport error: "+err.Error())
-			return nil, fmt.Errorf("send Anthropic request: %w", err)
+			return nil, fail(fmt.Errorf("send Anthropic request: %w", err))
 		}
 		if response.StatusCode != http.StatusOK {
 			body, _ := io.ReadAll(response.Body)
 			response.Body.Close()
 			_ = m.logRawHTTP(ctx, request.Model, "response", response.StatusCode, string(body))
-			return nil, newProviderHTTPError(response.StatusCode, body)
+			return nil, fail(newProviderHTTPError(response.StatusCode, body))
 		}
 
 		if request.Stream {
@@ -309,6 +319,18 @@ func (m *anthropicModel) GenerateContent(ctx context.Context, messages []llms.Me
 			if errors.As(streamErr, &responseProtocolErr) {
 				retryLimit = m.protocolRetries
 				retryDelay = m.protocolDelay
+				if protocolRetries >= retryLimit && shouldRetryAnthropicStreamError(streamErr) &&
+					isAnthropicEmptyEndTurnResponseError(streamErr) && !nonStreamingFallback {
+					nonStreamingFallback = true
+					streamFallbackCause = streamErr
+					request.Stream = false
+					payload, err = json.Marshal(request)
+					if err != nil {
+						return nil, fail(fmt.Errorf("marshal Anthropic non-streaming fallback request: %w", err))
+					}
+					log.Printf("[WARN] [anthropic] semantic stream retries exhausted; falling back to non-streaming response")
+					continue
+				}
 				if protocolRetries >= retryLimit || !shouldRetryAnthropicStreamError(streamErr) {
 					return nil, streamErr
 				}
@@ -333,17 +355,17 @@ func (m *anthropicModel) GenerateContent(ctx context.Context, messages []llms.Me
 		response.Body.Close()
 		if err != nil {
 			_ = m.logRawHTTP(ctx, request.Model, "response", response.StatusCode, "read response error: "+err.Error())
-			return nil, fmt.Errorf("read Anthropic response: %w", err)
+			return nil, fail(fmt.Errorf("read Anthropic response: %w", err))
 		}
 		_ = m.logRawHTTP(ctx, request.Model, "response", response.StatusCode, string(body))
 		var decoded anthropicResponse
 		if err := json.Unmarshal(body, &decoded); err != nil {
-			return nil, fmt.Errorf("decode Anthropic response: %w", err)
+			return nil, fail(fmt.Errorf("decode Anthropic response: %w", err))
 		}
 		normalized, recovery, protocolErr := normalizeAnthropicResponse(decoded, request.Thinking != nil)
 		if protocolErr != nil {
 			if protocolRetries >= m.protocolRetries {
-				return nil, protocolErr
+				return nil, fail(protocolErr)
 			}
 			protocolRetries++
 			log.Printf("[WARN] [anthropic] retrying semantic protocol error (%d/%d): %v", protocolRetries, m.protocolRetries, protocolErr)
@@ -353,12 +375,37 @@ func (m *anthropicModel) GenerateContent(ctx context.Context, messages []llms.Me
 			continue
 		}
 		generationInfo := map[string]any{}
+		if nonStreamingFallback {
+			generationInfo["llm_anthropic_stream_fallback"] = "non_stream"
+		}
 		if recovery != "" {
 			log.Printf("[WARN] [anthropic] recovered response %s as user-visible text (response_id=%s)", recovery, decoded.ID)
 			generationInfo["llm_anthropic_response_recovery"] = recovery
 		}
-		return aggregateAnthropicResponseWithGenerationInfo(normalized, callStarted, generationInfo), nil
+		result := aggregateAnthropicResponseWithGenerationInfo(normalized, callStarted, generationInfo)
+		if nonStreamingFallback {
+			if err := emitAnthropicNonStreamingFallback(ctx, &callOpts, result, request.Thinking != nil); err != nil {
+				return nil, err
+			}
+		}
+		return result, nil
 	}
+}
+
+func emitAnthropicNonStreamingFallback(ctx context.Context, opts *llms.CallOptions, response *llms.ContentResponse, thinkingEnabled bool) error {
+	if opts == nil || response == nil || len(response.Choices) == 0 || response.Choices[0] == nil {
+		return nil
+	}
+	choice := response.Choices[0]
+	if thinkingEnabled && opts.StreamingReasoningFunc != nil && choice.ReasoningContent != "" {
+		if err := opts.StreamingReasoningFunc(ctx, []byte(choice.ReasoningContent), nil); err != nil {
+			return err
+		}
+	}
+	if opts.StreamingFunc != nil && choice.Content != "" {
+		return opts.StreamingFunc(ctx, []byte(choice.Content))
+	}
+	return nil
 }
 
 func convertAnthropicMessages(messages []llms.MessageContent) ([]anthropicContentBlock, []anthropicRequestMessage, error) {
@@ -635,6 +682,11 @@ func newAnthropicResponseProtocolError(message string) error {
 	return &anthropicResponseProtocolError{message: message}
 }
 
+func isAnthropicEmptyEndTurnResponseError(err error) bool {
+	var protocolErr *anthropicResponseProtocolError
+	return errors.As(err, &protocolErr) && protocolErr.message == anthropicEmptyEndTurnMessage
+}
+
 func normalizeAnthropicResponse(response anthropicResponse, thinkingEnabled bool) (anthropicResponse, string, error) {
 	hasText := false
 	hasThinking := false
@@ -680,7 +732,7 @@ func normalizeAnthropicResponse(response anthropicResponse, thinkingEnabled bool
 			}
 			return response, "thinking_as_text", nil
 		}
-		return response, "", newAnthropicResponseProtocolError("end_turn response has no text or tool_use content")
+		return response, "", newAnthropicResponseProtocolError(anthropicEmptyEndTurnMessage)
 	}
 
 	return response, "", nil

--- a/src/agent/internal/agent/anthropic_model.go
+++ b/src/agent/internal/agent/anthropic_model.go
@@ -273,7 +273,7 @@ func (m *anthropicModel) GenerateContent(ctx context.Context, messages []llms.Me
 	nonStreamingFallback := false
 	var streamFallbackCause error
 	fail := func(err error) error {
-		if streamFallbackCause == nil {
+		if streamFallbackCause == nil || isAnthropicContextError(err) {
 			return err
 		}
 		log.Printf("[WARN] [anthropic] non-streaming fallback failed: %v", err)
@@ -390,6 +390,10 @@ func (m *anthropicModel) GenerateContent(ctx context.Context, messages []llms.Me
 		}
 		return result, nil
 	}
+}
+
+func isAnthropicContextError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func emitAnthropicNonStreamingFallback(ctx context.Context, opts *llms.CallOptions, response *llms.ContentResponse, thinkingEnabled bool) error {

--- a/src/agent/internal/agent/anthropic_model_test.go
+++ b/src/agent/internal/agent/anthropic_model_test.go
@@ -495,6 +495,48 @@ func TestAnthropicModelFallsBackToNonStreamingAfterSemanticStreamRetries(t *test
 	}
 }
 
+func TestAnthropicModelPreservesCancellationDuringNonStreamingFallback(t *testing.T) {
+	fallbackStarted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request anthropicRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		if request.Stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte(strings.Join([]string{
+				`data: {"type":"message_start","message":{"id":"msg_empty","usage":{"input_tokens":10}}}`,
+				``,
+				`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":0}}`,
+				``,
+				`data: {"type":"message_stop"}`,
+				``,
+			}, "\n")))
+			return
+		}
+
+		close(fallbackStarted)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-fallbackStarted
+		cancel()
+	}()
+
+	model := newAnthropicModel(server.URL, "claude-test", "test-token", server.Client(), withAnthropicProtocolRetry(0, 0))
+	_, err := model.GenerateContent(ctx, []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "hello"),
+	}, llms.WithStreamingFunc(func(context.Context, []byte) error { return nil }))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("GenerateContent() error = %v, want context.Canceled", err)
+	}
+}
+
 func TestAnthropicModelDoesNotFallbackAfterStreamingOutputWasDelivered(t *testing.T) {
 	t.Parallel()
 

--- a/src/agent/internal/agent/anthropic_model_test.go
+++ b/src/agent/internal/agent/anthropic_model_test.go
@@ -436,6 +436,104 @@ func TestAnthropicModelRetriesEmptyStreamedEndTurn(t *testing.T) {
 	}
 }
 
+func TestAnthropicModelFallsBackToNonStreamingAfterSemanticStreamRetries(t *testing.T) {
+	t.Parallel()
+
+	var streams []bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request anthropicRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		streams = append(streams, request.Stream)
+		w.Header().Set("Content-Type", "application/json")
+		if request.Stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte(strings.Join([]string{
+				`data: {"type":"message_start","message":{"id":"msg_empty","usage":{"input_tokens":10}}}`,
+				``,
+				`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":0}}`,
+				``,
+				`data: {"type":"message_stop"}`,
+				``,
+			}, "\n")))
+			return
+		}
+		_, _ = w.Write([]byte(`{
+			"id":"msg_fallback",
+			"content":[{"type":"text","text":"fallback ok"}],
+			"stop_reason":"end_turn",
+			"usage":{"input_tokens":10,"output_tokens":2}
+		}`))
+	}))
+	defer server.Close()
+
+	var streamed strings.Builder
+	model := newAnthropicModel(server.URL, "claude-test", "test-token", server.Client(), withAnthropicProtocolRetry(1, 0))
+	response, err := model.GenerateContent(context.Background(), []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "hello"),
+	}, llms.WithStreamingFunc(func(_ context.Context, chunk []byte) error {
+		streamed.Write(chunk)
+		return nil
+	}))
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+	if len(streams) != 3 || !streams[0] || !streams[1] || streams[2] {
+		t.Fatalf("stream flags = %#v, want [true true false]", streams)
+	}
+	if streamed.String() != "fallback ok" {
+		t.Fatalf("streamed = %q, want fallback ok", streamed.String())
+	}
+	choice := response.Choices[0]
+	if choice.Content != "fallback ok" {
+		t.Fatalf("content = %q, want fallback ok", choice.Content)
+	}
+	if got := choice.GenerationInfo["llm_anthropic_stream_fallback"]; got != "non_stream" {
+		t.Fatalf("fallback info = %#v, want non_stream", got)
+	}
+}
+
+func TestAnthropicModelDoesNotFallbackAfterStreamingOutputWasDelivered(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(strings.Join([]string{
+			`data: {"type":"message_start","message":{"id":"msg_partial","usage":{"input_tokens":10}}}`,
+			``,
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text"}}`,
+			``,
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}`,
+			``,
+			`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+			``,
+		}, "\n")))
+	}))
+	defer server.Close()
+
+	var streamed strings.Builder
+	model := newAnthropicModel(server.URL, "claude-test", "test-token", server.Client(), withAnthropicProtocolRetry(0, 0))
+	_, err := model.GenerateContent(context.Background(), []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "hello"),
+	}, llms.WithStreamingFunc(func(_ context.Context, chunk []byte) error {
+		streamed.Write(chunk)
+		return nil
+	}))
+	if err == nil {
+		t.Fatal("GenerateContent() error = nil, want stream protocol error")
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want no non-streaming fallback after output delivery", attempts)
+	}
+	if streamed.String() != "partial" {
+		t.Fatalf("streamed = %q, want partial", streamed.String())
+	}
+}
+
 func TestAnthropicModelDefaultsToThreeSemanticRetries(t *testing.T) {
 	t.Parallel()
 

--- a/src/agent/internal/agent/anthropic_model_test.go
+++ b/src/agent/internal/agent/anthropic_model_test.go
@@ -436,6 +436,45 @@ func TestAnthropicModelRetriesEmptyStreamedEndTurn(t *testing.T) {
 	}
 }
 
+func TestAnthropicModelDefaultsToThreeSemanticRetries(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts <= 3 {
+			_, _ = w.Write([]byte(`{
+				"id":"msg_empty",
+				"content":[],
+				"stop_reason":"end_turn",
+				"usage":{"input_tokens":10,"output_tokens":0}
+			}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{
+			"id":"msg_ok",
+			"content":[{"type":"text","text":"ok"}],
+			"stop_reason":"end_turn",
+			"usage":{"input_tokens":10,"output_tokens":1}
+		}`))
+	}))
+	defer server.Close()
+
+	model := newAnthropicModel(server.URL, "claude-test", "test-token", server.Client())
+	response, err := model.GenerateContent(context.Background(), []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "hello"),
+	})
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+	if attempts != 4 {
+		t.Fatalf("attempts = %d, want initial request plus three semantic retries", attempts)
+	}
+	if response.Choices[0].Content != "ok" {
+		t.Fatalf("content = %q, want ok", response.Choices[0].Content)
+	}
+}
+
 func TestAnthropicModelStreamsTextAndToolArguments(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- increase the default Anthropic semantic protocol retry limit from 1 to 3
- fall back to one non-streaming request after streamed empty `end_turn` responses exhaust their retries
- replay fallback text through the existing streaming callback and expose recovery telemetry

## Root cause
Raw SSE captured from the configured Anthropic relay showed intermittent HTTP 200 responses with:

- a request that did not enable thinking
- one signed `thinking` content block containing the user-visible final answer
- no `text` or `tool_use` content block
- `stop_reason: end_turn`

The same request can return a valid response when replayed. Replaying it with `stream: false` also returned a normal `text` block, indicating an intermittent upstream generation or streaming protocol adaptation failure rather than local SSE aggregation loss.

## Behavior
The recovery path is deliberately bounded:

1. Retry the malformed semantic response up to three times.
2. If the streamed response still ends with no text or tool use, and no output has been delivered, retry once with `stream: false`.
3. Validate the non-streaming response through the existing Anthropic response normalization path.
4. Forward recovered text to the original streaming callback.
5. Record `llm_anthropic_stream_fallback=non_stream` in generation metadata.

The fallback is limited to `end_turn response has no text or tool_use content`. Other protocol errors retain their existing behavior. It never runs after streamed output has been delivered, avoiding duplicate user output or tool execution. Signed thinking is not exposed as text.

If the non-streaming fallback also fails, the original streamed protocol error is returned so its raw SSE diagnostic remains the primary failure evidence.

## Validation
- `go test ./internal/agent -run TestAnthropicModel -count=1`
- `go test ./internal/agent -count=1`
- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for Anthropic responses by retrying protocol failures up to three times.
  * Added recovery for certain empty streaming responses by retrying with a standard request.
  * Preserved partial streamed output and original errors when recovery is unsuccessful.
  * Recovered reasoning and text are now delivered through the normal streaming experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->