### PR TITLE
ci: skip docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- exclude `docs/**` changes from pull request CI triggers
- exclude `docs/**` changes from pushes to `main`

## Validation
- `git diff --check`
- parsed `.github/workflows/ci.yml` with Ruby Psych

## Notes
- `scripts/test_release_ci_scripts.sh` could not run locally because PyYAML is not installed in the environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation-only changes no longer trigger CI workflows for pull requests or updates to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->