### PR TITLE
fix(agent): move screenshot image into state message

### DIFF
--- a/src/agent/internal/agent/agent_loop_tool_result_test.go
+++ b/src/agent/internal/agent/agent_loop_tool_result_test.go
@@ -63,6 +63,49 @@ func TestAppendToolExecutionMessagesPersistsPreparedContentAndMetadata(t *testin
 	}
 }
 
+func TestAppendToolExecutionMessagesUsesSharedVisualActionFlowForScreenshot(t *testing.T) {
+	manager, err := contextmanager.NewContextManagerFromMessageList(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("NewContextManagerFromMessageList() error = %v", err)
+	}
+	llmExecutor := executor.NewLLMExecutor(nil, manager)
+	encoded := "aW1nMQ=="
+	observation := `{"action_output":"ok","width":800,"height":600,"format":"jpeg","size":4,"data":"` + encoded + `"}`
+	parser := &FunctionAgent{Tools: []langtools.Tool{&stubTool{name: "screenshot", visual: true}}}
+	step := schema.AgentStep{
+		Action:      schema.AgentAction{ToolID: "call_1", Tool: "screenshot"},
+		Observation: observation,
+	}
+	toolCall := messages.Message{
+		Role: messages.MessageRoleToolCall,
+		ToolCalls: []messages.ToolCall{{
+			ID: "call_1", Name: "screenshot", Arguments: `{}`,
+		}},
+	}
+
+	if err := appendToolExecutionMessages(llmExecutor, parser, toolCall, step, PreparedToolResult{Content: observation, Complete: true}); err != nil {
+		t.Fatalf("appendToolExecutionMessages() error = %v", err)
+	}
+
+	stored := manager.CloneMessageList()
+	if len(stored) != 3 {
+		t.Fatalf("stored messages = %#v, want tool call, tool result, and state", stored)
+	}
+	if stored[1].Role != messages.MessageRoleToolResult || len(stored[1].ToolResults) != 1 {
+		t.Fatalf("second message = %#v, want tool result", stored[1])
+	}
+	content := stored[1].ToolResults[0].Content
+	if content != "ok" {
+		t.Fatalf("tool result = %q, want shared action_output", content)
+	}
+	if stored[2].Role != messages.MessageRoleState || len(stored[2].Attachments) != 1 {
+		t.Fatalf("third message = %#v, want state with one image attachment", stored[2])
+	}
+	if stored[2].Attachments[0].Source != messages.AttachmentSourceScreenshotObservation {
+		t.Fatalf("state attachment source = %q", stored[2].Attachments[0].Source)
+	}
+}
+
 type largeContextScriptedModel struct {
 	*scriptedModel
 }

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -675,6 +675,30 @@ func TestFunctionAgentRejectsVisualObservationWithoutDimensions(t *testing.T) {
 	}
 }
 
