### PR TITLE
fix(benchmark): resolve mac desktop health check path

### DIFF
--- a/benchmark/desktop/bridge/device.py
+++ b/benchmark/desktop/bridge/device.py
@@ -91,7 +91,11 @@ class DesktopDevice:
             size = self._pyautogui.size()
             return int(size[0]), int(size[1])
         if self.system == "darwin":
-            result = subprocess.run(["/usr/bin/system_profiler", "SPDisplaysDataType"], capture_output=True, text=True, timeout=5)
+            system_profiler = shutil.which("system_profiler") or next(
+                (candidate for candidate in ("/usr/sbin/system_profiler", "/usr/bin/system_profiler") if os.path.exists(candidate)),
+                "system_profiler",
+            )
+            result = subprocess.run([system_profiler, "SPDisplaysDataType"], capture_output=True, text=True, timeout=5)
             import re
             match = re.search(r"Resolution:\s*(\d+) x (\d+)", result.stdout)
             if match:

--- a/benchmark/tests/test_desktop_bridge.py
+++ b/benchmark/tests/test_desktop_bridge.py
@@ -109,15 +109,16 @@ def test_desktop_device_clamps_normalized_screen_edges():
     assert device._pixels(1000, 1000) == (99, 49)
 
 
-def test_desktop_device_uses_discoverable_system_profiler_on_macos(monkeypatch):
+def test_desktop_device_uses_system_profiler_fallback_on_macos(monkeypatch):
     device = DesktopDevice.__new__(DesktopDevice)
     device.system = "darwin"
     device._pyautogui = None
     captured = {}
 
+    monkeypatch.setattr("desktop.bridge.device.shutil.which", lambda name: None)
     monkeypatch.setattr(
-        "desktop.bridge.device.shutil.which",
-        lambda name: "/usr/sbin/system_profiler" if name == "system_profiler" else None,
+        "desktop.bridge.device.os.path.exists",
+        lambda path: path == "/usr/sbin/system_profiler",
     )
 
     def fake_run(command, capture_output, text, timeout):

--- a/benchmark/tests/test_desktop_bridge.py
+++ b/benchmark/tests/test_desktop_bridge.py
@@ -109,6 +109,31 @@ def test_desktop_device_clamps_normalized_screen_edges():
     assert device._pixels(1000, 1000) == (99, 49)
 
 
+def test_desktop_device_uses_discoverable_system_profiler_on_macos(monkeypatch):
+    device = DesktopDevice.__new__(DesktopDevice)
+    device.system = "darwin"
+    device._pyautogui = None
+    captured = {}
+
+    monkeypatch.setattr(
+        "desktop.bridge.device.shutil.which",
+        lambda name: "/usr/sbin/system_profiler" if name == "system_profiler" else None,
+    )
+
+    def fake_run(command, capture_output, text, timeout):
+        captured["command"] = command
+
+        class Result:
+            stdout = "Resolution: 1440 x 900\n"
+
+        return Result()
+
+    monkeypatch.setattr("desktop.bridge.device.subprocess.run", fake_run)
+
+    assert device.screen_size() == (1440, 900)
+    assert captured["command"][0] == "/usr/sbin/system_profiler"
+
+
 def test_task_access_requires_matching_active_lease():
     state = DesktopBridgeState(device=FakeDevice())
     with pytest.raises(NoBridgeEnvAvailableError):


### PR DESCRIPTION
## Summary\n- resolve macOS desktop bridge health checks by discovering system_profiler instead of using a fixed /usr/bin path\n- add a regression test for the macOS fallback path\n\n## Tests\n- uv run pytest tests/test_desktop_bridge.py -q -p no:capture\n- uv run python -m runner start-desktop-env --bridge-port 0 --ready-timeout-sec 8 --json\n- manual /health and screenshot provider smoke check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS screen-size detection by locating the system profiling utility across supported installation paths.
  * Increased compatibility on systems where the utility is not installed in its previously expected location.
  * Preserved accurate screen-resolution reporting when using an alternate utility location.

* **Tests**
  * Added coverage verifying utility discovery, fallback behavior, command execution, and screen-resolution parsing on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->