### PR TITLE
fix(agent): honor explicit memory commands and validate notification lifecycle

### DIFF
--- a/benchmark/manual.md
+++ b/benchmark/manual.md
@@ -315,7 +315,7 @@ Common fields:
 | --- | --- |
 | `prompt_prefix` | Prefix for every task prompt; constrains device type, tool usage, etc. |
 | `global_reset` | Suite-level reset configuration |
-| `setup` | Task-level pre-steps; supports `agent_prompt`, benchmark-token-protected `seed_memory`, `seed_episode`, and `seed_notification` |
+| `setup` | One task-level pre-step or an ordered array of pre-steps; supports `agent_prompt`, benchmark-token-protected `seed_memory`, `seed_episode`, `seed_notification`, and generic `assert_memory` checks |
 | `app_ids` | Optional MobileGym app IDs to preload during environment setup; omitted tasks skip eager app data loading |
 | `rubric` | The judge model's scoring items |
 | `hard_assertions` | Deterministic checks, e.g. tool-call counts, timeout, required/forbidden tools |
@@ -342,7 +342,7 @@ benchmark-only control endpoint, and then checks the Agent's `recall_memory`
 behavior. The setup endpoint is benchmark-token protected and does not
 exist on a daemon without a benchmark token.
 
-The suite intentionally separates three claims:
+The suite separates ingestion/recall claims from explicit Memory action claims:
 
 - `delivery_notification_recall` checks that a useful notification becomes one
   temporary memory and is recalled with the original delivery fact.
@@ -350,21 +350,33 @@ The suite intentionally separates three claims:
   in the raw log but do not become memory.
 - `notification_batch_cursor_drain` checks that a backlog larger than one batch
   is fully committed without producing memory for verification-code noise.
+- `notification_explicit_update` checks revision-guarded replacement of an
+  existing conclusion.
+- `notification_explicit_reinforce` checks that repeated evidence preserves the
+  conclusion while advancing its revision without creating a duplicate.
+- `notification_explicit_remove` checks that a removed notification deletes only
+  the temporary conclusion tied to that stable notification identity.
+- `notification_explicit_promote` checks temporary-to-long-term promotion and
+  removal of the temporary source.
 
 The useful-notification case depends on the configured model's consolidation
 decision; the raw-log and obvious-noise cases have deterministic setup gates.
 The Go notification processor tests cover cursor recovery, generation reset,
 batch-call count, proposal validation, update/remove, and storage behavior.
-Run the suite against a fresh benchmark daemon because notification cursors and
-memory are durable:
+Run the suite against isolated benchmark daemons because notification cursors
+and memory are durable. Explicit action tasks compose generic setup primitives:
+`seed_memory`, `seed_notification`, then `assert_memory`.
+`assert_memory.expected` supports scalar/content/tag/entity checks plus generic
+`source_refs_contain` and `evidence_refs_contain` entries. Reference entries may
+match `type`, `id`, and `event_ids_contains`, which lets suites verify evidence
+preservation without adding scenario-specific runner logic.
 
 ```bash
 cd benchmark
 uv run python -m runner run \
   --suite suites/notification_memory_v1.json \
-  --agent-url http://127.0.0.1:18081 \
-  --benchmark-token-file /path/to/control_token \
-  --skip-clock-wait \
+  --auto-agent-setup \
+  --agent-config /path/to/agent.toml \
   --run-id notification-memory-v1
 ```
 

--- a/benchmark/manual.md
+++ b/benchmark/manual.md
@@ -315,7 +315,7 @@ Common fields:
 | --- | --- |
 | `prompt_prefix` | Prefix for every task prompt; constrains device type, tool usage, etc. |
 | `global_reset` | Suite-level reset configuration |
-| `setup` | Task-level pre-steps; supports `agent_prompt` and benchmark-token-protected `seed_memory` |
+| `setup` | Task-level pre-steps; supports `agent_prompt`, benchmark-token-protected `seed_memory`, `seed_episode`, and `seed_notification` |
 | `app_ids` | Optional MobileGym app IDs to preload during environment setup; omitted tasks skip eager app data loading |
 | `rubric` | The judge model's scoring items |
 | `hard_assertions` | Deterministic checks, e.g. tool-call counts, timeout, required/forbidden tools |
@@ -332,6 +332,56 @@ the task setup on any other output.
 
 A unit suite is a different format with `kind` set to `unit`; it tests a tool's
 input/output directly without going through agent chat.
+
+#### Notification Memory benchmark
+
+Use `suites/notification_memory_v1.json` to validate the notification memory
+path end to end. Its `seed_notification` setup writes deterministic raw events
+to the date-sharded JSONL log, runs the real notification processor through the
+benchmark-only control endpoint, and then checks the Agent's `recall_memory`
+behavior. The setup endpoint is benchmark-token protected and does not
+exist on a daemon without a benchmark token.
+
+The suite intentionally separates three claims:
+
+- `delivery_notification_recall` checks that a useful notification becomes one
+  temporary memory and is recalled with the original delivery fact.
+- `notification_noise_is_filtered` checks that OTP and marketing events remain
+  in the raw log but do not become memory.
+- `notification_batch_cursor_drain` checks that a backlog larger than one batch
+  is fully committed without producing memory for verification-code noise.
+
+The useful-notification case depends on the configured model's consolidation
+decision; the raw-log and obvious-noise cases have deterministic setup gates.
+The Go notification processor tests cover cursor recovery, generation reset,
+batch-call count, proposal validation, update/remove, and storage behavior.
+Run the suite against a fresh benchmark daemon because notification cursors and
+memory are durable:
+
+```bash
+cd benchmark
+uv run python -m runner run \
+  --suite suites/notification_memory_v1.json \
+  --agent-url http://127.0.0.1:18081 \
+  --benchmark-token-file /path/to/control_token \
+  --skip-clock-wait \
+  --run-id notification-memory-v1
+```
+
+This command enables the configured LLM judge for effect checks: whether the
+useful notification answer preserves the delivery fact and whether it states
+that OTP/marketing noise is not retained. Use `--no-judge` for deterministic
+functional gates only; those gates still validate fixture persistence through
+the benchmark endpoint, cursor advancement, memory count/scope, and tool-call
+policy. Raw JSONL preservation is covered by the Go integration tests rather
+than an Agent shell task. A judge API key is required for the effect run.
+
+For a lower-level performance snapshot, run the deterministic Go benchmarks:
+
+```bash
+cd src/agent
+go test ./internal/agent -run '^$' -bench 'BenchmarkNotification' -benchmem
+```
 
 ## 2. WebUI guide
 

--- a/benchmark/runner/agent_client.py
+++ b/benchmark/runner/agent_client.py
@@ -171,6 +171,32 @@ class AgentClient:
         body = _parse_json_response(body_bytes, "episode-memory process")
         return body if isinstance(body, dict) else {}
 
+    def seed_notification(self, events: list[dict[str, Any]], timeout: int = 30) -> dict[str, Any]:
+        headers = {}
+        if self._benchmark_token:
+            headers["Authorization"] = f"Bearer {self._benchmark_token}"
+        status, body_bytes = self._post(
+            "/api/benchmark/seed_notification",
+            {"events": list(events)}, timeout=timeout, headers=headers
+        )
+        if status != 200:
+            raise AgentRequestError(f"seed_notification returned {status}")
+        body = _parse_json_response(body_bytes, "seed_notification")
+        return body if isinstance(body, dict) else {}
+
+    def process_notification_memory(self, timeout: int = 90) -> dict[str, Any]:
+        headers = {}
+        if self._benchmark_token:
+            headers["Authorization"] = f"Bearer {self._benchmark_token}"
+        status, body_bytes = self._post(
+            "/api/benchmark/notification-memory/process", {},
+            timeout=timeout, headers=headers
+        )
+        if status != 200:
+            raise AgentRequestError(f"notification-memory process returned {status}")
+        body = _parse_json_response(body_bytes, "notification-memory process")
+        return body if isinstance(body, dict) else {}
+
     def set_phone_bridge_state(
         self, state: dict[str, Any], timeout: int = 30
     ) -> dict[str, Any]:

--- a/benchmark/runner/agent_client.py
+++ b/benchmark/runner/agent_client.py
@@ -17,9 +17,20 @@ class AgentTimeoutError(TimeoutError):
 
 
 class AgentRequestError(RuntimeError):
-    def __init__(self, message: str = "", *, request_id: str | None = None):
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        request_id: str | None = None,
+        status_code: int | None = None,
+    ):
         super().__init__(message)
         self.request_id = request_id
+        self.status_code = status_code
+
+
+class AgentSemanticError(AgentRequestError):
+    """The agent rejected a well-formed request because its semantic result was invalid."""
 
 
 def _parse_json_response(
@@ -89,7 +100,10 @@ class AgentClient:
                 body = e.read()
             except Exception:
                 pass
-            raise AgentRequestError(f"HTTP {e.code}: {body[:200]!r}") from e
+            error_type = AgentSemanticError if e.code == 422 else AgentRequestError
+            raise error_type(
+                f"HTTP {e.code}: {body[:200]!r}", status_code=e.code
+            ) from e
         except urllib.error.URLError as e:
             if isinstance(e.reason, socket.timeout):
                 raise AgentTimeoutError(str(e)) from e
@@ -193,7 +207,11 @@ class AgentClient:
             timeout=timeout, headers=headers
         )
         if status != 200:
-            raise AgentRequestError(f"notification-memory process returned {status}")
+            error_type = AgentSemanticError if status == 422 else AgentRequestError
+            raise error_type(
+                f"notification-memory process returned {status}",
+                status_code=status,
+            )
         body = _parse_json_response(body_bytes, "notification-memory process")
         return body if isinstance(body, dict) else {}
 

--- a/benchmark/runner/main.py
+++ b/benchmark/runner/main.py
@@ -511,9 +511,6 @@ def _cmd_run_auto_agent_setup_inner(
     run_dir: Path,
     mock_server=None,
 ) -> int:
-    if not args.environment_url:
-        print("Error: --auto-agent-setup requires --environment-url", file=sys.stderr)
-        return 2
     if args.repeats is not None and args.repeats <= 0:
         print(f"Error: --repeats must be positive, got {args.repeats}", file=sys.stderr)
         return 2
