### PR TITLE
ci: parallelize and speed up test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,24 +177,3 @@ jobs:
           node-version: '22'
       - name: Run Agent Web UI tests
         run: make test-agent-webui
-
-  # Preserve the existing required-check name while making it represent every
-  # parallel test job. `always()` ensures a failed dependency produces a failed
-  # aggregate check instead of leaving the required check skipped.
-  run-tests:
-    if: always()
-    needs:
-      - script-tests
-      - docker-tests
-      - cpp-tests
-      - go-tests
-      - web-tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify parallel test jobs
-        run: |
-          test '${{ needs.script-tests.result }}' = success
-          test '${{ needs.docker-tests.result }}' = success
-          test '${{ needs.cpp-tests.result }}' = success
-          test '${{ needs.go-tests.result }}' = success
-          test '${{ needs.web-tests.result }}' = success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           PICO_SDK_DIR: ${{ steps.sdk.outputs.dir }}
         run: bash scripts/test_reproducible_rootfs_policy.sh
 
-  run-tests:
+  script-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -103,21 +103,28 @@ jobs:
         run: |
           python3 scripts/check_normalized_coords.py
           bash scripts/test_check_normalized_coords.sh
+      - name: Verify swap initialization
+        run: sh scripts/test_swap_init.sh
+
+  docker-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Verify Docker sandbox contract
         timeout-minutes: 25
         run: |
           python3 -m unittest tests.benchmark.test_docker_sandbox
           docker compose config --quiet
           sh scripts/test_docker_sandbox.sh
-      - name: Verify swap initialization
-        run: sh scripts/test_swap_init.sh
-      # dnsmasq-base gives the test a real parser for the config S55 generates
-      # at runtime; without it that syntax check downgrades to a skip.
-      - name: Verify usb0 DHCP options
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y dnsmasq-base
-          sh scripts/test_usb0_dhcp_options.sh
+
+  cpp-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -132,10 +139,62 @@ jobs:
       - name: Run C++ unit tests
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake libopencv-dev
+          # The host tests only use OpenCV core and imgproc. Installing the
+          # libopencv-dev metapackage pulled 199 MB of unrelated modules into
+          # every clean runner (Java, stitching, video, contrib, and more).
+          # dnsmasq-base keeps the usb0 CTest syntax check from downgrading to
+          # a skip, so that contract needs no separate duplicate test step.
+          sudo apt-get install -y --no-install-recommends \
+            dnsmasq-base \
+            libopencv-core-dev \
+            libopencv-imgproc-dev
           make test
+
+  go-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: src/agent/go.mod
+          cache-dependency-path: src/agent/go.sum
       - name: Run Go unit tests
         working-directory: src/agent
         run: go test ./...
+
+  web-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Run Agent Web UI tests
         run: make test-agent-webui
+
+  # Preserve the existing required-check name while making it represent every
+  # parallel test job. `always()` ensures a failed dependency produces a failed
+  # aggregate check instead of leaving the required check skipped.
+  run-tests:
+    if: always()
+    needs:
+      - script-tests
+      - docker-tests
+      - cpp-tests
+      - go-tests
+      - web-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify parallel test jobs
+        run: |
+          test '${{ needs.script-tests.result }}' = success
+          test '${{ needs.docker-tests.result }}' = success
+          test '${{ needs.cpp-tests.result }}' = success
+          test '${{ needs.go-tests.result }}' = success
+          test '${{ needs.web-tests.result }}' = success

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test-configure:
 	cmake -S . -B $(TEST_BUILD_DIR) -DAIDEN_TESTS=ON
 
 test-build: test-configure
-	cmake --build $(TEST_BUILD_DIR)
+	cmake --build $(TEST_BUILD_DIR) --parallel $$(getconf _NPROCESSORS_ONLN)
 
 test: test-build
 	cd $(TEST_BUILD_DIR) && ctest --output-on-failure

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,34 @@ if(NOT OpenCV_FOUND)
     endif()
 endif()
 
+# Debian and Ubuntu keep OpenCVConfig.cmake in the all-module libopencv-dev
+# metapackage. Host tests need only core and imgproc, so discover those component
+# packages directly when the config file is intentionally not installed.
+if(NOT OpenCV_FOUND AND NOT CMAKE_CROSSCOMPILING)
+    find_path(OpenCV_COMPONENT_INCLUDE_DIR
+        NAMES opencv2/core.hpp
+        PATH_SUFFIXES opencv4
+    )
+    find_library(OpenCV_CORE_LIBRARY NAMES opencv_core)
+    find_library(OpenCV_IMGPROC_LIBRARY NAMES opencv_imgproc)
+    if(OpenCV_COMPONENT_INCLUDE_DIR AND OpenCV_CORE_LIBRARY AND OpenCV_IMGPROC_LIBRARY)
+        add_library(opencv_core UNKNOWN IMPORTED)
+        set_target_properties(opencv_core PROPERTIES
+            IMPORTED_LOCATION "${OpenCV_CORE_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${OpenCV_COMPONENT_INCLUDE_DIR}"
+        )
+        add_library(opencv_imgproc UNKNOWN IMPORTED)
+        set_target_properties(opencv_imgproc PROPERTIES
+            IMPORTED_LOCATION "${OpenCV_IMGPROC_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${OpenCV_COMPONENT_INCLUDE_DIR}"
+            INTERFACE_LINK_LIBRARIES opencv_core
+        )
+        set(OpenCV_FOUND TRUE)
+        set(OpenCV_INCLUDE_DIRS "${OpenCV_COMPONENT_INCLUDE_DIR}")
+        set(OpenCV_VERSION "system-components")
+    endif()
+endif()
+
 set(AIDEN_IMAGE_TEST_SOURCES "")
 if(OpenCV_FOUND)
     add_library(aiden_image STATIC ${CMAKE_SOURCE_DIR}/src/image_process.cpp)


### PR DESCRIPTION
## Summary

- split the serial test job into parallel script, Docker, C++, Go, and Web jobs
- build host C++ tests in parallel
- replace the full OpenCV development metapackage with only core and imgproc components
- keep image processing tests enabled by discovering component-only OpenCV installations
- remove the duplicate standalone usb0 DHCP test invocation

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 -config-file actionlint.yaml .github/workflows/ci.yml`
- `sh scripts/test_release_ci_scripts.sh`
- `python3 -m unittest tests.benchmark.test_docker_sandbox`
- `bash scripts/test_github_actions_self_hosted_safety.sh`
- `make test`
- `node src/agent/internal/agent/web_ui_test/history_reconciliation.test.js`
- clean Ubuntu 24.04 container configuration and `aiden_image` build with only `libopencv-core-dev` and `libopencv-imgproc-dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * CI tests now run in parallel across Docker, C++, Go, and Web UI environments.
  * Improved test setup, including swap initialization and DHCP validation.
  * Added support for running image tests on systems without standard OpenCV configuration files.

* **Build Improvements**
  * Test builds now use available processor cores for faster compilation.
  * Reduced required OpenCV components for C++ testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->