### PR TITLE
Preserve original post-action tool results

### DIFF
--- a/src/agent/internal/agent/function_agent.go
+++ b/src/agent/internal/agent/function_agent.go
@@ -152,36 +152,14 @@ func (a *FunctionAgent) observationMessagesForStep(step schema.AgentStep, includ
 	}
 	result := visual.Result
 
-	imageAvailability := "The image is attached in the next message."
-	if !includeVisual {
-		imageAvailability = "The image is replaced with a placeholder in the next message."
-	}
-	toolContent := fmt.Sprintf(
-		"%s returned a screenshot observation: format=%s width=%d height=%d size=%d bytes. %s",
-		step.Action.Tool,
-		result.Format,
-		result.Width,
-		result.Height,
-		result.Size,
-		imageAvailability,
-	)
-	if strings.TrimSpace(result.ActionOutput) != "" {
-		actionOutput := compactToolObservation(result.ActionOutput)
-		toolContent = fmt.Sprintf(
-			"%s completed with output %q, then returned a screenshot observation after the action settled: format=%s width=%d height=%d size=%d bytes. %s",
-			step.Action.Tool,
-			actionOutput,
-			result.Format,
-			result.Width,
-			result.Height,
-			result.Size,
-			imageAvailability,
-		)
-	}
-	if summary := screenshotObservationStatusSummary(step.Action.Tool, result); summary != "" {
-		toolContent += " " + summary
+	toolContent := step.Observation
+	if actionOutput, ok := actionOutputFromScreenshotObservation(step.Observation); ok {
+		toolContent = actionOutput
 	}
 	caption := fmt.Sprintf("This image is the screenshot observation returned by the %s tool. Use it when answering the original request.", step.Action.Tool)
+	if summary := screenshotObservationStatusSummary(step.Action.Tool, result); summary != "" {
+		caption += " " + summary
+	}
 	if !includeVisual {
 		return toolContent, []llms.MessageContent{{
 			Role: llms.ChatMessageTypeHuman,

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -675,11 +675,11 @@ func TestFunctionAgentRejectsVisualObservationWithoutDimensions(t *testing.T) {
 	}
 }
 
-func TestFunctionAgentPostActionScreenshotWarnsWhenScreenDidNotChange(t *testing.T) {
+func TestFunctionAgentPostActionScreenshotPreservesActionOutput(t *testing.T) {
 	agent := &FunctionAgent{
 		Tools: []langtools.Tool{&stubTool{name: "keyboard_tap", visual: true}},
 	}
-	observation := `{"action_output":"ok","screen_changed":false,"screen_stable":true,"stable_wait_ms":250,"width":800,"height":600,"format":"jpeg","size":4,"data":"` +
+	observation := `{"action_output":"  ok\nwith details  ","screen_changed":false,"screen_stable":true,"stable_wait_ms":250,"width":800,"height":600,"format":"jpeg","size":4,"data":"` +
 		base64.StdEncoding.EncodeToString([]byte("img1")) + `"}`
 	step := schema.AgentStep{
 		Action:      schema.AgentAction{Tool: "keyboard_tap"},
@@ -688,14 +688,28 @@ func TestFunctionAgentPostActionScreenshotWarnsWhenScreenDidNotChange(t *testing
 
 	toolContent, followups := agent.observationMessagesForStep(step, true)
 
-	if !strings.Contains(toolContent, "No meaningful visible UI change was detected between the pre-action baseline and the final settled screenshot") {
-		t.Fatalf("toolContent missing screen_changed warning: %q", toolContent)
+	if toolContent != "  ok\nwith details  " {
+		t.Fatalf("toolContent = %q, want original action output", toolContent)
 	}
-	if !strings.Contains(toolContent, "Do not assume the action succeeded") {
-		t.Fatalf("toolContent missing success warning: %q", toolContent)
+	if len(followups) != 1 {
+		t.Fatalf("expected one followup screenshot message, got %#v", followups)
 	}
-	if !strings.Contains(toolContent, "The screen was stable when the screenshot was captured") {
-		t.Fatalf("toolContent missing stable summary: %q", toolContent)
+}
+
+func TestFunctionAgentPostActionScreenshotPreservesEmptyActionOutput(t *testing.T) {
+	agent := &FunctionAgent{
+		Tools: []langtools.Tool{&stubTool{name: "keyboard_tap", visual: true}},
+	}
+	observation := `{"action_output":"","width":800,"height":600,"format":"jpeg","size":4,"data":"` +
+		base64.StdEncoding.EncodeToString([]byte("img1")) + `"}`
+
+	toolContent, followups := agent.observationMessagesForStep(schema.AgentStep{
+		Action:      schema.AgentAction{Tool: "keyboard_tap"},
+		Observation: observation,
+	}, true)
+
+	if toolContent != "" {
+		t.Fatalf("toolContent = %q, want empty original action output", toolContent)
 	}
 	if len(followups) != 1 {
 		t.Fatalf("expected one followup screenshot message, got %#v", followups)
@@ -714,17 +728,21 @@ func TestFunctionAgentWaitStableScreenDoesNotTreatMotionAsActionResult(t *testin
 	}
 
 	toolContent, followups := agent.observationMessagesForStep(step, true)
-	if strings.Contains(toolContent, "between the pre-action baseline and the final settled screenshot") {
-		t.Fatalf("wait_for_stable_screen used post-action screen_changed wording: %q", toolContent)
-	}
-	if !strings.Contains(toolContent, "No frame-to-frame screen motion was observed during this wait window") {
-		t.Fatalf("toolContent missing wait-window motion wording: %q", toolContent)
-	}
-	if strings.Contains(toolContent, "Do not assume the action succeeded") {
-		t.Fatalf("standalone wait incorrectly warned about action success: %q", toolContent)
+	if toolContent != observation {
+		t.Fatalf("toolContent = %q, want original observation", toolContent)
 	}
 	if len(followups) != 1 {
 		t.Fatalf("expected one followup screenshot message, got %#v", followups)
+	}
+	caption, ok := followups[0].Parts[0].(llms.TextContent)
+	if !ok {
+		t.Fatalf("state message caption = %T, want text", followups[0].Parts[0])
+	}
+	if !strings.Contains(caption.Text, "No frame-to-frame screen motion was observed during this wait window") {
+		t.Fatalf("state message missing wait-window motion note: %q", caption.Text)
+	}
+	if strings.Contains(caption.Text, "Do not assume the action succeeded") {
+		t.Fatalf("standalone wait state message incorrectly warned about action success: %q", caption.Text)
 	}
 }
 

--- a/src/agent/internal/agent/loop_helpers.go
+++ b/src/agent/internal/agent/loop_helpers.go
@@ -1,9 +1,7 @@
 package agent
 
 import (
-	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 
@@ -34,7 +32,23 @@ func compactPromptLine(value string, max int) string {
 	return truncateForLog(value, max)
 }
 
-func compactScreenshotObservation(toolName, observation string) (string, bool) {
+func actionOutputFromScreenshotObservation(observation string) (string, bool) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(observation), &fields); err != nil {
+		return "", false
+	}
+	raw, ok := fields["action_output"]
+	if !ok {
+		return "", false
+	}
+	var output string
+	if err := json.Unmarshal(raw, &output); err != nil {
+		return "", false
+	}
+	return output, true
+}
+
+func compactScreenshotObservation(_ string, observation string) (string, bool) {
 	var result postActionScreenshotResult
 	if err := json.Unmarshal([]byte(observation), &result); err != nil {
 		return "", false
@@ -42,38 +56,10 @@ func compactScreenshotObservation(toolName, observation string) (string, bool) {
 	if (result.Data == "" && strings.TrimSpace(result.ScreenshotRef) == "") || result.Width <= 0 || result.Height <= 0 {
 		return "", false
 	}
-	if strings.TrimSpace(toolName) == "" {
-		toolName = "tool"
+	if actionOutput, ok := actionOutputFromScreenshotObservation(observation); ok {
+		return actionOutput, true
 	}
-	format := strings.TrimSpace(result.Format)
-	if format == "" {
-		format = "jpeg"
-	}
-	size := result.Size
-	if size <= 0 {
-		if imageBytes, err := base64.StdEncoding.DecodeString(result.Data); err == nil {
-			size = len(imageBytes)
-		}
-	}
-	if strings.TrimSpace(result.ActionOutput) != "" {
-		return fmt.Sprintf(
-			"%s completed with output %q, then returned a screenshot observation after the action settled: format=%s width=%d height=%d size=%d bytes. Image data omitted from text summary.",
-			toolName,
-			compactToolObservation(result.ActionOutput),
-			format,
-			result.Width,
-			result.Height,
-			size,
-		), true
-	}
-	return fmt.Sprintf(
-		"%s returned a screenshot observation: format=%s width=%d height=%d size=%d bytes. Image data omitted from text summary.",
-		toolName,
-		format,
-		result.Width,
-		result.Height,
-		size,
-	), true
+	return observation, true
 }
 
 func (o observedWorldState) IsEmpty() bool {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -3961,21 +3961,15 @@ func TestRuntimeRunKeyboardToolFeedsPostActionScreenshotImage(t *testing.T) {
 		t.Fatalf("unexpected output: %q", result.Output)
 	}
 
-	var foundToolResponse, foundImage bool
+	var foundToolResponse, foundImage, foundStateNote bool
 	for _, msg := range model.messages[1] {
 		for _, part := range msg.Parts {
 			switch p := part.(type) {
 			case llms.ToolCallResponse:
 				if p.ToolCallID == "call_1" {
 					foundToolResponse = true
-					if !strings.Contains(p.Content, "returned a screenshot observation") {
-						t.Fatalf("keyboard tool response = %q, want screenshot observation summary", p.Content)
-					}
-					if !strings.Contains(p.Content, "No meaningful visible UI change was detected between the pre-action baseline and the final settled screenshot") {
-						t.Fatalf("keyboard tool response = %q, want screen_changed warning", p.Content)
-					}
-					if !strings.Contains(p.Content, "Do not assume the action succeeded") {
-						t.Fatalf("keyboard tool response = %q, want no-success warning", p.Content)
+					if p.Content != "ok" {
+						t.Fatalf("keyboard tool response = %q, want original action output", p.Content)
 					}
 					if strings.Contains(p.Content, base64.StdEncoding.EncodeToString(jpegBytes)) {
 						t.Fatalf("keyboard tool response should not inline screenshot payload: %q", p.Content)
@@ -3985,6 +3979,10 @@ func TestRuntimeRunKeyboardToolFeedsPostActionScreenshotImage(t *testing.T) {
 				if p.MIMEType == "image/jpeg" && string(p.Data) == string(jpegBytes) {
 					foundImage = true
 				}
+			case llms.TextContent:
+				if strings.Contains(p.Text, "No meaningful visible UI change was detected between the pre-action baseline and the final settled screenshot") {
+					foundStateNote = true
+				}
 			}
 		}
 	}
@@ -3993,6 +3991,9 @@ func TestRuntimeRunKeyboardToolFeedsPostActionScreenshotImage(t *testing.T) {
 	}
 	if !foundImage {
 		t.Fatalf("expected keyboard post-action screenshot image in second model call")
+	}
+	if !foundStateNote {
+		t.Fatalf("expected keyboard post-action status in the following state message")
 	}
 }
 

--- a/src/agent/internal/agent/tool_execution_test.go
+++ b/src/agent/internal/agent/tool_execution_test.go
@@ -516,7 +516,7 @@ func TestExecuteToolCallPropagatesParentCancellation(t *testing.T) {
 	}
 }
 
-func TestDefaultAfterToolCallSummarizesScreenshotAndMarksTerminate(t *testing.T) {
+func TestDefaultAfterToolCallPreservesScreenshotActionOutputAndMarksTerminate(t *testing.T) {
 	image := []byte("jpeg")
 	output := `{"action_output":"ok","width":320,"height":240,"format":"jpeg","size":4,"data":"` +
 		base64.StdEncoding.EncodeToString(image) + `"}`
@@ -541,11 +541,8 @@ func TestDefaultAfterToolCallSummarizesScreenshotAndMarksTerminate(t *testing.T)
 	if result.Result.Output != output {
 		t.Fatalf("raw screenshot output should remain available to the agent")
 	}
-	if strings.Contains(result.Result.Summary, base64.StdEncoding.EncodeToString(image)) {
-		t.Fatalf("after hook should summarize screenshot data, got raw output")
-	}
-	if !strings.Contains(result.Result.Summary, "screenshot observation") {
-		t.Fatalf("unexpected screenshot summary: %q", result.Result.Summary)
+	if result.Result.Summary != "ok" {
+		t.Fatalf("screenshot summary = %q, want original action output", result.Result.Summary)
 	}
 	if result.Step.Observation != result.Result.Output {
 		t.Fatalf("step observation should preserve raw output")

--- a/src/agent/internal/agent/tools_post_action_screenshot.go
+++ b/src/agent/internal/agent/tools_post_action_screenshot.go
@@ -24,7 +24,7 @@ const postActionCompletedDetail = "action_completed"
 
 type postActionScreenshotResult struct {
 	screenshotResult
-	ActionOutput  string   `json:"action_output,omitempty"`
+	ActionOutput  string   `json:"action_output"`
 	ScreenStable  *bool    `json:"screen_stable,omitempty"`
 	StableWaitMs  *int64   `json:"stable_wait_ms,omitempty"`
 	ScreenChanged *bool    `json:"screen_changed,omitempty"`
@@ -55,7 +55,7 @@ func stripScreenshotData(content string) string {
 		"size":   result.Size,
 	}
 	if strings.TrimSpace(result.ActionOutput) != "" {
-		compact["action_output"] = strings.TrimSpace(result.ActionOutput)
+		compact["action_output"] = result.ActionOutput
 	}
 	if result.ScreenStable != nil {
 		compact["screen_stable"] = *result.ScreenStable

--- a/src/agent/internal/agent/tools_post_action_screenshot_test.go
+++ b/src/agent/internal/agent/tools_post_action_screenshot_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestStripScreenshotDataPreservesStableScreenStatus(t *testing.T) {
+func TestStripScreenshotDataPreservesActionOutputAndStableScreenStatus(t *testing.T) {
 	content := `{"width":320,"height":240,"format":"jpeg","size":4,"data":"ZmFrZQ==","action_output":" completed ","screen_stable":false,"stable_wait_ms":0,"screen_changed":true,"last_diff":1.25}`
 
 	stripped := stripScreenshotData(content)
@@ -27,8 +27,8 @@ func TestStripScreenshotDataPreservesStableScreenStatus(t *testing.T) {
 	if result.Width != 320 || result.Height != 240 || result.Format != "jpeg" || result.Size != 4 {
 		t.Fatalf("screenshot metadata = %#v", result)
 	}
-	if result.ActionOutput != "completed" {
-		t.Fatalf("ActionOutput = %q, want completed", result.ActionOutput)
+	if result.ActionOutput != " completed " {
+		t.Fatalf("ActionOutput = %q, want original output", result.ActionOutput)
 	}
 	if result.ScreenStable == nil || *result.ScreenStable {
 		t.Fatalf("ScreenStable = %#v, want false", result.ScreenStable)


### PR DESCRIPTION
## Summary
- preserve the wrapped action output verbatim in `tool_result` instead of replacing it with prose
- keep screenshot and screen stability guidance in the following state message
- preserve whitespace and empty action outputs through screenshot observation handling

## Testing
- `go test ./internal/agent -run "(PostAction|FunctionAgent|DefaultAfterToolCall|AppendToolExecutionMessages)" -count=1`
- `go test ./internal/agent -run "TestFunctionAgentPostActionScreenshotPreservesEmptyActionOutput|TestRuntimeRunKeyboardToolFeedsPostActionScreenshotImage|TestPostAction" -count=1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved raw screenshot action output, including whitespace and empty values.
  - Kept screenshot status information separate from the original tool response.
  - Ensured screenshot data and captions remain unchanged while action results are reported accurately.
  - Removed misleading screen-change and action-success warnings from screenshot follow-ups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->