### PR TITLE
fix(audio): restore CI build for audio capture

### DIFF
--- a/src/aiden_sdk.cpp
+++ b/src/aiden_sdk.cpp
@@ -612,10 +612,10 @@ public:
                     af.data = data;
                     af.length = frame.u32Len;
                     af.timestamp = frame.u64TimeStamp;
-                    af.channels = audio_frame_channels(frame.enSoundMode, self->config.channels);
+                    af.channels = audio_frame_channels(frame.enSoundMode, config.channels);
                     af.sample_rate = frame.s32SampleRate > 0
                                          ? static_cast<uint32_t>(frame.s32SampleRate)
-                                         : static_cast<uint32_t>(self->config.sample_rate);
+                                         : static_cast<uint32_t>(config.sample_rate);
                     callback(af);
                 }
                 RK_MPI_AI_ReleaseFrame(dev_id, chn_id, &frame, nullptr);


### PR DESCRIPTION
## Summary
- fix `AudioCaptureImpl::run()` using an out-of-scope `self` identifier
- read capture configuration through the `config` member

## Root cause
The CI firmware build failed in `src/aiden_sdk.cpp` with `error: 'self' was not declared in this scope` after the realtime audio changes. `self` only exists in `thread_func()`, not in the member function `run()`.\n\n## Validation\n- `git diff --check` passed\n- host test build with `cmake -S . -B /tmp/aiden-host-tests -DAIDEN_TESTS=ON` passed\n- full host `ctest` reached execution but had unrelated local Unix socket/port bind failures\n- Rockchip cross-compiler is unavailable locally; firmware build is left for CI verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected audio frame metadata so captured audio reports the configured channel count and sample rate accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->