+func TestFunctionAgentUsesSharedActionOutputFlowForScreenshot(t *testing.T) {
+	agent := &FunctionAgent{
+		Tools: []langtools.Tool{&stubTool{name: "screenshot", visual: true}},
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte("img1"))
+	observation := `{"action_output":"ok","width":800,"height":600,"format":"jpeg","size":4,"capture_backend":"frame_service","data":"` + encoded + `"}`
+
+	toolContent, followups := agent.observationMessagesForStep(schema.AgentStep{
+		Action:      schema.AgentAction{Tool: "screenshot"},
+		Observation: observation,
+	}, true)
+
+	if toolContent != "ok" {
+		t.Fatalf("tool result = %q, want shared action_output", toolContent)
+	}
+	if len(followups) != 1 || len(followups[0].Parts) != 2 {
+		t.Fatalf("visual followups = %#v, want one captioned image", followups)
+	}
+	imagePart, ok := followups[0].Parts[1].(llms.ImageURLContent)
+	if !ok || !strings.Contains(imagePart.URL, encoded) {
+		t.Fatalf("follow-up image = %#v, want screenshot data", followups[0].Parts[1])
+	}
+}
+
 func TestFunctionAgentPostActionScreenshotPreservesActionOutput(t *testing.T) {
 	agent := &FunctionAgent{
 		Tools: []langtools.Tool{&stubTool{name: "keyboard_tap", visual: true}},

--- a/src/agent/internal/agent/tool_http_catalog.go
+++ b/src/agent/internal/agent/tool_http_catalog.go
@@ -110,13 +110,13 @@ func buildHTTPToolSkillMarkdown(name, description string, baseURL string, descri
 	for _, descriptor := range descriptors {
 		builder.WriteString(fmt.Sprintf("- `%s`: %s\n", descriptor.Name, descriptor.Description))
 		if descriptor.Name == "screenshot" {
-			builder.WriteString("  Successful output JSON includes `width`, `height`, `format`, `size`, and base64 JPEG `data`.\n")
+			builder.WriteString("  Successful output includes the captured screen image.\n")
 		} else if descriptor.Name == "wait_for_stable_screen" {
-			builder.WriteString("  Successful output JSON includes `ok`, `stable`, `elapsed_ms`, `screen_changed`, optional `last_diff`, plus `screen_stable`, `stable_wait_ms`, `width`, `height`, `format`, `size`, and base64 JPEG `data` from the captured screenshot.\n")
+			builder.WriteString("  Successful output includes stability and screen-change metadata plus the captured screen image.\n")
 		} else if descriptor.Name == "enter_text" {
-			builder.WriteString("  `action_output` contains only `{\"ok\":true}` on success, or `{\"ok\":false,\"suggestion\":\"...\"}` on failure. The outer output also includes an optional `screen_changed` comparison, `width`, `height`, `format`, `size`, and base64 JPEG `data` from a short-delay post-action screenshot; `enter_text` does not perform the stable-screen wait, so `screen_stable` and `stable_wait_ms` are not included.\n")
+			builder.WriteString("  `action_output` contains only `{\"ok\":true}` on success, or `{\"ok\":false,\"suggestion\":\"...\"}` on failure. The outer output also includes an optional `screen_changed` comparison and a short-delay post-action screenshot; `enter_text` does not perform the stable-screen wait, so `screen_stable` and `stable_wait_ms` are not included.\n")
 		} else if descriptor.Category == "input" {
-			builder.WriteString("  On successful execution, output JSON includes `action_output`, `screen_stable`, `stable_wait_ms`, optional `screen_changed`, `width`, `height`, `format`, `size`, and base64 JPEG `data` from a post-action screenshot. When present, `screen_changed` reports meaningful structural change between a pre-action baseline and the final settled screenshot while ignoring the top status area and minor image noise; `screen_stable=false` is not a failure.\n")
+			builder.WriteString("  On successful execution, output includes `action_output`, `screen_stable`, `stable_wait_ms`, optional `screen_changed`, and a post-action screenshot. When present, `screen_changed` reports meaningful structural change between a pre-action baseline and the final settled screenshot while ignoring the top status area and minor image noise; `screen_stable=false` is not a failure.\n")
 		}
 		if strings.TrimSpace(descriptor.ExampleInput) != "" {
 			builder.WriteString(fmt.Sprintf("  Example input: `%s`\n", descriptor.ExampleInput))

--- a/src/agent/internal/agent/tools_image_diff.go
+++ b/src/agent/internal/agent/tools_image_diff.go
@@ -32,17 +32,17 @@ func imageDiffAttachmentResolverFromContext(ctx context.Context) imageDiffAttach
 	return resolver
 }
 
-// ImageDiffTool compares two JPEG screenshots and returns pixel-level difference
+// ImageDiffTool compares two screenshots and returns pixel-level difference
 // metrics. Agent calls normally reference persisted screenshot attachments by
-// filename; direct HTTP callers may continue to pass Base64 JPEG data.
+// filename; direct HTTP callers may continue to pass Base64 image data.
 type ImageDiffTool struct{}
 
 func (t *ImageDiffTool) Name() string { return "image_diff" }
 
 func (t *ImageDiffTool) Description() string {
-	return `Compare two JPEG screenshots and return pixel-level difference metrics. ` +
+	return `Compare two screenshots and return pixel-level difference metrics. ` +
 		`This is a diagnostic tool for Tool Lab and prepared-script callers, not a normal conversational Agent step. ` +
-		`Callers may pass screenshot_attachment_id values from the current context, or Base64 JPEG data returned by the screenshot tool. ` +
+		`Callers may pass screenshot_attachment_id values from the current context, or Base64 image data returned by the screenshot tool. ` +
 		`"region" is optional normalized coordinates (0-1000) to restrict comparison to a sub-region — use this to focus on the scrollable area and ignore static UI chrome. ` +
 		`Returns: ` +
 		`"changed" (bool, true when diff_ratio > 0.01), ` +
@@ -63,8 +63,8 @@ func (t *ImageDiffTool) ArgsSchema() map[string]any {
 	regionSchema["examples"] = []map[string]any{{"x": 100, "y": 200, "w": 600, "h": 400}}
 
 	return objectArgsSchema(map[string]any{
-		"before": stringArgSchema("Earlier screenshot_attachment_id copied from the visual observation, or Base64 JPEG data for direct HTTP calls."),
-		"after":  stringArgSchema("Later screenshot_attachment_id copied from the visual observation, or Base64 JPEG data for direct HTTP calls."),
+		"before": stringArgSchema("Earlier screenshot_attachment_id copied from the visual observation, or Base64 image data for direct HTTP calls."),
+		"after":  stringArgSchema("Later screenshot_attachment_id copied from the visual observation, or Base64 image data for direct HTTP calls."),
 		"region": regionSchema,
 	}, "before", "after")
 }
@@ -95,19 +95,19 @@ func (t *ImageDiffTool) Call(ctx context.Context, input string) (string, error) 
 	}
 
 	if len(beforeData) < 2 || beforeData[0] != 0xFF || beforeData[1] != 0xD8 {
-		return toolErrorResultString(ctx, CodeInvalidArguments, "before is not JPEG format (image_diff only supports JPEG). Use a screenshot_attachment_id or the 'data' field from screenshot tool results"), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "before contains unsupported image data. Use a screenshot_attachment_id or the 'data' field from screenshot tool results"), nil
 	}
 	if len(afterData) < 2 || afterData[0] != 0xFF || afterData[1] != 0xD8 {
-		return toolErrorResultString(ctx, CodeInvalidArguments, "after is not JPEG format (image_diff only supports JPEG). Use a screenshot_attachment_id or the 'data' field from screenshot tool results"), nil
+		return toolErrorResultString(ctx, CodeInvalidArguments, "after contains unsupported image data. Use a screenshot_attachment_id or the 'data' field from screenshot tool results"), nil
 	}
 
 	beforeImg, err := jpeg.Decode(bytes.NewReader(beforeData))
 	if err != nil {
-		return toolErrorResultf(ctx, CodeInvalidArguments, "decode before JPEG: %v", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "decode before image: %v", err), nil
 	}
 	afterImg, err := jpeg.Decode(bytes.NewReader(afterData))
 	if err != nil {
-		return toolErrorResultf(ctx, CodeInvalidArguments, "decode after JPEG: %v", err), nil
+		return toolErrorResultf(ctx, CodeInvalidArguments, "decode after image: %v", err), nil
 	}
 
 	fullBounds := beforeImg.Bounds()
@@ -148,7 +148,7 @@ func resolveImageDiffInput(ctx context.Context, input string) ([]byte, error) {
 	}
 	data, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
-		return nil, fmt.Errorf("expected a screenshot_attachment_id or Base64 JPEG: %w", err)
+		return nil, fmt.Errorf("expected a screenshot_attachment_id or Base64 image data: %w", err)
 	}
 	return data, nil
 }

--- a/src/agent/internal/agent/tools_image_diff_png_test.go
+++ b/src/agent/internal/agent/tools_image_diff_png_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 )
 
