### PR TITLE
fix: rotate truncated realtime context session

### DIFF
--- a/src/agent/cmd/daemon/main_test.go
+++ b/src/agent/cmd/daemon/main_test.go
@@ -227,6 +227,66 @@ func TestRecentRealtimeContextMessagesKeepsLatestTenUserTurns(t *testing.T) {
 	}
 }
 
+func TestRotateRealtimeContextForReplayStartsRevisionWhenTruncated(t *testing.T) {
+	sessionFolder := t.TempDir()
+	manager, err := contextmanager.NewContextManager(sessionFolder, "system")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 3; i++ {
+		if err := manager.AppendMessages([]messages.Message{
+			{Role: messages.MessageRoleUser, Content: fmt.Sprintf("user-%d", i)},
+			{Role: messages.MessageRoleAssistant, Content: fmt.Sprintf("assistant-%d", i)},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	originalSessionID := manager.GetSessionID()
+
+	rotated, err := rotateRealtimeContextForReplay(manager, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rotated.GetSessionID() == originalSessionID {
+		t.Fatal("truncated context reused the original session")
+	}
+	dump := rotated.MessageListDump()
+	if dump.ParentSessionID != originalSessionID {
+		t.Fatalf("parent session = %q, want %q", dump.ParentSessionID, originalSessionID)
+	}
+	if len(dump.Messages) != 5 ||
+		dump.Messages[0].Role != messages.MessageRoleSystem ||
+		dump.Messages[1].Content != "user-2" ||
+		dump.Messages[4].Content != "assistant-3" {
+		t.Fatalf("rotated messages = %+v", dump.Messages)
+	}
+	current, err := contextmanager.LoadContextManagerFromCurrentSession(sessionFolder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.GetSessionID() != rotated.GetSessionID() {
+		t.Fatalf("current session = %q, want %q", current.GetSessionID(), rotated.GetSessionID())
+	}
+}
+
+func TestRotateRealtimeContextForReplayReusesSessionWithoutTruncation(t *testing.T) {
+	manager, err := contextmanager.NewContextManager(t.TempDir(), "system")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.AppendMessage(messages.Message{Role: messages.MessageRoleUser, Content: "hello"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := rotateRealtimeContextForReplay(manager, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.GetSessionID() != manager.GetSessionID() {
+		t.Fatal("untruncated context started a new session")
+	}
+}
+
 type fakeBackgroundTaskRunner struct {
 	started chan string
 	release chan struct{}

--- a/src/agent/cmd/daemon/realtime_wakeup.go
+++ b/src/agent/cmd/daemon/realtime_wakeup.go
@@ -600,6 +600,10 @@ func runRealtimeSession(cfg agent.Config, sigChan chan os.Signal, runtime *agent
 	if err != nil {
 		return fmt.Errorf("initialize realtime user context: %w", err)
 	}
+	userContext, err = rotateRealtimeContextForReplay(userContext, realtimeContextReplayTurns)
+	if err != nil {
+		return fmt.Errorf("rotate truncated realtime user context: %w", err)
+	}
 
 	client, err := rtclient.New(rtclient.Config{
 		APIKey:      cfg.VoiceModel.APIKey,
@@ -1404,6 +1408,37 @@ func replayRealtimeContext(ctx context.Context, session *rtclient.Session, manag
 		}
 	}
 	return nil
+}
+
+// rotateRealtimeContextForReplay makes the durable session match the context
+// restored into a new provider session. Keeping the shortened context under the
+// old session ID would violate the invariant that one session identifies one
+// conversation context.
+func rotateRealtimeContextForReplay(manager *contextmanager.ContextManager, maxTurns int) (*contextmanager.ContextManager, error) {
+	if manager == nil {
+		return nil, nil
+	}
+	all := manager.MessageListDump().Messages
+	recent := recentRealtimeContextMessages(all, maxTurns)
+	if len(recent) == len(all) {
+		return manager, nil
+	}
+
+	retained := make([]messages.Message, 0, len(recent)+1)
+	if len(all) > 0 && all[0].Role == messages.MessageRoleSystem {
+		retained = append(retained, all[0])
+	}
+	retained = append(retained, recent...)
+	revision, err := contextmanager.NewContextManagerRevisionFromMessageList(manager, retained)
+	if err != nil {
+		return nil, err
+	}
+	if err := contextmanager.SwitchSession(revision.GetSessionFolder(), revision.GetSessionID()); err != nil {
+		return nil, err
+	}
+	log.Printf("[realtime] Rotated user context after replay truncation: parent=%s session=%s retained_messages=%d",
+		manager.GetSessionID(), revision.GetSessionID(), len(retained))
+	return revision, nil
 }
 
 func recentRealtimeContextMessages(all []messages.Message, maxTurns int) []messages.Message {


### PR DESCRIPTION
## Summary
- detect when realtime user-context replay drops older turns
- create and switch to a child session whose persisted messages match the shortened provider context
- retain the system prompt and session lineage, while reusing the existing session when no truncation occurs

## Testing
- `cd src/agent && go test ./cmd/daemon ./internal/agent/contextmanager`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Realtime sessions now create a new context revision when replay history is truncated.
  * New revisions preserve the system message and recent replayable messages.
  * The active session automatically switches to the new revision.

* **Bug Fixes**
  * Rotation failures are now reported instead of being silently ignored.
  * Existing sessions continue to be reused when replay history is not truncated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->