### PR TITLE
fix(agent): wait for remount before completing format

### DIFF
--- a/src/agent/internal/agent/storage_manager.go
+++ b/src/agent/internal/agent/storage_manager.go
@@ -370,6 +370,17 @@ func (m *StorageManager) runFormatJob(fs string) {
 	// let callers tear down resources that the mount attempt is still using.
 	m.tryMountLocked()
 	m.formatJob.FinishedAt = time.Now()
+	if !m.card.Mounted {
+		reason := m.card.Reason
+		if reason == "" {
+			reason = "card unavailable after format"
+			m.card.Reason = reason
+		}
+		m.formatJob.Status = StorageFormatFailed
+		m.formatJob.Error = fmt.Sprintf("post-format mount failed: %s", reason)
+		m.finishTransitionLocked()
+		return
+	}
 	m.formatJob.Status = StorageFormatSuccess
 	m.finishTransitionLocked()
 }

--- a/src/agent/internal/agent/storage_manager.go
+++ b/src/agent/internal/agent/storage_manager.go
@@ -352,8 +352,8 @@ func (m *StorageManager) runFormatJob(fs string) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.formatJob.FinishedAt = time.Now()
 	if err != nil {
+		m.formatJob.FinishedAt = time.Now()
 		m.formatJob.Status = StorageFormatFailed
 		m.formatJob.Error = err.Error()
 		m.card.Reason = fmt.Sprintf("format failed: %v", err)
@@ -361,11 +361,16 @@ func (m *StorageManager) runFormatJob(fs string) {
 		m.finishTransitionLocked()
 		return
 	}
-	m.formatJob.Status = StorageFormatSuccess
 	m.card.Reason = ""
 	m.ejected = false
 	m.mountFailed = false
+	// Keep the job running until the post-format mount attempt has landed.
+	// tryMountLocked releases m.mu while Prepare runs, so publishing success
+	// first would let observers see a completed job with an unmounted card and
+	// let callers tear down resources that the mount attempt is still using.
 	m.tryMountLocked()
+	m.formatJob.FinishedAt = time.Now()
+	m.formatJob.Status = StorageFormatSuccess
 	m.finishTransitionLocked()
 }
 

--- a/src/agent/internal/agent/storage_manager_test.go
+++ b/src/agent/internal/agent/storage_manager_test.go
@@ -479,6 +479,38 @@ func TestStorageManagerFormatExt4MountsAfterSuccess(t *testing.T) {
 	}
 }
 
+func TestStorageManagerFormatRemainsRunningUntilRemountFinishes(t *testing.T) {
+	ops := &fakeStorageOps{present: true, free: 1 << 30, total: 1 << 31, healthy: true}
+	m := newTestStorageManager(t, ops)
+	tickN(m, 2)
+
+	// Block only the post-format Prepare call so the state exposed during the
+	// remount is deterministic.
+	ops.prepareBlock = make(chan struct{})
+	ops.prepareEntered = make(chan struct{})
+	if err := m.StartFormat(StorageFormatFAT32, StorageFormatConfirmToken); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-ops.prepareEntered:
+	case <-time.After(time.Second):
+		t.Fatal("post-format mount did not start")
+	}
+
+	if status := m.Status(); status.FormatJob.Status != StorageFormatRunning {
+		t.Fatalf("format job published completion before remount finished: %+v", status)
+	}
+
+	close(ops.prepareBlock)
+	job := waitForFormatJob(t, m)
+	if job.Status != StorageFormatSuccess {
+		t.Fatalf("job = %+v, want success", job)
+	}
+	if status := m.Status(); !status.Card.Mounted || status.EffectiveMode != StorageModeDual {
+		t.Fatalf("status = %+v, want mounted dual storage after completed job", status)
+	}
+}
+
 func TestStorageManagerFormatExFATMountsAfterSuccess(t *testing.T) {
 	ops := &fakeStorageOps{present: true, free: 1 << 30, total: 1 << 31, healthy: true}
 	m := newTestStorageManager(t, ops)

--- a/src/agent/internal/agent/storage_manager_test.go
+++ b/src/agent/internal/agent/storage_manager_test.go
@@ -21,10 +21,12 @@ type fakeStorageOps struct {
 	prepareBlock   chan struct{}
 	prepareEntered chan struct{}
 	prepareOnce    sync.Once
+
 	free       int64
 	total      int64
 	spaceErr   error
 	formatErr  error
+	remountErr error
 	unmountErr error
 	blank      bool
 	// spaceFn, when set, answers SpaceInfo per path (used by migration
@@ -96,7 +98,7 @@ func (f *fakeStorageOps) FormatDisk(fs string) (string, error) {
 	}
 	// A freshly formatted card is no longer blank and mounts cleanly.
 	f.blank = false
-	f.prepareErr = nil
+	f.prepareErr = f.remountErr
 	return "/dev/mmcblk2p1", nil
 }
 
@@ -548,6 +550,30 @@ func TestStorageManagerFormatFailureReported(t *testing.T) {
 	}
 }
 
