### PR TITLE
fix(ble): receive ObjectManager signals so a phone paired later is seen

### DIFF
--- a/src/agent/internal/ble/bluez.go
+++ b/src/agent/internal/ble/bluez.go
@@ -445,27 +445,64 @@ func exportIntrospection(conn *dbus.Conn, path dbus.ObjectPath, interfaceName st
 	return conn.Export(introspect.NewIntrospectable(node), path, introspect.IntrospectData.Name)
 }
 
+// signalMatchSpec describes one AddMatchSignal subscription. Kept as data so the
+// scope of each subscription is assertable without a live bus.
+type signalMatchSpec struct {
+	name    string
+	options []dbus.MatchOption
+}
+
+// signalMatchSpecs lists every BlueZ signal subscription the backend needs.
+//
+// The ObjectManager entry deliberately does NOT filter on a path namespace.
+// BlueZ exports its ObjectManager at the root path "/" (see blueZRootPath, used
+// by getManagedObjects), and InterfacesAdded/InterfacesRemoved are emitted from
+// that object -- the path of the object being added travels in argument 0, not
+// in the message path. A path_namespace of "/org/bluez" therefore matches
+// neither, and the bus drops every one of those signals before delivery.
+//
+// Losing them breaks discovery of anything that appears after startup: a device
+// paired later, and the ANCS GattService1/GattCharacteristic1 objects iOS only
+// exposes to a bonded peer, are all announced solely via InterfacesAdded. The
+// reconciler never runs while those objects exist, so notifications are never
+// ingested until the service restarts and re-reads the whole tree directly.
+func signalMatchSpecs() []signalMatchSpec {
+	return []signalMatchSpec{
+		{
+			name: "properties",
+			options: []dbus.MatchOption{
+				dbus.WithMatchSender(BlueZBusName),
+				dbus.WithMatchInterface(dbusPropertiesInterface),
+				dbus.WithMatchPathNamespace(dbus.ObjectPath("/org/bluez")),
+			},
+		},
+		{
+			name: "object_manager",
+			options: []dbus.MatchOption{
+				dbus.WithMatchSender(BlueZBusName),
+				dbus.WithMatchInterface(dbusObjectManagerInterface),
+				dbus.WithMatchObjectPath(blueZRootPath),
+			},
+		},
+		{
+			name: "name_owner_changed",
+			options: []dbus.MatchOption{
+				dbus.WithMatchSender(dbusBusName),
+				dbus.WithMatchInterface(dbusBusInterface),
+				dbus.WithMatchMember("NameOwnerChanged"),
+				dbus.WithMatchArg(0, BlueZBusName),
+			},
+		},
+	}
+}
+
 func (b *blueZBackend) addSignalMatches() error {
-	if err := b.conn.AddMatchSignal(
-		dbus.WithMatchSender(BlueZBusName),
-		dbus.WithMatchInterface(dbusPropertiesInterface),
-		dbus.WithMatchPathNamespace(dbus.ObjectPath("/org/bluez")),
-	); err != nil {
-		return err
+	for _, spec := range signalMatchSpecs() {
+		if err := b.conn.AddMatchSignal(spec.options...); err != nil {
+			return fmt.Errorf("subscribe %s signals: %w", spec.name, err)
+		}
 	}
-	if err := b.conn.AddMatchSignal(
-		dbus.WithMatchSender(BlueZBusName),
-		dbus.WithMatchInterface(dbusObjectManagerInterface),
-		dbus.WithMatchPathNamespace(dbus.ObjectPath("/org/bluez")),
-	); err != nil {
-		return err
-	}
-	return b.conn.AddMatchSignal(
-		dbus.WithMatchSender(dbusBusName),
-		dbus.WithMatchInterface(dbusBusInterface),
-		dbus.WithMatchMember("NameOwnerChanged"),
-		dbus.WithMatchArg(0, BlueZBusName),
-	)
+	return nil
 }
 
 func (b *blueZBackend) configureAdapter(pairingOpen bool) error {

--- a/src/agent/internal/ble/bluez_test.go
+++ b/src/agent/internal/ble/bluez_test.go
@@ -80,3 +80,69 @@ func TestANCSRescanDoesNotWaitForWakeSubscriber(t *testing.T) {
 		t.Fatalf("metadata error = %q; ANCS must be reconciled independently of Wake subscription", got)
 	}
 }
+
+func TestObjectManagerSignalMatchCoversRootPath(t *testing.T) {
+	// Regression test: BlueZ exports its ObjectManager at "/" and emits
+	// InterfacesAdded/InterfacesRemoved from that object, carrying the added
+	// object's path in argument 0. Subscribing with path_namespace=/org/bluez
+	// matches neither "/" nor its own emissions, so the bus silently drops every
+	// one of those signals.
+	//
+	// The visible symptom is narrow but severe: a phone paired AFTER ble_service
+	// starts is announced only via InterfacesAdded, as are the ANCS
+	// GattService1/GattCharacteristic1 objects iOS exposes once bonded. Losing
+	// them means the reconciler never runs while those objects exist and no
+	// notifications are ingested until the service restarts and re-reads the
+	// whole object tree via a direct GetManagedObjects call.
+	var spec *signalMatchSpec
+	for _, candidate := range signalMatchSpecs() {
+		if candidate.name == "object_manager" {
+			spec = &candidate
+			break
+		}
+	}
+	if spec == nil {
+		t.Fatal("no object_manager signal subscription is registered")
+	}
+
+	// MatchOption keeps its fields private and formatMatchOptions is unexported,
+	// so assert by comparing against independently constructed options.
+	forbidden := dbus.WithMatchPathNamespace(dbus.ObjectPath("/org/bluez"))
+	wantPath := dbus.WithMatchObjectPath(blueZRootPath)
+	sawRootPath := false
+	for _, option := range spec.options {
+		if option == forbidden {
+			t.Error("ObjectManager subscription filters on path_namespace=/org/bluez, " +
+				"which excludes the root path the signals are emitted from")
+		}
+		if option == wantPath {
+			sawRootPath = true
+		}
+	}
+	if !sawRootPath {
+		t.Errorf("ObjectManager subscription does not cover the root path %q", blueZRootPath)
+	}
+}
+
+func TestPropertiesSignalMatchStaysScopedToBlueZObjects(t *testing.T) {
+	// The Properties subscription is correct as-is and must not be widened while
+	// fixing the ObjectManager one: PropertiesChanged is emitted from the object
+	// that changed, so /org/bluez is the right namespace there.
+	var spec *signalMatchSpec
+	for _, candidate := range signalMatchSpecs() {
+		if candidate.name == "properties" {
+			spec = &candidate
+			break
+		}
+	}
+	if spec == nil {
+		t.Fatal("no properties signal subscription is registered")
+	}
+	want := dbus.WithMatchPathNamespace(dbus.ObjectPath("/org/bluez"))
+	for _, option := range spec.options {
+		if option == want {
+			return
+		}
+	}
+	t.Error("properties subscription lost its /org/bluez path namespace")
+}


### PR DESCRIPTION
## The bug

On a freshly flashed board, pairing a phone produced no notification ingestion at
all. Bluetooth itself looked perfect — `Paired: yes`, `Bonded: yes`,
`Connected: yes`, link `AUTH ENCRYPT`, battery read, ANCS UUID present — but
`ble_service.log` held nothing past its startup line. Restarting the service
fixed it.

## Why

`addSignalMatches` subscribed to ObjectManager signals with
`path_namespace=/org/bluez`. BlueZ exports its ObjectManager at the **root path
`/`** and emits `InterfacesAdded` / `InterfacesRemoved` from that object, with
the added object's path travelling in **argument 0**, not in the message path.
`/` is neither `/org/bluez` nor below it, so the bus dropped every one of those
signals before delivery and the rescan branch for them was dead code. The same
file already reads that object at `/` via `blueZRootPath` in
`getManagedObjects` — the subscription simply disagreed with the call.

Everything that appears *after* startup is announced only through those signals:
a device paired later, and the ANCS `GattService1` / `GattCharacteristic1`
objects iOS exposes once bonded. So the reconciler never ran at a moment when
the ANCS objects existed. A freshly flashed board boots with nothing paired, by
definition, which is why this reproduces every time on a new device.

Restarting masked it because `start()` re-reads the whole object tree with a
direct `GetManagedObjects` call — a poll standing in for the broken
subscription.

## Verification

**On hardware.** With nothing paired, `ble_service` was started, then an iPhone
was paired. The same process — unchanged PID, uptime spanning both events —
discovered the device and completed GATT subscription. Before this change that
path stayed inert until a restart.

**Unit tests.** Match options move into `signalMatchSpecs()` so each
subscription's scope is assertable without a live bus. `MatchOption` keeps its
fields private and `formatMatchOptions` is unexported, so the tests compare
against independently constructed options. Confirmed the new test fails against
the unfixed rule and passes after — not merely that it passes now.

A second test pins the Properties subscription's `/org/bluez` namespace so it
does not get widened along with this fix: `PropertiesChanged` is emitted from the
object that changed, so that scope is correct as-is.

`go test ./internal/ble/` passes; `go vet` and `gofmt` clean.

## Worth flagging separately

Two follow-ups this PR deliberately leaves alone, both found while verifying:

- **No periodic reconciliation.** `runRescans` is purely edge-triggered, so a
  rescan landing in a transient bad window (`ServicesResolved` still false, or
  `startNotify` failing before encryption completes) sticks forever. The existing
  1s maintenance ticker never rescans. Adding reconciliation there would make
  this whole class self-healing rather than dependent on catching each edge.
- **`GattService1` `PropertiesChanged` never triggers a rescan**, so a change to
  a service's `Characteristics` list is silently ignored — the same blind spot by
  another route.

Also noted during hardware verification, unrelated to this change: after
removing the pairing on the board, the phone must also forget the device.
iOS otherwise reconnects with a stale bond key against a peer that no longer
has it, and encryption fails with no user-visible prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth device discovery and event handling across the BlueZ root object path.
  * Preserved scoped monitoring for Bluetooth object property changes.
  * Added clearer diagnostics when Bluetooth signal subscriptions fail.

* **Tests**
  * Added regression coverage to verify correct BlueZ signal matching and path scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->