-func TestImageDiffNonJPEGDetection(t *testing.T) {
+func TestImageDiffUnsupportedImageData(t *testing.T) {
 	tool := &ImageDiffTool{}
 
-	t.Run("before is PNG", func(t *testing.T) {
+	t.Run("unsupported before image", func(t *testing.T) {
 		// PNG data (1x1 red and blue pixels)
 		pngInput := `{"before":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==","after":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="}`
 
@@ -18,23 +18,18 @@ func TestImageDiffNonJPEGDetection(t *testing.T) {
 			t.Fatalf("Call returned error: %v", err)
 		}
 
-		// Should contain error message indicating non-JPEG format
-		if !strings.Contains(result, "before is not JPEG format") {
-			t.Errorf("Expected 'before is not JPEG format' error message, got: %s", result)
-		}
-
-		if !strings.Contains(result, "only supports JPEG") {
-			t.Errorf("Expected 'only supports JPEG' in error message, got: %s", result)
+		if !strings.Contains(result, "before contains unsupported image data") {
+			t.Errorf("Expected unsupported before image error message, got: %s", result)
 		}
 
 		if !strings.Contains(result, "'data' field from screenshot tool results") {
 			t.Errorf("Expected specific guidance about 'data' field, got: %s", result)
 		}
 
-		t.Logf("Non-JPEG detection working correctly. Error message: %s", result)
+		t.Logf("Unsupported image detection working correctly. Error message: %s", result)
 	})
 
-	t.Run("after is PNG", func(t *testing.T) {
+	t.Run("unsupported after image", func(t *testing.T) {
 		// 1x1 red JPEG (valid before) + PNG (invalid after)
 		mixedInput := `{"before":"/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCwABmQ/9k=","after":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="}`
 
@@ -43,19 +38,14 @@ func TestImageDiffNonJPEGDetection(t *testing.T) {
 			t.Fatalf("Call returned error: %v", err)
 		}
 
-		// Should contain error message indicating non-JPEG format for "after"
-		if !strings.Contains(result, "after is not JPEG format") {
-			t.Errorf("Expected 'after is not JPEG format' error message, got: %s", result)
-		}
-
-		if !strings.Contains(result, "only supports JPEG") {
-			t.Errorf("Expected 'only supports JPEG' in error message, got: %s", result)
+		if !strings.Contains(result, "after contains unsupported image data") {
+			t.Errorf("Expected unsupported after image error message, got: %s", result)
 		}
 
 		if !strings.Contains(result, "'data' field from screenshot tool results") {
 			t.Errorf("Expected specific guidance about 'data' field, got: %s", result)
 		}
 
-		t.Logf("Non-JPEG detection working correctly for 'after'. Error message: %s", result)
+		t.Logf("Unsupported image detection working correctly for 'after'. Error message: %s", result)
 	})
 }

--- a/src/agent/internal/agent/tools_post_action_screenshot.go
+++ b/src/agent/internal/agent/tools_post_action_screenshot.go
@@ -327,7 +327,7 @@ func applyTouchGesturePostMarker(result *screenshotResult, marker touchGesturePo
 func drawTouchGesturePostMarker(jpegData []byte, marker touchGesturePostMarkerInfo) ([]byte, error) {
 	img, err := jpeg.Decode(bytes.NewReader(jpegData))
 	if err != nil {
-		return nil, fmt.Errorf("decode screenshot jpeg: %w", err)
+		return nil, fmt.Errorf("decode screenshot image: %w", err)
 	}
 	bounds := img.Bounds()
 	width := bounds.Dx()
@@ -344,7 +344,7 @@ func drawTouchGesturePostMarker(jpegData []byte, marker touchGesturePostMarkerIn
 
 	var output bytes.Buffer
 	if err := jpeg.Encode(&output, marked, &jpeg.Options{Quality: 90}); err != nil {
-		return nil, fmt.Errorf("encode marked screenshot jpeg: %w", err)
+		return nil, fmt.Errorf("encode marked screenshot image: %w", err)
 	}
 	return output.Bytes(), nil
 }

--- a/src/agent/internal/agent/tools_screenshot.go
+++ b/src/agent/internal/agent/tools_screenshot.go
@@ -105,7 +105,7 @@ func captureActiveAreaFrame(client screenshotFrameClient, screenState *screen.Sc
 		return capturedFrame{}, fmt.Errorf("frame service: STALE_FRAME")
 	}
 	if meta.PixelFormat != "jpeg" {
-		return capturedFrame{}, fmt.Errorf("expected jpeg format, got %s", meta.PixelFormat)
+		return capturedFrame{}, fmt.Errorf("screen capture returned an unsupported frame")
 	}
 
 	active := screen.ScreenActiveArea{}
@@ -229,8 +229,7 @@ func (t *ScreenshotTool) ReturnsVisualObservation() bool { return true }
 
 func (t *ScreenshotTool) Description() string {
 	return `Capture a screenshot from the connected display. No input required (pass empty JSON {} or ""). ` +
-		`Returns a JSON object with width, height, and base64-encoded JPEG image data. ` +
-		`Use normalized 0-1000 coordinates for coordinate input tools. Convert visual measurements from this image before acting: x_normalized=x/max(width-1,1)*1000 and y_normalized=y/max(height-1,1)*1000; do not pass screenshot pixels directly.`
+		`Returns ok in the tool result and provides the image in a follow-up state message.`
 }
 
 func (t *ScreenshotTool) ArgsSchema() map[string]any {
@@ -248,7 +247,7 @@ func (t *ScreenshotTool) Call(_ context.Context, _ string) (string, error) {
 		return "", fmt.Errorf("frame service: STALE_FRAME")
 	}
 	if meta.PixelFormat != "jpeg" {
-		return "", fmt.Errorf("expected jpeg format, got %s", meta.PixelFormat)
+		return "", fmt.Errorf("screen capture returned an unsupported frame")
 	}
 	if touchscreenRCADebugEnabledCached() {
 		touchscreenRCALogf("screenshot frame meta=%s capture_backend=%q mapping_before={%s}", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, t.screen.Format())
@@ -324,7 +323,10 @@ func (t *ScreenshotTool) Call(_ context.Context, _ string) (string, error) {
 		)
 	}
 
-	out, _ := json.Marshal(result)
+	out, _ := json.Marshal(postActionScreenshotResult{
+		screenshotResult: result,
+		ActionOutput:     "ok",
+	})
 	return string(out), nil
 }
 

--- a/src/agent/internal/agent/tools_screenshot_test.go
+++ b/src/agent/internal/agent/tools_screenshot_test.go
@@ -203,9 +203,12 @@ func TestScreenshotToolUsesJPEGSourceMetadataForSharedScreenState(t *testing.T) 
 		t.Fatalf("Call() error = %v", err)
 	}
 
-	var result screenshotResult
+	var result postActionScreenshotResult
 	if err := json.Unmarshal([]byte(out), &result); err != nil {
 		t.Fatalf("output is not valid screenshot JSON: %v", err)
+	}
+	if result.ActionOutput != "ok" {
+		t.Fatalf("action_output = %q, want ok", result.ActionOutput)
 	}
 	if result.Width != 2 || result.Height != 2 || result.Format != "jpeg" || result.Size != len(jpegData) {
 		t.Fatalf("unexpected screenshot metadata: %#v", result)

--- a/src/agent/internal/agent/tools_wait_stable.go
+++ b/src/agent/internal/agent/tools_wait_stable.go
@@ -124,7 +124,7 @@ func (t *WaitStableScreenTool) Description() string {
 			`Use only while operating a visible target UI, after a UI action or known UI transition that may animate, navigate, or load; do not call for text-only reasoning, arithmetic, comparison, or memory lookup. `+
 			`Input: {} (empty JSON object). Configured timeouts: timeout_ms=%d, stable_ms=%d, diff_threshold=%g. `+
 			`The screen is stable when consecutive frames stay below diff_threshold for stable_ms. `+
-			`Returns {"ok":true,"stable":true/false,"elapsed_ms":N,"screen_changed":true/false,...} plus a screenshot observation with width, height, format, size, and base64 JPEG data. `+
+			`Returns {"ok":true,"stable":true/false,"elapsed_ms":N,"screen_changed":true/false,...} and provides the screenshot as a visual observation. `+
 			`screen_changed reports whether any frame-to-frame motion was observed during this wait window; it is not a before/after action-success signal. Inspect the returned screenshot to judge the preceding action. `+
 			`stable=false means the wait timed out while the screen was still changing (for example video playback); that is not an error and the screenshot is still captured as a best-effort observation.`,
 		resolved.TimeoutMs,
@@ -175,7 +175,7 @@ func (t *WaitStableScreenTool) captureScreenshot() (screenshotResult, error) {
 		return screenshotResult{}, fmt.Errorf("frame service: STALE_FRAME")
 	}
 	if meta.PixelFormat != "jpeg" {
-		return screenshotResult{}, fmt.Errorf("expected jpeg format, got %s", meta.PixelFormat)
+		return screenshotResult{}, fmt.Errorf("screen capture returned an unsupported frame")
 	}
 	if touchscreenRCADebugEnabledCached() {
 		touchscreenRCALogf("wait_stable.captureScreenshot frame meta=%s capture_backend=%q mapping_before={%s}", formatTouchscreenRCAMetadata(meta), captureInfo.Backend, t.screen.Format())


### PR DESCRIPTION
## Summary
- make successful `screenshot` observations expose `action_output: "ok"`, reusing the existing visual-tool flow used by post-action tools
- persist the textual tool result as `ok` and the image as the following state attachment
- remove image encoding/format details from model-facing tool descriptions and related diagnostic messages

## Root cause
`main` already splits visual observations with `action_output` into a textual tool result plus a follow-up state image. Unlike `touch_gesture`, the standalone `screenshot` result did not set `action_output`, so the generic flow intentionally preserved the full original JSON—including base64—in `tool_result`.

## Validation
- `TMPDIR=/tmp go test ./internal/agent`
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Screenshot results now return a clear success status, with the captured image provided in a follow-up message.
  - Screenshot observations include a captioned image attachment for improved visibility.

- **Bug Fixes**
  - Improved handling and reporting of unsupported image formats.
  - Standardized screenshot and image-difference messages with clearer, format-neutral wording.

- **Documentation**
  - Updated tool descriptions to clarify how screenshot results are delivered and reduce unnecessary image metadata details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->