@@ -552,14 +549,27 @@ def _cmd_run_auto_agent_setup_inner(
     total_runs = len(units)
     has_runnable_units = any(not unit.skip_reason for unit in units)
     if has_runnable_units:
-        clear_stale_adb_android_owner(args.environment_url)
+        if args.environment_url:
+            clear_stale_adb_android_owner(args.environment_url)
         ensure_daemon_image(args.daemon_image, not args.no_build_daemon_image, setup_log)
-        concurrency = read_environment_bridge_concurrency(args.environment_url) or 1
+        concurrency = (
+            read_environment_bridge_concurrency(args.environment_url) or 1
+            if args.environment_url
+            else 1
+        )
         if args.max_concurrency > 0:
-            concurrency = min(concurrency, args.max_concurrency)
+            concurrency = (
+                min(concurrency, args.max_concurrency)
+                if args.environment_url
+                else args.max_concurrency
+            )
     else:
         concurrency = 1
-    docker_environment_url = endpoint_for_docker(args.environment_url.rstrip("/"))
+    docker_environment_url = (
+        endpoint_for_docker(args.environment_url.rstrip("/"))
+        if args.environment_url
+        else ""
+    )
     judge_cfg = None if args.no_judge else JudgeConfig(model=args.judge_model, base_url=args.judge_base_url)
     active_skills = _selected_skills(args)
     judge_cache = run_dir / "_judge_cache"
@@ -627,10 +637,10 @@ def _cmd_run_auto_agent_setup_inner(
         )
         job = Job(
             id=f"{run_id}-{token}",
-            endpoint=args.environment_url.rstrip("/"),
+            endpoint=args.environment_url.rstrip("/") if args.environment_url else "",
             docker_endpoint=docker_environment_url,
             suites=[str(suite.source_path)],
-            environment_endpoint=args.environment_url.rstrip("/"),
+            environment_endpoint=args.environment_url.rstrip("/") if args.environment_url else "",
             agent_url=agent_url,
             container_name=f"aiden-benchmark-agent-{run_id}-{token}",
             config_dir=str(config_dir),
@@ -664,7 +674,7 @@ def _cmd_run_auto_agent_setup_inner(
                 environment_bridge_endpoint=docker_environment_url,
                 benchmark_task_id=route_id,
                 device_type=unit.target_platform,
-                environment_bridge_mode=True,
+                environment_bridge_mode=bool(args.environment_url),
                 log_path=runner_log,
             )
             published_port = docker_published_port(container_id, 8080)

--- a/benchmark/runner/recovery.py
+++ b/benchmark/runner/recovery.py
@@ -4,7 +4,12 @@ import time
 from typing import TYPE_CHECKING
 
 from runner.agent_client import AgentClient, AgentRequestError, AgentTimeoutError
-from runner.reset import ResetError, call_environment_setup, per_task_setup
+from runner.reset import (
+    ResetError,
+    SetupAssertionError,
+    call_environment_setup,
+    per_task_setup,
+)
 
 if TYPE_CHECKING:
     from runner.suite import Suite, TaskSpec
@@ -82,6 +87,8 @@ def prepare_task_isolation(
             if not task.input_screenshot:
                 per_task_setup(client, task.setup, prompt_prefix=suite.prompt_prefix)
             return
+        except SetupAssertionError:
+            raise
         except (ResetError, AgentTimeoutError, AgentRequestError) as e:
             last_error = e
             if attempt >= setup_attempts:

--- a/benchmark/runner/reset.py
+++ b/benchmark/runner/reset.py
@@ -145,6 +145,9 @@ def per_task_setup(client: AgentClient, setup: dict[str, Any] | None, *, prompt_
     if setup_type == "seed_episode":
         _per_task_setup_seed_episode(client, setup)
         return
+    if setup_type == "seed_notification":
+        _per_task_setup_seed_notification(client, setup)
+        return
     raise ResetError(f"unsupported setup form: {setup!r}")
 
 
@@ -255,3 +258,92 @@ def _per_task_setup_seed_episode(client: AgentClient, setup: dict[str, Any]) -> 
     memory_ids = result.get("memory_ids")
     if not isinstance(memory_ids, list) or not memory_ids:
         raise ResetError(f"episode memory consolidation for {episode_id!r} produced no device memory")
+
+
+def _per_task_setup_seed_notification(client: AgentClient, setup: dict[str, Any]) -> None:
+    events = setup.get("events")
+    if not isinstance(events, list) or not events or len(events) > 100:
+        raise ResetError("seed_notification setup requires 1 to 100 events")
+    for index, event in enumerate(events):
+        if not isinstance(event, dict):
+            raise ResetError(f"seed_notification events[{index}] must be an object")
+        if not str(event.get("title") or event.get("message") or "").strip():
+            raise ResetError(f"seed_notification events[{index}] requires a title or message")
+    consolidate = setup.get("consolidate", False)
+    if not isinstance(consolidate, bool):
+        raise ResetError(f"seed_notification consolidate must be boolean: {consolidate!r}")
+    try:
+        timeout = int(setup.get("timeout_sec", 90 if consolidate else 30))
+    except (ValueError, TypeError) as e:
+        raise ResetError(f"invalid timeout_sec: {setup.get('timeout_sec')!r}") from e
+    try:
+        seeded = client.seed_notification(events, timeout=timeout)
+        if not isinstance(seeded, dict):
+            raise ResetError("seed_notification returned an invalid response")
+        context_ids = seeded.get("context_ids")
+        if not isinstance(context_ids, list) or len(context_ids) != len(events):
+            raise ResetError(
+                "seed_notification did not persist every fixture event: "
+                f"expected {len(events)} context ids, got {context_ids!r}"
+            )
+        if not consolidate:
+            return
+        result = client.process_notification_memory(timeout=timeout)
+    except AgentTimeoutError as e:
+        raise ResetError(f"notification benchmark setup timed out: {e}") from e
+    except AgentRequestError as e:
+        raise ResetError(f"notification benchmark setup failed: {e}") from e
+    expected_cursor = str(context_ids[-1]).strip() if context_ids else ""
+    cursor = str(result.get("memory_cursor") or "").strip()
+    if expected_cursor and cursor != expected_cursor:
+        raise ResetError(f"notification memory cursor mismatch: expected {expected_cursor!r}, got {cursor or 'missing'}")
+    memory_ids = result.get("memory_ids")
+    if not isinstance(memory_ids, list):
+        raise ResetError("notification memory consolidation returned invalid memory_ids")
+    expected_count = setup.get("expected_memory_count")
+    if expected_count is not None:
+        try:
+            expected_count = int(expected_count)
+        except (ValueError, TypeError) as e:
+            raise ResetError(
+                f"invalid expected_memory_count: {setup.get('expected_memory_count')!r}"
+            ) from e
+        if expected_count < 0 or len(memory_ids) != expected_count:
+            raise ResetError(
+                "notification memory count mismatch: "
+                f"expected {expected_count}, got {len(memory_ids)}"
+            )
+    expected_scope = str(setup.get("expected_memory_scope") or "").strip().lower()
+    if not expected_scope:
+        return
+    if expected_scope not in {"temporary", "long_term"}:
+        raise ResetError(
+            f"invalid expected_memory_scope: {setup.get('expected_memory_scope')!r}"
+        )
+    try:
+        recalled = client.invoke_tool(
+            "recall_memory",
+            {"tags": ["notification"], "limit": 20},
+            timeout=timeout,
+        )
+    except (AgentTimeoutError, AgentRequestError) as e:
+        raise ResetError(f"notification memory scope check failed: {e}") from e
+    if recalled.is_error:
+        raise ResetError("notification memory scope check returned an error")
+    try:
+        payload = json.loads(recalled.output)
+    except (TypeError, json.JSONDecodeError) as e:
+        raise ResetError(f"notification memory scope check returned invalid JSON: {e}") from e
+    matches = payload.get("results") if isinstance(payload, dict) else []
+    scopes_by_id = {
+        item.get("id"): str(item.get("memory_scope") or "").strip().lower()
+        for item in matches or []
+        if isinstance(item, dict) and item.get("id")
+    }
+    for memory_id in memory_ids:
+        actual_scope = scopes_by_id.get(memory_id, "")
+        if actual_scope != expected_scope:
+            raise ResetError(
+                f"notification memory {memory_id!r} scope mismatch: "
+                f"expected {expected_scope!r}, got {actual_scope or 'missing'}"
+            )

--- a/benchmark/runner/reset.py
+++ b/benchmark/runner/reset.py
@@ -3,13 +3,22 @@ import json
 import urllib.error
 import urllib.request
 from typing import Any
-from runner.agent_client import AgentClient, AgentRequestError, AgentTimeoutError
+from runner.agent_client import (
+    AgentClient,
+    AgentRequestError,
+    AgentSemanticError,
+    AgentTimeoutError,
+)
 from runner.environment_endpoint import EnvironmentEndpoint
 from runner.suite import SETUP_KEYS
 
 
 class ResetError(RuntimeError):
     pass
+
+
+class SetupAssertionError(ResetError):
+    """A setup assertion observed a benchmark capability mismatch."""
 
 
 STALE_ADB_OWNER_LEASE_STATES = {"expired", "abandoned"}
@@ -124,9 +133,29 @@ def clear_stale_adb_android_owner(environment_url: str, timeout: float = 2.0) ->
     return active_task_id
 
 
-def per_task_setup(client: AgentClient, setup: dict[str, Any] | None, *, prompt_prefix: str = "") -> None:
+def per_task_setup(
+    client: AgentClient,
+    setup: dict[str, Any] | list[dict[str, Any]] | None,
+    *,
+    prompt_prefix: str = "",
+) -> None:
     if setup is None:
         return
+    if isinstance(setup, list):
+        if not setup:
+            raise ResetError("setup sequence must contain at least one setup")
+        for index, item in enumerate(setup):
+            if not isinstance(item, dict):
+                raise ResetError(f"setup[{index}] must be an object")
+            try:
+                per_task_setup(client, item, prompt_prefix=prompt_prefix)
+            except SetupAssertionError as e:
+                raise SetupAssertionError(f"setup[{index}] failed: {e}") from e
+            except ResetError as e:
+                raise ResetError(f"setup[{index}] failed: {e}") from e
+        return
+    if not isinstance(setup, dict):
+        raise ResetError(f"setup must be an object or an array: {setup!r}")
     setup_type = setup.get("type")
     if not isinstance(setup_type, str):
         raise ResetError(f"setup type must be a string: {setup!r}")
@@ -147,6 +176,9 @@ def per_task_setup(client: AgentClient, setup: dict[str, Any] | None, *, prompt_
         return
     if setup_type == "seed_notification":
         _per_task_setup_seed_notification(client, setup)
+        return
+    if setup_type == "assert_memory":
+        _per_task_setup_assert_memory(client, setup)
         return
     raise ResetError(f"unsupported setup form: {setup!r}")
 
@@ -288,15 +320,24 @@ def _per_task_setup_seed_notification(client: AgentClient, setup: dict[str, Any]
             )
         if not consolidate:
             return
-        result = client.process_notification_memory(timeout=timeout)
     except AgentTimeoutError as e:
         raise ResetError(f"notification benchmark setup timed out: {e}") from e
     except AgentRequestError as e:
         raise ResetError(f"notification benchmark setup failed: {e}") from e
+    try:
+        result = client.process_notification_memory(timeout=timeout)
+    except AgentTimeoutError as e:
+        raise ResetError(f"notification memory processing timed out: {e}") from e
+    except AgentSemanticError as e:
+        raise SetupAssertionError(
+            f"notification memory processing failed: {e}"
+        ) from e
+    except AgentRequestError as e:
+        raise ResetError(f"notification memory processing failed: {e}") from e
     expected_cursor = str(context_ids[-1]).strip() if context_ids else ""
     cursor = str(result.get("memory_cursor") or "").strip()
     if expected_cursor and cursor != expected_cursor:
-        raise ResetError(f"notification memory cursor mismatch: expected {expected_cursor!r}, got {cursor or 'missing'}")
+        raise SetupAssertionError(f"notification memory cursor mismatch: expected {expected_cursor!r}, got {cursor or 'missing'}")
     memory_ids = result.get("memory_ids")
     if not isinstance(memory_ids, list):
         raise ResetError("notification memory consolidation returned invalid memory_ids")
@@ -309,7 +350,7 @@ def _per_task_setup_seed_notification(client: AgentClient, setup: dict[str, Any]
                 f"invalid expected_memory_count: {setup.get('expected_memory_count')!r}"
             ) from e
         if expected_count < 0 or len(memory_ids) != expected_count:
-            raise ResetError(
+            raise SetupAssertionError(
                 "notification memory count mismatch: "
                 f"expected {expected_count}, got {len(memory_ids)}"
             )
@@ -343,7 +384,142 @@ def _per_task_setup_seed_notification(client: AgentClient, setup: dict[str, Any]
     for memory_id in memory_ids:
         actual_scope = scopes_by_id.get(memory_id, "")
         if actual_scope != expected_scope:
-            raise ResetError(
+            raise SetupAssertionError(
                 f"notification memory {memory_id!r} scope mismatch: "
                 f"expected {expected_scope!r}, got {actual_scope or 'missing'}"
             )
+
+
+def _per_task_setup_assert_memory(client: AgentClient, setup: dict[str, Any]) -> None:
+    query = setup.get("query") or {"limit": 20}
+    if not isinstance(query, dict):
+        raise ResetError("assert_memory query must be an object")
+    try:
+        timeout = int(setup.get("timeout_sec", 30))
+    except (ValueError, TypeError) as e:
+        raise ResetError(f"invalid timeout_sec: {setup.get('timeout_sec')!r}") from e
+    try:
+        recalled = client.invoke_tool("recall_memory", query, timeout=timeout)
+    except (AgentTimeoutError, AgentRequestError) as e:
+        raise ResetError(f"assert_memory recall failed: {e}") from e
+    if recalled.is_error:
+        raise ResetError("assert_memory recall returned an error")
+    try:
+        payload = json.loads(recalled.output)
+    except (TypeError, json.JSONDecodeError) as e:
+        raise ResetError(f"assert_memory recall returned invalid JSON: {e}") from e
+    results = payload.get("results") if isinstance(payload, dict) else None
+    if not isinstance(results, list) or not all(isinstance(item, dict) for item in results):
+        raise ResetError("assert_memory recall returned invalid results")
+
+    expected_count = setup.get("expected_count")
+    if expected_count is not None:
+        try:
+            expected_count = int(expected_count)
+        except (ValueError, TypeError) as e:
+            raise ResetError(f"invalid expected_count: {setup.get('expected_count')!r}") from e
+        if expected_count < 0 or len(results) != expected_count:
+            raise SetupAssertionError(
+                f"assert_memory count mismatch: expected {expected_count}, got {len(results)}"
+            )
+
+    absent_ids = setup.get("absent_ids") or []
+    if not isinstance(absent_ids, list) or not all(
+        isinstance(item, str) and item.strip() for item in absent_ids
+    ):
+        raise ResetError("assert_memory absent_ids must be a list of non-empty strings")
+    result_ids = {str(item.get("id") or "").strip() for item in results}
+    unexpected = [item for item in absent_ids if item.strip() in result_ids]
+    if unexpected:
+        raise SetupAssertionError(f"assert_memory found absent id(s): {', '.join(unexpected)}")
+
+    expected = setup.get("expected") or []
+    if not isinstance(expected, list) or not all(isinstance(item, dict) for item in expected):
+        raise ResetError("assert_memory expected must be a list of objects")
+    for index, spec in enumerate(expected):
+        if not spec:
+            raise ResetError(f"assert_memory expected[{index}] must not be empty")
+        if not any(_memory_result_matches(item, spec) for item in results):
+            raise SetupAssertionError(
+                f"assert_memory expected[{index}] did not match any recalled memory: {spec!r}"
+            )
+
+
+def _memory_result_matches(result: dict[str, Any], spec: dict[str, Any]) -> bool:
+    supported = {
+        "id", "memory_scope", "type", "revision", "content_contains",
+        "title_contains", "tags_contains", "entities_contains",
+        "source_refs_contain", "evidence_refs_contain",
+    }
+    unknown = sorted(set(spec) - supported)
+    if unknown:
+        raise ResetError(f"assert_memory expected contains unsupported keys: {', '.join(unknown)}")
+    for field in ("id", "memory_scope", "type"):
+        if field in spec and str(result.get(field) or "").strip().lower() != str(spec[field]).strip().lower():
+            return False
+    if "revision" in spec:
+        try:
+            if int(result.get("revision") or 0) != int(spec["revision"]):
+                return False
+        except (ValueError, TypeError):
+            return False
+    for field, result_field in (("content_contains", "content"), ("title_contains", "title")):
+        if field in spec and str(spec[field]).strip().lower() not in str(result.get(result_field) or "").lower():
+            return False
+    for field, result_field in (("tags_contains", "tags"), ("entities_contains", "entities")):
+        if field not in spec:
+            continue
+        wanted = spec[field]
+        if not isinstance(wanted, list) or not all(isinstance(item, str) for item in wanted):
+            raise ResetError(f"assert_memory {field} must be a list of strings")
+        actual = {str(item).strip().lower() for item in result.get(result_field) or []}
+        if any(item.strip().lower() not in actual for item in wanted):
+            return False
+    for field, result_field in (
+        ("source_refs_contain", "source_refs"),
+        ("evidence_refs_contain", "evidence_refs"),
+    ):
+        if field not in spec:
+            continue
+        wanted_refs = spec[field]
+        if not isinstance(wanted_refs, list) or not all(
+            isinstance(item, dict) for item in wanted_refs
+        ):
+            raise ResetError(f"assert_memory {field} must be a list of objects")
+        actual_refs = result.get(result_field) or []
+        if not isinstance(actual_refs, list):
+            return False
+        if not all(
+            isinstance(item, dict) and _memory_source_ref_matches(actual_refs, item)
+            for item in wanted_refs
+        ):
+            return False
+    return True
+
+
+def _memory_source_ref_matches(
+    actual_refs: list[Any], wanted: dict[str, Any]
+) -> bool:
+    supported = {"type", "id", "event_ids_contains"}
+    unknown = sorted(set(wanted) - supported)
+    if unknown:
+        raise ResetError(
+            "assert_memory source reference contains unsupported keys: "
+            + ", ".join(unknown)
+        )
+    for actual in actual_refs:
+        if not isinstance(actual, dict):
+            continue
+        if "type" in wanted and str(actual.get("type") or "").strip().lower() != str(wanted["type"]).strip().lower():
+            continue
+        if "id" in wanted and str(actual.get("id") or "").strip() != str(wanted["id"]).strip():
+            continue
+        event_ids = wanted.get("event_ids_contains")
+        if event_ids is not None:
+            if not isinstance(event_ids, list) or not all(isinstance(item, str) for item in event_ids):
+                raise ResetError("assert_memory source reference event_ids_contains must be a list of strings")
+            actual_event_ids = {str(item).strip() for item in actual.get("event_ids") or []}
+            if any(str(item).strip() not in actual_event_ids for item in event_ids):
+                continue
+        return True
+    return False

--- a/benchmark/runner/reset.py
+++ b/benchmark/runner/reset.py
@@ -10,7 +10,7 @@ from runner.agent_client import (
     AgentTimeoutError,
 )
 from runner.environment_endpoint import EnvironmentEndpoint
-from runner.suite import SETUP_KEYS
+from runner.suite import SETUP_KEYS, SuiteValidationError, validate_assert_memory_setup
 
 
 class ResetError(RuntimeError):
@@ -361,10 +361,21 @@ def _per_task_setup_seed_notification(client: AgentClient, setup: dict[str, Any]
         raise ResetError(
             f"invalid expected_memory_scope: {setup.get('expected_memory_scope')!r}"
         )
+    query = setup.get("expected_memory_query")
+    if query is None:
+        query = {}
+    if not isinstance(query, dict):
+        raise ResetError("seed_notification expected_memory_query must be an object")
+    query = dict(query)
+    try:
+        configured_limit = int(query.get("limit", 0))
+    except (ValueError, TypeError) as e:
+        raise ResetError("seed_notification expected_memory_query limit must be an integer") from e
+    query["limit"] = max(20, len(memory_ids), configured_limit)
     try:
         recalled = client.invoke_tool(
             "recall_memory",
-            {"tags": ["notification"], "limit": 20},
+            query,
             timeout=timeout,
         )
     except (AgentTimeoutError, AgentRequestError) as e:
@@ -391,6 +402,10 @@ def _per_task_setup_seed_notification(client: AgentClient, setup: dict[str, Any]
 
 
 def _per_task_setup_assert_memory(client: AgentClient, setup: dict[str, Any]) -> None:
+    try:
+        validate_assert_memory_setup(setup)
+    except SuiteValidationError as e:
+        raise ResetError(str(e)) from e
     query = setup.get("query") or {"limit": 20}
     if not isinstance(query, dict):
         raise ResetError("assert_memory query must be an object")
@@ -446,14 +461,6 @@ def _per_task_setup_assert_memory(client: AgentClient, setup: dict[str, Any]) ->
 
 
 def _memory_result_matches(result: dict[str, Any], spec: dict[str, Any]) -> bool:
-    supported = {
-        "id", "memory_scope", "type", "revision", "content_contains",
-        "title_contains", "tags_contains", "entities_contains",
-        "source_refs_contain", "evidence_refs_contain",
-    }
-    unknown = sorted(set(spec) - supported)
-    if unknown:
-        raise ResetError(f"assert_memory expected contains unsupported keys: {', '.join(unknown)}")
     for field in ("id", "memory_scope", "type"):
         if field in spec and str(result.get(field) or "").strip().lower() != str(spec[field]).strip().lower():
             return False
@@ -470,8 +477,6 @@ def _memory_result_matches(result: dict[str, Any], spec: dict[str, Any]) -> bool
         if field not in spec:
             continue
         wanted = spec[field]
-        if not isinstance(wanted, list) or not all(isinstance(item, str) for item in wanted):
-            raise ResetError(f"assert_memory {field} must be a list of strings")
         actual = {str(item).strip().lower() for item in result.get(result_field) or []}
         if any(item.strip().lower() not in actual for item in wanted):
             return False
@@ -482,10 +487,6 @@ def _memory_result_matches(result: dict[str, Any], spec: dict[str, Any]) -> bool
         if field not in spec:
             continue
         wanted_refs = spec[field]
-        if not isinstance(wanted_refs, list) or not all(
-            isinstance(item, dict) for item in wanted_refs
-        ):
-            raise ResetError(f"assert_memory {field} must be a list of objects")
         actual_refs = result.get(result_field) or []
         if not isinstance(actual_refs, list):
             return False
@@ -500,13 +501,6 @@ def _memory_result_matches(result: dict[str, Any], spec: dict[str, Any]) -> bool
 def _memory_source_ref_matches(
     actual_refs: list[Any], wanted: dict[str, Any]
 ) -> bool:
-    supported = {"type", "id", "event_ids_contains"}
-    unknown = sorted(set(wanted) - supported)
-    if unknown:
-        raise ResetError(
-            "assert_memory source reference contains unsupported keys: "
-            + ", ".join(unknown)
-        )
     for actual in actual_refs:
         if not isinstance(actual, dict):
             continue
@@ -516,8 +510,6 @@ def _memory_source_ref_matches(
             continue
         event_ids = wanted.get("event_ids_contains")
         if event_ids is not None:
-            if not isinstance(event_ids, list) or not all(isinstance(item, str) for item in event_ids):
-                raise ResetError("assert_memory source reference event_ids_contains must be a list of strings")
             actual_event_ids = {str(item).strip() for item in actual.get("event_ids") or []}
             if any(str(item).strip() not in actual_event_ids for item in event_ids):
                 continue

--- a/benchmark/runner/runtask.py
+++ b/benchmark/runner/runtask.py
@@ -20,7 +20,7 @@ from runner.capture import take_environment_screenshot
 from runner.judge import judge_task, JudgeConfig
 from runner.models import HardAssertionFailure, HardAssertionResults, RubricVerdict, TaskResult
 from runner.recovery import prepare_task_isolation, recover_agent_after_timeout
-from runner.reset import ResetError
+from runner.reset import ResetError, SetupAssertionError
 from runner.suite import Suite, TaskSpec, effective_mock_environment
 from runner.trace import extract_trace
 from runner.report import now_iso
@@ -283,6 +283,11 @@ def run_one_task(
             environment_url=environment_url,
             benchmark_task_id=benchmark_task_id,
         )
+    except SetupAssertionError as e:
+        base.status = "failed"
+        base.metrics = {"error": f"setup assertion: {e}"}
+        base.finished_at = now_iso()
+        return base
     except (ResetError, AgentTimeoutError, AgentRequestError) as e:
         base.status = "skipped"
         base.metrics = {"error": f"setup: {e}"}

--- a/benchmark/runner/suite.py
+++ b/benchmark/runner/suite.py
@@ -17,6 +17,10 @@ SETUP_KEYS = {
     "agent_prompt": {"type", "prompt", "timeout_sec", "clear_history_after", "expected_response"},
     "seed_memory": {"type", "memories", "timeout_sec", "clear_history_after"},
     "seed_episode": {"type", "episode", "consolidate", "timeout_sec"},
+    "seed_notification": {
+        "type", "events", "consolidate", "timeout_sec",
+        "expected_memory_count", "expected_memory_scope",
+    },
 }
 
 class SuiteValidationError(ValueError):

--- a/benchmark/runner/suite.py
+++ b/benchmark/runner/suite.py
@@ -19,12 +19,19 @@ SETUP_KEYS = {
     "seed_episode": {"type", "episode", "consolidate", "timeout_sec"},
     "seed_notification": {
         "type", "events", "consolidate", "timeout_sec",
-        "expected_memory_count", "expected_memory_scope",
+        "expected_memory_count", "expected_memory_scope", "expected_memory_query",
     },
     "assert_memory": {
         "type", "query", "expected", "absent_ids", "expected_count", "timeout_sec",
     },
 }
+
+ASSERT_MEMORY_EXPECTED_KEYS = {
+    "id", "memory_scope", "type", "revision", "content_contains",
+    "title_contains", "tags_contains", "entities_contains",
+    "source_refs_contain", "evidence_refs_contain",
+}
+ASSERT_MEMORY_REFERENCE_KEYS = {"type", "id", "event_ids_contains"}
 
 class SuiteValidationError(ValueError):
     pass
@@ -260,6 +267,18 @@ def load_suite(path: Path) -> Suite:
                     raise SuiteValidationError(
                         f"task {tid}: unsupported {setup_type} setup keys: {', '.join(unknown_setup_keys)}"
                     )
+                if setup_type == "assert_memory":
+                    validate_assert_memory_setup(
+                        setup_item,
+                        path=f"task {tid}: setup[{setup_index}] assert_memory",
+                    )
+                if setup_type == "seed_notification":
+                    expected_query = setup_item.get("expected_memory_query")
+                    if expected_query is not None and not isinstance(expected_query, dict):
+                        raise SuiteValidationError(
+                            f"task {tid}: setup[{setup_index}] seed_notification "
+                            "expected_memory_query must be an object"
+                        )
         tasks.append(TaskSpec(
             id=tid, category=cat,
             description_for_judge=raw["description_for_judge"],
@@ -323,6 +342,100 @@ def load_suite(path: Path) -> Suite:
         trace_observations=trace_observations,
         mock_environment=mock_environment,
     )
+
+
+def validate_assert_memory_setup(
+    setup: dict[str, Any],
+    *,
+    path: str = "assert_memory",
+) -> None:
+    query = setup.get("query")
+    if query is not None and not isinstance(query, dict):
+        raise SuiteValidationError(f"{path} query must be an object")
+    absent_ids = setup.get("absent_ids")
+    if absent_ids is not None and (
+        not isinstance(absent_ids, list)
+        or not all(isinstance(item, str) and item.strip() for item in absent_ids)
+    ):
+        raise SuiteValidationError(
+            f"{path} absent_ids must be a list of non-empty strings"
+        )
+    expected = setup.get("expected")
+    if expected is None:
+        return
+    if not isinstance(expected, list) or not all(
+        isinstance(item, dict) for item in expected
+    ):
+        raise SuiteValidationError(f"{path} expected must be a list of objects")
+    for index, spec in enumerate(expected):
+        spec_path = f"{path} expected[{index}]"
+        if not spec:
+            raise SuiteValidationError(f"{spec_path} must not be empty")
+        unknown = sorted(set(spec) - ASSERT_MEMORY_EXPECTED_KEYS)
+        if unknown:
+            raise SuiteValidationError(
+                f"{spec_path} contains unsupported keys: {', '.join(unknown)}"
+            )
+        for field in (
+            "id", "memory_scope", "type", "content_contains", "title_contains",
+        ):
+            value = spec.get(field)
+            if value is not None and (
+                not isinstance(value, str) or not value.strip()
+            ):
+                raise SuiteValidationError(
+                    f"{spec_path} {field} must be a non-empty string"
+                )
+        revision = spec.get("revision")
+        if revision is not None and (
+            isinstance(revision, bool) or not isinstance(revision, int) or revision <= 0
+        ):
+            raise SuiteValidationError(
+                f"{spec_path} revision must be a positive integer"
+            )
+        for field in ("tags_contains", "entities_contains"):
+            wanted = spec.get(field)
+            if wanted is not None and (
+                not isinstance(wanted, list)
+                or not all(isinstance(item, str) for item in wanted)
+            ):
+                raise SuiteValidationError(
+                    f"{spec_path} {field} must be a list of strings"
+                )
+        for field in ("source_refs_contain", "evidence_refs_contain"):
+            refs = spec.get(field)
+            if refs is None:
+                continue
+            if not isinstance(refs, list) or not all(
+                isinstance(item, dict) for item in refs
+            ):
+                raise SuiteValidationError(
+                    f"{spec_path} {field} must be a list of objects"
+                )
+            for ref_index, ref in enumerate(refs):
+                ref_path = f"{spec_path} {field}[{ref_index}]"
+                unknown_ref_keys = sorted(set(ref) - ASSERT_MEMORY_REFERENCE_KEYS)
+                if unknown_ref_keys:
+                    raise SuiteValidationError(
+                        f"{ref_path} contains unsupported keys: "
+                        + ", ".join(unknown_ref_keys)
+                    )
+                for ref_field in ("type", "id"):
+                    ref_value = ref.get(ref_field)
+                    if ref_value is not None and (
+                        not isinstance(ref_value, str) or not ref_value.strip()
+                    ):
+                        raise SuiteValidationError(
+                            f"{ref_path} {ref_field} must be a non-empty string"
+                        )
+                event_ids = ref.get("event_ids_contains")
+                if event_ids is not None and (
+                    not isinstance(event_ids, list)
+                    or not all(isinstance(item, str) and item.strip() for item in event_ids)
+                ):
+                    raise SuiteValidationError(
+                        f"{ref_path} event_ids_contains must be a list of non-empty strings"
+                    )
 
 
 def _string_list_assertion(raw: Any, task_id: str, field: str) -> list[str]:

--- a/benchmark/runner/suite.py
+++ b/benchmark/runner/suite.py
@@ -21,6 +21,9 @@ SETUP_KEYS = {
         "type", "events", "consolidate", "timeout_sec",
         "expected_memory_count", "expected_memory_scope",
     },
+    "assert_memory": {
+        "type", "query", "expected", "absent_ids", "expected_count", "timeout_sec",
+    },
 }
 
 class SuiteValidationError(ValueError):
@@ -82,7 +85,7 @@ class TaskSpec:
     prompt: str
     rubric: list[RubricItem]
     hard_assertions: HardAssertions
-    setup: dict[str, Any] | None = None
+    setup: dict[str, Any] | list[dict[str, Any]] | None = None
     mock_environment: MockEnvironmentSpec | None = None
     repeats: int = 1
     input_screenshot: str | None = None
@@ -234,19 +237,29 @@ def load_suite(path: Path) -> Suite:
         )
         setup = raw.get("setup")
         if setup is not None:
-            if not isinstance(setup, dict):
-                raise SuiteValidationError(f"task {tid}: setup must be an object")
-            setup_type = setup.get("type")
-            if not isinstance(setup_type, str):
-                raise SuiteValidationError(f"task {tid}: setup type must be a string")
-            allowed_setup_keys = SETUP_KEYS.get(setup_type)
-            if allowed_setup_keys is None:
-                raise SuiteValidationError(f"task {tid}: unsupported setup type {setup_type!r}")
-            unknown_setup_keys = sorted(set(setup) - allowed_setup_keys)
-            if unknown_setup_keys:
-                raise SuiteValidationError(
-                    f"task {tid}: unsupported {setup_type} setup keys: {', '.join(unknown_setup_keys)}"
-                )
+            setup_items = setup if isinstance(setup, list) else [setup]
+            if not setup_items:
+                raise SuiteValidationError(f"task {tid}: setup sequence must not be empty")
+            for setup_index, setup_item in enumerate(setup_items):
+                if not isinstance(setup_item, dict):
+                    raise SuiteValidationError(
+                        f"task {tid}: setup[{setup_index}] must be an object"
+                    )
+                setup_type = setup_item.get("type")
+                if not isinstance(setup_type, str):
+                    raise SuiteValidationError(
+                        f"task {tid}: setup type must be a string (setup[{setup_index}])"
+                    )
+                allowed_setup_keys = SETUP_KEYS.get(setup_type)
+                if allowed_setup_keys is None:
+                    raise SuiteValidationError(
+                        f"task {tid}: unsupported setup type {setup_type!r}"
+                    )
+                unknown_setup_keys = sorted(set(setup_item) - allowed_setup_keys)
+                if unknown_setup_keys:
+                    raise SuiteValidationError(
+                        f"task {tid}: unsupported {setup_type} setup keys: {', '.join(unknown_setup_keys)}"
+                    )
         tasks.append(TaskSpec(
             id=tid, category=cat,
             description_for_judge=raw["description_for_judge"],

--- a/benchmark/suites/notification_memory_v1.json
+++ b/benchmark/suites/notification_memory_v1.json
@@ -1,0 +1,153 @@
+{
+  "name": "notification_memory_v1",
+  "suite_category": "Memory & Cognition",
+  "description": "Notification memory benchmark - checks durable fixture ingestion, idle consolidation into temporary memory, recall, noise filtering, and multi-batch cursor drain.",
+  "global_reset": {},
+  "tasks": [
+    {
+      "id": "delivery_notification_recall",
+      "category": "memory",
+      "description_for_judge": "The seeded delivery notification should be consolidated into temporary memory and recalled when the user asks what the notification said. The answer must preserve the delivery timing.",
+      "prompt": "I received a package notification earlier. First call recall_memory with notification and com.delivery, then tell me when the package is expected to arrive. Do not call bridge_notification.",
+      "rubric": [
+        {
+          "id": "recalls_notification_memory",
+          "check": "The trace contains recall_memory with notification-related tags or the final answer clearly uses the recalled delivery memory."
+        },
+        {
+          "id": "preserves_delivery_time",
+          "check": "The final answer says the package is expected tomorrow."
+        },
+        {
+          "id": "does_not_invent",
+          "check": "The answer does not invent a carrier, address, or delivery time not present in the notification."
+        }
+      ],
+      "hard_assertions": {
+        "min_tool_calls": 1,
+        "max_tool_calls": 5,
+        "must_complete_within_sec": 120,
+        "response_required": true,
+        "required_tools": ["recall_memory"],
+        "forbidden_tools": ["bridge_notification"]
+      },
+      "expected_recalled_memory_ids": ["tmp_notification_1"],
+      "setup": {
+        "type": "seed_notification",
+        "consolidate": true,
+        "timeout_sec": 120,
+        "expected_memory_count": 1,
+        "expected_memory_scope": "temporary",
+        "events": [
+          {
+            "source": "android",
+            "source_id": "delivery-1",
+            "source_event_id": "delivery-event-1",
+            "device_id": "benchmark-device",
+            "notification_uid": 101,
+            "event": "added",
+            "app_identifier": "com.delivery",
+            "title": "Package update",
+            "message": "Package arrives tomorrow",
+            "received_at": "2026-08-21T00:01:00Z"
+          }
+        ]
+      }
+    },
+    {
+      "id": "notification_noise_is_filtered",
+      "category": "memory",
+      "description_for_judge": "OTP and marketing notifications must not create user memory.",
+      "prompt": "Check memory for the verification-code and marketing notifications in this fixture. Tell me whether either notification was retained as user memory. Do not call bridge_notification.",
+      "rubric": [
+        {
+          "id": "rejects_noise_memory",
+          "check": "The final answer says OTP/verification-code and marketing notifications should not be stored as memory."
+        }
+      ],
+      "hard_assertions": {
+        "min_tool_calls": 1,
+        "max_tool_calls": 3,
+        "must_complete_within_sec": 90,
+        "response_required": true,
+        "required_tools": ["recall_memory"],
+        "forbidden_tools": ["bridge_notification"]
+      },
+      "setup": {
+        "type": "seed_notification",
+        "consolidate": true,
+        "timeout_sec": 120,
+        "expected_memory_count": 0,
+        "events": [
+          {
+            "source": "android",
+            "source_id": "otp-1",
+            "source_event_id": "otp-event-1",
+            "device_id": "benchmark-device",
+            "notification_uid": 103,
+            "event": "added",
+            "app_identifier": "com.auth",
+            "title": "Verification code",
+            "message": "Login verification code 123456",
+            "received_at": "2026-08-21T00:03:00Z"
+          },
+          {
+            "source": "android",
+            "source_id": "marketing-1",
+            "source_event_id": "marketing-event-1",
+            "device_id": "benchmark-device",
+            "notification_uid": 104,
+            "event": "added",
+            "app_identifier": "com.shop",
+            "title": "Limited-time promotion",
+            "message": "Limited-time discount",
+            "received_at": "2026-08-21T00:04:00Z"
+          }
+        ]
+      }
+    },
+    {
+      "id": "notification_batch_cursor_drain",
+      "category": "memory",
+      "description_for_judge": "A backlog larger than one processor batch must be fully drained, while verification-code noise remains absent from user memory.",
+      "prompt": "Check memory for the verification-code notifications and report whether any were retained. Do not call bridge_notification.",
+      "rubric": [
+        {
+          "id": "checks_notification_memory",
+          "check": "The trace contains recall_memory and the answer is based on its result."
+        },
+        {
+          "id": "reports_noise_absence",
+          "check": "The answer states that the verification-code notifications were not retained as user memory."
+        }
+      ],
+      "hard_assertions": {
+        "min_tool_calls": 1,
+        "max_tool_calls": 3,
+        "must_complete_within_sec": 120,
+        "response_required": true,
+        "required_tools": ["recall_memory"],
+        "forbidden_tools": ["bridge_notification"]
+      },
+      "setup": {
+        "type": "seed_notification",
+        "consolidate": true,
+        "timeout_sec": 120,
+        "expected_memory_count": 0,
+        "events": [
+          {"source": "android", "source_id": "otp-batch-1", "source_event_id": "otp-batch-event-1", "device_id": "benchmark-device", "notification_uid": 201, "event": "added", "app_identifier": "com.auth", "title": "Verification code", "message": "Code 100001", "received_at": "2026-08-21T01:00:01Z"},
+          {"source": "android", "source_id": "otp-batch-2", "source_event_id": "otp-batch-event-2", "device_id": "benchmark-device", "notification_uid": 202, "event": "added", "app_identifier": "com.auth", "title": "Verification code", "message": "Code 100002", "received_at": "2026-08-21T01:00:02Z"},
+          {"source": "android", "source_id": "otp-batch-3", "source_event_id": "otp-batch-event-3", "device_id": "benchmark-device", "notification_uid": 203, "event": "added", "app_identifier": "com.auth", "title": "Verification code", "message": "Code 100003", "received_at": "2026-08-21T01:00:03Z"},
+          {"source": "android", "source_id": "otp-batch-4", "source_event_id": "otp-batch-event-4", "device_id": "benchmark-device", "notification_uid": 204, "event": "added", "app_identifier": "com.auth", "title": "Verification code", "message": "Code 100004", "received_at": "2026-08-21T01:00:04Z"},
+          {"source": "android", "source_id": "otp-batch-5", "source_event_id": "otp-batch-event-5", "device_id": "benchmark-device", "notification_uid": 205, "event": "added", "app_identifier": "com.auth", "title": "Verification code", "message": "Code 100005", "received_at": "2026-08-21T01:00:05Z"},
+          {"source": "android", "source_id": "otp-batch-6", "source_event_id": "otp-batch-event-6", "device_id": "benchmark-device", "notification_uid": 206, "event": "added", "app_identifier": "com.auth", "title": "Verification code", "message": "Code 100006", "received_at": "2026-08-21T01:00:06Z"},
+          {"source": "android", "source_id": "otp-batch-7", "source_event_id": "otp-batch-event-7", "device_id": "benchmark-device", "notification_uid": 207, "event": "added", "app_identifier": "com.auth", "title": "Verification code", "message": "Code 100007", "received_at": "2026-08-21T01:00:07Z"},
+          {"source": "android", "source_id": "otp-batch-8", "source_event_id": "otp-batch-event-8", "device_id": "benchmark-device", "notification_uid": 208, "event": "added", "app_identifier": "com.auth", "title": "Verification code", "message": "Code 100008", "received_at": "2026-08-21T01:00:08Z"},
+          {"source": "android", "source_id": "otp-batch-9", "source_event_id": "otp-batch-event-9", "device_id": "benchmark-device", "notification_uid": 209, "event": "added", "app_identifier": "com.auth", "title": "Verification code", "message": "Code 100009", "received_at": "2026-08-21T01:00:09Z"},
+          {"source": "android", "source_id": "otp-batch-10", "source_event_id": "otp-batch-event-10", "device_id": "benchmark-device", "notification_uid": 210, "event": "added", "app_identifier": "com.auth", "title": "Verification code", "message": "Code 100010", "received_at": "2026-08-21T01:00:10Z"},
+          {"source": "android", "source_id": "otp-batch-11", "source_event_id": "otp-batch-event-11", "device_id": "benchmark-device", "notification_uid": 211, "event": "added", "app_identifier": "com.auth", "title": "Verification code", "message": "Code 100011", "received_at": "2026-08-21T01:00:11Z"}
+        ]
+      }
+    }
+  ]
+}

--- a/benchmark/suites/notification_memory_v1.json
+++ b/benchmark/suites/notification_memory_v1.json
@@ -148,6 +148,309 @@
           {"source": "android", "source_id": "otp-batch-11", "source_event_id": "otp-batch-event-11", "device_id": "benchmark-device", "notification_uid": 211, "event": "added", "app_identifier": "com.auth", "title": "Verification code", "message": "Code 100011", "received_at": "2026-08-21T01:00:11Z"}
         ]
       }
+    },
+    {
+      "id": "notification_explicit_update",
+      "category": "memory",
+      "description_for_judge": "A changed notification must update the related temporary memory selected from the memory catalog, preserving one record and advancing its revision.",
+      "prompt": "Check the delivery update memory and tell me the current delivery conclusion. Use recall_memory with com.delivery.update. Do not call bridge_notification.",
+      "rubric": [
+        {
+          "id": "uses_updated_memory",
+          "check": "The final answer says the package arrives tomorrow and does not repeat the obsolete today conclusion."
+        },
+        {
+          "id": "keeps_one_memory",
+          "check": "The recalled result shows the existing delivery memory as one updated conclusion rather than two competing records."
+        }
+      ],
+      "hard_assertions": {
+        "min_tool_calls": 1,
+        "max_tool_calls": 4,
+        "must_complete_within_sec": 120,
+        "response_required": true,
+        "required_tools": ["recall_memory"],
+        "forbidden_tools": ["bridge_notification"]
+      },
+      "setup": [
+        {
+          "type": "seed_memory",
+          "memories": [
+            {
+              "store": "temporary",
+              "id": "tmp_update_delivery",
+              "type": "fact",
+              "title": "Delivery status",
+              "content": "The package arrives today.",
+              "tags": ["notification", "com.delivery.update"],
+              "entities": ["com.delivery.update"],
+              "source_refs": [{"type": "notification", "id": "fixture-update-old", "event_ids": ["old-event"]}],
+              "evidence_refs": [{"type": "notification", "id": "fixture-update-evidence", "event_ids": ["old-evidence-event"]}],
+              "evidence": ["The package arrives today."],
+              "expires_at": "2026-09-30T00:00:00Z"
+            }
+          ]
+        },
+        {
+          "type": "seed_notification",
+          "consolidate": true,
+          "timeout_sec": 120,
+          "expected_memory_count": 1,
+          "expected_memory_scope": "temporary",
+          "events": [
+            {
+              "source": "android",
+              "source_id": "update-delivery-1",
+              "source_event_id": "update-delivery-event-1",
+              "device_id": "benchmark-device",
+              "notification_uid": 301,
+              "event": "modified",
+              "app_identifier": "com.delivery.update",
+              "title": "Package update",
+              "message": "Package arrives tomorrow",
+              "received_at": "2026-08-22T00:01:00Z"
+            }
+          ]
+        },
+        {
+          "type": "assert_memory",
+          "query": {"tags": ["com.delivery.update"], "limit": 20},
+          "expected": [
+            {"id": "tmp_update_delivery", "memory_scope": "temporary", "revision": 2, "content_contains": "tomorrow", "source_refs_contain": [{"type": "notification", "id": "fixture-update-old", "event_ids_contains": ["old-event"]}, {"type": "notification", "event_ids_contains": ["update-delivery-event-1"]}], "evidence_refs_contain": [{"type": "notification", "id": "fixture-update-evidence", "event_ids_contains": ["old-evidence-event"]}]}
+          ],
+          "expected_count": 1
+        }
+      ]
+    },
+    {
+      "id": "notification_explicit_reinforce",
+      "category": "memory",
+      "description_for_judge": "A repeated notification with the same conclusion must reinforce the existing temporary memory instead of replacing its content or creating a duplicate.",
+      "prompt": "Check the calendar notification memory for the meeting time. Use recall_memory with com.calendar.reinforce and report the time. Do not call bridge_notification.",
+      "rubric": [
+        {
+          "id": "preserves_conclusion",
+          "check": "The final answer says the meeting is tomorrow at 10:00."
+        },
+        {
+          "id": "does_not_duplicate",
+          "check": "The answer is based on one reinforced calendar conclusion, not multiple conflicting memories."
+        }
+      ],
+      "hard_assertions": {
+        "min_tool_calls": 1,
+        "max_tool_calls": 4,
+        "must_complete_within_sec": 120,
+        "response_required": true,
+        "required_tools": ["recall_memory"],
+        "forbidden_tools": ["bridge_notification"]
+      },
+      "setup": [
+        {
+          "type": "seed_memory",
+          "memories": [
+            {
+              "store": "temporary",
+              "id": "tmp_reinforce_calendar",
+              "type": "fact",
+              "title": "Calendar reminder",
+              "content": "The meeting is tomorrow at 10:00.",
+              "tags": ["notification", "com.calendar.reinforce"],
+              "entities": ["com.calendar.reinforce"],
+              "source_refs": [{"type": "notification", "id": "fixture-reinforce-old", "event_ids": ["old-event"]}],
+              "evidence": ["The meeting is tomorrow at 10:00."],
+              "expires_at": "2026-09-30T00:00:00Z"
+            }
+          ]
+        },
+        {
+          "type": "seed_notification",
+          "consolidate": true,
+          "timeout_sec": 120,
+          "expected_memory_count": 1,
+          "expected_memory_scope": "temporary",
+          "events": [
+            {
+              "source": "android",
+              "source_id": "reinforce-calendar-1",
+              "source_event_id": "reinforce-calendar-event-1",
+              "device_id": "benchmark-device",
+              "notification_uid": 302,
+              "event": "added",
+              "app_identifier": "com.calendar.reinforce",
+              "title": "Meeting confirmation",
+              "message": "The meeting remains tomorrow at 10:00",
+              "received_at": "2026-08-22T00:02:00Z"
+            }
+          ]
+        },
+        {
+          "type": "assert_memory",
+          "query": {"tags": ["com.calendar.reinforce"], "limit": 20},
+          "expected": [
+            {"id": "tmp_reinforce_calendar", "memory_scope": "temporary", "revision": 2, "content_contains": "tomorrow at 10:00", "source_refs_contain": [{"type": "notification", "id": "fixture-reinforce-old", "event_ids_contains": ["old-event"]}, {"type": "notification", "event_ids_contains": ["reinforce-calendar-event-1"]}]}
+          ],
+          "expected_count": 1
+        }
+      ]
+    },
+    {
+      "id": "notification_explicit_remove",
+      "category": "memory",
+      "description_for_judge": "A notification that explicitly withdraws an existing conclusion must produce a targeted remove action and leave a related control memory intact.",
+      "prompt": "Check memory for the cancelled delivery notification. Use recall_memory with com.delivery.remove and tell me whether it is still retained. Do not call bridge_notification.",
+      "rubric": [
+        {
+          "id": "removed_memory_absent",
+          "check": "The final answer says the cancelled delivery notification is no longer retained as memory."
+        }
+      ],
+      "hard_assertions": {
+        "min_tool_calls": 1,
+        "max_tool_calls": 4,
+        "must_complete_within_sec": 90,
+        "response_required": true,
+        "required_tools": ["recall_memory"],
+        "forbidden_tools": ["bridge_notification"]
+      },
+      "setup": [
+        {
+          "type": "seed_memory",
+          "memories": [
+            {
+              "store": "temporary",
+              "id": "tmp_remove_delivery",
+              "type": "fact",
+              "title": "Cancelled delivery",
+              "content": "The package delivery was scheduled for Friday.",
+              "tags": ["notification", "com.delivery.remove"],
+              "entities": ["com.delivery.remove"],
+              "source_refs": [
+                {
+                  "type": "notification",
+                  "id": "fixture-remove-old",
+                  "event_ids": ["old-remove-event"]
+                }
+              ],
+              "evidence": ["The package delivery was scheduled for Friday."],
+              "expires_at": "2026-09-30T00:00:00Z"
+            },
+            {
+              "store": "temporary",
+              "id": "tmp_remove_delivery_control",
+              "type": "fact",
+              "title": "Unrelated delivery",
+              "content": "A different package is scheduled for Monday.",
+              "tags": ["notification", "com.delivery.remove"],
+              "entities": ["com.delivery.remove"],
+              "source_refs": [{"type": "notification", "id": "fixture-remove-control", "event_ids": ["control-event"]}],
+              "evidence": ["A different package is scheduled for Monday."],
+              "expires_at": "2026-09-30T00:00:00Z"
+            }
+          ]
+        },
+        {
+          "type": "seed_notification",
+          "consolidate": true,
+          "timeout_sec": 120,
+          "expected_memory_count": 0,
+          "events": [
+            {
+              "source": "android",
+              "source_id": "remove-delivery-1",
+              "source_event_id": "remove-delivery-event-1",
+              "device_id": "benchmark-device",
+              "notification_uid": 303,
+              "event": "modified",
+              "app_identifier": "com.delivery.remove",
+              "title": "Friday delivery notice withdrawn",
+              "message": "The earlier Friday delivery notice was sent in error and is withdrawn. There is no replacement delivery information.",
+              "received_at": "2026-08-22T00:03:00Z"
+            }
+          ]
+        },
+        {
+          "type": "assert_memory",
+          "query": {"tags": ["com.delivery.remove"], "limit": 20},
+          "absent_ids": ["tmp_remove_delivery"],
+          "expected": [{"id": "tmp_remove_delivery_control", "source_refs_contain": [{"type": "notification", "id": "fixture-remove-control", "event_ids_contains": ["control-event"]}]}],
+          "expected_count": 1
+        }
+      ]
+    },
+    {
+      "id": "notification_explicit_promote",
+      "category": "memory",
+      "description_for_judge": "A stable notification conclusion must be promoted from temporary to long-term memory, leaving the temporary source inactive.",
+      "prompt": "Check the delivery rule memory. Use recall_memory with com.delivery.promote and tell me where future packages should be delivered. Do not call bridge_notification.",
+      "rubric": [
+        {
+          "id": "recalls_long_term_rule",
+          "check": "The final answer says future packages should be delivered to the office."
+        },
+        {
+          "id": "uses_promoted_scope",
+          "check": "The recalled rule is a long-term memory, not the temporary source record."
+        }
+      ],
+      "hard_assertions": {
+        "min_tool_calls": 1,
+        "max_tool_calls": 4,
+        "must_complete_within_sec": 120,
+        "response_required": true,
+        "required_tools": ["recall_memory"],
+        "forbidden_tools": ["bridge_notification"]
+      },
+      "setup": [
+        {
+          "type": "seed_memory",
+          "memories": [
+            {
+              "store": "temporary",
+              "id": "tmp_promote_delivery",
+              "type": "rule",
+              "title": "Delivery destination",
+              "content": "Future packages should be delivered to the office.",
+              "tags": ["notification", "com.delivery.promote"],
+              "entities": ["com.delivery.promote"],
+              "source_refs": [{"type": "notification", "id": "fixture-promote-old", "event_ids": ["old-event"]}],
+              "evidence_refs": [{"type": "notification", "id": "fixture-promote-evidence", "event_ids": ["old-evidence-event"]}],
+              "evidence": ["Future packages should be delivered to the office."],
+              "expires_at": "2026-09-30T00:00:00Z"
+            }
+          ]
+        },
+        {
+          "type": "seed_notification",
+          "consolidate": true,
+          "timeout_sec": 120,
+          "expected_memory_count": 1,
+          "expected_memory_scope": "long_term",
+          "events": [
+            {
+              "source": "android",
+              "source_id": "promote-delivery-1",
+              "source_event_id": "promote-delivery-event-1",
+              "device_id": "benchmark-device",
+              "notification_uid": 304,
+              "event": "added",
+              "app_identifier": "com.delivery.promote",
+              "title": "Delivery preference",
+              "message": "Future packages should be delivered to the office",
+              "received_at": "2026-08-22T00:04:00Z"
+            }
+          ]
+        },
+        {
+          "type": "assert_memory",
+          "query": {"tags": ["com.delivery.promote"], "limit": 20},
+          "expected": [
+            {"memory_scope": "long_term", "content_contains": "delivered to the office", "source_refs_contain": [{"type": "notification", "id": "fixture-promote-old", "event_ids_contains": ["old-event"]}, {"type": "notification", "event_ids_contains": ["promote-delivery-event-1"]}], "evidence_refs_contain": [{"type": "notification", "id": "fixture-promote-evidence", "event_ids_contains": ["old-evidence-event"]}]}
+          ],
+          "absent_ids": ["tmp_promote_delivery"],
+          "expected_count": 1
+        }
+      ]
     }
   ]
 }

--- a/benchmark/tests/test_agent_client.py
+++ b/benchmark/tests/test_agent_client.py
@@ -301,6 +301,36 @@ def test_process_episode_memory_sends_benchmark_token_header():
     assert result == response
 
 
+def test_seed_notification_sends_benchmark_token_header():
+    seen = {}
+    client = AgentClient(base_url="http://test", benchmark_token="notification-token")
+    events = [{"title": "Package", "message": "Tomorrow"}]
+    with patch(
+        "urllib.request.urlopen",
+        _captured(seen, body={"status": "seeded", "context_ids": ["1"]}),
+    ):
+        result = client.seed_notification(events)
+
+    assert seen["url"].endswith("/api/benchmark/seed_notification")
+    assert seen["headers"]["authorization"] == "Bearer notification-token"
+    assert '"events"' in seen["body"]
+    assert result == {"status": "seeded", "context_ids": ["1"]}
+
+
+def test_process_notification_memory_sends_benchmark_token_header():
+    seen = {}
+    client = AgentClient(base_url="http://test", benchmark_token="notification-token")
+    with patch(
+        "urllib.request.urlopen",
+        _captured(seen, body={"memory_cursor": "1", "memory_ids": ["tmp_notification_1"]}),
+    ):
+        result = client.process_notification_memory()
+
+    assert seen["url"].endswith("/api/benchmark/notification-memory/process")
+    assert seen["headers"]["authorization"] == "Bearer notification-token"
+    assert result["memory_cursor"] == "1"
+
+
 def test_set_phone_bridge_state_sends_benchmark_token_header():
     seen = {}
     client = AgentClient(base_url="http://test", benchmark_token="state-token")

--- a/benchmark/tests/test_agent_client.py
+++ b/benchmark/tests/test_agent_client.py
@@ -5,7 +5,12 @@ from unittest.mock import patch
 
 import pytest
 
-from runner.agent_client import AgentClient, AgentRequestError, AgentTimeoutError
+from runner.agent_client import (
+    AgentClient,
+    AgentRequestError,
+    AgentSemanticError,
+    AgentTimeoutError,
+)
 
 
 class FakeResponse:
@@ -329,6 +334,34 @@ def test_process_notification_memory_sends_benchmark_token_header():
     assert seen["url"].endswith("/api/benchmark/notification-memory/process")
     assert seen["headers"]["authorization"] == "Bearer notification-token"
     assert result["memory_cursor"] == "1"
+
+
+def test_http_422_raises_structured_semantic_error():
+    class SemanticHTTPErrorResponse:
+        def read(self):
+            return b"invalid proposal"
+
+        def close(self):
+            pass
+
+    def fail_urlopen(*args, **kwargs):
+        import urllib.error
+
+        raise urllib.error.HTTPError(
+            "http://test/api/benchmark/notification-memory/process",
+            422,
+            "Unprocessable Entity",
+            {},
+            SemanticHTTPErrorResponse(),
+        )
+
+    client = AgentClient(base_url="http://test", benchmark_token="token")
+    with patch("urllib.request.urlopen", fail_urlopen), pytest.raises(
+        AgentSemanticError
+    ) as exc_info:
+        client.process_notification_memory()
+
+    assert exc_info.value.status_code == 422
 
 
 def test_set_phone_bridge_state_sends_benchmark_token_header():

--- a/benchmark/tests/test_main.py
+++ b/benchmark/tests/test_main.py
@@ -1092,6 +1092,94 @@ def test_auto_agent_setup_injects_environment_url_as_bridge_endpoint(monkeypatch
     assert stale_clears == ["http://127.0.0.1:19090"]
 
 
+def test_auto_agent_setup_runs_memory_suite_without_environment_bridge(monkeypatch, tmp_path):
+    suite_path = tmp_path / "memory-suite.json"
+    suite_path.write_text(
+        json.dumps(
+            {
+                "name": "memory_suite",
+                "tasks": [
+                    {
+                        "id": "recall_memory",
+                        "category": "memory",
+                        "prompt": "recall memory",
+                        "description_for_judge": "recall memory",
+                        "rubric": [{"id": "done", "check": "done"}],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, base_url, benchmark_token=""):
+            captured["client_base_url"] = base_url
+            captured["benchmark_token"] = benchmark_token
+
+        def close(self):
+            pass
+
+    def fake_prepare_run_config(base_config_dir, config_dir, **kwargs):
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "control_token").write_text("memory-token", encoding="utf-8")
+
+    def fake_start_daemon_compose(job, **kwargs):
+        captured["job"] = job
+        captured["daemon_kwargs"] = kwargs
+        return "container-id"
+
+    def fake_run_one_task(client, suite, task, attempt, artifact_dir, *args, **kwargs):
+        captured["task_kwargs"] = kwargs
+        return TaskResult(
+            suite=suite.name,
+            run_id="memory-run",
+            task_id=task.id,
+            category=task.category,
+            attempt=attempt,
+            status="passed",
+            rubric=[],
+            rubric_pass_count=0,
+            rubric_total=0,
+            artifact_dir=str(artifact_dir),
+        )
+
+    monkeypatch.setattr(main, "AgentClient", FakeClient)
+    monkeypatch.setattr(main, "wait_for_agent_ready", lambda *args, **kwargs: True)
+    monkeypatch.setattr(main, "wait_for_agent_clock", lambda *args, **kwargs: True)
+    monkeypatch.setattr(main, "generate_report_html", lambda run_dir: "<html></html>")
+    monkeypatch.setattr(webui, "ensure_daemon_image", lambda *args, **kwargs: None)
+    monkeypatch.setattr(webui, "prepare_run_config", fake_prepare_run_config)
+    monkeypatch.setattr(webui, "docker_published_port", lambda *args, **kwargs: 18082)
+    monkeypatch.setattr(webui, "start_daemon_compose", fake_start_daemon_compose)
+    monkeypatch.setattr(webui, "start_daemon_logs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(webui, "stop_daemon_compose", lambda *args, **kwargs: None)
+    monkeypatch.setattr(main, "run_one_task", fake_run_one_task)
+
+    rc = main.cli(
+        [
+            "run",
+            "--suite",
+            str(suite_path),
+            "--out",
+            str(tmp_path / "runs"),
+            "--run-id",
+            "memory-run",
+            "--auto-agent-setup",
+            "--no-judge",
+        ]
+    )
+
+    assert rc == 0
+    assert captured["job"].endpoint == ""
+    assert captured["job"].docker_endpoint == ""
+    assert captured["daemon_kwargs"]["environment_bridge_endpoint"] == ""
+    assert captured["daemon_kwargs"]["environment_bridge_mode"] is False
+    assert captured["task_kwargs"]["environment_url"] is None
+    assert captured["benchmark_token"] == "memory-token"
+
+
 def test_run_rejects_external_daemon_platform_mismatch(monkeypatch, tmp_path, capsys):
     suite_path = tmp_path / "suite.json"
     suite_path.write_text(

--- a/benchmark/tests/test_recovery.py
+++ b/benchmark/tests/test_recovery.py
@@ -4,7 +4,7 @@ import pytest
 
 from runner.agent_client import AgentRequestError, AgentTimeoutError
 from runner.recovery import prepare_task_isolation, wait_for_agent_ready
-from runner.reset import ResetError
+from runner.reset import ResetError, SetupAssertionError
 from runner.suite import HardAssertions, RubricItem, Suite, TaskSpec
 
 
@@ -308,6 +308,46 @@ def test_prepare_task_isolation_runs_seed_memory_with_environment_setup(monkeypa
     assert client.seeded_memories == [
         ({"id": "mem-1", "content": "The user likes flashcards.", "tags": ["study"]}, 7)
     ]
+
+
+def test_prepare_task_isolation_does_not_retry_setup_assertion(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+    setup_calls = []
+
+    def fail_assertion(*args, **kwargs):
+        setup_calls.append((args, kwargs))
+        raise SetupAssertionError("expected memory is absent")
+
+    monkeypatch.setattr("runner.recovery.per_task_setup", fail_assertion)
+    client = SetupClient()
+    suite = Suite(
+        name="memory",
+        global_reset={},
+        tasks=[],
+        sha256="sha",
+        source_path=__import__("pathlib").Path("memory.json"),
+    )
+    task = TaskSpec(
+        id="memory_update",
+        category="memory",
+        description_for_judge="Update memory.",
+        prompt="check memory",
+        rubric=[RubricItem(id="ok", check="ok")],
+        hard_assertions=HardAssertions(),
+        setup={"type": "assert_memory", "expected_count": 1},
+    )
+
+    with pytest.raises(SetupAssertionError, match="expected memory is absent"):
+        prepare_task_isolation(
+            client,
+            suite,
+            task,
+            ready_timeout_sec=10,
+            setup_attempts=3,
+        )
+
+    assert len(setup_calls) == 1
+    assert client.clears == 1
 
 
 def test_prepare_task_isolation_raises_after_exhausting_retries(monkeypatch):

--- a/benchmark/tests/test_reset.py
+++ b/benchmark/tests/test_reset.py
@@ -47,12 +47,57 @@ class RecordingSetupClient:
         self.calls.append(("process_episode_memory", episode_id, timeout))
         return {"episode_id": episode_id, "status": "done", "memory_ids": ["devmem-1"]}
 
+    def seed_notification(self, events, timeout=30):
+        self.calls.append(("seed_notification", events, timeout))
+        return {"status": "seeded", "context_ids": [str(index + 1) for index in range(len(events))]}
+
+    def process_notification_memory(self, timeout=90):
+        self.calls.append(("process_notification_memory", timeout))
+        return {"memory_cursor": "1", "memory_ids": ["tmp_notification_1"]}
+
+    def invoke_tool(self, name, args, timeout=90):
+        self.calls.append(("invoke_tool", name, args, timeout))
+        from runner.agent_client import ToolInvokeResult
+
+        return ToolInvokeResult(
+            output='{"results":[{"id":"tmp_notification_1","memory_scope":"temporary"}]}',
+            is_error=False,
+            duration_ms=0,
+        )
+
 
 def test_agent_prompt_setup_wraps_chat_errors_as_reset_error():
     setup = {"type": "agent_prompt", "prompt": "remember this", "timeout_sec": 5}
 
     with pytest.raises(ResetError, match="setup agent_prompt failed"):
         per_task_setup(FailingChatClient(), setup)
+
+
+def test_notification_setup_seeds_and_processes_fixture():
+    client = RecordingSetupClient()
+    setup = {
+        "type": "seed_notification",
+        "events": [{"title": "Package", "message": "Tomorrow"}],
+        "consolidate": True,
+        "expected_memory_count": 1,
+        "expected_memory_scope": "temporary",
+    }
+
+    per_task_setup(client, setup)
+
+    assert client.calls == [
+        ("seed_notification", setup["events"], 90),
+        ("process_notification_memory", 90),
+        ("invoke_tool", "recall_memory", {"tags": ["notification"], "limit": 20}, 90),
+    ]
+
+
+def test_notification_setup_rejects_non_boolean_consolidate():
+    with pytest.raises(ResetError, match="consolidate must be boolean"):
+        per_task_setup(
+            RecordingSetupClient(),
+            {"type": "seed_notification", "events": [{"title": "x"}], "consolidate": "false"},
+        )
 
 
 def test_agent_prompt_setup_wraps_timeouts_as_reset_error():

--- a/benchmark/tests/test_reset.py
+++ b/benchmark/tests/test_reset.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from runner.agent_client import AgentRequestError, AgentTimeoutError, ChatResponse
@@ -93,8 +95,47 @@ def test_notification_setup_seeds_and_processes_fixture():
     assert client.calls == [
         ("seed_notification", setup["events"], 90),
         ("process_notification_memory", 90),
-        ("invoke_tool", "recall_memory", {"tags": ["notification"], "limit": 20}, 90),
+        ("invoke_tool", "recall_memory", {"limit": 20}, 90),
     ]
+
+
+def test_notification_scope_setup_uses_configured_query_and_covers_all_memory_ids():
+    client = RecordingSetupClient()
+    setup = {
+        "type": "seed_notification",
+        "events": [{"title": "Package", "message": "Tomorrow"}],
+        "consolidate": True,
+        "expected_memory_count": 25,
+        "expected_memory_scope": "long_term",
+        "expected_memory_query": {"types": ["fact"], "limit": 3},
+    }
+
+    def process_notification_memory(timeout=90):
+        client.calls.append(("process_notification_memory", timeout))
+        return {
+            "memory_cursor": "1",
+            "memory_ids": [f"mem-{index}" for index in range(25)],
+        }
+
+    def invoke_tool(name, args, timeout=90):
+        client.calls.append(("invoke_tool", name, args, timeout))
+        from runner.agent_client import ToolInvokeResult
+
+        return ToolInvokeResult(
+            output=json.dumps({
+                "results": [
+                    {"id": f"mem-{index}", "memory_scope": "long_term"}
+                    for index in range(25)
+                ]
+            }),
+            is_error=False,
+            duration_ms=0,
+        )
+
+    client.process_notification_memory = process_notification_memory
+    client.invoke_tool = invoke_tool
+    per_task_setup(client, setup)
+    assert client.calls[-1][2] == {"types": ["fact"], "limit": 25}
 
 
 def test_setup_sequence_runs_existing_primitives_in_order():
@@ -132,6 +173,25 @@ def test_assert_memory_mismatch_is_a_setup_assertion_failure():
             MismatchClient(),
             {"type": "assert_memory", "expected_count": 1},
         )
+
+
+def test_assert_memory_rejects_malformed_nested_reference_before_recall():
+    client = RecordingSetupClient()
+    with pytest.raises(ResetError, match="event_ids_contains must be a list of non-empty strings"):
+        per_task_setup(
+            client,
+            {
+                "type": "assert_memory",
+                "expected": [
+                    {
+                        "source_refs_contain": [
+                            {"type": "notification", "event_ids_contains": "not-a-list"}
+                        ]
+                    }
+                ],
+            },
+        )
+    assert not any(call[0] == "invoke_tool" for call in client.calls)
 
 
 def test_assert_memory_matches_source_reference_evidence():

--- a/benchmark/tests/test_reset.py
+++ b/benchmark/tests/test_reset.py
@@ -3,6 +3,7 @@ import pytest
 from runner.agent_client import AgentRequestError, AgentTimeoutError, ChatResponse
 from runner.reset import (
     ResetError,
+    SetupAssertionError,
     call_environment_release,
     call_environment_setup,
     clear_stale_adb_android_owner,
@@ -42,6 +43,10 @@ class RecordingSetupClient:
     def seed_episode(self, episode, timeout=30):
         self.calls.append(("seed_episode", episode, timeout))
         return {"status": "seeded", "id": episode["id"]}
+
+    def seed_memory(self, memory, timeout=30):
+        self.calls.append(("seed_memory", memory, timeout))
+        return {"status": "seeded", "id": memory["id"]}
 
     def process_episode_memory(self, episode_id, timeout=90):
         self.calls.append(("process_episode_memory", episode_id, timeout))
@@ -90,6 +95,96 @@ def test_notification_setup_seeds_and_processes_fixture():
         ("process_notification_memory", 90),
         ("invoke_tool", "recall_memory", {"tags": ["notification"], "limit": 20}, 90),
     ]
+
+
+def test_setup_sequence_runs_existing_primitives_in_order():
+    client = RecordingSetupClient()
+    memory = {"id": "tmp-1", "content": "Existing conclusion"}
+    event = {"title": "Update", "message": "New conclusion"}
+
+    per_task_setup(
+        client,
+        [
+            {"type": "seed_memory", "memories": [memory]},
+            {"type": "seed_notification", "events": [event], "consolidate": False},
+        ],
+    )
+
+    assert client.calls == [
+        ("seed_memory", memory, 30),
+        ("seed_notification", [event], 30),
+    ]
+
+
+def test_assert_memory_mismatch_is_a_setup_assertion_failure():
+    class MismatchClient(RecordingSetupClient):
+        def invoke_tool(self, name, args, timeout=90):
+            from runner.agent_client import ToolInvokeResult
+
+            return ToolInvokeResult(
+                output='{"results":[]}',
+                is_error=False,
+                duration_ms=0,
+            )
+
+    with pytest.raises(SetupAssertionError, match="expected 1, got 0"):
+        per_task_setup(
+            MismatchClient(),
+            {"type": "assert_memory", "expected_count": 1},
+        )
+
+
+def test_assert_memory_matches_source_reference_evidence():
+    class SourceRefClient(RecordingSetupClient):
+        def invoke_tool(self, name, args, timeout=90):
+            from runner.agent_client import ToolInvokeResult
+
+            return ToolInvokeResult(
+                output=(
+                    '{"results":[{"id":"m-1","source_refs":['
+                    '{"type":"notification","id":"old","event_ids":["e-old"]},'
+                    '{"type":"notification","id":"new","event_ids":["e-new"]}]}]}'
+                ),
+                is_error=False,
+                duration_ms=0,
+            )
+
+    per_task_setup(
+        SourceRefClient(),
+        {
+            "type": "assert_memory",
+            "expected": [
+                {
+                    "id": "m-1",
+                    "source_refs_contain": [
+                        {"type": "notification", "id": "old", "event_ids_contains": ["e-old"]},
+                        {"type": "notification", "id": "new", "event_ids_contains": ["e-new"]},
+                    ],
+                }
+            ],
+        },
+    )
+
+
+def test_setup_sequence_preserves_setup_assertion_failure_type():
+    class MismatchClient(RecordingSetupClient):
+        def invoke_tool(self, name, args, timeout=90):
+            from runner.agent_client import ToolInvokeResult
+
+            return ToolInvokeResult(
+                output='{"results":[]}',
+                is_error=False,
+                duration_ms=0,
+            )
+
+    with pytest.raises(SetupAssertionError, match=r"setup\[1\] failed"):
+        per_task_setup(
+            MismatchClient(),
+            [
+                {"type": "seed_memory", "memories": [{"id": "m-1", "content": "x"}]},
+                {"type": "assert_memory", "expected_count": 1},
+            ],
+        )
 
 
 def test_notification_setup_rejects_non_boolean_consolidate():

--- a/benchmark/tests/test_runtask.py
+++ b/benchmark/tests/test_runtask.py
@@ -6,6 +6,7 @@ from PIL import Image
 from runner.agent_client import AgentTimeoutError, ChatResponse
 from runner.judge import JudgeConfig, JudgeOutput
 from runner.models import RubricVerdict
+from runner.reset import SetupAssertionError
 from runner.runtask import run_one_task
 from runner.suite import (
     HardAssertions,
@@ -45,6 +46,36 @@ class FakeClient:
             response=self.response,
             history=[{"type": "assistant", "content": self.response}],
         )
+
+
+def test_run_one_task_marks_setup_assertion_as_failed(tmp_path: Path, monkeypatch):
+    suite = Suite(
+        name="memory",
+        global_reset={},
+        tasks=[],
+        sha256="sha",
+        source_path=tmp_path / "suite.json",
+    )
+    task = TaskSpec(
+        id="memory_update",
+        category="memory",
+        description_for_judge="Update memory.",
+        prompt="check memory",
+        rubric=[],
+        hard_assertions=HardAssertions(),
+    )
+
+    def fail_setup(*args, **kwargs):
+        raise SetupAssertionError("expected revision 2")
+
+    monkeypatch.setattr(runtask_mod, "prepare_task_isolation", fail_setup)
+
+    result = run_one_task(
+        FakeClient(), suite, task, 1, tmp_path / "artifacts", None, None, "run-1"
+    )
+
+    assert result.status == "failed"
+    assert result.metrics["error"] == "setup assertion: expected revision 2"
 
 
 def test_run_one_task_includes_static_screenshot_dimensions(tmp_path: Path):

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -40,11 +40,20 @@ def test_notification_memory_suite_uses_benchmark_seed_setup():
         "delivery_notification_recall",
         "notification_noise_is_filtered",
         "notification_batch_cursor_drain",
+        "notification_explicit_update",
+        "notification_explicit_reinforce",
+        "notification_explicit_remove",
+        "notification_explicit_promote",
     ]
     assert suite.tasks[0].setup["type"] == "seed_notification"
     assert suite.tasks[0].setup["expected_memory_scope"] == "temporary"
     assert suite.tasks[1].setup["consolidate"] is True
     assert suite.tasks[1].setup["expected_memory_count"] == 0
+    assert [step["type"] for step in suite.tasks[3].setup] == [
+        "seed_memory",
+        "seed_notification",
+        "assert_memory",
+    ]
 
 
 def test_perception_v1_settings_rubric_uses_0_1000_normalized_coordinates():

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -30,6 +30,36 @@ def test_load_suite_returns_parsed(tmp_path: Path):
     assert suite.tasks[0].rubric[0].id == "in_settings"
 
 
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ([{"unsupported": True}], "contains unsupported keys"),
+        (
+            [{"source_refs_contain": [{"event_ids_contains": "bad"}]}],
+            "event_ids_contains must be a list of non-empty strings",
+        ),
+        (
+            [{"evidence_refs_contain": [{"id": 123}]}],
+            "id must be a non-empty string",
+        ),
+        ([{"id": 123}], "id must be a non-empty string"),
+        ([{"revision": "2"}], "revision must be a positive integer"),
+    ],
+)
+def test_load_suite_rejects_malformed_assert_memory_nested_schema(
+    tmp_path: Path, value, message
+):
+    fixture = json.loads(json.dumps(FIXTURE))
+    fixture["tasks"][0]["setup"] = {
+        "type": "assert_memory",
+        "expected": value,
+    }
+    path = tmp_path / "invalid.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+    with pytest.raises(SuiteValidationError, match=message):
+        load_suite(path)
+
+
 def test_notification_memory_suite_uses_benchmark_seed_setup():
     suite_path = Path(__file__).resolve().parents[1] / "suites" / "notification_memory_v1.json"
     suite = load_suite(suite_path)

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -30,6 +30,23 @@ def test_load_suite_returns_parsed(tmp_path: Path):
     assert suite.tasks[0].rubric[0].id == "in_settings"
 
 
+def test_notification_memory_suite_uses_benchmark_seed_setup():
+    suite_path = Path(__file__).resolve().parents[1] / "suites" / "notification_memory_v1.json"
+    suite = load_suite(suite_path)
+    assert suite_path.read_text(encoding="utf-8").isascii()
+
+    assert suite.name == "notification_memory_v1"
+    assert [task.id for task in suite.tasks] == [
+        "delivery_notification_recall",
+        "notification_noise_is_filtered",
+        "notification_batch_cursor_drain",
+    ]
+    assert suite.tasks[0].setup["type"] == "seed_notification"
+    assert suite.tasks[0].setup["expected_memory_scope"] == "temporary"
+    assert suite.tasks[1].setup["consolidate"] is True
+    assert suite.tasks[1].setup["expected_memory_count"] == 0
+
+
 def test_perception_v1_settings_rubric_uses_0_1000_normalized_coordinates():
     suite_path = Path(__file__).resolve().parents[1] / "suites" / "perception" / "perception_v1.json"
     suite = load_suite(suite_path)

--- a/benchmark/tests/test_vphone_runner_integration.py
+++ b/benchmark/tests/test_vphone_runner_integration.py
@@ -29,7 +29,7 @@ def test_vphone_ios_basic_suite_loads():
     ]
     warmup = suite.tasks[0]
     assert warmup.category == "diagnostic"
-    assert warmup.hard_assertions.required_tools == []
+    assert warmup.hard_assertions.required_tools == ["screenshot"]
     assert all(task.repeats == 1 for task in suite.tasks)
 
     ethernet = next(task for task in suite.tasks if task.id == "settings_read_ethernet_ipv4")

--- a/docs/04-agent/memory-plane.md
+++ b/docs/04-agent/memory-plane.md
@@ -182,9 +182,9 @@ When `goal_result=not_achieved`, a candidate cannot claim that the full goal pat
 
 ## Create, Update, And Conflict
 
-The model proposes `create` or `update`, but code owns admission, storage paths, and final status.
+The model proposes `create` or `update`, but code owns admission, storage paths, and final status. The Processor supplies the bounded related-memory view used for that decision and assigns a deterministic create ID. The Store executes an explicit create intent without running a second similarity or scope decision.
 
-Create checks active and disputed Device Memory for an existing record with the same type and normalized scope. A mistaken create proposal cannot produce a second active record for that scope.
+If a create proposal missed an existing record outside the bounded view, duplicate resolution is handled as a later explicit consolidation/update operation rather than silently rewriting the create intent at persistence time.
 
 Update requires the exact Memory revision observed during extraction. It preserves prior evidence and existing Procedure steps. Material body changes append the previous value to bounded revision history.
 

--- a/docs/04-agent/notification-context-memory.md
+++ b/docs/04-agent/notification-context-memory.md
@@ -81,7 +81,7 @@ The Processor owns the complete business flow for the notification scenario:
 3. Deterministically filter obvious noise like OTP, verification codes, marketing, and secrets;
 4. For each notification in the batch, retrieve related Memory and merge into one `MemoryMergeEngine.Extract` call;
 5. Split by `context_id`, parse and validate notification-specific proposals; each notification produces at most one action;
-6. Apply actions (add, update, delete, reinforce, or promote) in Temporary or Long-Term Store;
+6. Apply actions (add, update, remove, reinforce, or promote) in Temporary or Long-Term Store;
 7. Only `CommitProcessed` after all related Memory writes succeed; if backlog remains, continue next batch in the same idle window without waiting another 5 minutes.
 
 When no model is available, tests and offline scenarios can use a deterministic Temporary Memory fallback. The Processor does not place notification business rules into the Worker, nor does it require Episode and Notification to use the same action set or state machine.

--- a/docs/04-agent/notification-context-memory.md
+++ b/docs/04-agent/notification-context-memory.md
@@ -1,0 +1,160 @@
+---
+sidebar_position: 12
+---
+
+# Notification Persistence and Automatic Memory
+
+This document describes the notification consumption, persistence, and automatic memory extraction pipeline. Notification events from the BLE service are consumed by the Agent, persisted to disk, and consolidated into Temporary or Long-Term Memory during idle windows.
+
+## Architecture
+
+The notification memory system uses a shared background worker that processes both Episode and Notification scenarios serially:
+
+```text
+MemoryWorker (idle-scheduled, serial execution)
+├── EpisodeProcessor
+└── NotificationProcessor
+```
+
+The Worker is responsible for foreground preemption, a default 5-minute idle delay, serial invocation of registered Processors in order, pending state, and lifecycle management. The Worker does not understand Episode, Notification, Memory types, or Store semantics, nor does it establish cross-scenario priority queues.
+
+Each Processor owns its read strategy, batch size, extraction rules, proposal validation, and persistence. Both processors are registered at startup before the Worker starts, ensuring the first idle batch also follows the fixed Episode → Notification order.
+
+`MemoryMergeEngine` extracts only the mechanical steps both scenarios need:
+
+```text
+Scenario input + related Memory → build messages → call LLM → return raw proposal
+```
+
+Episode and Notification proposal schemas, evidence thresholds, and conflict resolution remain in their respective Processors. After validation, both Processors submit explicit `MemoryIntent` operations to their Store adapter. Intent execution has shared create/update/reinforce/remove semantics while retaining the existing Device Memory and Temporary/Long-Term record schemas.
+
+## Component Responsibilities
+
+| Module                        | Responsibility                                                                                            |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `ble_service`                 | Receives iOS/Android notifications, normalizes, assigns event IDs, maintains short-term event ring        |
+| `NotificationContext`         | Consumes events, deduplicates, persists to JSONL, manages source/memory cursors, cleanup                  |
+| `MemoryWorker`                | Unified idle window, foreground cancellation, serial Processor execution, retry, and stop                 |
+| `episodeMemoryProcessor`      | Reads Episodes, extracts per-Episode rules, writes to Device Memory                                       |
+| `NotificationMemoryProcessor` | Reads notifications, filters, calls extraction, validates proposals, writes to Temporary/Long-Term Memory |
+| `MemoryMergeEngine`           | Recalls related Memory, builds messages, calls LLM, returns raw proposal                                  |
+
+## Lifecycle
+
+Notifications enter the `ble_service` event ring first. When the Agent enters an idle state, the NotificationProcessor consumes the ring, persists raw records to NotificationContext, and continues with extraction:
+
+```text
+Notification source → ble_service event ring
+Agent foreground task ends → wait 5 minutes idle
+                           → EpisodeProcessor (up to 5 Episodes)
+                           → NotificationProcessor
+                                → Consume / NotificationContext.append
+                                → Extract up to 10 notifications
+                           → Continue next batch in same idle window if still pending
+```
+
+When a notification is published, it wakes the shared Worker's idle timer. When the Worker is scheduled, the Processor calls `Consume` on the BLE ring, then reads its pending data. When no pending work remains, it returns an empty result.
+
+## Notification Context
+
+`NotificationContext` provides the runtime with:
+
+```text
+Consume(limit)               Pull from events_since and persist reliably
+ReadPending(limit)           Read records after memory cursor
+CommitProcessed(batch)       Advance memory cursor after Memory write succeeds
+CleanupProcessedBefore(...)  Only clean processed date shards
+```
+
+Persisted records retain BLE original fields and add an Agent-local monotonically increasing `context_id`. The memory cursor uses `context_id` and does not depend on BLE generation. Persistence uses UTC date-sharded JSONL; the source cursor advances only after write succeeds. On power recovery, completely written records are retained and the last incomplete JSON line is repaired.
+
+`CommitProcessed` requires passing in a contiguous batch starting from the current cursor. Cleaners must call `NotificationContext` cleanup methods and cannot bypass Context to delete JSONL directly, to avoid racing with append/commit.
+
+The Agent's `shell` tool can access `/userdata/agent/memory/notifications/events/` read-only. Files are saved as `YYYY-MM-DD.jsonl` by UTC date, one raw notification record per line. Date, app, body, and count filtering use the system's existing read-only shell tools. The Agent must not modify these files through the shell.
+
+## Notification Processor
+
+The Processor owns the complete business flow for the notification scenario:
+
+1. `Consume` the current BLE ring, then `ReadPending` for this batch;
+2. Coalesce added/modified/removed changes for the same notification;
+3. Deterministically filter obvious noise like OTP, verification codes, marketing, and secrets;
+4. For each notification in the batch, retrieve related Memory and merge into one `MemoryMergeEngine.Extract` call;
+5. Split by `context_id`, parse and validate notification-specific proposals; each notification produces at most one action;
+6. Apply actions (add, update, delete, reinforce, or promote) in Temporary or Long-Term Store;
+7. Only `CommitProcessed` after all related Memory writes succeed; if backlog remains, continue next batch in the same idle window without waiting another 5 minutes.
+
+When no model is available, tests and offline scenarios can use a deterministic Temporary Memory fallback. The Processor does not place notification business rules into the Worker, nor does it require Episode and Notification to use the same action set or state machine.
+
+Notification proposal actions include `ignore`, `add`, `update`, `reinforce`, `remove`, and `promote`. Updating existing records requires accurate `memory_id` and `memory_revision`; invalid proposals do not advance the memory cursor.
+
+Explicit Processor actions are not reinterpreted by the Store. `add` creates the Processor-assigned ID without similarity search; `update`, `reinforce`, and `remove` operate only on the specified ID with revision validation. The separate `save_memory` candidate path continues to use Store-owned duplicate detection because it does not carry a prevalidated target action.
+
+## Episode Processor
+
+EpisodeProcessor retains existing Episode semantics:
+
+- Only accepts completed Episodes with device evidence;
+- Processes at most 5 Episodes per batch and merges the entire batch of Episodes and related Device Memory into one LLM call;
+- The LLM returns results with `episode_id`, then the Processor validates and persists item-by-item per Episode;
+- Validates `goal_result`, candidate types, evidence references, and revisions itself;
+- Executes Device Memory add, update, and conflict resolution itself;
+- Uses the Episode processing ledger to save `processing → proposed → done/retry/ignored`, supporting crash recovery.
+
+## Memory and Recall
+
+```text
+memory/
+├── notifications/   # Raw notifications and cursors
+├── temporary/       # Short-term conclusions with expires_at
+├── long_term/       # Stable preferences, rules, and facts
+├── device/          # Device knowledge produced by Episodes
+└── episodes/        # Immutable Episode traces
+```
+
+Temporary and Long-Term use the same retrievable record format. `recall_memory` searches both Stores simultaneously and filters expired Temporary entries; Device Memory is maintained separately by EpisodeProcessor.
+
+Default values: single notification body up to 4 KiB; single BLE consume up to 100 entries; Notification single batch up to 10 entries; notification replay deduplication window retains up to 4096 fingerprints; Temporary default 7 days; auto-generated Long-Term default 90 days. Episode idle delay is configured by `episode_memory_idle_delay_seconds`, default 300 seconds; this value is also the shared Worker's idle window.
+
+## Storage Levels and Privacy
+
+`StorageMonitor` uniformly manages storage levels and Cleaners. Normal/Warning/Critical enable Notification Context cleanup at 14/7/1 days respectively; Emergency cleans all processed shards; no level deletes unprocessed records. Critical and Emergency disable `notification_context` write capability, so the Processor no longer consumes new notifications from BLE and resumes from the original source cursor after the level recovers. The Temporary Memory Cleaner can clean expired or deleted records starting at Normal level.
+
+Notification body content is sent to the currently configured LLM provider as extraction input; only when a local model is configured does this content remain entirely on-device. Logs record event ID, App ID, processing results, and gaps only; they do not record body content.
+
+## Failure and Recovery
+
+- BLE consume failure: does not advance source cursor, retains pending, retries at next idle;
+- LLM, proposal validation, or Memory write failure: does not advance memory cursor;
+- Single Processor failure: logs the scenario error and retains its pending, backs off by idle delay to avoid hot loops from persistent BLE/LLM/disk errors; other registered scenarios can still execute serially in the same round and do not share business transactions;
+- Foreground task starts: shared Worker cancels in-flight model call; Processor retains its own persistent state and continues at next idle;
+- Worker restart: Episode recovers from processing ledger, Notification recovers from source/memory cursors;
+- Notification add/update logic must remain idempotent; if the process crashes after Memory write succeeds but before cursor commit, the next run will re-extract that record;
+- Store actions within one Notification batch execute sequentially; on mid-I/O failure, the cursor is not advanced and convergence relies on fixed IDs, revision checks, and retry;
+- Any gap must be written to `NotificationContextState.Gaps` and must not be silently swallowed.
+
+## Acceptance Criteria
+
+- Episode and Notification are serially scheduled by the same `MemoryWorker` in registration order; each Processor calls the LLM once per batch, then validates and persists results item-by-item locally;
+- Agent foreground tasks are not blocked by background Memory extraction and can cancel in-flight model calls;
+- Both Processors can independently decide batch size, proposal structure, and Apply logic;
+- `MemoryMergeEngine` does not own cross-scenario Apply semantics; Store adapters execute the shared explicit `MemoryIntent` contract;
+- Cursors advance only after corresponding Memory writes succeed.
+
+## Verification
+
+Run the core regression suite from `src/agent`:
+
+```bash
+go test ./internal/agent -count=1
+go vet ./...
+```
+
+Real-device validation is still required to measure notification extraction quality, cursor correctness, and foreground p50/p95 latency under a real model provider and BLE event stream.
+
+## Related Documentation
+
+- [Memory Plane](memory-plane.md)
+- [Agent Context Lifecycle](context-lifecycle.md)
+- [Storage Manager](storage-manager.md)
+- [BLE Service](../03-services/ble-service.md)

--- a/docs/09-benchmark/README.md
+++ b/docs/09-benchmark/README.md
@@ -39,6 +39,26 @@ uv run python -m runner run \
 
 Use the `stop_command` printed by `start-agent-daemon` when the run is complete.
 
+For notification memory, run the dedicated suite against a fresh daemon with a
+benchmark token. It injects deterministic raw notification fixtures, processes
+them through the real notification processor, and checks temporary-memory
+recall, OTP/marketing filtering, and multi-batch cursor drain:
+
+```bash
+uv run python -m runner run \
+  --suite suites/notification_memory_v1.json \
+  --agent-url http://127.0.0.1:18081 \
+  --benchmark-token-file /path/to/control_token \
+  --skip-clock-wait
+```
+
+This run enables the judge so the useful-notification answer and noise-filtering
+behavior are scored for effect. Add `--no-judge` when checking only the
+deterministic gates (fixture persistence through the benchmark endpoint, cursor
+advancement, memory count/scope, and required/forbidden tool calls). Raw JSONL
+preservation is covered by the Go integration tests rather than an Agent shell
+task. See the full manual for the corresponding Go performance benchmarks.
+
 ### WebUI
 
 ```bash

--- a/docs/09-benchmark/README.md
+++ b/docs/09-benchmark/README.md
@@ -47,9 +47,8 @@ recall, OTP/marketing filtering, and multi-batch cursor drain:
 ```bash
 uv run python -m runner run \
   --suite suites/notification_memory_v1.json \
-  --agent-url http://127.0.0.1:18081 \
-  --benchmark-token-file /path/to/control_token \
-  --skip-clock-wait
+  --auto-agent-setup \
+  --agent-config /path/to/agent.toml
 ```
 
 This run enables the judge so the useful-notification answer and noise-filtering
@@ -58,6 +57,12 @@ deterministic gates (fixture persistence through the benchmark endpoint, cursor
 advancement, memory count/scope, and required/forbidden tool calls). Raw JSONL
 preservation is covered by the Go integration tests rather than an Agent shell
 task. See the full manual for the corresponding Go performance benchmarks.
+
+The notification suite also preloads existing temporary memories and validates
+the externally observable `update`, `reinforce`, `remove`, and `promote` paths.
+It uses ordered generic setup primitives and `assert_memory`; the runner does not
+contain action-specific notification logic. Source/evidence reference checks use
+the generic `source_refs_contain`/`evidence_refs_contain` assertion fields.
 
 ### WebUI
 

--- a/src/agent/internal/agent/device_memory.go
+++ b/src/agent/internal/agent/device_memory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -232,15 +233,16 @@ func (s *DeviceMemoryStore) Upsert(ctx context.Context, item DeviceMemoryItem) (
 	return s.upsertLocked(item)
 }
 
-// ApplyMemoryIntent is the Device Memory adapter for the shared memory merge
-// seam. Episode processors provide a complete candidate; this adapter owns
-// identity-preserving updates, revision checks, evidence/tag union, and
-// tombstoning.
+// ApplyMemoryIntent applies a Processor-selected operation without making a
+// second semantic merge decision in the persistence layer.
 func (s *DeviceMemoryStore) ApplyMemoryIntent(ctx context.Context, intent MemoryIntent) (MemoryApplyResult, error) {
 	select {
 	case <-ctx.Done():
 		return MemoryApplyResult{}, ctx.Err()
 	default:
+	}
+	if intent.Action == "" {
+		return MemoryApplyResult{}, errors.New("memory intent requires an action")
 	}
 	if s == nil || s.rootDir == "" || intent.DeviceItem == nil {
 		return MemoryApplyResult{}, nil
@@ -251,56 +253,86 @@ func (s *DeviceMemoryStore) ApplyMemoryIntent(ctx context.Context, intent Memory
 	if err != nil {
 		return MemoryApplyResult{}, err
 	}
+	return s.applyDeviceMemoryIntentLocked(items, intent)
+}
+
+func (s *DeviceMemoryStore) applyDeviceMemoryIntentLocked(items []DeviceMemoryItem, intent MemoryIntent) (MemoryApplyResult, error) {
 	candidate := cloneDeviceMemoryItem(*intent.DeviceItem)
+	id := strings.TrimSpace(candidate.ID)
+	if id == "" {
+		return MemoryApplyResult{}, fmt.Errorf("memory %s requires an id", intent.Action)
+	}
 	for index := range items {
-		if items[index].ID != candidate.ID {
+		if items[index].ID != id {
 			continue
 		}
-		if intent.ExpectedRevision > 0 && effectiveDeviceMemoryRevision(items[index]) != intent.ExpectedRevision {
-			return MemoryApplyResult{}, errEpisodeMemoryRevisionChanged
-		}
-		if intent.Remove {
-			items[index].Status = deviceMemoryStatusDeleted
-			if _, err := s.upsertLocked(items[index]); err != nil {
+		existing := &items[index]
+		switch intent.Action {
+		case MemoryIntentActionCreate:
+			if deviceMemoryCreateAlreadyApplied(*existing, candidate) {
+				if existing.Status == deviceMemoryStatusDeleted {
+					existing.Status = candidate.Status
+					if existing.Status == "" {
+						existing.Status = deviceMemoryStatusActive
+					}
+					if _, err := s.upsertLocked(*existing); err != nil {
+						return MemoryApplyResult{}, err
+					}
+					s.invalidateReadAllCache()
+				}
+				return MemoryApplyResult{Operation: MemoryOperationAdd, ID: id}, nil
+			}
+			return MemoryApplyResult{}, fmt.Errorf("%w: %s", errMemoryIDConflict, id)
+		case MemoryIntentActionUpdate, MemoryIntentActionReinforce:
+			if intent.ExpectedRevision <= 0 {
+				return MemoryApplyResult{}, fmt.Errorf("memory %s requires expected revision", intent.Action)
+			}
+			if effectiveDeviceMemoryRevision(*existing) != intent.ExpectedRevision {
+				alreadyApplied := deviceMemoryUpdateAlreadyApplied(*existing, candidate)
+				if intent.Action == MemoryIntentActionReinforce {
+					alreadyApplied = deviceMemoryReinforceAlreadyApplied(*existing, candidate)
+				}
+				if alreadyApplied {
+					return MemoryApplyResult{Operation: deviceOperationForIntent(intent.Action), ID: id}, nil
+				}
+				return MemoryApplyResult{}, errEpisodeMemoryRevisionChanged
+			}
+			if intent.Action == MemoryIntentActionReinforce {
+				reinforceDeviceMemoryItem(existing, &candidate)
+			} else {
+				appendDeviceMemoryRevision(existing, &candidate)
+				mergeDeviceMemoryItem(existing, candidate)
+			}
+			if _, err := s.upsertLocked(*existing); err != nil {
 				return MemoryApplyResult{}, err
 			}
 			s.invalidateReadAllCache()
-			return MemoryApplyResult{Operation: MemoryOperationRemove, ID: candidate.ID}, nil
-		}
-		if hasSameDeviceMemoryEvidence(items[index].EvidenceRefs, candidate.EvidenceRefs) {
-			return MemoryApplyResult{Operation: MemoryOperationIgnore, ID: candidate.ID}, nil
-		}
-		same := normalizeMemorySearchTerm(items[index].Content) == normalizeMemorySearchTerm(candidate.Content) &&
-			normalizeMemorySearchTerm(items[index].Summary) == normalizeMemorySearchTerm(candidate.Summary)
-		if deviceMemoryBodyChanged(items[index], candidate) {
-			prior := DeviceMemoryRevision{
-				Revision:      effectiveDeviceMemoryRevision(items[index]),
-				Status:        items[index].Status,
-				Title:         items[index].Title,
-				Summary:       items[index].Summary,
-				Content:       items[index].Content,
-				Tags:          append([]string(nil), items[index].Tags...),
-				Applicability: cloneStringMap(items[index].Applicability),
-				Steps:         append([]ProcedureStep(nil), items[index].Steps...),
-				UpdatedAt:     items[index].UpdatedAt,
+			return MemoryApplyResult{Operation: deviceOperationForIntent(intent.Action), ID: id}, nil
+		case MemoryIntentActionRemove:
+			if intent.ExpectedRevision <= 0 {
+				return MemoryApplyResult{}, fmt.Errorf("memory remove requires expected revision")
 			}
-			items[index].RevisionHistory = append(items[index].RevisionHistory, prior)
-			if len(items[index].RevisionHistory) > 20 {
-				items[index].RevisionHistory = append([]DeviceMemoryRevision(nil), items[index].RevisionHistory[len(items[index].RevisionHistory)-20:]...)
+			if effectiveDeviceMemoryRevision(*existing) != intent.ExpectedRevision {
+				return MemoryApplyResult{}, errEpisodeMemoryRevisionChanged
 			}
+			if existing.Status == deviceMemoryStatusDeleted {
+				return MemoryApplyResult{Operation: MemoryOperationIgnore, ID: id}, nil
+			}
+			existing.Status = deviceMemoryStatusDeleted
+			if _, err := s.upsertLocked(*existing); err != nil {
+				return MemoryApplyResult{}, err
+			}
+			s.invalidateReadAllCache()
+			return MemoryApplyResult{Operation: MemoryOperationRemove, ID: id}, nil
+		default:
+			return MemoryApplyResult{}, fmt.Errorf("unsupported memory intent action %q", intent.Action)
 		}
-		mergeDeviceMemoryItem(&items[index], candidate)
-		if _, err := s.upsertLocked(items[index]); err != nil {
-			return MemoryApplyResult{}, err
-		}
-		s.invalidateReadAllCache()
-		if same {
-			return MemoryApplyResult{Operation: MemoryOperationReinforce, ID: candidate.ID}, nil
-		}
-		return MemoryApplyResult{Operation: MemoryOperationUpdate, ID: candidate.ID}, nil
 	}
-	if intent.Remove {
-		return MemoryApplyResult{Operation: MemoryOperationIgnore, ID: candidate.ID}, nil
+	if intent.Action != MemoryIntentActionCreate {
+		if intent.Action == MemoryIntentActionRemove {
+			return MemoryApplyResult{Operation: MemoryOperationIgnore, ID: id}, nil
+		}
+		return MemoryApplyResult{}, fmt.Errorf("%w: %s", errMemoryTargetMissing, id)
 	}
 	if candidate.Revision <= 0 {
 		candidate.Revision = 1
@@ -309,24 +341,144 @@ func (s *DeviceMemoryStore) ApplyMemoryIntent(ctx context.Context, intent Memory
 		return MemoryApplyResult{}, err
 	}
 	s.invalidateReadAllCache()
-	return MemoryApplyResult{Operation: MemoryOperationAdd, ID: candidate.ID}, nil
+	return MemoryApplyResult{Operation: MemoryOperationAdd, ID: id}, nil
 }
 
-func hasSameDeviceMemoryEvidence(existing, candidate []MemorySourceRef) bool {
-	for _, ref := range candidate {
+func deviceOperationForIntent(action MemoryIntentAction) MemoryOperation {
+	if action == MemoryIntentActionReinforce {
+		return MemoryOperationReinforce
+	}
+	return MemoryOperationUpdate
+}
+
+func deviceMemoryCreateAlreadyApplied(existing, candidate DeviceMemoryItem) bool {
+	if existing.Title != candidate.Title || existing.Summary != candidate.Summary || existing.Content != candidate.Content {
+		return false
+	}
+	if candidate.Type != "" && existing.Type != candidate.Type {
+		return false
+	}
+	if candidate.DeviceID != "" && existing.DeviceID != candidate.DeviceID {
+		return false
+	}
+	if candidate.AppName != "" && existing.AppName != candidate.AppName {
+		return false
+	}
+	if candidate.PageName != "" && existing.PageName != candidate.PageName {
+		return false
+	}
+	if candidate.LessonKey != "" && existing.LessonKey != candidate.LessonKey {
+		return false
+	}
+	if candidate.ExtractorVersion > 0 && existing.ExtractorVersion != candidate.ExtractorVersion {
+		return false
+	}
+	return deviceMemoryMergedMetadataAlreadyApplied(existing, candidate)
+}
+
+func deviceMemoryUpdateAlreadyApplied(existing, candidate DeviceMemoryItem) bool {
+	if !deviceMemoryCreateAlreadyApplied(existing, candidate) {
+		return false
+	}
+	if candidate.Status != "" && existing.Status != candidate.Status {
+		return false
+	}
+	return true
+}
+
+func deviceMemoryReinforceAlreadyApplied(existing, candidate DeviceMemoryItem) bool {
+	return len(candidate.EvidenceRefs) > 0 && deviceMemoryMergedMetadataAlreadyApplied(existing, candidate)
+}
+
+func deviceMemoryMergedMetadataAlreadyApplied(existing, candidate DeviceMemoryItem) bool {
+	if candidate.ExpiresAt != "" && existing.ExpiresAt != candidate.ExpiresAt {
+		return false
+	}
+	if candidate.Applicability != nil && !equalEpisodeMemoryScope(existing.Applicability, candidate.Applicability) {
+		return false
+	}
+	if !memoryStringsContain(existing.Tags, candidate.Tags) ||
+		!memoryStringsContain(existing.Entities, candidate.Entities) ||
+		!memoryStringsContain(existing.Aliases, candidate.Aliases) ||
+		!memoryStringsContain(existing.ConflictsWith, candidate.ConflictsWith) ||
+		!memorySourceRefsContain(existing.EvidenceRefs, candidate.EvidenceRefs) ||
+		!procedureStepsContain(existing.Steps, candidate.Steps) {
+		return false
+	}
+	return existing.Priority >= candidate.Priority && existing.Confidence >= candidate.Confidence
+}
+
+func procedureStepsContain(existing, candidate []ProcedureStep) bool {
+	for _, step := range candidate {
+		found := false
 		for _, current := range existing {
-			if ref.Type == current.Type && ref.ID == current.ID && len(ref.EventIDs) > 0 {
-				for _, eventID := range ref.EventIDs {
-					for _, currentID := range current.EventIDs {
-						if eventID == currentID {
-							return true
-						}
-					}
-				}
+			if current == step {
+				found = true
+				break
 			}
 		}
+		if !found {
+			return false
+		}
 	}
-	return false
+	return true
+}
+
+func containsAllStrings(haystack, needles []string) bool {
+	for _, needle := range needles {
+		found := false
+		for _, value := range haystack {
+			if needle == value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func appendDeviceMemoryRevision(existing, candidate *DeviceMemoryItem) {
+	if existing == nil || candidate == nil || !deviceMemoryBodyChanged(*existing, *candidate) {
+		return
+	}
+	prior := DeviceMemoryRevision{
+		Revision:      effectiveDeviceMemoryRevision(*existing),
+		Status:        existing.Status,
+		Title:         existing.Title,
+		Summary:       existing.Summary,
+		Content:       existing.Content,
+		Tags:          append([]string(nil), existing.Tags...),
+		Applicability: cloneStringMap(existing.Applicability),
+		Steps:         append([]ProcedureStep(nil), existing.Steps...),
+		UpdatedAt:     existing.UpdatedAt,
+	}
+	existing.RevisionHistory = append(existing.RevisionHistory, prior)
+	if len(existing.RevisionHistory) > 20 {
+		existing.RevisionHistory = append([]DeviceMemoryRevision(nil), existing.RevisionHistory[len(existing.RevisionHistory)-20:]...)
+	}
+}
+
+func reinforceDeviceMemoryItem(existing, candidate *DeviceMemoryItem) {
+	if existing == nil || candidate == nil {
+		return
+	}
+	existing.Tags = mergeUniqueStrings(existing.Tags, candidate.Tags)
+	existing.Entities = mergeUniqueStrings(existing.Entities, candidate.Entities)
+	existing.Aliases = mergeUniqueStrings(existing.Aliases, candidate.Aliases)
+	existing.EvidenceRefs = mergeMemorySourceRefs(existing.EvidenceRefs, candidate.EvidenceRefs)
+	existing.ConflictsWith = mergeUniqueStrings(existing.ConflictsWith, candidate.ConflictsWith)
+	existing.Steps = mergeEpisodeMemorySteps(existing.Steps, candidate.Steps)
+	if candidate.Priority > existing.Priority {
+		existing.Priority = candidate.Priority
+	}
+	if candidate.Confidence > existing.Confidence {
+		existing.Confidence = candidate.Confidence
+	}
+	existing.Revision = effectiveDeviceMemoryRevision(*existing) + 1
+	existing.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
 }
 
 func deviceMemoryBodyChanged(existing, candidate DeviceMemoryItem) bool {

--- a/src/agent/internal/agent/device_memory.go
+++ b/src/agent/internal/agent/device_memory.go
@@ -236,15 +236,18 @@ func (s *DeviceMemoryStore) Upsert(ctx context.Context, item DeviceMemoryItem) (
 // ApplyMemoryIntent applies a Processor-selected operation without making a
 // second semantic merge decision in the persistence layer.
 func (s *DeviceMemoryStore) ApplyMemoryIntent(ctx context.Context, intent MemoryIntent) (MemoryApplyResult, error) {
+	if s == nil {
+		return MemoryApplyResult{}, errors.New("memory store is not configured")
+	}
+	if intent.Action == "" {
+		return MemoryApplyResult{}, errors.New("memory intent requires an action")
+	}
 	select {
 	case <-ctx.Done():
 		return MemoryApplyResult{}, ctx.Err()
 	default:
 	}
-	if intent.Action == "" {
-		return MemoryApplyResult{}, errors.New("memory intent requires an action")
-	}
-	if s == nil || s.rootDir == "" || intent.DeviceItem == nil {
+	if s.rootDir == "" || intent.DeviceItem == nil {
 		return MemoryApplyResult{}, nil
 	}
 	s.writeMu.Lock()
@@ -400,10 +403,10 @@ func deviceMemoryMergedMetadataAlreadyApplied(existing, candidate DeviceMemoryIt
 	if candidate.Applicability != nil && !equalEpisodeMemoryScope(existing.Applicability, candidate.Applicability) {
 		return false
 	}
-	if !containsAllStrings(existing.Tags, candidate.Tags) ||
-		!containsAllStrings(existing.Entities, candidate.Entities) ||
-		!containsAllStrings(existing.Aliases, candidate.Aliases) ||
-		!containsAllStrings(existing.ConflictsWith, candidate.ConflictsWith) ||
+	if !memoryStringsContain(existing.Tags, candidate.Tags) ||
+		!memoryStringsContain(existing.Entities, candidate.Entities) ||
+		!memoryStringsContain(existing.Aliases, candidate.Aliases) ||
+		!memoryStringsContain(existing.ConflictsWith, candidate.ConflictsWith) ||
 		!memorySourceRefsContain(existing.EvidenceRefs, candidate.EvidenceRefs) ||
 		!procedureStepsContain(existing.Steps, candidate.Steps) {
 		return false
@@ -416,22 +419,6 @@ func procedureStepsContain(existing, candidate []ProcedureStep) bool {
 		found := false
 		for _, current := range existing {
 			if current == step {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-	return true
-}
-
-func containsAllStrings(haystack, needles []string) bool {
-	for _, needle := range needles {
-		found := false
-		for _, value := range haystack {
-			if needle == value {
 				found = true
 				break
 			}

--- a/src/agent/internal/agent/device_memory.go
+++ b/src/agent/internal/agent/device_memory.go
@@ -282,6 +282,9 @@ func (s *DeviceMemoryStore) applyDeviceMemoryIntentLocked(items []DeviceMemoryIt
 				}
 				return MemoryApplyResult{Operation: MemoryOperationAdd, ID: id}, nil
 			}
+			if memorySourceRefIdentitiesContain(existing.EvidenceRefs, candidate.EvidenceRefs) {
+				return MemoryApplyResult{Operation: MemoryOperationAdd, ID: id}, nil
+			}
 			return MemoryApplyResult{}, fmt.Errorf("%w: %s", errMemoryIDConflict, id)
 		case MemoryIntentActionUpdate, MemoryIntentActionReinforce:
 			if intent.ExpectedRevision <= 0 {
@@ -397,10 +400,10 @@ func deviceMemoryMergedMetadataAlreadyApplied(existing, candidate DeviceMemoryIt
 	if candidate.Applicability != nil && !equalEpisodeMemoryScope(existing.Applicability, candidate.Applicability) {
 		return false
 	}
-	if !memoryStringsContain(existing.Tags, candidate.Tags) ||
-		!memoryStringsContain(existing.Entities, candidate.Entities) ||
-		!memoryStringsContain(existing.Aliases, candidate.Aliases) ||
-		!memoryStringsContain(existing.ConflictsWith, candidate.ConflictsWith) ||
+	if !containsAllStrings(existing.Tags, candidate.Tags) ||
+		!containsAllStrings(existing.Entities, candidate.Entities) ||
+		!containsAllStrings(existing.Aliases, candidate.Aliases) ||
+		!containsAllStrings(existing.ConflictsWith, candidate.ConflictsWith) ||
 		!memorySourceRefsContain(existing.EvidenceRefs, candidate.EvidenceRefs) ||
 		!procedureStepsContain(existing.Steps, candidate.Steps) {
 		return false

--- a/src/agent/internal/agent/episode_memory.go
+++ b/src/agent/internal/agent/episode_memory.go
@@ -896,18 +896,9 @@ func (p *episodeMemoryProcessor) createMemory(ctx context.Context, episode TaskE
 		return existing.ID, nil
 	}
 	deviceID := firstNonEmptyString([]string{candidate.Scope["device_id"], episode.DeviceScope["device_id"], defaultMemoryDeviceID})
-	existingID := ""
-	if scoped, equivalent, found, err := p.findMemoryInScope(ctx, candidate, deviceID); err != nil {
-		return "", err
-	} else if found {
-		if !equivalent {
-			return scoped.ID, nil
-		}
-		existingID = scoped.ID
-	}
 	priority, confidence, ttl := episodeMemoryDefaults(candidate.Type)
 	item := DeviceMemoryItem{
-		ID:               firstNonEmptyString([]string{existingID, "devmem_" + stableMemoryID(episode.ID, candidate.LessonKey)}),
+		ID:               "devmem_" + stableMemoryID(episode.ID, candidate.LessonKey),
 		Type:             string(candidate.Type),
 		Status:           deviceMemoryStatusActive,
 		Revision:         1,
@@ -930,35 +921,8 @@ func (p *episodeMemoryProcessor) createMemory(ctx context.Context, episode TaskE
 	if candidate.Type == episodeMemoryTypeProcedure {
 		item.Steps = episodeMemoryProcedureSteps(episode, candidate.EvidenceRefs)
 	}
-	result, err := p.plane.device.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &item})
+	result, err := p.plane.device.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &item, Action: MemoryIntentActionCreate})
 	return result.ID, err
-}
-
-func (p *episodeMemoryProcessor) findMemoryInScope(ctx context.Context, candidate episodeMemoryCandidate, deviceID string) (DeviceMemoryItem, bool, bool, error) {
-	items, err := p.plane.device.readAll()
-	if err != nil {
-		return DeviceMemoryItem{}, false, false, err
-	}
-	for _, item := range items {
-		select {
-		case <-ctx.Done():
-			return DeviceMemoryItem{}, false, false, ctx.Err()
-		default:
-		}
-		if item.Type != string(candidate.Type) || (item.Status != deviceMemoryStatusActive && item.Status != deviceMemoryStatusDisputed) {
-			continue
-		}
-		if item.DeviceID != "" && deviceID != "" && !strings.EqualFold(item.DeviceID, deviceID) {
-			continue
-		}
-		if !equalEpisodeMemoryScope(item.Applicability, candidate.Scope) {
-			continue
-		}
-		equivalent := normalizeEpisodeMemoryText(item.Title) == normalizeEpisodeMemoryText(candidate.Situation) &&
-			normalizeEpisodeMemoryText(item.Summary) == normalizeEpisodeMemoryText(candidate.Guidance)
-		return item, equivalent, true, nil
-	}
-	return DeviceMemoryItem{}, false, false, nil
 }
 
 func equalEpisodeMemoryScope(left, right map[string]string) bool {
@@ -973,10 +937,6 @@ func equalEpisodeMemoryScope(left, right map[string]string) bool {
 		}
 	}
 	return true
-}
-
-func normalizeEpisodeMemoryText(value string) string {
-	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(value))), " ")
 }
 
 func (p *episodeMemoryProcessor) updateMemory(ctx context.Context, episode TaskEpisode, candidate episodeMemoryCandidate) error {
@@ -1018,7 +978,7 @@ func (p *episodeMemoryProcessor) updateMemory(ctx context.Context, episode TaskE
 	if candidate.UnresolvedConflict {
 		item.ConflictsWith = []string{episode.ID}
 	}
-	_, err = p.plane.device.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &item, ExpectedRevision: candidate.MemoryRevision})
+	_, err = p.plane.device.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &item, Action: MemoryIntentActionUpdate, ExpectedRevision: candidate.MemoryRevision})
 	return err
 }
 

--- a/src/agent/internal/agent/episode_memory.go
+++ b/src/agent/internal/agent/episode_memory.go
@@ -722,7 +722,7 @@ func validateEpisodeMemoryCandidate(episode TaskEpisode, assessment episodeMemor
 	if candidate.Action != episodeMemoryActionCreate && candidate.Action != episodeMemoryActionUpdate {
 		return episodeMemoryCandidate{}, false
 	}
-	if candidate.Action == episodeMemoryActionUpdate && candidate.MemoryID == "" {
+	if candidate.Action == episodeMemoryActionUpdate && (candidate.MemoryID == "" || candidate.MemoryRevision <= 0) {
 		return episodeMemoryCandidate{}, false
 	}
 	if candidate.Action == episodeMemoryActionCreate && (candidate.MemoryID != "" || candidate.UnresolvedConflict) {

--- a/src/agent/internal/agent/episode_memory_test.go
+++ b/src/agent/internal/agent/episode_memory_test.go
@@ -1196,7 +1196,7 @@ func TestSearchEpisodeMemoryCandidatesPrioritizesPreferredAndSameScope(t *testin
 	}
 }
 
-func TestEpisodeMemoryCreateDoesNotDuplicateExistingScope(t *testing.T) {
+func TestEpisodeMemoryCreatePreservesExplicitCreateAction(t *testing.T) {
 	ctx := context.Background()
 	plane := NewFilesystemMemoryPlane(filepath.Join(t.TempDir(), "memory"), DefaultMemoryExtractionConfig(), nil)
 	if _, err := plane.device.Upsert(ctx, DeviceMemoryItem{
@@ -1217,12 +1217,12 @@ func TestEpisodeMemoryCreateDoesNotDuplicateExistingScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createMemory() error = %v", err)
 	}
-	if id != "existing_scope" {
-		t.Fatalf("createMemory() id = %q, want existing scoped memory", id)
+	if id == "existing_scope" || !strings.HasPrefix(id, "devmem_") {
+		t.Fatalf("createMemory() id = %q, want a new deterministic memory", id)
 	}
 	items, err := plane.device.readAll()
-	if err != nil || len(items) != 1 {
-		t.Fatalf("memories = %#v error=%v, want no duplicate", items, err)
+	if err != nil || len(items) != 2 {
+		t.Fatalf("memories = %#v error=%v, want explicit create to retain both records", items, err)
 	}
 }
 

--- a/src/agent/internal/agent/memory_apply.go
+++ b/src/agent/internal/agent/memory_apply.go
@@ -3,12 +3,25 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"time"
 )
 
 var errMemoryRevisionChanged = errors.New("memory revision changed")
+var errMemoryIDConflict = errors.New("memory id already exists")
+var errMemoryTargetMissing = errors.New("memory target does not exist")
+
+// MemoryIntentAction is the operation selected by a Processor.
+type MemoryIntentAction string
+
+const (
+	MemoryIntentActionCreate    MemoryIntentAction = "create"
+	MemoryIntentActionUpdate    MemoryIntentAction = "update"
+	MemoryIntentActionReinforce MemoryIntentAction = "reinforce"
+	MemoryIntentActionRemove    MemoryIntentAction = "remove"
+)
 
 // MemoryOperation describes the result of applying a candidate to a Memory
 // store. It is an operation, not the persisted lifecycle status of a Memory.
@@ -23,27 +36,19 @@ const (
 	MemoryOperationIgnore    MemoryOperation = "ignore"
 )
 
-// MemoryIntent is the small seam between a scenario Processor and the
-// persistence/merge implementation. Processors decide what is worth
-// remembering; the store decides whether it is an add, update, replacement,
-// or removal.
+// MemoryIntent is the shared operation envelope used by filesystem Memory
+// adapters. Item and DeviceItem retain their existing persisted schemas.
 type MemoryIntent struct {
 	Item             MemoryItem
 	DeviceItem       *DeviceMemoryItem
+	Action           MemoryIntentAction
 	ExpectedRevision int
-	Remove           bool
 }
 
-type MemoryApplyResult struct {
-	Operation MemoryOperation
-	ID        string
-}
-
-// ApplyMemoryIntent is the common write path for temporary and long-term
-// filesystem memories. An explicit ID is treated as the identity of the
-// record, so repeated observations update that record instead of creating a
-// second file.
 func (s *LongTermMemoryStore) ApplyMemoryIntent(ctx context.Context, intent MemoryIntent) (MemoryApplyResult, error) {
+	if intent.Action == "" {
+		return MemoryApplyResult{}, errors.New("memory intent requires an action")
+	}
 	if s == nil {
 		return MemoryApplyResult{}, errors.New("memory store is not configured")
 	}
@@ -52,40 +57,25 @@ func (s *LongTermMemoryStore) ApplyMemoryIntent(ctx context.Context, intent Memo
 	return s.applyMemoryIntentLocked(ctx, intent)
 }
 
-func (s *LongTermMemoryStore) applyMemoryIntentLocked(ctx context.Context, intent MemoryIntent) (MemoryApplyResult, error) {
-	if intent.Remove {
-		id := strings.TrimSpace(intent.Item.ID)
-		if id == "" {
-			return MemoryApplyResult{Operation: MemoryOperationIgnore}, nil
-		}
-		path := s.memoryPath(id)
-		parsed, err := readMemoryMarkdown(path)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return MemoryApplyResult{Operation: MemoryOperationIgnore, ID: id}, nil
-			}
-			return MemoryApplyResult{}, err
-		}
-		if intent.ExpectedRevision > 0 && effectiveMemoryRevision(parsed.Item) != intent.ExpectedRevision {
-			return MemoryApplyResult{}, errMemoryRevisionChanged
-		}
-		if parsed.Item.Status == "deleted" {
-			return MemoryApplyResult{Operation: MemoryOperationIgnore, ID: id}, nil
-		}
-		if err := s.forgetLocked(ctx, id, "memory intent removed"); err != nil {
-			return MemoryApplyResult{}, err
-		}
-		return MemoryApplyResult{Operation: MemoryOperationRemove, ID: id}, nil
+func (s *LongTermMemoryStore) ApplyMemoryCandidate(ctx context.Context, item MemoryItem) (MemoryApplyResult, error) {
+	if s == nil {
+		return MemoryApplyResult{}, errors.New("memory store is not configured")
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.applyMemoryCandidateLocked(ctx, item)
+}
 
-	item := intent.Item
+type MemoryApplyResult struct {
+	Operation MemoryOperation
+	ID        string
+}
+
+func (s *LongTermMemoryStore) applyMemoryCandidateLocked(ctx context.Context, item MemoryItem) (MemoryApplyResult, error) {
 	if strings.TrimSpace(item.ID) != "" {
 		path := s.memoryPath(item.ID)
 		parsed, err := readMemoryMarkdown(path)
 		if err == nil {
-			if intent.ExpectedRevision > 0 && effectiveMemoryRevision(parsed.Item) != intent.ExpectedRevision {
-				return MemoryApplyResult{}, errMemoryRevisionChanged
-			}
 			if parsed.Item.Status == "deleted" {
 				// A new observation can resurrect the same identity, but it must
 				// become a fresh active revision with the original ID.
@@ -124,6 +114,205 @@ func (s *LongTermMemoryStore) applyMemoryIntentLocked(ctx context.Context, inten
 		id, err := s.addMemoryLocked(ctx, item)
 		return MemoryApplyResult{Operation: MemoryOperationAdd, ID: id}, err
 	}
+}
+
+func (s *LongTermMemoryStore) applyMemoryIntentLocked(ctx context.Context, intent MemoryIntent) (MemoryApplyResult, error) {
+	if intent.Action == MemoryIntentActionRemove {
+		return s.applyMemoryRemoveIntentLocked(ctx, intent)
+	}
+	return s.applyMemoryWriteIntentLocked(ctx, intent)
+}
+
+func (s *LongTermMemoryStore) applyMemoryRemoveIntentLocked(ctx context.Context, intent MemoryIntent) (MemoryApplyResult, error) {
+	id := strings.TrimSpace(intent.Item.ID)
+	if id == "" {
+		return MemoryApplyResult{}, fmt.Errorf("memory remove requires an id")
+	}
+	path := s.memoryPath(id)
+	parsed, err := readMemoryMarkdown(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return MemoryApplyResult{Operation: MemoryOperationIgnore, ID: id}, nil
+		}
+		return MemoryApplyResult{}, err
+	}
+	if intent.ExpectedRevision <= 0 {
+		return MemoryApplyResult{}, fmt.Errorf("memory remove requires expected revision")
+	}
+	if effectiveMemoryRevision(parsed.Item) != intent.ExpectedRevision {
+		return MemoryApplyResult{}, errMemoryRevisionChanged
+	}
+	if parsed.Item.Status == "deleted" {
+		return MemoryApplyResult{Operation: MemoryOperationIgnore, ID: id}, nil
+	}
+	if err := s.forgetLocked(ctx, id, "memory intent removed"); err != nil {
+		return MemoryApplyResult{}, err
+	}
+	return MemoryApplyResult{Operation: MemoryOperationRemove, ID: id}, nil
+}
+
+func (s *LongTermMemoryStore) applyMemoryWriteIntentLocked(ctx context.Context, intent MemoryIntent) (MemoryApplyResult, error) {
+	item := intent.Item
+	id := strings.TrimSpace(item.ID)
+	if id == "" {
+		return MemoryApplyResult{}, fmt.Errorf("memory %s requires an id", intent.Action)
+	}
+	path := s.memoryPath(id)
+	parsed, err := readMemoryMarkdown(path)
+	exists := err == nil
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return MemoryApplyResult{}, err
+	}
+
+	switch intent.Action {
+	case MemoryIntentActionCreate:
+		if !exists {
+			newID, err := s.addMemoryLocked(ctx, item)
+			return MemoryApplyResult{Operation: MemoryOperationAdd, ID: newID}, err
+		}
+		if memoryCreateAlreadyApplied(parsed.Item, item) {
+			if parsed.Item.Status == "deleted" {
+				parsed.Item.Status = "active"
+				parsed.Item.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+				if err := writeFileAtomic(path, []byte(formatMemoryMarkdown(parsed.Item)), 0o644); err != nil {
+					return MemoryApplyResult{}, err
+				}
+				s.invalidateParsedMemoryCache(path)
+				if err := s.rebuildIndexLocked(ctx); err != nil {
+					return MemoryApplyResult{}, err
+				}
+			}
+			return MemoryApplyResult{Operation: MemoryOperationAdd, ID: id}, nil
+		}
+		return MemoryApplyResult{}, fmt.Errorf("%w: %s", errMemoryIDConflict, id)
+	case MemoryIntentActionUpdate, MemoryIntentActionReinforce:
+		if !exists {
+			return MemoryApplyResult{}, fmt.Errorf("%w: %s", errMemoryTargetMissing, id)
+		}
+		if intent.ExpectedRevision <= 0 {
+			return MemoryApplyResult{}, fmt.Errorf("memory %s requires expected revision", intent.Action)
+		}
+		if effectiveMemoryRevision(parsed.Item) != intent.ExpectedRevision {
+			alreadyApplied := memoryUpdateAlreadyApplied(parsed.Item, item)
+			if intent.Action == MemoryIntentActionReinforce {
+				alreadyApplied = memoryReinforceAlreadyApplied(parsed.Item, item)
+			}
+			if alreadyApplied {
+				return MemoryApplyResult{Operation: memoryOperationForIntent(intent.Action), ID: id}, nil
+			}
+			return MemoryApplyResult{}, errMemoryRevisionChanged
+		}
+		if intent.Action == MemoryIntentActionReinforce {
+			reinforceMemoryItem(&parsed.Item, item, time.Now().UTC())
+		} else {
+			mergeMemoryItem(&parsed.Item, item, time.Now().UTC())
+		}
+		if err := writeFileAtomic(path, []byte(formatMemoryMarkdown(parsed.Item)), 0o644); err != nil {
+			return MemoryApplyResult{}, err
+		}
+		s.invalidateParsedMemoryCache(path)
+		if err := s.rebuildIndexLocked(ctx); err != nil {
+			return MemoryApplyResult{}, err
+		}
+		return MemoryApplyResult{Operation: memoryOperationForIntent(intent.Action), ID: id}, nil
+	default:
+		return MemoryApplyResult{}, fmt.Errorf("unsupported memory intent action %q", intent.Action)
+	}
+}
+
+func memoryOperationForIntent(action MemoryIntentAction) MemoryOperation {
+	if action == MemoryIntentActionReinforce {
+		return MemoryOperationReinforce
+	}
+	return MemoryOperationUpdate
+}
+
+func memoryCreateAlreadyApplied(existing, candidate MemoryItem) bool {
+	if strings.TrimSpace(existing.Content) != strings.TrimSpace(candidate.Content) {
+		return false
+	}
+	if candidate.Type != "" && existing.Type != candidate.Type {
+		return false
+	}
+	if candidate.TimeScope != "" && existing.TimeScope != candidate.TimeScope {
+		return false
+	}
+	if !memoryStringsContain(existing.Tags, candidate.Tags) || !memoryStringsContain(existing.Entities, candidate.Entities) {
+		return false
+	}
+	if len(candidate.SourceRefs) == 0 {
+		return false
+	}
+	if strings.TrimSpace(candidate.Title) != "" && strings.TrimSpace(existing.Title) != strings.TrimSpace(candidate.Title) {
+		return false
+	}
+	return memorySourceRefsContain(existing.SourceRefs, candidate.SourceRefs) &&
+		memorySourceRefsContain(existing.EvidenceRefs, candidate.EvidenceRefs) &&
+		memoryStringsContain(existing.EvidenceExcerpts, candidate.EvidenceExcerpts)
+}
+
+func memoryUpdateAlreadyApplied(existing, candidate MemoryItem) bool {
+	if !memoryCreateAlreadyApplied(existing, candidate) {
+		return false
+	}
+	if candidate.ExpiresAt != "" && existing.ExpiresAt != candidate.ExpiresAt {
+		return false
+	}
+	if candidate.TTL != "" && existing.TTL != candidate.TTL {
+		return false
+	}
+	return existing.Priority >= candidate.Priority && existing.Confidence >= candidate.Confidence
+}
+
+func memoryReinforceAlreadyApplied(existing, candidate MemoryItem) bool {
+	if len(candidate.SourceRefs) == 0 || !memorySourceRefsContain(existing.SourceRefs, candidate.SourceRefs) {
+		return false
+	}
+	if !memorySourceRefsContain(existing.EvidenceRefs, candidate.EvidenceRefs) ||
+		!memoryStringsContain(existing.EvidenceExcerpts, candidate.EvidenceExcerpts) ||
+		!memoryStringsContain(existing.Tags, candidate.Tags) ||
+		!memoryStringsContain(existing.Entities, candidate.Entities) {
+		return false
+	}
+	if candidate.ExpiresAt != "" && existing.ExpiresAt != candidate.ExpiresAt {
+		return false
+	}
+	return existing.Priority >= candidate.Priority && existing.Confidence >= candidate.Confidence
+}
+
+func memorySourceRefsContain(existing, candidate []MemorySourceRef) bool {
+	for _, candidateRef := range candidate {
+		found := false
+		for _, existingRef := range existing {
+			if candidateRef.Type != existingRef.Type || candidateRef.ID != existingRef.ID {
+				continue
+			}
+			if containsAllStrings(existingRef.EventIDs, candidateRef.EventIDs) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func memoryStringsContain(existing, candidate []string) bool {
+	for _, value := range candidate {
+		found := false
+		for _, current := range existing {
+			if current == value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func effectiveMemoryRevision(item MemoryItem) int {
@@ -170,6 +359,34 @@ func mergeMemoryItem(existing *MemoryItem, candidate MemoryItem, now time.Time) 
 	}
 	if existing.CreatedAt == "" {
 		existing.CreatedAt = candidate.CreatedAt
+	}
+	existing.UpdatedAt = now.Format(time.RFC3339Nano)
+	if existing.Revision <= 0 {
+		existing.Revision = 1
+	} else {
+		existing.Revision++
+	}
+}
+
+func reinforceMemoryItem(existing *MemoryItem, candidate MemoryItem, now time.Time) {
+	existing.Tags = mergeUniqueStrings(existing.Tags, candidate.Tags)
+	existing.Entities = mergeUniqueStrings(existing.Entities, candidate.Entities)
+	existing.SourceRefs = mergeMemorySourceRefs(existing.SourceRefs, candidate.SourceRefs)
+	existing.EvidenceRefs = mergeMemorySourceRefs(existing.EvidenceRefs, candidate.EvidenceRefs)
+	if len(candidate.EvidenceExcerpts) > 0 {
+		existing.EvidenceExcerpts = mergeUniqueStrings(existing.EvidenceExcerpts, candidate.EvidenceExcerpts)
+	}
+	if candidate.Priority > existing.Priority {
+		existing.Priority = candidate.Priority
+	}
+	if candidate.Confidence > existing.Confidence {
+		existing.Confidence = candidate.Confidence
+	}
+	if candidate.ExpiresAt != "" {
+		existing.ExpiresAt = candidate.ExpiresAt
+	}
+	if existing.Status == "" {
+		existing.Status = "active"
 	}
 	existing.UpdatedAt = now.Format(time.RFC3339Nano)
 	if existing.Revision <= 0 {

--- a/src/agent/internal/agent/memory_apply.go
+++ b/src/agent/internal/agent/memory_apply.go
@@ -184,6 +184,12 @@ func (s *LongTermMemoryStore) applyMemoryWriteIntentLocked(ctx context.Context, 
 			}
 			return MemoryApplyResult{Operation: MemoryOperationAdd, ID: id}, nil
 		}
+		if memorySourceRefIdentitiesContain(parsed.Item.SourceRefs, item.SourceRefs) {
+			// Processor-assigned IDs are stable across crash retries. A retry may
+			// reword the same proposal, but create must neither overwrite the first
+			// committed result nor block the source cursor indefinitely.
+			return MemoryApplyResult{Operation: MemoryOperationAdd, ID: id}, nil
+		}
 		return MemoryApplyResult{}, fmt.Errorf("%w: %s", errMemoryIDConflict, id)
 	case MemoryIntentActionUpdate, MemoryIntentActionReinforce:
 		if !exists {
@@ -237,7 +243,7 @@ func memoryCreateAlreadyApplied(existing, candidate MemoryItem) bool {
 	if candidate.TimeScope != "" && existing.TimeScope != candidate.TimeScope {
 		return false
 	}
-	if !memoryStringsContain(existing.Tags, candidate.Tags) || !memoryStringsContain(existing.Entities, candidate.Entities) {
+	if !containsAllStrings(existing.Tags, candidate.Tags) || !containsAllStrings(existing.Entities, candidate.Entities) {
 		return false
 	}
 	if len(candidate.SourceRefs) == 0 {
@@ -248,7 +254,7 @@ func memoryCreateAlreadyApplied(existing, candidate MemoryItem) bool {
 	}
 	return memorySourceRefsContain(existing.SourceRefs, candidate.SourceRefs) &&
 		memorySourceRefsContain(existing.EvidenceRefs, candidate.EvidenceRefs) &&
-		memoryStringsContain(existing.EvidenceExcerpts, candidate.EvidenceExcerpts)
+		containsAllStrings(existing.EvidenceExcerpts, candidate.EvidenceExcerpts)
 }
 
 func memoryUpdateAlreadyApplied(existing, candidate MemoryItem) bool {
@@ -269,9 +275,9 @@ func memoryReinforceAlreadyApplied(existing, candidate MemoryItem) bool {
 		return false
 	}
 	if !memorySourceRefsContain(existing.EvidenceRefs, candidate.EvidenceRefs) ||
-		!memoryStringsContain(existing.EvidenceExcerpts, candidate.EvidenceExcerpts) ||
-		!memoryStringsContain(existing.Tags, candidate.Tags) ||
-		!memoryStringsContain(existing.Entities, candidate.Entities) {
+		!containsAllStrings(existing.EvidenceExcerpts, candidate.EvidenceExcerpts) ||
+		!containsAllStrings(existing.Tags, candidate.Tags) ||
+		!containsAllStrings(existing.Entities, candidate.Entities) {
 		return false
 	}
 	if candidate.ExpiresAt != "" && existing.ExpiresAt != candidate.ExpiresAt {
@@ -299,11 +305,17 @@ func memorySourceRefsContain(existing, candidate []MemorySourceRef) bool {
 	return true
 }
 
-func memoryStringsContain(existing, candidate []string) bool {
-	for _, value := range candidate {
+func memorySourceRefIdentitiesContain(existing, candidate []MemorySourceRef) bool {
+	if len(candidate) == 0 {
+		return false
+	}
+	for _, candidateRef := range candidate {
+		if strings.TrimSpace(candidateRef.Type) == "" || strings.TrimSpace(candidateRef.ID) == "" {
+			return false
+		}
 		found := false
-		for _, current := range existing {
-			if current == value {
+		for _, existingRef := range existing {
+			if existingRef.Type == candidateRef.Type && existingRef.ID == candidateRef.ID {
 				found = true
 				break
 			}

--- a/src/agent/internal/agent/memory_apply.go
+++ b/src/agent/internal/agent/memory_apply.go
@@ -46,11 +46,11 @@ type MemoryIntent struct {
 }
 
 func (s *LongTermMemoryStore) ApplyMemoryIntent(ctx context.Context, intent MemoryIntent) (MemoryApplyResult, error) {
-	if intent.Action == "" {
-		return MemoryApplyResult{}, errors.New("memory intent requires an action")
-	}
 	if s == nil {
 		return MemoryApplyResult{}, errors.New("memory store is not configured")
+	}
+	if intent.Action == "" {
+		return MemoryApplyResult{}, errors.New("memory intent requires an action")
 	}
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
@@ -185,9 +185,6 @@ func (s *LongTermMemoryStore) applyMemoryWriteIntentLocked(ctx context.Context, 
 			return MemoryApplyResult{Operation: MemoryOperationAdd, ID: id}, nil
 		}
 		if memorySourceRefIdentitiesContain(parsed.Item.SourceRefs, item.SourceRefs) {
-			// Processor-assigned IDs are stable across crash retries. A retry may
-			// reword the same proposal, but create must neither overwrite the first
-			// committed result nor block the source cursor indefinitely.
 			return MemoryApplyResult{Operation: MemoryOperationAdd, ID: id}, nil
 		}
 		return MemoryApplyResult{}, fmt.Errorf("%w: %s", errMemoryIDConflict, id)
@@ -243,7 +240,7 @@ func memoryCreateAlreadyApplied(existing, candidate MemoryItem) bool {
 	if candidate.TimeScope != "" && existing.TimeScope != candidate.TimeScope {
 		return false
 	}
-	if !containsAllStrings(existing.Tags, candidate.Tags) || !containsAllStrings(existing.Entities, candidate.Entities) {
+	if !memoryStringsContain(existing.Tags, candidate.Tags) || !memoryStringsContain(existing.Entities, candidate.Entities) {
 		return false
 	}
 	if len(candidate.SourceRefs) == 0 {
@@ -254,7 +251,7 @@ func memoryCreateAlreadyApplied(existing, candidate MemoryItem) bool {
 	}
 	return memorySourceRefsContain(existing.SourceRefs, candidate.SourceRefs) &&
 		memorySourceRefsContain(existing.EvidenceRefs, candidate.EvidenceRefs) &&
-		containsAllStrings(existing.EvidenceExcerpts, candidate.EvidenceExcerpts)
+		memoryStringsContain(existing.EvidenceExcerpts, candidate.EvidenceExcerpts)
 }
 
 func memoryUpdateAlreadyApplied(existing, candidate MemoryItem) bool {
@@ -275,9 +272,9 @@ func memoryReinforceAlreadyApplied(existing, candidate MemoryItem) bool {
 		return false
 	}
 	if !memorySourceRefsContain(existing.EvidenceRefs, candidate.EvidenceRefs) ||
-		!containsAllStrings(existing.EvidenceExcerpts, candidate.EvidenceExcerpts) ||
-		!containsAllStrings(existing.Tags, candidate.Tags) ||
-		!containsAllStrings(existing.Entities, candidate.Entities) {
+		!memoryStringsContain(existing.EvidenceExcerpts, candidate.EvidenceExcerpts) ||
+		!memoryStringsContain(existing.Tags, candidate.Tags) ||
+		!memoryStringsContain(existing.Entities, candidate.Entities) {
 		return false
 	}
 	if candidate.ExpiresAt != "" && existing.ExpiresAt != candidate.ExpiresAt {
@@ -293,7 +290,7 @@ func memorySourceRefsContain(existing, candidate []MemorySourceRef) bool {
 			if candidateRef.Type != existingRef.Type || candidateRef.ID != existingRef.ID {
 				continue
 			}
-			if containsAllStrings(existingRef.EventIDs, candidateRef.EventIDs) {
+			if memoryStringsContain(existingRef.EventIDs, candidateRef.EventIDs) {
 				found = true
 				break
 			}
@@ -316,6 +313,22 @@ func memorySourceRefIdentitiesContain(existing, candidate []MemorySourceRef) boo
 		found := false
 		for _, existingRef := range existing {
 			if existingRef.Type == candidateRef.Type && existingRef.ID == candidateRef.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func memoryStringsContain(existing, candidate []string) bool {
+	for _, value := range candidate {
+		found := false
+		for _, current := range existing {
+			if current == value {
 				found = true
 				break
 			}

--- a/src/agent/internal/agent/memory_apply_test.go
+++ b/src/agent/internal/agent/memory_apply_test.go
@@ -73,6 +73,17 @@ func TestApplyMemoryIntentRequiresExplicitAction(t *testing.T) {
 	}
 }
 
+func TestApplyMemoryIntentReportsNilStoreBeforeIntentValidation(t *testing.T) {
+	var longTerm *LongTermMemoryStore
+	if _, err := longTerm.ApplyMemoryIntent(context.Background(), MemoryIntent{}); err == nil || err.Error() != "memory store is not configured" {
+		t.Fatalf("long-term nil store error = %v", err)
+	}
+	var device *DeviceMemoryStore
+	if _, err := device.ApplyMemoryIntent(context.Background(), MemoryIntent{}); err == nil || err.Error() != "memory store is not configured" {
+		t.Fatalf("device nil store error = %v", err)
+	}
+}
+
 func TestApplyMemoryIntentCreateRestoresMatchingDeletedMemory(t *testing.T) {
 	store := NewLongTermMemoryStore(t.TempDir())
 	ctx := context.Background()

--- a/src/agent/internal/agent/memory_apply_test.go
+++ b/src/agent/internal/agent/memory_apply_test.go
@@ -186,6 +186,36 @@ func TestApplyMemoryIntentCreateDoesNotRunSimilarityMerge(t *testing.T) {
 	}
 }
 
+func TestApplyMemoryIntentCreateRetryKeepsFirstContentForSameSourceIdentity(t *testing.T) {
+	store := NewLongTermMemoryStore(t.TempDir())
+	ctx := context.Background()
+	first := MemoryItem{
+		ID: "tmp_notification_42", Type: "fact", TimeScope: "temporary",
+		Content:          "The package arrives tomorrow.",
+		SourceRefs:       []MemorySourceRef{{Type: "notification", ID: "42", EventIDs: []string{"event-42"}}},
+		EvidenceExcerpts: []string{"The package arrives tomorrow."},
+	}
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: first, Action: MemoryIntentActionCreate}); err != nil {
+		t.Fatal(err)
+	}
+	reworded := first
+	reworded.Content = "Delivery is expected tomorrow."
+	reworded.EvidenceExcerpts = []string{"Delivery is expected tomorrow."}
+	if result, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: reworded, Action: MemoryIntentActionCreate}); err != nil || result.Operation != MemoryOperationAdd {
+		t.Fatalf("reworded create retry=%#v err=%v", result, err)
+	}
+	memories, err := store.Search(ctx, MemoryQuery{Limit: 10})
+	if err != nil || len(memories) != 1 || memories[0].Content != first.Content || memories[0].Revision != 1 {
+		t.Fatalf("memories=%#v err=%v, want first create unchanged", memories, err)
+	}
+
+	unrelated := reworded
+	unrelated.SourceRefs = []MemorySourceRef{{Type: "notification", ID: "99", EventIDs: []string{"event-99"}}}
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: unrelated, Action: MemoryIntentActionCreate}); !errors.Is(err, errMemoryIDConflict) {
+		t.Fatalf("unrelated same-ID create error=%v, want ID conflict", err)
+	}
+}
+
 func TestApplyMemoryIntentPreservesActionAndIsRetrySafe(t *testing.T) {
 	store := NewLongTermMemoryStore(t.TempDir())
 	ctx := context.Background()
@@ -266,6 +296,29 @@ func TestDeviceMemoryApplyUsesCommonUpdateAndRevision(t *testing.T) {
 	}
 	if current.Revision != 2 || len(current.RevisionHistory) != 1 || len(current.EvidenceRefs) != 2 {
 		t.Fatalf("merged device memory=%#v", current)
+	}
+}
+
+func TestDeviceMemoryCreateRetryKeepsFirstContentForSameEpisode(t *testing.T) {
+	store := NewDeviceMemoryStore(t.TempDir())
+	ctx := context.Background()
+	first := DeviceMemoryItem{
+		ID: "devmem_retry", Type: "fact", Status: deviceMemoryStatusActive,
+		Title: "Delivery", Summary: "Tomorrow", Content: "The package arrives tomorrow.",
+		EvidenceRefs: []MemorySourceRef{{Type: "episode", ID: "episode-retry", EventIDs: []string{"event-1"}}},
+	}
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &first, Action: MemoryIntentActionCreate}); err != nil {
+		t.Fatal(err)
+	}
+	reworded := first
+	reworded.Summary = "Expected tomorrow"
+	reworded.Content = "Delivery is expected tomorrow."
+	if result, err := store.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &reworded, Action: MemoryIntentActionCreate}); err != nil || result.Operation != MemoryOperationAdd {
+		t.Fatalf("device create retry=%#v err=%v", result, err)
+	}
+	current, found, err := store.Get(ctx, first.ID)
+	if err != nil || !found || current.Content != first.Content || effectiveDeviceMemoryRevision(current) != 1 {
+		t.Fatalf("current=%#v found=%v err=%v, want first create unchanged", current, found, err)
 	}
 }
 

--- a/src/agent/internal/agent/memory_apply_test.go
+++ b/src/agent/internal/agent/memory_apply_test.go
@@ -2,11 +2,13 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-func TestApplyMemoryIntentUpdatesAndReinforcesByID(t *testing.T) {
+func TestApplyMemoryCandidateUpdatesAndReinforcesByID(t *testing.T) {
 	store := NewLongTermMemoryStore(t.TempDir())
 	ctx := context.Background()
 	first := MemoryItem{
@@ -15,7 +17,7 @@ func TestApplyMemoryIntentUpdatesAndReinforcesByID(t *testing.T) {
 		SourceRefs:       []MemorySourceRef{{Type: "notification", ID: "42", EventIDs: []string{"e1"}}},
 		EvidenceExcerpts: []string{"包裹明天送达"},
 	}
-	got, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: first})
+	got, err := store.ApplyMemoryCandidate(ctx, first)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +27,7 @@ func TestApplyMemoryIntentUpdatesAndReinforcesByID(t *testing.T) {
 
 	same := first
 	same.SourceRefs = []MemorySourceRef{{Type: "notification", ID: "42", EventIDs: []string{"e2"}}}
-	got, err = store.ApplyMemoryIntent(ctx, MemoryIntent{Item: same})
+	got, err = store.ApplyMemoryCandidate(ctx, same)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +37,7 @@ func TestApplyMemoryIntentUpdatesAndReinforcesByID(t *testing.T) {
 
 	updated := same
 	updated.Content = "包裹今天送达"
-	got, err = store.ApplyMemoryIntent(ctx, MemoryIntent{Item: updated})
+	got, err = store.ApplyMemoryCandidate(ctx, updated)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,6 +61,37 @@ func TestApplyMemoryIntentUpdatesAndReinforcesByID(t *testing.T) {
 	}
 }
 
+func TestApplyMemoryIntentRequiresExplicitAction(t *testing.T) {
+	store := NewLongTermMemoryStore(t.TempDir())
+	if _, err := store.ApplyMemoryIntent(context.Background(), MemoryIntent{Item: MemoryItem{ID: "missing-action"}}); err == nil {
+		t.Fatal("missing action unexpectedly accepted")
+	}
+	device := NewDeviceMemoryStore(t.TempDir())
+	item := DeviceMemoryItem{ID: "missing-action"}
+	if _, err := device.ApplyMemoryIntent(context.Background(), MemoryIntent{DeviceItem: &item}); err == nil {
+		t.Fatal("device missing action unexpectedly accepted")
+	}
+}
+
+func TestApplyMemoryIntentCreateRestoresMatchingDeletedMemory(t *testing.T) {
+	store := NewLongTermMemoryStore(t.TempDir())
+	ctx := context.Background()
+	item := MemoryItem{ID: "deleted-memory", Type: "fact", TimeScope: "temporary", Content: "same", SourceRefs: []MemorySourceRef{{Type: "notification", ID: "deleted", EventIDs: []string{"event-deleted"}}}, EvidenceExcerpts: []string{"same"}}
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: item, Action: MemoryIntentActionCreate}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: MemoryItem{ID: item.ID}, Action: MemoryIntentActionRemove, ExpectedRevision: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: item, Action: MemoryIntentActionCreate}); err != nil {
+		t.Fatal(err)
+	}
+	memories, err := store.Search(ctx, MemoryQuery{Limit: 10})
+	if err != nil || len(memories) != 1 || memories[0].Status != "active" {
+		t.Fatalf("restored memories=%#v err=%v", memories, err)
+	}
+}
+
 func TestLongTermMemoryStoresShareWriteLockByRoot(t *testing.T) {
 	root := t.TempDir()
 	first := NewLongTermMemoryStore(root)
@@ -78,11 +111,12 @@ func TestApplyMemoryIntentRemovesByID(t *testing.T) {
 	item := MemoryItem{
 		ID: "tmp_notification_7", Type: "fact", TimeScope: "temporary",
 		Title: "提醒", Content: "会议即将开始", EvidenceExcerpts: []string{"会议即将开始"},
+		SourceRefs: []MemorySourceRef{{Type: "notification", ID: "7", EventIDs: []string{"event-7"}}},
 	}
-	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: item}); err != nil {
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: item, Action: MemoryIntentActionCreate}); err != nil {
 		t.Fatal(err)
 	}
-	got, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: MemoryItem{ID: item.ID}, Remove: true})
+	got, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: MemoryItem{ID: item.ID}, Action: MemoryIntentActionRemove, ExpectedRevision: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,15 +135,99 @@ func TestApplyMemoryIntentRemovesByID(t *testing.T) {
 func TestApplyMemoryIntentRemoveChecksExpectedRevision(t *testing.T) {
 	store := NewLongTermMemoryStore(filepath.Join(t.TempDir(), "long_term"))
 	ctx := context.Background()
-	item := MemoryItem{ID: "mem_revision_remove", Type: "fact", TimeScope: "long_term", Content: "old", EvidenceExcerpts: []string{"evidence"}}
-	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: item}); err != nil {
+	item := MemoryItem{ID: "mem_revision_remove", Type: "fact", TimeScope: "long_term", Content: "old", SourceRefs: []MemorySourceRef{{Type: "notification", ID: "remove", EventIDs: []string{"event-remove"}}}, EvidenceExcerpts: []string{"evidence"}}
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: item, Action: MemoryIntentActionCreate}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: MemoryItem{ID: item.ID}, ExpectedRevision: 2, Remove: true}); err != errMemoryRevisionChanged {
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: MemoryItem{ID: item.ID}, Action: MemoryIntentActionRemove, ExpectedRevision: 2}); err != errMemoryRevisionChanged {
 		t.Fatalf("stale remove error=%v, want %v", err, errMemoryRevisionChanged)
 	}
 	if _, err := store.Search(ctx, MemoryQuery{Tags: nil, Limit: 10}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestApplyMemoryIntentCreateDoesNotRunSimilarityMerge(t *testing.T) {
+	store := NewLongTermMemoryStore(t.TempDir())
+	ctx := context.Background()
+	if _, err := store.AddMemory(ctx, MemoryItem{
+		ID: "existing", Type: "fact", Content: "The delivery arrives tomorrow", Tags: []string{"notification", "delivery"},
+		EvidenceExcerpts: []string{"existing"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	item := MemoryItem{
+		ID: "created", Type: "fact", Content: "The delivery arrives tomorrow at noon", Tags: []string{"notification", "delivery"},
+		SourceRefs: []MemorySourceRef{{Type: "notification", ID: "ctx-1", EventIDs: []string{"evt-1"}}}, EvidenceExcerpts: []string{"new"},
+	}
+	result, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: item, Action: MemoryIntentActionCreate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Operation != MemoryOperationAdd || result.ID != item.ID {
+		t.Fatalf("result=%#v, want explicit create", result)
+	}
+	if retry, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: item, Action: MemoryIntentActionCreate}); err != nil || retry.Operation != MemoryOperationAdd {
+		t.Fatalf("create retry=%#v err=%v", retry, err)
+	}
+	memories, err := store.Search(ctx, MemoryQuery{Tags: []string{"delivery"}, Limit: 10})
+	if err != nil || len(memories) != 2 {
+		t.Fatalf("memories=%#v err=%v, want both records", memories, err)
+	}
+	for _, memory := range memories {
+		if memory.ID == item.ID && memory.Revision != 1 {
+			t.Fatalf("create retry advanced revision: %#v", memory)
+		}
+	}
+	missing := item
+	missing.ID = "missing"
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: missing, Action: MemoryIntentActionUpdate, ExpectedRevision: 1}); !errors.Is(err, errMemoryTargetMissing) {
+		t.Fatalf("missing update error=%v, want target missing", err)
+	}
+}
+
+func TestApplyMemoryIntentPreservesActionAndIsRetrySafe(t *testing.T) {
+	store := NewLongTermMemoryStore(t.TempDir())
+	ctx := context.Background()
+	item := MemoryItem{ID: "memory-1", Type: "fact", Title: "Delivery", Content: "Arrives tomorrow", SourceRefs: []MemorySourceRef{{Type: "notification", ID: "ctx-1", EventIDs: []string{"evt-1"}}}, EvidenceExcerpts: []string{"Arrives tomorrow"}}
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: item, Action: MemoryIntentActionCreate}); err != nil {
+		t.Fatal(err)
+	}
+	update := item
+	update.Content = "Arrives today"
+	update.SourceRefs = []MemorySourceRef{{Type: "notification", ID: "ctx-2", EventIDs: []string{"evt-2"}}}
+	result, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: update, Action: MemoryIntentActionUpdate, ExpectedRevision: 1})
+	if err != nil || result.Operation != MemoryOperationUpdate {
+		t.Fatalf("update result=%#v err=%v", result, err)
+	}
+	result, err = store.ApplyMemoryIntent(ctx, MemoryIntent{Item: update, Action: MemoryIntentActionUpdate, ExpectedRevision: 1})
+	if err != nil || result.Operation != MemoryOperationUpdate {
+		t.Fatalf("retry result=%#v err=%v", result, err)
+	}
+	partial := update
+	partial.Tags = []string{"not-applied"}
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: partial, Action: MemoryIntentActionUpdate, ExpectedRevision: 1}); !errors.Is(err, errMemoryRevisionChanged) {
+		t.Fatalf("partial retry error=%v, want revision conflict", err)
+	}
+	memories, err := store.Search(ctx, MemoryQuery{Limit: 10})
+	if err != nil || len(memories) != 1 || memories[0].Revision != 2 || memories[0].Content != "Arrives today" {
+		t.Fatalf("memories=%#v err=%v, want one revision-2 update", memories, err)
+	}
+
+	reinforce := MemoryItem{ID: item.ID, Type: item.Type, Title: item.Title, Content: "Different text must not replace the conclusion", SourceRefs: []MemorySourceRef{{Type: "notification", ID: "ctx-3", EventIDs: []string{"evt-3"}}}, EvidenceExcerpts: []string{"evt-3"}}
+	result, err = store.ApplyMemoryIntent(ctx, MemoryIntent{Item: reinforce, Action: MemoryIntentActionReinforce, ExpectedRevision: 2})
+	if err != nil || result.Operation != MemoryOperationReinforce {
+		t.Fatalf("reinforce result=%#v err=%v", result, err)
+	}
+	memories, err = store.Search(ctx, MemoryQuery{Limit: 10})
+	if err != nil || len(memories) != 1 || memories[0].Content != "Arrives today" || memories[0].Revision != 3 {
+		t.Fatalf("reinforced memories=%#v err=%v, want unchanged content at revision 3", memories, err)
+	}
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: MemoryItem{ID: item.ID}, Action: MemoryIntentActionUpdate, ExpectedRevision: 1}); !errors.Is(err, errMemoryRevisionChanged) {
+		t.Fatalf("stale update error=%v, want revision conflict", err)
+	}
+	if strings.Contains(memories[0].Content, "Different text") {
+		t.Fatal("reinforce changed the memory conclusion")
 	}
 }
 
@@ -121,7 +239,7 @@ func TestDeviceMemoryApplyUsesCommonUpdateAndRevision(t *testing.T) {
 		Title: "包裹", Summary: "明天送达", Content: "包裹明天送达",
 		EvidenceRefs: []MemorySourceRef{{Type: "episode", ID: "episode-1", EventIDs: []string{"event-1"}}},
 	}
-	got, err := store.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &first})
+	got, err := store.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &first, Action: MemoryIntentActionCreate})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +252,7 @@ func TestDeviceMemoryApplyUsesCommonUpdateAndRevision(t *testing.T) {
 	updated.Summary = "今天送达"
 	updated.Content = "包裹今天送达"
 	updated.EvidenceRefs = []MemorySourceRef{{Type: "episode", ID: "episode-2", EventIDs: []string{"event-2"}}}
-	got, err = store.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &updated, ExpectedRevision: 1})
+	got, err = store.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &updated, Action: MemoryIntentActionUpdate, ExpectedRevision: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,5 +266,26 @@ func TestDeviceMemoryApplyUsesCommonUpdateAndRevision(t *testing.T) {
 	}
 	if current.Revision != 2 || len(current.RevisionHistory) != 1 || len(current.EvidenceRefs) != 2 {
 		t.Fatalf("merged device memory=%#v", current)
+	}
+}
+
+func TestDeviceMemoryRemoveIsIdempotent(t *testing.T) {
+	store := NewDeviceMemoryStore(t.TempDir())
+	ctx := context.Background()
+	item := DeviceMemoryItem{ID: "devmem_remove", Type: "fact", Status: deviceMemoryStatusActive, Content: "remove me", EvidenceRefs: []MemorySourceRef{{Type: "episode", ID: "remove", EventIDs: []string{"event-remove"}}}}
+	if _, err := store.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &item, Action: MemoryIntentActionCreate}); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := store.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &DeviceMemoryItem{ID: item.ID}, Action: MemoryIntentActionRemove, ExpectedRevision: 1})
+	if err != nil || removed.Operation != MemoryOperationRemove {
+		t.Fatalf("remove result=%#v err=%v", removed, err)
+	}
+	retried, err := store.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &DeviceMemoryItem{ID: item.ID}, Action: MemoryIntentActionRemove, ExpectedRevision: 1})
+	if err != nil || retried.Operation != MemoryOperationIgnore {
+		t.Fatalf("remove retry result=%#v err=%v", retried, err)
+	}
+	missing, err := store.ApplyMemoryIntent(ctx, MemoryIntent{DeviceItem: &DeviceMemoryItem{ID: "missing"}, Action: MemoryIntentActionRemove, ExpectedRevision: 1})
+	if err != nil || missing.Operation != MemoryOperationIgnore {
+		t.Fatalf("missing remove result=%#v err=%v", missing, err)
 	}
 }

--- a/src/agent/internal/agent/memory_plane.go
+++ b/src/agent/internal/agent/memory_plane.go
@@ -437,8 +437,22 @@ func (p *FilesystemMemoryPlane) SeedNotificationMemoryForBenchmark(ctx context.C
 // through the same processor and shared worker used during normal idle work.
 // It is a benchmark control path, not a foreground runtime API.
 func (p *FilesystemMemoryPlane) ProcessNotificationMemoryNow(ctx context.Context) (string, []string, error) {
+	return p.processNotificationMemoryNow(
+		ctx,
+		notificationMemoryProcessNowMaxAttempts,
+		notificationMemoryProcessNowBusyDelay,
+	)
+}
+
+func (p *FilesystemMemoryPlane) processNotificationMemoryNow(ctx context.Context, maxAttempts int, busyDelay time.Duration) (string, []string, error) {
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if maxAttempts <= 0 {
+		maxAttempts = 1
+	}
+	if busyDelay < 0 {
+		busyDelay = 0
 	}
 	if p == nil {
 		return "", nil, fmt.Errorf("notification memory is not configured")
@@ -452,7 +466,7 @@ func (p *FilesystemMemoryPlane) ProcessNotificationMemoryNow(ctx context.Context
 	}
 	processor.context.setConsumeDisabledForBenchmark(true)
 	defer processor.context.setConsumeDisabledForBenchmark(false)
-	pendingBefore, err := processor.context.ReadPending(ctx, 100)
+	pendingBefore, err := processor.context.ReadPendingAll(ctx)
 	if err != nil {
 		return "", nil, err
 	}
@@ -461,19 +475,22 @@ func (p *FilesystemMemoryPlane) ProcessNotificationMemoryNow(ctx context.Context
 		seededContextIDs[record.ContextID] = struct{}{}
 	}
 	var last MemoryBatchResult
-	for attempt := 0; attempt < notificationMemoryProcessNowMaxAttempts; attempt++ {
+	busy := false
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return "", nil, err
 		}
 		result, err := worker.ProcessProcessorNow(ctx, processor)
 		if errors.Is(err, errMemoryWorkerBusy) {
+			busy = true
 			select {
 			case <-ctx.Done():
 				return "", nil, ctx.Err()
-			case <-time.After(notificationMemoryProcessNowBusyDelay):
+			case <-time.After(busyDelay):
 			}
 			continue
 		}
+		busy = false
 		last = result
 		pending, readErr := processor.context.ReadPending(ctx, notificationMemoryBatchLimit)
 		if readErr != nil {
@@ -490,6 +507,9 @@ func (p *FilesystemMemoryPlane) ProcessNotificationMemoryNow(ctx context.Context
 			// committed successfully, so a consume-side error is irrelevant here.
 			break
 		}
+	}
+	if busy {
+		return "", nil, errMemoryWorkerBusy
 	}
 	if last.HasPending {
 		pending, err := processor.context.ReadPending(ctx, notificationMemoryBatchLimit)

--- a/src/agent/internal/agent/memory_plane.go
+++ b/src/agent/internal/agent/memory_plane.go
@@ -9,11 +9,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"aiden-agent/internal/agent/model"
+	"aiden-agent/internal/ble"
 )
 
 type MemoryPlane interface {
@@ -94,8 +96,10 @@ type MemoryHit struct {
 }
 
 const (
-	episodeMemoryProcessNowMaxAttempts = 2048
-	episodeMemoryProcessNowBusyDelay   = 50 * time.Millisecond
+	episodeMemoryProcessNowMaxAttempts      = 2048
+	episodeMemoryProcessNowBusyDelay        = 50 * time.Millisecond
+	notificationMemoryProcessNowMaxAttempts = 2048
+	notificationMemoryProcessNowBusyDelay   = 50 * time.Millisecond
 )
 
 const defaultMemoryDeviceID = "default"
@@ -412,6 +416,126 @@ func (p *FilesystemMemoryPlane) ProcessEpisodeMemoryNow(ctx context.Context, epi
 		}
 	}
 	return status, memoryIDs, nil
+}
+
+// SeedNotificationMemoryForBenchmark installs durable notification fixtures.
+// The server exposes this only through its benchmark-token-protected endpoint.
+func (p *FilesystemMemoryPlane) SeedNotificationMemoryForBenchmark(ctx context.Context, events []ble.NotificationEvent) ([]NotificationRecord, error) {
+	if p == nil {
+		return nil, fmt.Errorf("notification memory is not configured")
+	}
+	p.memoryWorkerMu.RLock()
+	processor := p.notificationProcessor
+	p.memoryWorkerMu.RUnlock()
+	if processor == nil || processor.context == nil {
+		return nil, fmt.Errorf("notification memory worker is not configured")
+	}
+	return processor.context.seedForBenchmark(ctx, events)
+}
+
+// ProcessNotificationMemoryNow drains seeded durable notification records
+// through the same processor and shared worker used during normal idle work.
+// It is a benchmark control path, not a foreground runtime API.
+func (p *FilesystemMemoryPlane) ProcessNotificationMemoryNow(ctx context.Context) (string, []string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if p == nil {
+		return "", nil, fmt.Errorf("notification memory is not configured")
+	}
+	p.memoryWorkerMu.RLock()
+	worker := p.memoryWorker
+	processor := p.notificationProcessor
+	p.memoryWorkerMu.RUnlock()
+	if worker == nil || processor == nil || processor.context == nil {
+		return "", nil, fmt.Errorf("notification memory worker is not configured")
+	}
+	processor.context.setConsumeDisabledForBenchmark(true)
+	defer processor.context.setConsumeDisabledForBenchmark(false)
+	pendingBefore, err := processor.context.ReadPending(ctx, 100)
+	if err != nil {
+		return "", nil, err
+	}
+	seededContextIDs := make(map[string]struct{}, len(pendingBefore))
+	for _, record := range pendingBefore {
+		seededContextIDs[record.ContextID] = struct{}{}
+	}
+	var last MemoryBatchResult
+	for attempt := 0; attempt < notificationMemoryProcessNowMaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return "", nil, err
+		}
+		result, err := worker.ProcessProcessorNow(ctx, processor)
+		if errors.Is(err, errMemoryWorkerBusy) {
+			select {
+			case <-ctx.Done():
+				return "", nil, ctx.Err()
+			case <-time.After(notificationMemoryProcessNowBusyDelay):
+			}
+			continue
+		}
+		last = result
+		pending, readErr := processor.context.ReadPending(ctx, notificationMemoryBatchLimit)
+		if readErr != nil {
+			return "", nil, readErr
+		}
+		if err != nil && len(pending) > 0 {
+			return "", nil, err
+		}
+		if len(pending) == 0 && !result.HasPending {
+			break
+		}
+		if len(pending) == 0 && err != nil {
+			// A seeded run may have no BLE reader. The durable batch has still
+			// committed successfully, so a consume-side error is irrelevant here.
+			break
+		}
+	}
+	if last.HasPending {
+		pending, err := processor.context.ReadPending(ctx, notificationMemoryBatchLimit)
+		if err != nil {
+			return "", nil, err
+		}
+		if len(pending) > 0 {
+			return "", nil, fmt.Errorf("notification memory benchmark did not drain durable pending records")
+		}
+	}
+	state := processor.context.State()
+	ids := make([]string, 0)
+	for _, store := range []*LongTermMemoryStore{processor.temporary, processor.longTerm} {
+		if store == nil {
+			continue
+		}
+		memories, err := store.searchAll(ctx)
+		if err != nil {
+			return "", nil, err
+		}
+		for _, memory := range memories {
+			if memory.Status != "active" || !memoryReferencesNotificationIDs(memory.SourceRefs, seededContextIDs) {
+				continue
+			}
+			ids = append(ids, memory.ID)
+		}
+	}
+	sort.Strings(ids)
+	return state.MemoryCursor, ids, nil
+}
+
+func memoryReferencesNotificationIDs(refs []MemorySourceRef, contextIDs map[string]struct{}) bool {
+	for _, ref := range refs {
+		if ref.Type != "notification" {
+			continue
+		}
+		if _, ok := contextIDs[ref.ID]; ok {
+			return true
+		}
+		for _, eventID := range ref.EventIDs {
+			if _, ok := contextIDs[eventID]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func episodeMemoryProcessNowTerminal(status episodeMemoryEpisodeStatus) bool {

--- a/src/agent/internal/agent/memory_tools.go
+++ b/src/agent/internal/agent/memory_tools.go
@@ -295,7 +295,7 @@ func (t *SaveMemoryTool) Call(ctx context.Context, input string) (string, error)
 		Entities:         req.Entities,
 		EvidenceExcerpts: req.Evidence,
 	}
-	result, err := t.store.ApplyMemoryIntent(ctx, MemoryIntent{Item: item})
+	result, err := t.store.ApplyMemoryCandidate(ctx, item)
 	if err != nil {
 		return "", err
 	}

--- a/src/agent/internal/agent/notification_context.go
+++ b/src/agent/internal/agent/notification_context.go
@@ -159,7 +159,15 @@ func (c *NotificationContext) seedForBenchmark(ctx context.Context, events []ble
 		}
 		event = sanitizeNotificationEvent(event)
 		fingerprint := notificationEventFingerprint(event)
-		if _, exists := c.fingerprints[fingerprint]; exists {
+		if contextID, exists := c.fingerprints[fingerprint]; exists {
+			// Setup may be retried after the processor or HTTP response fails.
+			// Return the original identity so benchmark fixture injection is
+			// idempotent instead of reporting that zero events were persisted.
+			accepted = append(accepted, NotificationRecord{
+				NotificationEvent: event,
+				ContextID:         contextID,
+				Generation:        firstNonEmptyString([]string{c.state.Generation, "benchmark"}),
+			})
 			continue
 		}
 		contextID := parseCursorOrZero(c.state.StoredCursor) + 1

--- a/src/agent/internal/agent/notification_context.go
+++ b/src/agent/internal/agent/notification_context.go
@@ -322,6 +322,24 @@ func (c *NotificationContext) ReadPending(ctx context.Context, limit int) ([]Not
 	return c.readPendingLocked(ctx, parseCursorOrZero(c.state.MemoryCursor), limit)
 }
 
+// ReadPendingAll reads every persisted event after MemoryCursor. It is used by
+// control paths that need a complete provenance set rather than a processing
+// batch and therefore must not silently truncate at the normal batch limit.
+func (c *NotificationContext) ReadPendingAll(ctx context.Context) ([]NotificationRecord, error) {
+	if c == nil {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.ensureLoadedLocked(); err != nil {
+		return nil, err
+	}
+	return c.readPendingLocked(ctx, parseCursorOrZero(c.state.MemoryCursor), 0)
+}
+
 // CommitProcessed advances MemoryCursor after the corresponding Memory write
 // succeeds. The caller must pass the contiguous batch returned by ReadPending.
 func (c *NotificationContext) CommitProcessed(ctx context.Context, events []NotificationRecord) error {
@@ -497,7 +515,11 @@ func (c *NotificationContext) readPendingLocked(ctx context.Context, cursor uint
 		}
 	}
 	sort.Strings(files)
-	result := make([]NotificationRecord, 0, limit)
+	capacity := limit
+	if capacity < 0 {
+		capacity = 0
+	}
+	result := make([]NotificationRecord, 0, capacity)
 	for _, name := range files {
 		records, err := readNotificationRecordFile(filepath.Join(c.eventsDir, name))
 		if err != nil {
@@ -522,7 +544,7 @@ func (c *NotificationContext) readPendingLocked(ctx context.Context, cursor uint
 		}
 		return result[i].ReceivedAt < result[j].ReceivedAt
 	})
-	if len(result) > limit {
+	if limit > 0 && len(result) > limit {
 		result = result[:limit]
 	}
 	return result, nil

--- a/src/agent/internal/agent/notification_context.go
+++ b/src/agent/internal/agent/notification_context.go
@@ -79,6 +79,10 @@ type NotificationContext struct {
 	storageGate  StorageWriteGate
 	state        NotificationContextState
 	fingerprints map[string]string
+	// consumeDisabled is used only by the benchmark fixture path. It lets a
+	// seeded durable log be processed without requiring a live BLE socket.
+	// Production ingestion always leaves this false.
+	consumeDisabled bool
 }
 
 var notificationContextMutexes sync.Map
@@ -133,6 +137,61 @@ func (c *NotificationContext) SetStorageWriteGate(gate StorageWriteGate) {
 	c.mu.Unlock()
 }
 
+// seedForBenchmark appends deterministic notification fixtures directly to the
+// durable context log. It is intentionally package-private; the only caller
+// is the benchmark-token-protected HTTP endpoint.
+func (c *NotificationContext) seedForBenchmark(ctx context.Context, events []ble.NotificationEvent) ([]NotificationRecord, error) {
+	if c == nil || len(events) == 0 {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.ensureLoadedLocked(); err != nil {
+		return nil, err
+	}
+	accepted := make([]NotificationRecord, 0, len(events))
+	for _, event := range events {
+		if err := ctx.Err(); err != nil {
+			return accepted, err
+		}
+		event = sanitizeNotificationEvent(event)
+		fingerprint := notificationEventFingerprint(event)
+		if _, exists := c.fingerprints[fingerprint]; exists {
+			continue
+		}
+		contextID := parseCursorOrZero(c.state.StoredCursor) + 1
+		record := NotificationRecord{
+			NotificationEvent: event,
+			ContextID:         strconv.FormatUint(contextID, 10),
+			Generation:        firstNonEmptyString([]string{c.state.Generation, "benchmark"}),
+		}
+		if err := c.appendEventLocked(record); err != nil {
+			return accepted, err
+		}
+		c.fingerprints[fingerprint] = record.ContextID
+		pruneNotificationFingerprints(c.fingerprints)
+		c.state.StoredCursor = record.ContextID
+		c.state.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		accepted = append(accepted, record)
+	}
+	if err := c.persistLocked(); err != nil {
+		return accepted, err
+	}
+	return accepted, nil
+}
+
+func (c *NotificationContext) setConsumeDisabledForBenchmark(disabled bool) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.consumeDisabled = disabled
+	c.mu.Unlock()
+}
+
 // Consume fetches a page from ble_service, appends accepted events durably,
 // and advances SourceCursor only after each event is synced to disk.
 func (c *NotificationContext) Consume(ctx context.Context, limit int) ([]NotificationRecord, error) {
@@ -148,6 +207,9 @@ func (c *NotificationContext) Consume(ctx context.Context, limit int) ([]Notific
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.consumeDisabled {
+		return nil, nil
+	}
 	if c.storageGate != nil && !c.storageGate.AllowWrite(StorageCapabilityNotificationContext) {
 		return nil, nil
 	}

--- a/src/agent/internal/agent/notification_context_test.go
+++ b/src/agent/internal/agent/notification_context_test.go
@@ -324,6 +324,35 @@ func TestNotificationContextReadPendingAppliesLimitAfterCursorSort(t *testing.T)
 	}
 }
 
+func TestNotificationContextReadPendingAllDoesNotApplyDefaultLimit(t *testing.T) {
+	root := t.TempDir()
+	c, err := NewNotificationContext(root, func(context.Context, string, string, int) (ble.EventPage, error) {
+		return ble.EventPage{}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := make([]ble.NotificationEvent, 0, 125)
+	for index := 1; index <= 125; index++ {
+		events = append(events, ble.NotificationEvent{
+			Source:        "android",
+			SourceEventID: "event-" + strconv.Itoa(index),
+			Title:         "Notification " + strconv.Itoa(index),
+			ReceivedAt:    "2026-08-21T00:00:00Z",
+		})
+	}
+	if records, err := c.seedForBenchmark(context.Background(), events); err != nil || len(records) != len(events) {
+		t.Fatalf("seedForBenchmark() records=%d err=%v", len(records), err)
+	}
+	got, err := c.ReadPendingAll(context.Background())
+	if err != nil || len(got) != len(events) {
+		t.Fatalf("ReadPendingAll() records=%d err=%v, want %d", len(got), err, len(events))
+	}
+	if got[0].ContextID != "1" || got[len(got)-1].ContextID != "125" {
+		t.Fatalf("ReadPendingAll() cursors=%q..%q", got[0].ContextID, got[len(got)-1].ContextID)
+	}
+}
+
 func TestNotificationContextSanitizeTruncatesUTF8ByRunes(t *testing.T) {
 	value := truncateNotificationText("你好世界", 3)
 	if value != "你好世" {

--- a/src/agent/internal/agent/notification_memory_bench_test.go
+++ b/src/agent/internal/agent/notification_memory_bench_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"aiden-agent/internal/ble"
+)
+
+func BenchmarkNotificationContextReadPending(b *testing.B) {
+	root := filepath.Join(b.TempDir(), "memory")
+	ctx, err := NewNotificationContext(root, func(context.Context, string, string, int) (ble.EventPage, error) {
+		return ble.EventPage{}, nil
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	events := make([]ble.NotificationEvent, 0, 100)
+	for index := 1; index <= 100; index++ {
+		events = append(events, ble.NotificationEvent{
+			ID: strconv.Itoa(index), Source: "android", SourceID: fmt.Sprintf("notification-%d", index),
+			SourceEventID: fmt.Sprintf("event-%d", index), AppIdentifier: "com.calendar",
+			Title: "会议", Message: "待处理日程", Event: "added",
+			ReceivedAt: time.Date(2026, 8, 21, 0, 0, index, 0, time.UTC).Format(time.RFC3339Nano),
+		})
+	}
+	if _, err := ctx.seedForBenchmark(context.Background(), events); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportMetric(float64(len(events)), "events")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ctx.ReadPending(context.Background(), 10); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkNotificationMemoryBatchPrompt(b *testing.B) {
+	records := make([]NotificationRecord, 0, notificationMemoryBatchLimit)
+	for index := 1; index <= notificationMemoryBatchLimit; index++ {
+		records = append(records, NotificationRecord{
+			ContextID: strconv.Itoa(index),
+			NotificationEvent: ble.NotificationEvent{
+				ID: strconv.Itoa(index), Source: "android",
+				SourceEventID: fmt.Sprintf("event-%d", index),
+				AppIdentifier: "com.calendar", Title: "会议",
+				Message: "明天十点开会", Event: "added",
+			},
+		})
+	}
+	b.ReportMetric(float64(len(records)), "events")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = buildNotificationMemoryBatchPrompt(records, nil)
+	}
+}
+
+func BenchmarkNotificationMemoryProcessBatch(b *testing.B) {
+	b.ReportMetric(float64(notificationMemoryBatchLimit), "events")
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		root := filepath.Join(b.TempDir(), strconv.Itoa(i))
+		ctxStore, err := NewNotificationContext(root, func(context.Context, string, string, int) (ble.EventPage, error) {
+			return ble.EventPage{}, nil
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		events := make([]ble.NotificationEvent, 0, notificationMemoryBatchLimit)
+		for index := 1; index <= notificationMemoryBatchLimit; index++ {
+			id := strconv.Itoa(index)
+			events = append(events, ble.NotificationEvent{
+				ID: id, Source: "android", SourceID: "notification-" + id,
+				SourceEventID: "event-" + id, AppIdentifier: "com.calendar",
+				Title: "会议", Message: "明天十点开会", Event: "added",
+				ReceivedAt: "2026-08-21T00:00:00Z",
+			})
+		}
+		if _, err := ctxStore.seedForBenchmark(context.Background(), events); err != nil {
+			b.Fatal(err)
+		}
+		model := &episodeMemoryScriptedModel{responses: []string{notificationIgnoreBatchResponse(events)}}
+		processor := NewNotificationMemoryProcessor(ctxStore, root, nil, model)
+		processor.context.setConsumeDisabledForBenchmark(true)
+		b.StartTimer()
+		if _, err := processor.ProcessBatch(context.Background(), nil); err != nil {
+			b.Fatal(err)
+		}
+		b.StopTimer()
+		if got := model.callCount(); got != 1 {
+			b.Fatalf("model calls = %d, want one", got)
+		}
+	}
+}
+
+func notificationIgnoreBatchResponse(events []ble.NotificationEvent) string {
+	results := make([]notificationMemoryBatchResult, 0, len(events))
+	for index := range events {
+		results = append(results, notificationMemoryBatchResult{
+			ContextID: strconv.Itoa(index + 1),
+			Proposal: notificationMemoryProposal{
+				Actions: []notificationMemoryAction{{Action: "ignore"}},
+			},
+		})
+	}
+	data, _ := json.Marshal(notificationMemoryBatchResponse{Results: results})
+	return string(data)
+}

--- a/src/agent/internal/agent/notification_memory_processor.go
+++ b/src/agent/internal/agent/notification_memory_processor.go
@@ -497,14 +497,14 @@ func (p *NotificationMemoryProcessor) findTemporaryNotificationReference(ctx con
 	if p.temporary == nil {
 		return MemoryMergeReference{}, false
 	}
-	parsed, err := readMemoryMarkdown(p.temporary.memoryPath(strings.TrimSpace(id)))
-	if err != nil {
-		return MemoryMergeReference{}, false
-	}
 	select {
 	case <-ctx.Done():
 		return MemoryMergeReference{}, false
 	default:
+	}
+	parsed, err := readMemoryMarkdown(p.temporary.memoryPath(strings.TrimSpace(id)))
+	if err != nil {
+		return MemoryMergeReference{}, false
 	}
 	item := parsed.Item
 	return MemoryMergeReference{Scope: "temporary", ID: item.ID, Type: item.Type, Status: item.Status, Title: item.Title, Summary: item.Content, Content: item.Content, Tags: item.Tags, Entities: item.Entities, Revision: effectiveMemoryRevision(item), ExpiresAt: item.ExpiresAt, Priority: item.Priority, Confidence: item.Confidence, SourceRefs: item.SourceRefs, EvidenceRefs: item.EvidenceRefs}, true

--- a/src/agent/internal/agent/notification_memory_processor.go
+++ b/src/agent/internal/agent/notification_memory_processor.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -137,6 +138,35 @@ type notificationMemoryProposal struct {
 	Actions []notificationMemoryAction `json:"actions"`
 }
 
+type notificationProposalError struct {
+	err error
+}
+
+func (e *notificationProposalError) Error() string {
+	if e == nil || e.err == nil {
+		return "invalid notification memory proposal"
+	}
+	return e.err.Error()
+}
+
+func (e *notificationProposalError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func wrapNotificationProposalError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var proposalErr *notificationProposalError
+	if errors.As(err, &proposalErr) {
+		return err
+	}
+	return &notificationProposalError{err: err}
+}
+
 type notificationMemoryAction struct {
 	Action         string   `json:"action"`
 	Scope          string   `json:"scope"`
@@ -234,7 +264,7 @@ func (p *NotificationMemoryProcessor) resolveRecords(ctx context.Context, record
 		}
 		seen[record.ContextID] = true
 		if err := validateNotificationProposalShape(result.Proposal); err != nil {
-			return err
+			return wrapNotificationProposalError(err)
 		}
 		proposalsByContext[record.ContextID] = validatedNotificationResult{record: record, proposal: result.Proposal, refs: refsByContext[record.ContextID]}
 	}
@@ -245,9 +275,9 @@ func (p *NotificationMemoryProcessor) resolveRecords(ctx context.Context, record
 	ordered = coalesceNotificationBatchTargets(ordered)
 	validated := make([]validatedNotificationResult, 0, len(ordered))
 	for _, result := range ordered {
-		proposal, err := p.validateNotificationProposal(result.record, result.proposal, result.refs)
+		proposal, err := p.validateNotificationProposal(ctx, result.record, result.proposal, result.refs)
 		if err != nil {
-			return err
+			return wrapNotificationProposalError(err)
 		}
 		result.proposal = proposal
 		validated = append(validated, result)
@@ -328,8 +358,10 @@ func buildNotificationMemoryBatchPrompt(records []NotificationRecord, refsByCont
 		"Return one result for every notification and at most one action per result. Do not combine evidence across notifications. " +
 		"A memory_catalog target may be modified by at most one result; when multiple notifications relate to it, only the latest notification may target it and earlier results must ignore it. " +
 		"Use only the supplied notification evidence. action must be ignore, add, update, reinforce, remove, or promote; scope must be temporary or long_term. " +
+		"Choose actions by these semantics: add creates a new conclusion with no target memory_id; update replaces a changed conclusion at the exact catalog memory_id and memory_revision; reinforce keeps the same conclusion while recording new evidence at the exact catalog memory_id and memory_revision; remove withdraws the exact catalog memory_id and memory_revision; promote copies the exact temporary catalog memory_id and memory_revision into scope long_term when the notification establishes a stable rule or preference that should outlive temporary expiry. Do not use reinforce for an explicit stable rule or preference that should be promoted. " +
+		"For add and update, content is required; for add also provide exactly one valid type: fact, preference, rule, or profile. For reinforce, remove, and promote, preserve the exact target identity and revision even when content is omitted. " +
 		"Do not retain OTPs, marketing, secrets, or one-off noise. For temporary conclusions use an expiry. " +
-		"For updates include the exact memory_id and memory_revision from memory_catalog.\n\n" + string(payload)
+		"Every targeted action must include the exact memory_id and memory_revision from memory_catalog.\n\n" + string(payload)
 }
 
 func (p *NotificationMemoryProcessor) searchRelatedNotificationMemories(ctx context.Context, record NotificationRecord) ([]MemoryMergeReference, error) {
@@ -371,7 +403,7 @@ func memoryResultMergeReference(scope string, result MemoryResult) MemoryMergeRe
 	return MemoryMergeReference{Scope: scope, ID: result.ID, Type: result.Type, Status: result.Status, Title: result.Title, Summary: result.Summary, Content: result.Content, Tags: result.Tags, Entities: result.Entities, Revision: result.Revision, ExpiresAt: result.ExpiresAt, Priority: result.Priority, Confidence: result.Confidence, SourceRefs: result.SourceRefs, EvidenceRefs: result.EvidenceRefs}
 }
 
-func (p *NotificationMemoryProcessor) validateNotificationProposal(record NotificationRecord, proposal notificationMemoryProposal, refs []MemoryMergeReference) (notificationMemoryProposal, error) {
+func (p *NotificationMemoryProcessor) validateNotificationProposal(ctx context.Context, record NotificationRecord, proposal notificationMemoryProposal, refs []MemoryMergeReference) (notificationMemoryProposal, error) {
 	if err := validateNotificationProposalShape(proposal); err != nil {
 		return notificationMemoryProposal{}, err
 	}
@@ -397,7 +429,16 @@ func (p *NotificationMemoryProcessor) validateNotificationProposal(record Notifi
 			if action.Scope != "long_term" || strings.TrimSpace(action.MemoryID) == "" || action.MemoryRevision <= 0 {
 				return notificationMemoryProposal{}, fmt.Errorf("notification promote proposal requires long_term scope, temporary memory_id, and memory_revision")
 			}
+			if err := validateNotificationProposalSourceEvents(record, action.SourceEventIDs); err != nil {
+				return notificationMemoryProposal{}, err
+			}
 			ref, ok := findNotificationReference(action.MemoryID, "temporary", refs)
+			if !ok {
+				ref, ok = p.findTemporaryNotificationReference(ctx, action.MemoryID)
+				if ok && ref.Status == "deleted" && !p.notificationPromotionAlreadyCreated(record, action, ref) {
+					ok = false
+				}
+			}
 			if !ok || effectiveMergeReferenceRevision(ref) != action.MemoryRevision {
 				return notificationMemoryProposal{}, fmt.Errorf("notification promote proposal references unknown or stale temporary memory %q", action.MemoryID)
 			}
@@ -452,6 +493,39 @@ func (p *NotificationMemoryProcessor) validateNotificationProposal(record Notifi
 	return validated, nil
 }
 
+func (p *NotificationMemoryProcessor) findTemporaryNotificationReference(ctx context.Context, id string) (MemoryMergeReference, bool) {
+	if p.temporary == nil {
+		return MemoryMergeReference{}, false
+	}
+	parsed, err := readMemoryMarkdown(p.temporary.memoryPath(strings.TrimSpace(id)))
+	if err != nil {
+		return MemoryMergeReference{}, false
+	}
+	select {
+	case <-ctx.Done():
+		return MemoryMergeReference{}, false
+	default:
+	}
+	item := parsed.Item
+	return MemoryMergeReference{Scope: "temporary", ID: item.ID, Type: item.Type, Status: item.Status, Title: item.Title, Summary: item.Content, Content: item.Content, Tags: item.Tags, Entities: item.Entities, Revision: effectiveMemoryRevision(item), ExpiresAt: item.ExpiresAt, Priority: item.Priority, Confidence: item.Confidence, SourceRefs: item.SourceRefs, EvidenceRefs: item.EvidenceRefs}, true
+}
+
+func (p *NotificationMemoryProcessor) notificationPromotionAlreadyCreated(record NotificationRecord, action notificationMemoryAction, ref MemoryMergeReference) bool {
+	if p.longTerm == nil {
+		return false
+	}
+	parsed, err := readMemoryMarkdown(p.longTerm.memoryPath("mem_notification_" + record.ContextID))
+	if err != nil || parsed.Item.Status != "active" {
+		return false
+	}
+	expectedContent := firstNonEmptyString([]string{action.Content, ref.Content, ref.Summary})
+	if strings.TrimSpace(parsed.Item.Content) != strings.TrimSpace(expectedContent) {
+		return false
+	}
+	expectedSourceRefs := mergeMemorySourceRefs(ref.SourceRefs, []MemorySourceRef{{Type: "notification", ID: record.ContextID, EventIDs: mergeUniqueStrings(notificationMemoryEvidenceIDs(record), action.SourceEventIDs)}})
+	return memorySourceRefsContain(parsed.Item.SourceRefs, expectedSourceRefs)
+}
+
 func validateNotificationProposalShape(proposal notificationMemoryProposal) error {
 	if len(proposal.Actions) > 1 {
 		return fmt.Errorf("notification proposal has %d actions; maximum is 1", len(proposal.Actions))
@@ -465,12 +539,16 @@ func (p *NotificationMemoryProcessor) applyNotificationProposal(ctx context.Cont
 			continue
 		}
 		if action.Action == "promote" {
-			ref, _ := findNotificationReference(action.MemoryID, "temporary", refs)
-			item := MemoryItem{ID: "mem_notification_" + record.ContextID, Type: firstNonEmptyString([]string{action.Type, ref.Type, "fact"}), TimeScope: "long_term", Title: firstNonEmptyString([]string{action.Title, ref.Title}), Content: firstNonEmptyString([]string{action.Content, ref.Content, ref.Summary}), ExpiresAt: p.now().Add(notificationLongTermTTL).Format(time.RFC3339Nano), Tags: mergeUniqueStrings(ref.Tags, action.Tags), Entities: mergeUniqueStrings(ref.Entities, action.Entities), SourceRefs: ref.SourceRefs, EvidenceRefs: ref.EvidenceRefs, EvidenceExcerpts: []string{firstNonEmptyString([]string{action.Content, ref.Content, ref.Summary, record.NotificationEvent.Message, record.NotificationEvent.Title})}}
-			if _, err := p.longTerm.ApplyMemoryIntent(ctx, MemoryIntent{Item: item}); err != nil {
+			ref, ok := findNotificationReference(action.MemoryID, "temporary", refs)
+			if !ok {
+				ref, _ = p.findTemporaryNotificationReference(ctx, action.MemoryID)
+			}
+			sourceRefs := mergeMemorySourceRefs(ref.SourceRefs, []MemorySourceRef{{Type: "notification", ID: record.ContextID, EventIDs: mergeUniqueStrings(notificationMemoryEvidenceIDs(record), action.SourceEventIDs)}})
+			item := MemoryItem{ID: "mem_notification_" + record.ContextID, Type: firstNonEmptyString([]string{action.Type, ref.Type, "fact"}), TimeScope: "long_term", Title: firstNonEmptyString([]string{action.Title, ref.Title}), Content: firstNonEmptyString([]string{action.Content, ref.Content, ref.Summary}), ExpiresAt: p.now().Add(notificationLongTermTTL).Format(time.RFC3339Nano), Tags: mergeUniqueStrings(ref.Tags, action.Tags), Entities: mergeUniqueStrings(ref.Entities, action.Entities), SourceRefs: sourceRefs, EvidenceRefs: ref.EvidenceRefs, EvidenceExcerpts: []string{firstNonEmptyString([]string{action.Content, ref.Content, ref.Summary, record.NotificationEvent.Message, record.NotificationEvent.Title})}}
+			if _, err := p.longTerm.ApplyMemoryIntent(ctx, MemoryIntent{Item: item, Action: MemoryIntentActionCreate}); err != nil {
 				return err
 			}
-			if _, err := p.temporary.ApplyMemoryIntent(ctx, MemoryIntent{Item: MemoryItem{ID: action.MemoryID}, ExpectedRevision: action.MemoryRevision, Remove: true}); err != nil {
+			if _, err := p.temporary.ApplyMemoryIntent(ctx, MemoryIntent{Item: MemoryItem{ID: action.MemoryID}, Action: MemoryIntentActionRemove, ExpectedRevision: action.MemoryRevision}); err != nil {
 				return err
 			}
 			continue
@@ -497,7 +575,16 @@ func (p *NotificationMemoryProcessor) applyNotificationProposal(ctx context.Cont
 		if store == nil {
 			return fmt.Errorf("notification memory store is not configured for scope %s", action.Scope)
 		}
-		_, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: item, ExpectedRevision: action.MemoryRevision, Remove: action.Action == "remove"})
+		intentAction := MemoryIntentActionCreate
+		switch action.Action {
+		case "update":
+			intentAction = MemoryIntentActionUpdate
+		case "reinforce":
+			intentAction = MemoryIntentActionReinforce
+		case "remove":
+			intentAction = MemoryIntentActionRemove
+		}
+		_, err := store.ApplyMemoryIntent(ctx, MemoryIntent{Item: item, Action: intentAction, ExpectedRevision: action.MemoryRevision})
 		if err != nil {
 			return err
 		}
@@ -640,7 +727,7 @@ func (p *NotificationMemoryProcessor) persistTemporary(ctx context.Context, reco
 	if p.temporary == nil {
 		return fmt.Errorf("temporary memory store is not configured")
 	}
-	_, err := p.temporary.ApplyMemoryIntent(ctx, MemoryIntent{Item: item})
+	_, err := p.temporary.ApplyMemoryIntent(ctx, MemoryIntent{Item: item, Action: MemoryIntentActionCreate})
 	return err
 }
 
@@ -657,7 +744,7 @@ func (p *NotificationMemoryProcessor) removeTemporary(ctx context.Context, recor
 		if !notificationMemoryReferencesRecord(memory.SourceRefs, record) {
 			continue
 		}
-		if _, err := p.temporary.ApplyMemoryIntent(ctx, MemoryIntent{Item: MemoryItem{ID: memory.ID}, ExpectedRevision: effectiveMemoryResultRevision(memory), Remove: true}); err != nil {
+		if _, err := p.temporary.ApplyMemoryIntent(ctx, MemoryIntent{Item: MemoryItem{ID: memory.ID}, Action: MemoryIntentActionRemove, ExpectedRevision: effectiveMemoryResultRevision(memory)}); err != nil {
 			return err
 		}
 		removed = true
@@ -665,8 +752,15 @@ func (p *NotificationMemoryProcessor) removeTemporary(ctx context.Context, recor
 	if removed {
 		return nil
 	}
-	_, err = p.temporary.ApplyMemoryIntent(ctx, MemoryIntent{Item: MemoryItem{ID: "tmp_notification_" + record.ContextID}, Remove: true})
-	return err
+	fallbackID := "tmp_notification_" + record.ContextID
+	for _, memory := range memories {
+		if memory.ID != fallbackID {
+			continue
+		}
+		_, err := p.temporary.ApplyMemoryIntent(ctx, MemoryIntent{Item: MemoryItem{ID: fallbackID}, Action: MemoryIntentActionRemove, ExpectedRevision: effectiveMemoryResultRevision(memory)})
+		return err
+	}
+	return nil
 }
 
 func effectiveMemoryResultRevision(memory MemoryResult) int {

--- a/src/agent/internal/agent/notification_memory_processor_test.go
+++ b/src/agent/internal/agent/notification_memory_processor_test.go
@@ -327,6 +327,86 @@ func TestNotificationMemoryBenchmarkPathDrainsMultipleBatches(t *testing.T) {
 	}
 }
 
+func TestNotificationMemoryBenchmarkPathTracksProvenanceBeyondFirstHundredPendingRecords(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "memory")
+	events := make([]ble.NotificationEvent, 0, 101)
+	responses := make([]string, 0, 11)
+	for index := 1; index <= 101; index++ {
+		events = append(events, ble.NotificationEvent{
+			ID: strconv.Itoa(index), Source: "android", SourceID: "backlog-" + strconv.Itoa(index),
+			SourceEventID: "backlog-event-" + strconv.Itoa(index), AppIdentifier: "com.backlog",
+			Title: "Backlog", Message: "Backlog item " + strconv.Itoa(index), Event: "added",
+			ReceivedAt: "2026-08-21T01:00:00Z",
+		})
+	}
+	for start := 1; start <= 100; start += 10 {
+		results := make([]notificationMemoryBatchResult, 0, 10)
+		for contextID := start; contextID < start+10; contextID++ {
+			results = append(results, notificationMemoryBatchResult{
+				ContextID: strconv.Itoa(contextID),
+				Proposal:  notificationMemoryProposal{Actions: []notificationMemoryAction{{Action: "ignore"}}},
+			})
+		}
+		data, _ := json.Marshal(notificationMemoryBatchResponse{Results: results})
+		responses = append(responses, string(data))
+	}
+	responses = append(responses, `{"results":[{"context_id":"101","proposal":{"actions":[{"action":"add","scope":"temporary","type":"fact","content":"Backlog item 101","tags":["backlog"]}]}}]}`)
+	model := &episodeMemoryScriptedModel{responses: responses}
+	plane := NewFilesystemMemoryPlane(root, DefaultMemoryExtractionConfig(), nil)
+	if err := plane.StartMemoryWorker(model); err != nil {
+		t.Fatalf("StartMemoryWorker() error = %v", err)
+	}
+	defer plane.StopEpisodeMemory()
+	defer plane.StopNotificationMemory()
+	if records, err := plane.notificationProcessor.context.seedForBenchmark(context.Background(), events); err != nil || len(records) != len(events) {
+		t.Fatalf("seeded records=%d err=%v, want %d", len(records), err, len(events))
+	}
+	cursor, memoryIDs, err := plane.ProcessNotificationMemoryNow(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessNotificationMemoryNow() error = %v", err)
+	}
+	if cursor != "101" || len(memoryIDs) != 1 || memoryIDs[0] != "tmp_notification_101" {
+		t.Fatalf("cursor=%q memoryIDs=%#v", cursor, memoryIDs)
+	}
+}
+
+func TestProcessNotificationMemoryNowReturnsBusyAfterRetryExhaustion(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "memory")
+	model := &episodeMemoryBlockingModel{
+		inner:   &episodeMemoryScriptedModel{responses: []string{`{"results":[{"context_id":"1","proposal":{"actions":[{"action":"ignore"}]}}]}`}},
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	plane := NewFilesystemMemoryPlane(root, DefaultMemoryExtractionConfig(), nil)
+	if err := plane.StartNotificationMemory(model); err != nil {
+		t.Fatalf("StartNotificationMemory() error = %v", err)
+	}
+	defer plane.StopNotificationMemory()
+	if _, err := plane.SeedNotificationMemoryForBenchmark(context.Background(), []ble.NotificationEvent{{
+		Source: "android", SourceEventID: "busy-event", Title: "Busy", Event: "added",
+		ReceivedAt: "2026-08-21T00:00:00Z",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	backgroundDone := make(chan error, 1)
+	plane.notificationProcessor.context.setConsumeDisabledForBenchmark(true)
+	go func() {
+		_, err := plane.memoryWorker.ProcessProcessorNow(context.Background(), plane.notificationProcessor)
+		backgroundDone <- err
+	}()
+	select {
+	case <-model.started:
+	case <-time.After(time.Second):
+		t.Fatal("background notification batch did not start")
+	}
+	if _, _, err := plane.processNotificationMemoryNow(context.Background(), 2, 0); !errors.Is(err, errMemoryWorkerBusy) {
+		t.Fatalf("processNotificationMemoryNow() error = %v, want %v", err, errMemoryWorkerBusy)
+	}
+	close(model.release)
+	_ = <-backgroundDone
+	plane.notificationProcessor.context.setConsumeDisabledForBenchmark(false)
+}
+
 func TestNotificationMemoryProcessorUsesTenRecordBatches(t *testing.T) {
 	root := t.TempDir()
 	events := make([]ble.NotificationEvent, 0, 11)

--- a/src/agent/internal/agent/notification_memory_processor_test.go
+++ b/src/agent/internal/agent/notification_memory_processor_test.go
@@ -112,6 +112,41 @@ func TestNotificationMemoryProcessorUsesMergeEngineForAdd(t *testing.T) {
 	}
 }
 
+func TestNotificationMemoryProcessorCreateRetryWithRewordedProposalCommits(t *testing.T) {
+	root := t.TempDir()
+	ctxStore, err := NewNotificationContext(root, func(context.Context, string, string, int) (ble.EventPage, error) {
+		return ble.EventPage{Generation: "g", Events: []ble.NotificationEvent{{ID: "1", Source: "android", SourceID: "n1", NotificationUID: 1, SourceEventID: "evt-1", AppIdentifier: "com.delivery", Title: "Delivery", Message: "Package arrives tomorrow", Event: "added", ReceivedAt: "2026-08-21T00:00:00Z"}}}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := &episodeMemoryScriptedModel{responses: []string{
+		`{"actions":[{"action":"add","scope":"temporary","type":"fact","content":"The package arrives tomorrow"}]}`,
+		`{"actions":[{"action":"add","scope":"temporary","type":"fact","content":"Delivery is expected tomorrow"}]}`,
+	}}
+	processor := NewNotificationMemoryProcessor(ctxStore, root, nil, model)
+	records, err := ctxStore.Consume(context.Background(), 10)
+	if err != nil || len(records) != 1 {
+		t.Fatalf("consume records=%#v err=%v", records, err)
+	}
+	if err := processor.resolveRecords(context.Background(), records); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	if err := processor.resolveRecords(context.Background(), records); err != nil {
+		t.Fatalf("retry resolve: %v", err)
+	}
+	if err := ctxStore.CommitProcessed(context.Background(), records); err != nil {
+		t.Fatalf("commit retry: %v", err)
+	}
+	if got := ctxStore.State().MemoryCursor; got != "1" {
+		t.Fatalf("memory cursor=%q, want 1", got)
+	}
+	memories, err := processor.temporary.Search(context.Background(), MemoryQuery{Limit: 10})
+	if err != nil || len(memories) != 1 || memories[0].Content != "The package arrives tomorrow" || memories[0].Revision != 1 {
+		t.Fatalf("memories=%#v err=%v, want first create unchanged", memories, err)
+	}
+}
+
 func TestNotificationMemoryProcessorAddDoesNotSupersedeSimilarMemory(t *testing.T) {
 	root := t.TempDir()
 	temporary := NewLongTermMemoryStore(filepath.Join(root, "temporary"))

--- a/src/agent/internal/agent/notification_memory_processor_test.go
+++ b/src/agent/internal/agent/notification_memory_processor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -40,6 +41,13 @@ func TestNotificationMemoryProcessorFiltersNoiseAndWritesTemporaryMemory(t *test
 	}
 	if got := ctxStore.State().MemoryCursor; got != "2" {
 		t.Fatalf("MemoryCursor=%q, want 2", got)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "notifications", "events", "2026-08-21.jsonl"))
+	if err != nil {
+		t.Fatalf("read raw notification log: %v", err)
+	}
+	if !strings.Contains(string(raw), `"message":"123456"`) || !strings.Contains(string(raw), `"message":"明天送达"`) {
+		t.Fatalf("raw log did not retain both ignored and useful notifications: %s", raw)
 	}
 }
 
@@ -112,6 +120,97 @@ func TestNotificationMemoryProcessorBatchesUsefulNotificationsIntoOneModelCall(t
 	}
 	if got := ctxStore.State().MemoryCursor; got != "2" {
 		t.Fatalf("MemoryCursor=%q, want 2", got)
+	}
+}
+
+func TestNotificationMemoryBenchmarkPathSeedsProcessesAndExposesDerivedMemory(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "memory")
+	model := &episodeMemoryScriptedModel{responses: []string{`{
+  "results":[
+    {"context_id":"1","proposal":{"actions":[{"action":"add","scope":"temporary","type":"fact","title":"包裹更新","content":"包裹明天送达","tags":["delivery"]}]}}
+  ]
+}`}}
+	plane := NewFilesystemMemoryPlane(root, DefaultMemoryExtractionConfig(), nil)
+	if err := plane.StartMemoryWorker(model); err != nil {
+		t.Fatalf("StartMemoryWorker() error = %v", err)
+	}
+	defer plane.StopEpisodeMemory()
+	defer plane.StopNotificationMemory()
+
+	records, err := plane.SeedNotificationMemoryForBenchmark(context.Background(), []ble.NotificationEvent{{
+		ID: "fixture-1", Source: "android", SourceID: "notification-1",
+		SourceEventID: "event-1", AppIdentifier: "com.delivery",
+		Title: "包裹更新", Message: "明天送达", Event: "added",
+		ReceivedAt: "2026-08-21T00:00:00Z",
+	}})
+	if err != nil {
+		t.Fatalf("SeedNotificationMemoryForBenchmark() error = %v", err)
+	}
+	if len(records) != 1 || records[0].ContextID != "1" {
+		t.Fatalf("seeded records = %#v, want one context_id=1 record", records)
+	}
+	cursor, memoryIDs, err := plane.ProcessNotificationMemoryNow(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessNotificationMemoryNow() error = %v", err)
+	}
+	if cursor != "1" {
+		t.Fatalf("memory cursor = %q, want 1", cursor)
+	}
+	if len(memoryIDs) != 1 || memoryIDs[0] != "tmp_notification_1" {
+		t.Fatalf("derived memory IDs = %#v, want tmp_notification_1", memoryIDs)
+	}
+	if got := model.callCount(); got != 1 {
+		t.Fatalf("model calls = %d, want one call", got)
+	}
+	plane.notificationProcessor.context.mu.Lock()
+	consumeDisabled := plane.notificationProcessor.context.consumeDisabled
+	plane.notificationProcessor.context.mu.Unlock()
+	if consumeDisabled {
+		t.Fatal("benchmark processing left live notification consumption disabled")
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "notifications", "events", "2026-08-21.jsonl"))
+	if err != nil {
+		t.Fatalf("read raw notification fixture: %v", err)
+	}
+	if !strings.Contains(string(raw), `"message":"明天送达"`) {
+		t.Fatalf("raw notification log did not preserve original message: %s", raw)
+	}
+}
+
+func TestNotificationMemoryBenchmarkPathDrainsMultipleBatches(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "memory")
+	events := make([]ble.NotificationEvent, 0, 11)
+	for index := 1; index <= 11; index++ {
+		events = append(events, ble.NotificationEvent{
+			ID: strconv.Itoa(index), Source: "android", SourceID: "calendar-batch-" + strconv.Itoa(index),
+			SourceEventID: "calendar-batch-event-" + strconv.Itoa(index), DeviceID: "benchmark-device",
+			NotificationUID: uint32(200 + index), AppIdentifier: "com.calendar",
+			Title: "Calendar update", Message: "Meeting update " + strconv.Itoa(index), Event: "added",
+			ReceivedAt: "2026-08-21T01:00:00Z",
+		})
+	}
+	model := &episodeMemoryScriptedModel{responses: []string{
+		notificationIgnoreBatchResponse(events[:10]),
+		`{"results":[{"context_id":"11","proposal":{"actions":[{"action":"ignore"}]}}]}`,
+	}}
+	plane := NewFilesystemMemoryPlane(root, DefaultMemoryExtractionConfig(), nil)
+	if err := plane.StartMemoryWorker(model); err != nil {
+		t.Fatalf("StartMemoryWorker() error = %v", err)
+	}
+	defer plane.StopEpisodeMemory()
+	defer plane.StopNotificationMemory()
+	if records, err := plane.SeedNotificationMemoryForBenchmark(context.Background(), events); err != nil || len(records) != len(events) {
+		t.Fatalf("seeded records=%d err=%v, want %d records", len(records), err, len(events))
+	}
+	cursor, memoryIDs, err := plane.ProcessNotificationMemoryNow(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessNotificationMemoryNow() error = %v", err)
+	}
+	if cursor != "11" || len(memoryIDs) != 0 {
+		t.Fatalf("cursor=%q memoryIDs=%#v, want cursor 11 and no memories", cursor, memoryIDs)
+	}
+	if got := model.callCount(); got != 2 {
+		t.Fatalf("model calls=%d, want two model calls for two processor batches", got)
 	}
 }
 

--- a/src/agent/internal/agent/notification_memory_processor_test.go
+++ b/src/agent/internal/agent/notification_memory_processor_test.go
@@ -68,6 +68,24 @@ func TestNotificationMemoryProcessorImplementsWorkerIsolationSeam(t *testing.T) 
 	worker.Stop()
 }
 
+func TestNotificationMemoryPromptDefinesTargetedActionContract(t *testing.T) {
+	prompt := buildNotificationMemoryBatchPrompt(
+		[]NotificationRecord{{ContextID: "1"}},
+		map[string][]MemoryMergeReference{"1": {{
+			Scope: "temporary", ID: "tmp-1", Revision: 2,
+		}}},
+	)
+	for _, required := range []string{
+		"add and update, content is required",
+		"promote copies the exact temporary catalog memory_id and memory_revision into scope long_term",
+		"Every targeted action must include the exact memory_id and memory_revision",
+	} {
+		if !strings.Contains(prompt, required) {
+			t.Fatalf("notification prompt missing %q: %s", required, prompt)
+		}
+	}
+}
+
 func TestNotificationMemoryProcessorUsesMergeEngineForAdd(t *testing.T) {
 	root := t.TempDir()
 	ctxStore, err := NewNotificationContext(root, func(context.Context, string, string, int) (ble.EventPage, error) {
@@ -91,6 +109,66 @@ func TestNotificationMemoryProcessorUsesMergeEngineForAdd(t *testing.T) {
 	}
 	if got := ctxStore.State().MemoryCursor; got != "1" {
 		t.Fatalf("MemoryCursor=%q, want 1", got)
+	}
+}
+
+func TestNotificationMemoryProcessorAddDoesNotSupersedeSimilarMemory(t *testing.T) {
+	root := t.TempDir()
+	temporary := NewLongTermMemoryStore(filepath.Join(root, "temporary"))
+	if _, err := temporary.AddMemory(context.Background(), MemoryItem{
+		ID: "existing-delivery", Type: "fact", TimeScope: "temporary", Title: "Delivery update", Content: "The package arrives tomorrow",
+		Tags: []string{"notification", "com.delivery"}, Entities: []string{"com.delivery"}, EvidenceExcerpts: []string{"old notification"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ctxStore, err := NewNotificationContext(root, func(context.Context, string, string, int) (ble.EventPage, error) {
+		return ble.EventPage{Generation: "g", Events: []ble.NotificationEvent{{ID: "1", Source: "android", SourceID: "n1", NotificationUID: 1, SourceEventID: "evt-1", AppIdentifier: "com.delivery", Title: "Delivery window", Message: "The package arrives tomorrow at noon", Event: "added", ReceivedAt: "2026-08-21T00:00:00Z"}}}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := &episodeMemoryScriptedModel{responses: []string{`{"actions":[{"action":"add","scope":"temporary","type":"fact","title":"Delivery window","content":"The package arrives tomorrow at noon","expires_at":"2026-08-28T00:00:00Z","tags":["notification","com.delivery"],"entities":["com.delivery"]}]}`}}
+	processor := NewNotificationMemoryProcessor(ctxStore, root, nil, model)
+	processor.now = func() time.Time { return time.Date(2026, 8, 21, 1, 0, 0, 0, time.UTC) }
+	if _, err := processor.ProcessBatch(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	memories, err := temporary.Search(context.Background(), MemoryQuery{Tags: []string{"com.delivery"}, Limit: 10})
+	if err != nil || len(memories) != 2 {
+		t.Fatalf("memories=%#v err=%v, want explicit add plus existing memory", memories, err)
+	}
+	active := map[string]bool{}
+	for _, memory := range memories {
+		active[memory.ID] = true
+	}
+	if !active["existing-delivery"] || !active["tmp_notification_1"] {
+		t.Fatalf("active IDs=%#v, want both records", active)
+	}
+}
+
+func TestNotificationMemoryProcessorPreservesReinforceAction(t *testing.T) {
+	root := t.TempDir()
+	temporary := NewLongTermMemoryStore(filepath.Join(root, "temporary"))
+	if _, err := temporary.AddMemory(context.Background(), MemoryItem{
+		ID: "tmp_delivery", Type: "fact", TimeScope: "temporary", Title: "Delivery", Content: "The package arrives tomorrow",
+		Tags: []string{"notification", "com.delivery"}, Entities: []string{"com.delivery"}, EvidenceExcerpts: []string{"old notification"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ctxStore, err := NewNotificationContext(root, func(context.Context, string, string, int) (ble.EventPage, error) {
+		return ble.EventPage{Generation: "g", Events: []ble.NotificationEvent{{ID: "1", Source: "android", SourceID: "n1", NotificationUID: 1, SourceEventID: "evt-1", AppIdentifier: "com.delivery", Title: "Delivery", Message: "Another notification confirms the delivery", Event: "modified", ReceivedAt: "2026-08-21T00:00:00Z"}}}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := &episodeMemoryScriptedModel{responses: []string{`{"actions":[{"action":"reinforce","scope":"temporary","memory_id":"tmp_delivery","memory_revision":1,"type":"fact","content":"Text that must not replace the conclusion"}]}`}}
+	processor := NewNotificationMemoryProcessor(ctxStore, root, nil, model)
+	if _, err := processor.ProcessBatch(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	memories, err := temporary.Search(context.Background(), MemoryQuery{Tags: []string{"com.delivery"}, Limit: 10})
+	if err != nil || len(memories) != 1 || memories[0].Revision != 2 || memories[0].Content != "The package arrives tomorrow" {
+		t.Fatalf("memories=%#v err=%v, want reinforced evidence without conclusion update", memories, err)
 	}
 }
 
@@ -493,7 +571,7 @@ func TestNotificationMemoryProcessorUpdatesWithRevisionAndCanPromote(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := temporary.ApplyMemoryIntent(context.Background(), MemoryIntent{Item: MemoryItem{ID: "tmp_notification_1", Type: "fact", TimeScope: "temporary", Title: "稳定规则", Content: "以后统一寄到公司", Tags: []string{"notification", "com.delivery"}, EvidenceExcerpts: []string{"通知"}}}); err != nil {
+	if _, err := temporary.ApplyMemoryIntent(context.Background(), MemoryIntent{Item: MemoryItem{ID: "tmp_notification_1", Type: "fact", TimeScope: "temporary", Title: "稳定规则", Content: "以后统一寄到公司", Tags: []string{"notification", "com.delivery"}, SourceRefs: []MemorySourceRef{{Type: "notification", ID: "1", EventIDs: []string{"event-1"}}}, EvidenceExcerpts: []string{"通知"}}, Action: MemoryIntentActionCreate}); err != nil {
 		t.Fatal(err)
 	}
 	processor2 := NewNotificationMemoryProcessor(ctxStore2, root, longTerm, &episodeMemoryScriptedModel{responses: []string{`{"actions":[{"action":"promote","scope":"long_term","memory_id":"tmp_notification_1","memory_revision":1}]}`}})
@@ -511,5 +589,58 @@ func TestNotificationMemoryProcessorUpdatesWithRevisionAndCanPromote(t *testing.
 				t.Fatalf("promoted temporary memory still active: %#v", item)
 			}
 		}
+	}
+}
+
+func TestNotificationMemoryPromoteRetryAfterTemporaryRemovalConverges(t *testing.T) {
+	root := t.TempDir()
+	temporary := NewLongTermMemoryStore(filepath.Join(root, "temporary"))
+	longTerm := NewLongTermMemoryStore(filepath.Join(root, "long_term"))
+	record := NotificationRecord{ContextID: "retry", NotificationEvent: ble.NotificationEvent{ID: "event-retry", Source: "android", SourceEventID: "source-retry", AppIdentifier: "com.delivery", Title: "Delivery rule", Message: "Always deliver to the office"}}
+	temporaryItem := MemoryItem{ID: "tmp_notification_retry", Type: "rule", TimeScope: "temporary", Title: "Delivery rule", Content: "Always deliver to the office", Tags: []string{"notification", "com.delivery"}, SourceRefs: []MemorySourceRef{{Type: "notification", ID: "original", EventIDs: []string{"original-event"}}}, EvidenceExcerpts: []string{"Always deliver to the office"}}
+	if _, err := temporary.ApplyMemoryIntent(context.Background(), MemoryIntent{Item: temporaryItem, Action: MemoryIntentActionCreate}); err != nil {
+		t.Fatal(err)
+	}
+	processor := NewNotificationMemoryProcessor(nil, root, longTerm, nil)
+	proposal := notificationMemoryProposal{Actions: []notificationMemoryAction{{Action: "promote", Scope: "long_term", MemoryID: temporaryItem.ID, MemoryRevision: 1, SourceEventIDs: []string{"source-retry"}}}}
+	activeRef := memoryResultMergeReference("temporary", MemoryResult{ID: temporaryItem.ID, Type: temporaryItem.Type, Status: "active", Revision: 1, Title: temporaryItem.Title, Summary: temporaryItem.Content, Content: temporaryItem.Content, Tags: temporaryItem.Tags, SourceRefs: temporaryItem.SourceRefs})
+	validated, err := processor.validateNotificationProposal(context.Background(), record, proposal, []MemoryMergeReference{activeRef})
+	if err != nil {
+		t.Fatalf("validate initial promote: %v", err)
+	}
+	if err := processor.applyNotificationProposal(context.Background(), record, validated, []MemoryMergeReference{activeRef}); err != nil {
+		t.Fatalf("apply initial promote: %v", err)
+	}
+	validated, err = processor.validateNotificationProposal(context.Background(), record, proposal, nil)
+	if err != nil {
+		t.Fatalf("validate retry promote: %v", err)
+	}
+	if err := processor.applyNotificationProposal(context.Background(), record, validated, nil); err != nil {
+		t.Fatalf("apply retry promote: %v", err)
+	}
+	promoted, err := longTerm.Search(context.Background(), MemoryQuery{Tags: []string{"com.delivery"}, Limit: 10})
+	if err != nil || len(promoted) != 1 {
+		t.Fatalf("promoted=%#v err=%v", promoted, err)
+	}
+	if !memorySourceRefsContain(promoted[0].SourceRefs, []MemorySourceRef{{Type: "notification", ID: record.ContextID, EventIDs: []string{"source-retry"}}}) {
+		t.Fatalf("promotion omitted retry evidence: %#v", promoted[0].SourceRefs)
+	}
+}
+
+func TestNotificationMemoryPromoteRejectsUnrelatedDeletedTemporary(t *testing.T) {
+	root := t.TempDir()
+	temporary := NewLongTermMemoryStore(filepath.Join(root, "temporary"))
+	processor := NewNotificationMemoryProcessor(nil, root, NewLongTermMemoryStore(filepath.Join(root, "long_term")), nil)
+	item := MemoryItem{ID: "tmp_deleted", Type: "rule", TimeScope: "temporary", Content: "Do not restore me", SourceRefs: []MemorySourceRef{{Type: "notification", ID: "old", EventIDs: []string{"old-event"}}}, EvidenceExcerpts: []string{"Do not restore me"}}
+	if _, err := temporary.ApplyMemoryIntent(context.Background(), MemoryIntent{Item: item, Action: MemoryIntentActionCreate}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := temporary.ApplyMemoryIntent(context.Background(), MemoryIntent{Item: MemoryItem{ID: item.ID}, Action: MemoryIntentActionRemove, ExpectedRevision: 1}); err != nil {
+		t.Fatal(err)
+	}
+	record := NotificationRecord{ContextID: "new", NotificationEvent: ble.NotificationEvent{ID: "new-event", SourceEventID: "new-event", Message: "Do not restore me"}}
+	proposal := notificationMemoryProposal{Actions: []notificationMemoryAction{{Action: "promote", Scope: "long_term", MemoryID: item.ID, MemoryRevision: 1}}}
+	if _, err := processor.validateNotificationProposal(context.Background(), record, proposal, nil); err == nil {
+		t.Fatal("deleted temporary without a completed promotion was accepted")
 	}
 }

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -2457,15 +2457,19 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 }
 
 type benchmarkSeedMemoryRequest struct {
-	Store    string   `json:"store"`
-	ID       string   `json:"id"`
-	Type     string   `json:"type"`
-	Title    string   `json:"title"`
-	Content  string   `json:"content"`
-	Tags     []string `json:"tags"`
-	Entities []string `json:"entities"`
-	Evidence []string `json:"evidence"`
-	Priority int      `json:"priority"`
+	Store        string            `json:"store"`
+	ID           string            `json:"id"`
+	Type         string            `json:"type"`
+	Title        string            `json:"title"`
+	Content      string            `json:"content"`
+	Tags         []string          `json:"tags"`
+	Entities     []string          `json:"entities"`
+	Evidence     []string          `json:"evidence"`
+	SourceRefs   []MemorySourceRef `json:"source_refs"`
+	EvidenceRefs []MemorySourceRef `json:"evidence_refs"`
+	TimeScope    string            `json:"time_scope"`
+	ExpiresAt    string            `json:"expires_at"`
+	Priority     int               `json:"priority"`
 }
 
 func (s *Server) handleBenchmarkSeedEpisode(w http.ResponseWriter, r *http.Request) {
@@ -2611,7 +2615,10 @@ func (s *Server) handleBenchmarkProcessNotificationMemory(w http.ResponseWriter,
 	cursor, memoryIDs, err := plane.ProcessNotificationMemoryNow(r.Context())
 	if err != nil {
 		code := http.StatusInternalServerError
-		if errors.Is(err, errMemoryWorkerBusy) {
+		var proposalErr *notificationProposalError
+		if errors.As(err, &proposalErr) {
+			code = http.StatusUnprocessableEntity
+		} else if errors.Is(err, errMemoryWorkerBusy) {
 			code = http.StatusConflict
 		}
 		http.Error(w, "process notification memory: "+err.Error(), code)
@@ -2703,8 +2710,8 @@ func (s *Server) handleBenchmarkSeedMemory(w http.ResponseWriter, r *http.Reques
 	if storeName == "" {
 		storeName = "long_term"
 	}
-	if storeName != "long_term" && storeName != "device" {
-		http.Error(w, "store must be long_term or device", http.StatusBadRequest)
+	if storeName != "long_term" && storeName != "temporary" && storeName != "device" {
+		http.Error(w, "store must be long_term, temporary, or device", http.StatusBadRequest)
 		return
 	}
 	priority := req.Priority
@@ -2738,22 +2745,32 @@ func (s *Server) handleBenchmarkSeedMemory(w http.ResponseWriter, r *http.Reques
 			Entities:   req.Entities,
 		})
 	} else {
-		if plane.LongTerm() == nil {
-			http.Error(w, "long-term memory not configured", http.StatusServiceUnavailable)
+		store := plane.LongTerm()
+		memoryScope := "long_term"
+		if storeName == "temporary" {
+			store = NewLongTermMemoryStore(filepath.Join(plane.memoryDir, "temporary"))
+			memoryScope = "temporary"
+		}
+		if store == nil {
+			http.Error(w, "memory store not configured", http.StatusServiceUnavailable)
 			return
 		}
 		item := MemoryItem{
 			ID:               req.ID,
 			Type:             req.Type,
+			TimeScope:        memoryScope,
 			Priority:         priority,
 			Confidence:       0.9,
 			Title:            req.Title,
 			Content:          req.Content,
 			Tags:             req.Tags,
 			Entities:         req.Entities,
+			SourceRefs:       req.SourceRefs,
+			EvidenceRefs:     req.EvidenceRefs,
+			ExpiresAt:        req.ExpiresAt,
 			EvidenceExcerpts: evidence,
 		}
-		id, err = plane.LongTerm().AddMemory(r.Context(), item)
+		id, err = store.AddMemory(r.Context(), item)
 	}
 	if err != nil {
 		if s.logger != nil {

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -512,6 +512,8 @@ func (s *Server) Handler() http.Handler {
 		mux.HandleFunc("/api/benchmark/seed_memory", s.handleBenchmarkSeedMemory)
 		mux.HandleFunc("/api/benchmark/seed_episode", s.handleBenchmarkSeedEpisode)
 		mux.HandleFunc("/api/benchmark/episode-memory/process", s.handleBenchmarkProcessEpisodeMemory)
+		mux.HandleFunc("/api/benchmark/seed_notification", s.handleBenchmarkSeedNotification)
+		mux.HandleFunc("/api/benchmark/notification-memory/process", s.handleBenchmarkProcessNotificationMemory)
 		mux.HandleFunc("/api/benchmark/phone_bridge_state", s.handleBenchmarkPhoneBridgeState)
 	}
 	mux.HandleFunc("/api/clear", s.handleClear)
@@ -2529,6 +2531,97 @@ type benchmarkProcessEpisodeMemoryResponse struct {
 	Status     string                   `json:"status"`
 	Assessment *episodeMemoryAssessment `json:"assessment,omitempty"`
 	MemoryIDs  []string                 `json:"memory_ids"`
+}
+
+type benchmarkSeedNotificationRequest struct {
+	Events []ble.NotificationEvent `json:"events"`
+}
+
+type benchmarkProcessNotificationMemoryResponse struct {
+	MemoryCursor string   `json:"memory_cursor"`
+	MemoryIDs    []string `json:"memory_ids"`
+}
+
+func (s *Server) handleBenchmarkSeedNotification(w http.ResponseWriter, r *http.Request) {
+	if !s.authorizeBenchmarkRequest(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req benchmarkSeedNotificationRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 512*1024))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		http.Error(w, "decode notification fixture: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		http.Error(w, "decode notification fixture: expected exactly one JSON object", http.StatusBadRequest)
+		return
+	}
+	if len(req.Events) == 0 || len(req.Events) > 100 {
+		http.Error(w, "events must contain between 1 and 100 entries", http.StatusBadRequest)
+		return
+	}
+	for index, event := range req.Events {
+		if strings.TrimSpace(event.Title) == "" && strings.TrimSpace(event.Message) == "" {
+			http.Error(w, fmt.Sprintf("events[%d] requires a title or message", index), http.StatusBadRequest)
+			return
+		}
+	}
+	plane, ok := s.runtime.MemoryPlane().(*FilesystemMemoryPlane)
+	if !ok || plane == nil {
+		http.Error(w, "filesystem memory plane not configured", http.StatusServiceUnavailable)
+		return
+	}
+	records, err := plane.SeedNotificationMemoryForBenchmark(r.Context(), req.Events)
+	if err != nil {
+		http.Error(w, "seed notification: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	ids := make([]string, 0, len(records))
+	for _, record := range records {
+		ids = append(ids, record.ContextID)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status":      "seeded",
+		"context_ids": ids,
+		"event_count": len(records),
+	})
+}
+
+func (s *Server) handleBenchmarkProcessNotificationMemory(w http.ResponseWriter, r *http.Request) {
+	if !s.authorizeBenchmarkRequest(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	plane, ok := s.runtime.MemoryPlane().(*FilesystemMemoryPlane)
+	if !ok || plane == nil {
+		http.Error(w, "filesystem memory plane not configured", http.StatusServiceUnavailable)
+		return
+	}
+	cursor, memoryIDs, err := plane.ProcessNotificationMemoryNow(r.Context())
+	if err != nil {
+		code := http.StatusInternalServerError
+		if errors.Is(err, errMemoryWorkerBusy) {
+			code = http.StatusConflict
+		}
+		http.Error(w, "process notification memory: "+err.Error(), code)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(benchmarkProcessNotificationMemoryResponse{
+		MemoryCursor: cursor,
+		MemoryIDs:    memoryIDs,
+	})
 }
 
 func (s *Server) handleBenchmarkProcessEpisodeMemory(w http.ResponseWriter, r *http.Request) {

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -2467,7 +2467,6 @@ type benchmarkSeedMemoryRequest struct {
 	Evidence     []string          `json:"evidence"`
 	SourceRefs   []MemorySourceRef `json:"source_refs"`
 	EvidenceRefs []MemorySourceRef `json:"evidence_refs"`
-	TimeScope    string            `json:"time_scope"`
 	ExpiresAt    string            `json:"expires_at"`
 	Priority     int               `json:"priority"`
 }

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -4075,6 +4075,10 @@ func startFakeFrameServiceSocket(t *testing.T, handler func(map[string]any) (str
 }
 
 func newBenchmarkSeedMemoryServer(t *testing.T) (*Server, string) {
+	return newBenchmarkSeedMemoryServerWithModel(t, &scriptedModel{})
+}
+
+func newBenchmarkSeedMemoryServerWithModel(t *testing.T, model *scriptedModel) (*Server, string) {
 	t.Helper()
 	configDir := ensureTestConfigDir(t, t.TempDir())
 	streamingDisabled := false
@@ -4087,7 +4091,7 @@ func newBenchmarkSeedMemoryServer(t *testing.T) (*Server, string) {
 			VoiceStreamingTTSEnabled: &streamingDisabled,
 			VoiceToolCallSpeech:      &streamingDisabled,
 		},
-		&testModelResolver{model: &scriptedModel{}},
+		&testModelResolver{model: model},
 		NewMemoryManager(filepath.Join(configDir, "memory")),
 		&ToolSet{tools: map[string]langtools.Tool{}},
 		NewSkillIndex(),
@@ -4128,6 +4132,59 @@ func TestHandleBenchmarkSeedMemorySucceeds(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "id: personamem_test_seed_1") {
 		t.Fatalf("memory file missing fixed id, got: %s", string(data))
+	}
+}
+
+func TestHandleBenchmarkSeedNotificationWritesDurableFixture(t *testing.T) {
+	server, configDir := newBenchmarkSeedMemoryServerWithModel(t, &scriptedModel{responses: []*llms.ContentResponse{
+		contentResponse(`{"results":[{"context_id":"1","proposal":{"actions":[{"action":"ignore"}]}}]}`),
+	}})
+	body := `{"events":[{"source":"android","source_id":"delivery-1","source_event_id":"delivery-event-1","device_id":"benchmark-device","notification_uid":101,"event":"added","app_identifier":"com.delivery","title":"包裹更新","message":"包裹明天送达","received_at":"2026-08-21T00:01:00Z"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/benchmark/seed_notification", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-benchmark-token")
+	rec := httptest.NewRecorder()
+
+	server.handleBenchmarkSeedNotification(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Status     string   `json:"status"`
+		ContextIDs []string `json:"context_ids"`
+		EventCount int      `json:"event_count"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Status != "seeded" || response.EventCount != 1 || len(response.ContextIDs) != 1 || response.ContextIDs[0] != "1" {
+		t.Fatalf("unexpected response: %#v", response)
+	}
+	rawPath := filepath.Join(configDir, "memory", "notifications", "events", "2026-08-21.jsonl")
+	raw, err := os.ReadFile(rawPath)
+	if err != nil {
+		t.Fatalf("read seeded notification fixture: %v", err)
+	}
+	if !strings.Contains(string(raw), `"message":"包裹明天送达"`) {
+		t.Fatalf("raw fixture missing original message: %s", raw)
+	}
+	processReq := httptest.NewRequest(http.MethodPost, "/api/benchmark/notification-memory/process", bytes.NewBufferString(`{}`))
+	processReq.Header.Set("Content-Type", "application/json")
+	processReq.Header.Set("Authorization", "Bearer test-benchmark-token")
+	processRec := httptest.NewRecorder()
+	server.handleBenchmarkProcessNotificationMemory(processRec, processReq)
+	if processRec.Code != http.StatusOK {
+		t.Fatalf("unexpected process status: %d body=%s", processRec.Code, processRec.Body.String())
+	}
+	var processResponse struct {
+		MemoryCursor string `json:"memory_cursor"`
+	}
+	if err := json.NewDecoder(processRec.Body).Decode(&processResponse); err != nil {
+		t.Fatalf("decode process response: %v", err)
+	}
+	if processResponse.MemoryCursor != "1" {
+		t.Fatalf("process cursor = %q, want 1", processResponse.MemoryCursor)
 	}
 }
 

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -4188,6 +4189,55 @@ func TestHandleBenchmarkSeedNotificationWritesDurableFixture(t *testing.T) {
 	}
 }
 
+func TestHandleBenchmarkProcessNotificationMemoryClassifiesInvalidProposal(t *testing.T) {
+	server, _ := newBenchmarkSeedMemoryServerWithModel(t, &scriptedModel{responses: []*llms.ContentResponse{
+		contentResponse(`{"results":[{"context_id":"1","proposal":{"actions":[{"action":"add","scope":"temporary","type":"not-a-memory-type","content":"Package arrives tomorrow"}]}}]}`),
+	}})
+	seedBody := `{"events":[{"source":"android","source_id":"delivery-invalid","source_event_id":"delivery-invalid-event","device_id":"benchmark-device","notification_uid":110,"event":"added","app_identifier":"com.delivery","title":"Package update","message":"Package arrives tomorrow","received_at":"2026-08-21T00:01:00Z"}]}`
+	seedReq := httptest.NewRequest(http.MethodPost, "/api/benchmark/seed_notification", bytes.NewBufferString(seedBody))
+	seedReq.Header.Set("Authorization", "Bearer test-benchmark-token")
+	seedRec := httptest.NewRecorder()
+	server.handleBenchmarkSeedNotification(seedRec, seedReq)
+	if seedRec.Code != http.StatusOK {
+		t.Fatalf("seed status=%d body=%s", seedRec.Code, seedRec.Body.String())
+	}
+
+	processReq := httptest.NewRequest(http.MethodPost, "/api/benchmark/notification-memory/process", bytes.NewBufferString(`{}`))
+	processReq.Header.Set("Authorization", "Bearer test-benchmark-token")
+	processRec := httptest.NewRecorder()
+	server.handleBenchmarkProcessNotificationMemory(processRec, processReq)
+
+	if processRec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("process status=%d body=%s, want 422", processRec.Code, processRec.Body.String())
+	}
+}
+
+func TestHandleBenchmarkSeedNotificationRetryReturnsOriginalContextID(t *testing.T) {
+	server, _ := newBenchmarkSeedMemoryServer(t)
+	body := `{"events":[{"source":"android","source_id":"delivery-retry","source_event_id":"delivery-retry-event","device_id":"benchmark-device","notification_uid":102,"event":"added","app_identifier":"com.delivery","title":"Package update","message":"Package arrives tomorrow","received_at":"2026-08-21T00:02:00Z"}]}`
+	seed := func() map[string]any {
+		req := httptest.NewRequest(http.MethodPost, "/api/benchmark/seed_notification", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer test-benchmark-token")
+		rec := httptest.NewRecorder()
+		server.handleBenchmarkSeedNotification(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+		}
+		var response map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		return response
+	}
+
+	first := seed()
+	retried := seed()
+	if !reflect.DeepEqual(first["context_ids"], retried["context_ids"]) || retried["event_count"] != float64(1) {
+		t.Fatalf("first=%#v retried=%#v", first, retried)
+	}
+}
+
 func TestHandleBenchmarkSeedMemoryCanSeedDeviceFixture(t *testing.T) {
 	server, configDir := newBenchmarkSeedMemoryServer(t)
 	body := `{"store":"device","id":"legacy_device_fixture","type":"procedure","title":"Legacy procedure","content":"Preview, then Edit, then Save.","tags":["qa-notes","save"],"entities":["QA Notes","Preview","Edit","Save"]}`
@@ -4215,6 +4265,29 @@ func TestHandleBenchmarkSeedMemoryCanSeedDeviceFixture(t *testing.T) {
 	}
 	if len(files) != 1 || !strings.Contains(files[0], "legacy_device_fixture") {
 		t.Fatalf("device fixture files = %#v", files)
+	}
+}
+
+func TestHandleBenchmarkSeedMemoryCanSeedTemporaryFixture(t *testing.T) {
+	server, configDir := newBenchmarkSeedMemoryServer(t)
+	body := `{"store":"temporary","id":"tmp_benchmark_delivery","type":"fact","title":"Delivery","content":"Package arrives today.","tags":["notification","com.delivery"],"source_refs":[{"type":"notification","id":"fixture-old","event_ids":["old-event"]}],"expires_at":"2099-01-01T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/benchmark/seed_memory", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-benchmark-token")
+	rec := httptest.NewRecorder()
+
+	server.handleBenchmarkSeedMemory(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	memPath := filepath.Join(configDir, "memory", "temporary", "memories", "tmp_benchmark_delivery.md")
+	parsed, err := readMemoryMarkdown(memPath)
+	if err != nil {
+		t.Fatalf("read temporary fixture: %v", err)
+	}
+	if parsed.Item.TimeScope != "temporary" || len(parsed.Item.SourceRefs) != 1 {
+		t.Fatalf("temporary fixture = %#v", parsed.Item)
 	}
 }
 


### PR DESCRIPTION
## Summary

- apply Processor-selected memory create/update/reinforce/remove operations without a second semantic merge in the Store
- make deterministic create IDs idempotent across crash retries and reworded LLM proposals while preserving ID-conflict detection across different sources
- add generic ordered benchmark setup and memory assertions, plus end-to-end notification memory lifecycle coverage
- validate Episode update revisions and preserve notification promotion provenance

Stacked on #561.

## Verification

- `669 passed` (benchmark Python tests)
- `go test ./internal/agent -count=1`
- notification memory real-model benchmark: `7/7 passed`
- suite JSON and ASCII-only validation
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a notification-memory benchmark covering ingestion, recall, consolidation, updates, reinforcement, removal, and long-term promotion.
  * Added deterministic notification and temporary-memory fixtures for benchmark scenarios.
  * Added multi-step benchmark setup with memory assertions for counts, scopes, fields, tags, entities, and source references.
  * Improved memory operations with explicit create, update, reinforce, and remove actions, including safer retries and revision checks.
  * Enabled benchmark runs without an environment bridge and added authenticated notification processing controls.

* **Documentation**
  * Added guides for notification-memory architecture, lifecycle, privacy, recovery, and benchmark execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->