### PR TITLE
fix(agent): skip automatic screenshot for image messages

### DIFF
--- a/src/agent/internal/agent/prompt_test.go
+++ b/src/agent/internal/agent/prompt_test.go
@@ -129,6 +129,80 @@ func TestStateHookAttachesFreshScreenshotToUserTurn(t *testing.T) {
 	}
 }
 
+func TestStateHookSkipsFreshScreenshotWhenUserProvidesImage(t *testing.T) {
+	screenshot := &stubTool{
+		name:        "screenshot",
+		description: "Capture screenshot.",
+		output:      `{"width":390,"height":844,"format":"jpeg","size":18,"data":"unused"}`,
+	}
+	runtime := NewRuntimeWithDeps(Config{}, nil, nil, &ToolSet{tools: map[string]langtools.Tool{
+		"screenshot": screenshot,
+	}}, NewSkillIndex())
+	runtime.stateManager.SetState("device", "connected")
+	manager := newPromptTestContextManager(t)
+	runtime.contextManager = manager
+	manager.AddAppendMessageHook(runtime.getStateHook())
+
+	message := userMessageFromInput(manager, "analyze this", []InputAttachment{{
+		Kind:     AttachmentKindImage,
+		MIMEType: "image/png",
+		Data:     []byte("user image"),
+	}})
+	if err := manager.AppendMessage(message); err != nil {
+		t.Fatalf("AppendMessage() error = %v", err)
+	}
+
+	messageList := manager.MessageListDump().Messages
+	if len(messageList) != 2 || messageList[0].Role != messages.MessageRoleState || messageList[1].Role != messages.MessageRoleUser {
+		t.Fatalf("messages = %#v, want text state followed by the user message", messageList)
+	}
+	if len(messageList[0].Attachments) != 0 {
+		t.Fatalf("state attachments = %#v, want no automatic screenshot", messageList[0].Attachments)
+	}
+	if len(messageList[1].Attachments) != 1 || messageList[1].Attachments[0].MIMEType != "image/png" {
+		t.Fatalf("user attachments = %#v, want uploaded image", messageList[1].Attachments)
+	}
+	if len(screenshot.inputs) != 0 {
+		t.Fatalf("screenshot inputs = %#v, want no screenshot call", screenshot.inputs)
+	}
+}
+
+func TestStateHookStillAttachesFreshScreenshotForNonImageAttachment(t *testing.T) {
+	imageData := []byte("current screenshot")
+	screenshot := &stubTool{
+		name:        "screenshot",
+		description: "Capture screenshot.",
+		output: `{"width":390,"height":844,"format":"jpeg","size":18,"data":"` +
+			base64.StdEncoding.EncodeToString(imageData) + `"}`,
+	}
+	runtime := NewRuntimeWithDeps(Config{}, nil, nil, &ToolSet{tools: map[string]langtools.Tool{
+		"screenshot": screenshot,
+	}}, NewSkillIndex())
+	manager := newPromptTestContextManager(t)
+	runtime.contextManager = manager
+	manager.AddAppendMessageHook(runtime.getStateHook())
+
+	message := userMessageFromInput(manager, "listen to this", []InputAttachment{{
+		Kind:     AttachmentKindAudio,
+		MIMEType: "audio/wav",
+		Data:     []byte("audio"),
+	}})
+	if err := manager.AppendMessage(message); err != nil {
+		t.Fatalf("AppendMessage() error = %v", err)
+	}
+
+	messageList := manager.MessageListDump().Messages
+	if len(messageList) != 2 || len(messageList[0].Attachments) != 1 {
+		t.Fatalf("messages = %#v, want state screenshot followed by the user message", messageList)
+	}
+	if messageList[0].Attachments[0].Source != messages.AttachmentSourceScreenshotObservation {
+		t.Fatalf("state attachment = %#v, want screenshot observation", messageList[0].Attachments[0])
+	}
+	if len(screenshot.inputs) != 1 || screenshot.inputs[0] != "{}" {
+		t.Fatalf("screenshot inputs = %#v, want one empty-object call", screenshot.inputs)
+	}
+}
+
 func TestStateHookKeepsTextStateWhenScreenshotFails(t *testing.T) {
 	screenshot := &stubTool{
 		name:        "screenshot",

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1311,7 +1311,10 @@ func (r *Runtime) getStateHook() contextmanager.AppendMessageHook {
 				Message: &message,
 			}
 		}
-		attachment := r.captureStateScreenshot()
+		var attachment *messages.Attachment
+		if !messageHasImageAttachment(message) {
+			attachment = r.captureStateScreenshot()
+		}
 		entries := r.stateManager.GetAllStates()
 		// If neither runtime state nor a screenshot is available, just skip.
 		if len(entries) == 0 && attachment == nil {
@@ -1354,6 +1357,15 @@ func (r *Runtime) getStateHook() contextmanager.AppendMessageHook {
 			After:   []messages.Message{},
 		}
 	}
+}
+
+func messageHasImageAttachment(message messages.Message) bool {
+	for _, attachment := range message.Attachments {
+		if isImageMIMEType(attachment.MIMEType) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Runtime) captureStateScreenshot() *messages.Attachment {


### PR DESCRIPTION
Summary:
- skip the automatic device screenshot when the current user message already contains an image attachment
- preserve text device state injection and automatic screenshots for text, audio, and other non-image turns
- add regression coverage for image and audio attachment behavior

Verification:
- go test ./internal/agent -count=1
- Linux ARMv7 agent cross-build succeeded
- full ./build.sh reaches the existing unrelated src/aiden_sdk.cpp:615 error: undefined self

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant automatic screenshots when a user message already includes an image.
  * Continued capturing screenshots for messages with non-image attachments, such as audio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->