### PR TITLE
fix(agent): remove screen dimensions from state

### DIFF
--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -517,7 +517,6 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 	rt.screenState = screenState
 	rt.phoneBridge = NewPhoneBridge(logger)
 	rt.phoneBridge.SetConfiguredPlatform(cfg.DevicePlatformOrDefault())
-	rt.stateManager.RegisterUpdater(screenState)
 	rt.stateManager.RegisterUpdater(rt.phoneBridge)
 
 	return rt, nil

--- a/src/agent/internal/agent/screen/screen.go
+++ b/src/agent/internal/agent/screen/screen.go
@@ -318,14 +318,3 @@ func (ps *PhoneScreenInfo) Format() string {
 func (saa *ScreenActiveArea) Format() string {
 	return fmt.Sprintf("{x:%d y:%d w:%d h:%d valid:%v}", saa.X, saa.Y, saa.Width, saa.Height, saa.Valid)
 }
-
-func (s *ScreenState) UpdateState() map[string]string {
-	_, _, active, _, ok := s.ActiveAreaWithAge()
-	if !ok {
-		return map[string]string{}
-	}
-	return map[string]string{
-		"screen_width":  fmt.Sprintf("%d", active.Width),
-		"screen_height": fmt.Sprintf("%d", active.Height),
-	}
-}


### PR DESCRIPTION
## Summary
- stop registering `ScreenState` as a state updater
- remove the obsolete updater that published `screen_width` and `screen_height`

## Testing
- `go test ./internal/agent/screen`
- `go test ./internal/agent -run '^$'`\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime state handling by removing an obsolete screen-state update.
  * Preserved phone bridge state updates for more consistent runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->