### PR TITLE
test(agent): avoid expired notification fixtures

### DIFF
--- a/src/agent/internal/agent/notification_memory_processor_test.go
+++ b/src/agent/internal/agent/notification_memory_processor_test.go
@@ -27,7 +27,6 @@ func TestNotificationMemoryProcessorFiltersNoiseAndWritesTemporaryMemory(t *test
 		t.Fatal(err)
 	}
 	processor := NewNotificationMemoryProcessor(ctxStore, root, nil, nil)
-	processor.now = func() time.Time { return time.Date(2026, 8, 21, 1, 0, 0, 0, time.UTC) }
 	_, err = processor.ProcessBatch(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -94,9 +93,8 @@ func TestNotificationMemoryProcessorUsesMergeEngineForAdd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	llm := &episodeMemoryScriptedModel{responses: []string{`{"actions":[{"action":"add","scope":"temporary","type":"fact","title":"包裹更新","content":"包裹明天送达","expires_at":"2026-08-28T00:00:00Z","tags":["notification","com.delivery"]}]}`}}
+	llm := &episodeMemoryScriptedModel{responses: []string{`{"actions":[{"action":"add","scope":"temporary","type":"fact","title":"包裹更新","content":"包裹明天送达","tags":["notification","com.delivery"]}]}`}}
 	processor := NewNotificationMemoryProcessor(ctxStore, root, nil, llm)
-	processor.now = func() time.Time { return time.Date(2026, 8, 21, 1, 0, 0, 0, time.UTC) }
 	if _, err := processor.ProcessBatch(context.Background(), nil); err != nil {
 		t.Fatal(err)
 	}
@@ -162,9 +160,8 @@ func TestNotificationMemoryProcessorAddDoesNotSupersedeSimilarMemory(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	model := &episodeMemoryScriptedModel{responses: []string{`{"actions":[{"action":"add","scope":"temporary","type":"fact","title":"Delivery window","content":"The package arrives tomorrow at noon","expires_at":"2026-08-28T00:00:00Z","tags":["notification","com.delivery"],"entities":["com.delivery"]}]}`}}
+	model := &episodeMemoryScriptedModel{responses: []string{`{"actions":[{"action":"add","scope":"temporary","type":"fact","title":"Delivery window","content":"The package arrives tomorrow at noon","tags":["notification","com.delivery"],"entities":["com.delivery"]}]}`}}
 	processor := NewNotificationMemoryProcessor(ctxStore, root, nil, model)
-	processor.now = func() time.Time { return time.Date(2026, 8, 21, 1, 0, 0, 0, time.UTC) }
 	if _, err := processor.ProcessBatch(context.Background(), nil); err != nil {
 		t.Fatal(err)
 	}
@@ -669,7 +666,7 @@ func TestNotificationMemoryProcessorUpdatesWithRevisionAndCanPromote(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	responses := []string{`{"actions":[{"action":"update","scope":"temporary","memory_id":"tmp_existing","memory_revision":1,"type":"fact","title":"包裹","content":"包裹改为明天送达","expires_at":"2026-08-28T00:00:00Z"}]}`}
+	responses := []string{`{"actions":[{"action":"update","scope":"temporary","memory_id":"tmp_existing","memory_revision":1,"type":"fact","title":"包裹","content":"包裹改为明天送达"}]}`}
 	processor := NewNotificationMemoryProcessor(ctxStore, root, longTerm, &episodeMemoryScriptedModel{responses: responses})
 	if _, err := processor.ProcessBatch(context.Background(), nil); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- stop pinning notification-memory tests to an already-expired August 2026 clock
- omit unrelated explicit expiry values so the production default TTL is evaluated against the current clock
- keep the notification event fixtures fixed where their dates are part of raw-log assertions

## Root cause
The processor tests used a fake 2026-08-21 clock and temporary memories expiring on 2026-08-28, while `LongTermMemoryStore.Search` evaluates expiration using the real clock. The tests began failing when CI crossed 2026-08-28 UTC.

## Testing
- `go test ./internal/agent -run 'TestNotificationMemoryProcessor(FiltersNoiseAndWritesTemporaryMemory|UsesMergeEngineForAdd|AddDoesNotSupersedeSimilarMemory|UpdatesWithRevisionAndCanPromote)$' -count=1`\n- `go test ./internal/agent -run '^TestNotificationMemoryProcessor' -count=1`\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated notification memory coverage to verify default expiration behavior for additions and updates.
  * Removed reliance on a fixed test clock and explicit expiration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->