### PR TITLE
feat: tool call / result commit

### DIFF
--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -176,10 +176,7 @@ func TestRealtimeToolCallAndResultPersistInUserContext(t *testing.T) {
 		t.Fatal(err)
 	}
 	call := rtclient.FunctionCallEvent{CallID: "call_1", Name: realtimeCreateTaskTool, Arguments: `{"task":"打开微信"}`}
-	if err := appendRealtimeToolCall(manager, call); err != nil {
-		t.Fatal(err)
-	}
-	if err := appendRealtimeToolResult(manager, call, `{"id":"task_1","status":"queued"}`); err != nil {
+	if err := appendRealtimeToolExecution(manager, call, `{"id":"task_1","status":"queued"}`); err != nil {
 		t.Fatal(err)
 	}
 	got := manager.MessageListDump().Messages

--- a/src/agent/cmd/daemon/realtime_wakeup.go
+++ b/src/agent/cmd/daemon/realtime_wakeup.go
@@ -711,8 +711,8 @@ func runRealtimeSession(cfg agent.Config, sigChan chan os.Signal, runtime *agent
 			if err := session.SendFunctionOutput(ctx, call.CallID, result.output); err != nil {
 				return fmt.Errorf("send realtime tool result: %w", err)
 			}
-			if err := appendRealtimeToolResult(userContext, call, result.output); err != nil {
-				return fmt.Errorf("persist realtime tool result: %w", err)
+			if err := appendRealtimeToolExecution(userContext, call, result.output); err != nil {
+				return fmt.Errorf("persist realtime tool call and result: %w", err)
 			}
 			if toolTracker.complete(call.ResponseID) {
 				responseActive = true
@@ -903,9 +903,6 @@ func runRealtimeSession(cfg agent.Config, sigChan chan os.Signal, runtime *agent
 					return err
 				}
 				log.Printf("[realtime] Tool call: %s", call.Name)
-				if err := appendRealtimeToolCall(userContext, call); err != nil {
-					return fmt.Errorf("persist realtime tool call: %w", err)
-				}
 				toolTracker.start(call.ResponseID)
 				startRealtimeToolCall(ctx, toolExecutor, call, toolResults)
 			case "response.done":
@@ -1038,31 +1035,29 @@ func appendRealtimeAssistantMessage(manager *contextmanager.ContextManager, cont
 	return manager.AppendMessage(messages.Message{Role: messages.MessageRoleAssistant, Content: content, Usage: usage})
 }
 
-func appendRealtimeToolCall(manager *contextmanager.ContextManager, call rtclient.FunctionCallEvent) error {
+// appendRealtimeToolExecution persists the protocol pair only after the tool
+// has produced an output, so an interrupted call cannot remain in user context.
+func appendRealtimeToolExecution(manager *contextmanager.ContextManager, call rtclient.FunctionCallEvent, output string) error {
 	if manager == nil {
 		return nil
 	}
-	return manager.AppendMessage(messages.Message{
-		Role: messages.MessageRoleToolCall,
-		ToolCalls: []messages.ToolCall{{
-			ID:        strings.TrimSpace(call.CallID),
-			Name:      strings.TrimSpace(call.Name),
-			Arguments: strings.TrimSpace(call.Arguments),
-		}},
-	})
-}
-
-func appendRealtimeToolResult(manager *contextmanager.ContextManager, call rtclient.FunctionCallEvent, output string) error {
-	if manager == nil {
-		return nil
-	}
-	return manager.AppendMessage(messages.Message{
-		Role: messages.MessageRoleToolResult,
-		ToolResults: []messages.ToolResult{{
-			ToolCallID: strings.TrimSpace(call.CallID),
-			Name:       strings.TrimSpace(call.Name),
-			Content:    output,
-		}},
+	return manager.AppendMessages([]messages.Message{
+		{
+			Role: messages.MessageRoleToolCall,
+			ToolCalls: []messages.ToolCall{{
+				ID:        strings.TrimSpace(call.CallID),
+				Name:      strings.TrimSpace(call.Name),
+				Arguments: strings.TrimSpace(call.Arguments),
+			}},
+		},
+		{
+			Role: messages.MessageRoleToolResult,
+			ToolResults: []messages.ToolResult{{
+				ToolCallID: strings.TrimSpace(call.CallID),
+				Name:       strings.TrimSpace(call.Name),
+				Content:    output,
+			}},
+		},
 	})
 }
 

--- a/src/agent/internal/agent/agent_loop.go
+++ b/src/agent/internal/agent/agent_loop.go
@@ -287,8 +287,11 @@ func (l *AgentLoop) runIteration(ctx context.Context, iteration int, callOptions
 
 	actions, finish, err := parser.ParseOutput(contentResp)
 	if errors.Is(err, agents.ErrUnableToParseOutput) {
-		if err := llmExecutor.AppendMessage(messages.ConvertChoiceToContextManagerMessage(*contentResp.Choices[0])); err != nil {
-			return "", iterationContinue, err
+		choiceMessage := messages.ConvertChoiceToContextManagerMessage(*contentResp.Choices[0])
+		if choiceMessage.Role != messages.MessageRoleToolCall {
+			if err := llmExecutor.AppendMessage(choiceMessage); err != nil {
+				return "", iterationContinue, err
+			}
 		}
 		decision := policy.RecordParseFailure()
 		if decision.Stop {
@@ -334,11 +337,6 @@ func (l *AgentLoop) runIteration(ctx context.Context, iteration int, callOptions
 	// Problem 4: Check for pending steer after LLM returns actions (before tool execution)
 	if steer, hasPending := l.checkPendingSteer(ctx); hasPending {
 		policy.ResetForSteer()
-		// Append LLM response first, then steer, so context order is correct:
-		// assistant(tool_call) → user(steer)
-		if err := llmExecutor.AppendMessage(messages.ConvertChoiceToContextManagerMessage(*contentResp.Choices[0])); err != nil {
-			return "", iterationContinue, err
-		}
 		if err := l.persistSteer(ctx, llmExecutor, steer); err != nil {
 			return "", iterationContinue, err
 		}
@@ -347,9 +345,7 @@ func (l *AgentLoop) runIteration(ctx context.Context, iteration int, callOptions
 	}
 
 	action := actions[0]
-	if err := llmExecutor.AppendMessage(messages.ConvertChoiceToContextManagerMessage(choiceWithOnlyToolCall(*contentResp.Choices[0], action.ToolID))); err != nil {
-		return "", iterationContinue, err
-	}
+	toolCallMessage := messages.ConvertChoiceToContextManagerMessage(choiceWithOnlyToolCall(*contentResp.Choices[0], action.ToolID))
 	var after AfterToolCallHook
 	if toolExecutionHooks != nil {
 		after = func(ctx context.Context, call ToolCall, result ToolResult) ToolResult {
@@ -429,7 +425,7 @@ func (l *AgentLoop) runIteration(ctx context.Context, iteration int, callOptions
 			},
 		})
 	}
-	appendErr := appendToolExecutionMessages(llmExecutor, parser, toolExecution.Step, prepared)
+	appendErr := appendToolExecutionMessages(llmExecutor, parser, toolCallMessage, toolExecution.Step, prepared)
 	if toolExecution.Error != nil {
 		if appendErr != nil {
 			return "", iterationContinue, errors.Join(toolExecution.Error, appendErr)
@@ -837,7 +833,7 @@ func roleResponseDebugText(res *llms.ContentResponse) string {
 	return strings.Join(parts, "\n")
 }
 
-func appendToolExecutionMessages(llmExecutor *executor.LLMExecutor, parser *FunctionAgent, step schema.AgentStep, prepared PreparedToolResult) error {
+func appendToolExecutionMessages(llmExecutor *executor.LLMExecutor, parser *FunctionAgent, toolCall messages.Message, step schema.AgentStep, prepared PreparedToolResult) error {
 	if llmExecutor == nil {
 		return fmt.Errorf("llm executor is nil")
 	}
@@ -853,17 +849,16 @@ func appendToolExecutionMessages(llmExecutor *executor.LLMExecutor, parser *Func
 	}
 	prepared.Content = toolContent
 
-	if err := llmExecutor.AppendMessage(toolResultMessage(
+	contextMessages := []messages.Message{toolCall, toolResultMessage(
 		step.Action.ToolID,
 		step.Action.Tool,
 		prepared,
-	)); err != nil {
-		return fmt.Errorf("failed to append tool result message: %w", err)
-	}
+	)}
 	for _, followup := range followups {
-		if err := llmExecutor.AppendMessage(visualFollowupMessageFromLLMContent(llmExecutor.ContextManager(), followup)); err != nil {
-			return fmt.Errorf("failed to append visual followup message: %w", err)
-		}
+		contextMessages = append(contextMessages, visualFollowupMessageFromLLMContent(llmExecutor.ContextManager(), followup))
+	}
+	if err := llmExecutor.AppendMessages(contextMessages); err != nil {
+		return fmt.Errorf("failed to append tool call and result messages: %w", err)
 	}
 	return nil
 }

--- a/src/agent/internal/agent/agent_loop_tool_result_test.go
+++ b/src/agent/internal/agent/agent_loop_tool_result_test.go
@@ -41,10 +41,20 @@ func TestAppendToolExecutionMessagesPersistsPreparedContentAndMetadata(t *testin
 		Action:      schema.AgentAction{ToolID: "call_1", Tool: "shell"},
 		Observation: "RAW_OUTPUT_MUST_NOT_BE_STORED",
 	}
-	if err := appendToolExecutionMessages(llmExecutor, nil, step, prepared); err != nil {
+	toolCall := messages.Message{
+		Role: messages.MessageRoleToolCall,
+		ToolCalls: []messages.ToolCall{{
+			ID: "call_1", Name: "shell", Arguments: `{"command":"produce"}`,
+		}},
+	}
+	if err := appendToolExecutionMessages(llmExecutor, nil, toolCall, step, prepared); err != nil {
 		t.Fatalf("appendToolExecutionMessages() error = %v", err)
 	}
-	stored := manager.CloneMessageList()[0].ToolResults[0]
+	storedMessages := manager.CloneMessageList()
+	if len(storedMessages) != 2 || storedMessages[0].Role != messages.MessageRoleToolCall || storedMessages[1].Role != messages.MessageRoleToolResult {
+		t.Fatalf("stored messages = %#v, want tool call followed by result", storedMessages)
+	}
+	stored := storedMessages[1].ToolResults[0]
 	if stored.Content != prepared.Content {
 		t.Fatalf("stored content = %q, want prepared content", stored.Content)
 	}

--- a/src/agent/internal/agent/contextmanager/context_manager.go
+++ b/src/agent/internal/agent/contextmanager/context_manager.go
@@ -201,11 +201,18 @@ func (c *ContextManager) flushFull() error {
 }
 
 func (c *ContextManager) AppendMessage(message messages.Message) error {
+	return c.AppendMessages([]messages.Message{message})
+}
+
+// AppendMessages applies append hooks to a batch and persists the resulting
+// messages in one context-manager append operation. This keeps related
+// protocol messages, such as a tool call and its result, together.
+func (c *ContextManager) AppendMessages(messagesToAppend []messages.Message) error {
 	c.mu.RLock()
 	hooks := append([]AppendMessageHook(nil), c.appendHooks...)
 	c.mu.RUnlock()
 
-	messageList := []messages.Message{message.Clone()}
+	messageList := cloneMessages(messagesToAppend)
 	for _, entry := range hooks {
 		var next []messages.Message
 		for _, current := range messageList {

--- a/src/agent/internal/agent/executor/executor.go
+++ b/src/agent/internal/agent/executor/executor.go
@@ -77,6 +77,10 @@ func (e *LLMExecutor) AppendMessage(message messages.Message) error {
 	return e.contextManager.AppendMessage(message)
 }
 
+func (e *LLMExecutor) AppendMessages(messagesToAppend []messages.Message) error {
+	return e.contextManager.AppendMessages(messagesToAppend)
+}
+
 func (e *LLMExecutor) GenerateContent(ctx context.Context, options ...llms.CallOption) (*llms.ContentResponse, error) {
 	messageList := e.contextManager.CloneMessageList()
 	for _, transform := range e.transforms {


### PR DESCRIPTION
## Summary
- Persist tool calls and their results atomically as an ordered batch.
- Avoid retaining incomplete tool calls when realtime execution is interrupted.
- Add batched append APIs and update agent-loop context handling.
- Extend unit coverage for tool-call/result ordering and prepared result content.

## Testing
- Unit tests updated for realtime and agent-loop tool execution persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence of tool interactions by saving tool calls and results together.
  * Prevented interrupted or failed tool calls from appearing as incomplete conversation entries.
  * Preserved assistant tool-call context alongside results and visual follow-ups.
  * Improved handling of parsing failures and steering interruptions to avoid misleading conversation history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->