### PR TITLE
fix(agent): write current session atomically

### DIFF
--- a/src/agent/internal/agent/contextmanager/session_persist.go
+++ b/src/agent/internal/agent/contextmanager/session_persist.go
@@ -34,7 +34,32 @@ func fetchCurrentSession(sessionFolder string) string {
 
 func saveCurrentSession(sessionFolder string, sessionID string) error {
 	sessionIDFile := filepath.Join(sessionFolder, ".current_session")
-	return os.WriteFile(sessionIDFile, []byte(sessionID), 0o644)
+	file, err := os.CreateTemp(sessionFolder, ".current_session-*")
+	if err != nil {
+		return fmt.Errorf("create current session temp file: %w", err)
+	}
+	tempPath := file.Name()
+	defer os.Remove(tempPath)
+
+	if err := file.Chmod(0o644); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("chmod current session temp file: %w", err)
+	}
+	if _, err := file.WriteString(sessionID); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write current session temp file: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("sync current session temp file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close current session temp file: %w", err)
+	}
+	if err := os.Rename(tempPath, sessionIDFile); err != nil {
+		return fmt.Errorf("install current session file: %w", err)
+	}
+	return nil
 }
 
 func sessionMetadataPath(sessionFolder, sessionID string) string {

--- a/src/agent/internal/agent/contextmanager/session_persist_test.go
+++ b/src/agent/internal/agent/contextmanager/session_persist_test.go
@@ -1,0 +1,49 @@
+package contextmanager
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSaveCurrentSessionAtomicallyReplacesFile(t *testing.T) {
+	sessionFolder := t.TempDir()
+	sessionPath := filepath.Join(sessionFolder, ".current_session")
+	if err := os.WriteFile(sessionPath, []byte("old-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	before, err := os.Stat(sessionPath)
+	if err != nil {
+		t.Fatalf("Stat() before save error = %v", err)
+	}
+
+	const sessionID = "new-session"
+	if err := saveCurrentSession(sessionFolder, sessionID); err != nil {
+		t.Fatalf("saveCurrentSession() error = %v", err)
+	}
+
+	after, err := os.Stat(sessionPath)
+	if err != nil {
+		t.Fatalf("Stat() after save error = %v", err)
+	}
+	if os.SameFile(before, after) {
+		t.Fatal("saveCurrentSession() updated the existing file instead of atomically replacing it")
+	}
+	if got := fetchCurrentSession(sessionFolder); got != sessionID {
+		t.Fatalf("fetchCurrentSession() = %q, want %q", got, sessionID)
+	}
+	if got := after.Mode().Perm(); got != 0o644 {
+		t.Fatalf(".current_session permissions = %o, want 644", got)
+	}
+
+	entries, err := os.ReadDir(sessionFolder)
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".current_session-") {
+			t.Errorf("temporary file was not removed: %s", entry.Name())
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- write `.current_session` through a temporary file in the session directory
- sync and close the temporary file before atomically replacing the current-session pointer
- clean up temporary files on failure and preserve the existing `0644` permissions
- verify replacement semantics, contents, permissions, and cleanup in a focused test

## Testing
- `cd src/agent && go test ./internal/agent/contextmanager`
- `cd src/agent && go test ./internal/agent/...` *(contextmanager and other subpackages pass; `internal/agent` has unrelated macOS Unix socket path-length failures in existing tests)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session saving reliability by writing updates safely and atomically.
  * Prevented incomplete or corrupted session files if saving is interrupted.
  * Ensured saved session files use the expected permissions and temporary files are cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->