### PR TITLE
fix(agent): remove context sessions on clear

### DIFF
--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1503,9 +1503,16 @@ func (r *Runtime) ClearMemory(ctx context.Context) error {
 	if err := r.memories.ClearSession(ctx, "default"); err != nil {
 		return err
 	}
-	r.rotateContext()
 	r.resetActiveUserContext()
-	if err := r.rotateUserContext(); err != nil {
+	userSystemPrompt := r.currentUserContextSystemPrompt()
+	if err := contextmanager.ClearAllSessions(agentpath.ContextManagerSessionFolder(r.config.ConfigDir)); err != nil {
+		return fmt.Errorf("clear backend context sessions: %w", err)
+	}
+	if err := contextmanager.ClearAllSessions(agentpath.UserContextManagerSessionFolder(r.config.ConfigDir)); err != nil {
+		return fmt.Errorf("clear user context sessions: %w", err)
+	}
+	r.rotateContext()
+	if err := r.rotateUserContext(userSystemPrompt); err != nil {
 		return err
 	}
 	return nil
@@ -1544,23 +1551,29 @@ func (r *Runtime) resetActiveUserContext() {
 	}
 }
 
-func (r *Runtime) rotateUserContext() error {
+func (r *Runtime) currentUserContextSystemPrompt() string {
 	if r == nil || strings.TrimSpace(r.config.ConfigDir) == "" {
-		return nil
+		return ""
 	}
 	folder := agentpath.UserContextManagerSessionFolder(r.config.ConfigDir)
-	var systemPrompt string
 	if manager, err := contextmanager.LoadContextManagerFromCurrentSession(folder); err == nil && manager != nil {
 		for _, message := range manager.MessageListDump().Messages {
 			if message.Role == messages.MessageRoleSystem {
-				systemPrompt = message.Content
-				break
+				return message.Content
 			}
 		}
+	}
+	return ""
+}
+
+func (r *Runtime) rotateUserContext(systemPrompt string) error {
+	if r == nil || strings.TrimSpace(r.config.ConfigDir) == "" {
+		return nil
 	}
 	if strings.TrimSpace(systemPrompt) == "" {
 		return nil
 	}
+	folder := agentpath.UserContextManagerSessionFolder(r.config.ConfigDir)
 	if _, err := contextmanager.NewContextManager(folder, systemPrompt); err != nil {
 		return fmt.Errorf("create user context session: %w", err)
 	}

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1635,8 +1635,12 @@ func (r *Runtime) ClearAllMemory(ctx context.Context) error {
 		return err
 	}
 
-	_ = contextmanager.ClearAllSessions(agentpath.ContextManagerSessionFolder(r.config.ConfigDir))
-	_ = contextmanager.ClearAllSessions(agentpath.UserContextManagerSessionFolder(r.config.ConfigDir))
+	if err := contextmanager.ClearAllSessions(agentpath.ContextManagerSessionFolder(r.config.ConfigDir)); err != nil {
+		return fmt.Errorf("clear backend context sessions: %w", err)
+	}
+	if err := contextmanager.ClearAllSessions(agentpath.UserContextManagerSessionFolder(r.config.ConfigDir)); err != nil {
+		return fmt.Errorf("clear user context sessions: %w", err)
+	}
 	if err := r.rotateContext(); err != nil {
 		return fmt.Errorf("create backend context session: %w", err)
 	}

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1024,7 +1024,9 @@ func (r *Runtime) run(ctx context.Context, req RunRequest) (result RunResult, ru
 	}
 	boundaryTelemetry = beginResult.Boundary
 	if boundaryTelemetry.Rotated {
-		r.rotateContext()
+		if err := r.rotateContext(); err != nil && r.logger != nil {
+			r.logger.Warn("[context] rotate after session boundary failed: %v", err)
+		}
 	}
 	if boundaryTelemetry.PendingRecallCounter == nil {
 		boundaryTelemetry.PendingRecallCounter = &atomic.Int64{}
@@ -1504,16 +1506,23 @@ func (r *Runtime) ClearMemory(ctx context.Context) error {
 		return err
 	}
 	r.resetActiveUserContext()
-	userSystemPrompt := r.currentUserContextSystemPrompt()
+	userSystemPrompt, hasUserContext, err := r.currentUserContextSystemPrompt()
+	if err != nil {
+		return err
+	}
 	if err := contextmanager.ClearAllSessions(agentpath.ContextManagerSessionFolder(r.config.ConfigDir)); err != nil {
 		return fmt.Errorf("clear backend context sessions: %w", err)
 	}
 	if err := contextmanager.ClearAllSessions(agentpath.UserContextManagerSessionFolder(r.config.ConfigDir)); err != nil {
 		return fmt.Errorf("clear user context sessions: %w", err)
 	}
-	r.rotateContext()
-	if err := r.rotateUserContext(userSystemPrompt); err != nil {
-		return err
+	if err := r.rotateContext(); err != nil {
+		return fmt.Errorf("create backend context session: %w", err)
+	}
+	if hasUserContext {
+		if err := r.rotateUserContext(userSystemPrompt); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1551,26 +1560,32 @@ func (r *Runtime) resetActiveUserContext() {
 	}
 }
 
-func (r *Runtime) currentUserContextSystemPrompt() string {
+func (r *Runtime) currentUserContextSystemPrompt() (string, bool, error) {
 	if r == nil || strings.TrimSpace(r.config.ConfigDir) == "" {
-		return ""
+		return "", false, nil
 	}
 	folder := agentpath.UserContextManagerSessionFolder(r.config.ConfigDir)
-	if manager, err := contextmanager.LoadContextManagerFromCurrentSession(folder); err == nil && manager != nil {
-		for _, message := range manager.MessageListDump().Messages {
-			if message.Role == messages.MessageRoleSystem {
-				return message.Content
-			}
+	currentSessionPath := filepath.Join(folder, ".current_session")
+	if _, err := os.Stat(currentSessionPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("stat current user context session: %w", err)
+	}
+	manager, err := contextmanager.LoadContextManagerFromCurrentSession(folder)
+	if err != nil {
+		return "", false, fmt.Errorf("load current user context session: %w", err)
+	}
+	for _, message := range manager.MessageListDump().Messages {
+		if message.Role == messages.MessageRoleSystem {
+			return message.Content, true, nil
 		}
 	}
-	return ""
+	return "", false, fmt.Errorf("current user context session has no system prompt")
 }
 
 func (r *Runtime) rotateUserContext(systemPrompt string) error {
 	if r == nil || strings.TrimSpace(r.config.ConfigDir) == "" {
-		return nil
-	}
-	if strings.TrimSpace(systemPrompt) == "" {
 		return nil
 	}
 	folder := agentpath.UserContextManagerSessionFolder(r.config.ConfigDir)
@@ -1622,7 +1637,9 @@ func (r *Runtime) ClearAllMemory(ctx context.Context) error {
 
 	_ = contextmanager.ClearAllSessions(agentpath.ContextManagerSessionFolder(r.config.ConfigDir))
 	_ = contextmanager.ClearAllSessions(agentpath.UserContextManagerSessionFolder(r.config.ConfigDir))
-	r.rotateContext()
+	if err := r.rotateContext(); err != nil {
+		return fmt.Errorf("create backend context session: %w", err)
+	}
 
 	return nil
 }
@@ -1703,13 +1720,14 @@ func (r *Runtime) ReadContextAttachment(role, attachmentID string) ([]byte, stri
 	return data, mimeType, nil
 }
 
-func (r *Runtime) rotateContext() {
+func (r *Runtime) rotateContext() error {
 	newContextManager, err := contextmanager.NewContextManager(agentpath.ContextManagerSessionFolder(r.config.ConfigDir), r.getSystemPrompt())
 	if err != nil {
-		return
+		return err
 	}
 	newContextManager.AddAppendMessageHooks([]contextmanager.AppendMessageHook{r.getStateHook()})
 	r.contextManager = newContextManager
+	return nil
 }
 
 func (r *Runtime) availableTools() []langtools.Tool {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -5228,6 +5228,7 @@ func TestRuntimeClearMemoryRemovesPersistedSession(t *testing.T) {
 	if _, err := runtime.Run(context.Background(), RunRequest{Input: "hello"}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
+	oldBackendSessionID := runtime.ContextDump().SessionID
 
 	memoryDir := filepath.Join(configDir, "memory")
 	eventsPath := filepath.Join(memoryDir, "session", "events.jsonl")
@@ -5250,9 +5251,21 @@ func TestRuntimeClearMemoryRemovesPersistedSession(t *testing.T) {
 	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
 		t.Fatalf("expected legacy snapshot to be removed, stat err = %v", err)
 	}
+	backendFolder := agentpath.ContextManagerSessionFolder(configDir)
+	oldBackendSessionPath := filepath.Join(backendFolder, oldBackendSessionID+".jsonl")
+	if _, err := os.Stat(oldBackendSessionPath); !os.IsNotExist(err) {
+		t.Fatalf("old backend context session file should be removed, stat err = %v", err)
+	}
+	newBackendSession := runtime.ContextDump()
+	if newBackendSession.SessionID == "" || newBackendSession.SessionID == oldBackendSessionID {
+		t.Fatalf("backend context session was not replaced: old=%q new=%q", oldBackendSessionID, newBackendSession.SessionID)
+	}
+	if newBackendSession.ParentSessionID != "" {
+		t.Fatalf("cleared backend context parent session = %q, want root session", newBackendSession.ParentSessionID)
+	}
 }
 
-func TestRuntimeClearMemoryRotatesUserContextSession(t *testing.T) {
+func TestRuntimeClearMemoryReplacesAndRemovesUserContextSession(t *testing.T) {
 	configDir := ensureTestConfigDir(t, t.TempDir())
 	runtime, err := NewRuntime(Config{
 		ConfigDir: configDir,
@@ -5283,8 +5296,12 @@ func TestRuntimeClearMemoryRotatesUserContextSession(t *testing.T) {
 	if rotated.GetSessionID() == oldSessionID {
 		t.Fatalf("user context session was not rotated: %q", oldSessionID)
 	}
-	if _, err := contextmanager.LoadContextManagerFromSessionID(folder, oldSessionID); err != nil {
-		t.Fatalf("old user context should remain archived and loadable: %v", err)
+	oldUserSessionPath := filepath.Join(folder, oldSessionID+".jsonl")
+	if _, err := os.Stat(oldUserSessionPath); !os.IsNotExist(err) {
+		t.Fatalf("old user context session file should be removed, stat err = %v", err)
+	}
+	if rotated.GetParentSessionID() != "" {
+		t.Fatalf("cleared user context parent session = %q, want root session", rotated.GetParentSessionID())
 	}
 	rotatedMessages := rotated.MessageListDump().Messages
 	if len(rotatedMessages) != 1 || rotatedMessages[0].Role != messages.MessageRoleSystem || rotatedMessages[0].Content != "realtime system prompt" {

--- a/src/agent/internal/agent/runtime_test.go
+++ b/src/agent/internal/agent/runtime_test.go
@@ -5309,6 +5309,43 @@ func TestRuntimeClearMemoryReplacesAndRemovesUserContextSession(t *testing.T) {
 	}
 }
 
+func TestRuntimeClearMemoryPreservesSessionsWhenUserContextCannotLoad(t *testing.T) {
+	configDir := ensureTestConfigDir(t, t.TempDir())
+	runtime, err := NewRuntime(Config{
+		ConfigDir: configDir,
+		Model:     ModelConfig{Provider: "fake"},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime() error = %v", err)
+	}
+	defer runtime.Close()
+
+	userFolder := agentpath.UserContextManagerSessionFolder(configDir)
+	manager, err := contextmanager.NewContextManager(userFolder, "realtime system prompt")
+	if err != nil {
+		t.Fatalf("NewContextManager() error = %v", err)
+	}
+	userSessionPath := filepath.Join(userFolder, manager.GetSessionID()+".jsonl")
+	if err := os.WriteFile(userSessionPath, []byte("{invalid json\n"), 0o644); err != nil {
+		t.Fatalf("corrupt user context session: %v", err)
+	}
+	backendFolder := agentpath.ContextManagerSessionFolder(configDir)
+	backendManager, err := contextmanager.NewContextManager(backendFolder, "backend system prompt")
+	if err != nil {
+		t.Fatalf("create backend context session: %v", err)
+	}
+	backendSessionPath := filepath.Join(backendFolder, backendManager.GetSessionID()+".jsonl")
+
+	if err := runtime.ClearMemory(context.Background()); err == nil {
+		t.Fatal("ClearMemory() error = nil, want user context load error")
+	}
+	for _, path := range []string{userSessionPath, backendSessionPath} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("session should remain after user context load failure, stat %s: %v", path, err)
+		}
+	}
+}
+
 func TestRuntimeClearMemoryResetsActiveUserContext(t *testing.T) {
 	runtime := NewRuntimeWithDeps(
 		withTestConfigDir(t, Config{Model: ModelConfig{Provider: "fake"}}),


### PR DESCRIPTION
## Summary
- delete all persisted backend and realtime user context sessions when `/api/clear` is called
- recreate fresh root sessions while preserving the realtime system prompt
- verify old session files are removed and replacement sessions have no parent

## Testing
- `go test ./internal/agent -run 'TestRuntimeClearMemory'`\n- `go test ./cmd/daemon`\n- `git diff --check`\n\n## Note\nThe full `./internal/agent` suite still has unrelated pre-existing audio/config environment failures in this checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing memory now preserves the user context system prompt.
  * Memory clearing fully resets backend and user context sessions, removing previous session history and creating fresh sessions.
  * Improved context reset behavior prevents cleared sessions from retaining parent-session data.
  * Memory-clearing failures are now reported instead of silently ignored.
  * If a context cannot be loaded, existing sessions are preserved to prevent unintended data loss.
  * Session reset failures are now surfaced consistently, helping identify incomplete resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->