+func TestStorageManagerPostFormatMountFailureReported(t *testing.T) {
+	ops := &fakeStorageOps{
+		present: true, free: 1 << 30, total: 1 << 31, healthy: true,
+		remountErr: errors.New("mount: device unavailable"),
+	}
+	m := newTestStorageManager(t, ops)
+	tickN(m, 2)
+
+	if err := m.StartFormat(StorageFormatFAT32, StorageFormatConfirmToken); err != nil {
+		t.Fatal(err)
+	}
+	job := waitForFormatJob(t, m)
+	if job.Status != StorageFormatFailed || !strings.Contains(job.Error, "mount: device unavailable") {
+		t.Fatalf("job = %+v, want post-format mount failure", job)
+	}
+	status := m.Status()
+	if status.Card.Mounted {
+		t.Fatal("card reported mounted after post-format mount failure")
+	}
+	if !strings.Contains(status.Card.Reason, "mount: device unavailable") {
+		t.Fatalf("card reason = %q, want mount failure", status.Card.Reason)
+	}
+}
+
 func TestStorageManagerRejectsActionsDuringFormat(t *testing.T) {
 	ops := &fakeStorageOps{present: true, free: 1 << 30, total: 1 << 31, healthy: true}
 	m := newTestStorageManager(t, ops)
@@ -621,7 +647,7 @@ func TestStorageManagerNeverAutoFormatsUnreadableCard(t *testing.T) {
 
 func TestStorageManagerAutoFormatOncePerInsertion(t *testing.T) {
 	ops := &fakeStorageOps{
-		present: true, healthy: true,
+		present: true, healthy: true, free: 1 << 30, total: 1 << 31,
 		prepareErr: errors.New("no filesystem"), blank: true,
 		formatErr: errors.New("card yanked"),
 	}

--- a/src/agent/internal/agent/storage_manager_test.go
+++ b/src/agent/internal/agent/storage_manager_test.go
@@ -26,9 +26,11 @@ type fakeStorageOps struct {
 	total      int64
 	spaceErr   error
 	formatErr  error
-	remountErr error
 	unmountErr error
 	blank      bool
+
+	remountErr     error
+	nextPrepareErr error
 	// spaceFn, when set, answers SpaceInfo per path (used by migration
 	// tests to model eMMC free space changing as files move).
 	spaceFn func(path string) (int64, int64, error)
@@ -57,6 +59,11 @@ func (f *fakeStorageOps) Prepare(dev, mountPoint string) error {
 	if f.prepareBlock != nil {
 		f.prepareOnce.Do(func() { close(f.prepareEntered) })
 		<-f.prepareBlock
+	}
+	if f.nextPrepareErr != nil {
+		err := f.nextPrepareErr
+		f.nextPrepareErr = nil
+		return err
 	}
 	if f.prepareErr != nil {
 		return f.prepareErr
@@ -98,7 +105,9 @@ func (f *fakeStorageOps) FormatDisk(fs string) (string, error) {
 	}
 	// A freshly formatted card is no longer blank and mounts cleanly.
 	f.blank = false
-	f.prepareErr = f.remountErr
+	f.prepareErr = nil
+	f.nextPrepareErr = f.remountErr
+	f.remountErr = nil
 	return "/dev/mmcblk2p1", nil
 }
 
@@ -571,6 +580,16 @@ func TestStorageManagerPostFormatMountFailureReported(t *testing.T) {
 	}
 	if !strings.Contains(status.Card.Reason, "mount: device unavailable") {
 		t.Fatalf("card reason = %q, want mount failure", status.Card.Reason)
+	}
+
+	// The injected remount failure is transient. A physical reinsertion should
+	// get a fresh mount attempt rather than inheriting the consumed error.
+	ops.present = false
+	tickN(m, 2)
+	ops.present = true
+	tickN(m, 2)
+	if status := m.Status(); !status.Card.Mounted {
+		t.Fatalf("card did not recover after reinsertion: %+v", status.Card)
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep storage format jobs running until the post-format mount attempt finishes
- prevent observers from seeing a completed job with stale unmounted card state
- add a deterministic regression test that blocks the remount and verifies state publication order

## Root cause

`runFormatJob` published `StorageFormatSuccess` before calling `tryMountLocked`. Because `tryMountLocked` releases the manager mutex while `Prepare` runs, callers could observe `success` with `Mounted:false`. Tests could then tear down their temporary directory while the background mount was still writing to it.

## Verification

- `go test ./internal/agent -run 'TestStorageManager(AutoFormatsBlankCard|FormatRemainsRunningUntilRemountFinishes)$' -count=100`\n- `go test -race ./internal/agent -run 'TestStorageManager(AutoFormatsBlankCard|FormatRemainsRunningUntilRemountFinishes)$' -count=20`\n- `TMPDIR=/tmp go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Formatting jobs now remain marked as running until post-format remounting completes.
  * Job success is reported only after storage is successfully remounted.
  * Post-format remount failures now correctly mark the job as failed and include the failure reason.
  * Storage remains safely unmounted when remounting fails.
  * Improved status accuracy for dual-storage formatting workflows.
  * Storage can recover correctly after the affected card is removed and reinserted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->