### PR TITLE
feat(agent): combine clear actions into menu

### DIFF
--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -2783,6 +2783,39 @@ func TestWebUISteerModeControlsArePresent(t *testing.T) {
 	}
 }
 
+func TestWebUIClearMenuUsesConfirmedSessionActions(t *testing.T) {
+	index := readWebUIResource(t, "index.html")
+	chatScript := readWebUIResource(t, "scripts/chat.js")
+
+	for _, want := range []string{
+		`id="clearMenu"`,
+		"Clear Session",
+		"Clear Session &amp; Memory",
+		`onclick="clearSession()"`,
+		`onclick="clearSessionAndMemory()"`,
+	} {
+		if !strings.Contains(index, want) {
+			t.Errorf("web UI clear menu missing %q", want)
+		}
+	}
+	for _, want := range []string{
+		"async function clearSession()",
+		"async function clearSessionAndMemory()",
+		"if (!confirm(",
+		"fetch('/api/clear', { method: 'POST' })",
+		"fetch('/api/clear-all', { method: 'POST' })",
+	} {
+		if !strings.Contains(chatScript, want) {
+			t.Errorf("web UI clear action missing %q", want)
+		}
+	}
+	for _, unwanted := range []string{">New Chat</button>", ">Reset Memory</button>"} {
+		if strings.Contains(index, unwanted) {
+			t.Errorf("web UI still contains old action %q", unwanted)
+		}
+	}
+}
+
 func TestWebUIIsEmbeddedFromStaticResource(t *testing.T) {
 	want, err := os.ReadFile("web_ui/index.html")
 	if err != nil {

--- a/src/agent/internal/agent/web_ui/index.html
+++ b/src/agent/internal/agent/web_ui/index.html
@@ -24,8 +24,13 @@
                         <a href="/web-ui/context.html" target="_blank" rel="noopener" class="new-chat-btn">Context</a>
                     </nav>
                     <div class="session-actions">
-                        <button type="button" class="new-chat-btn" onclick="clearHistory()">New Chat</button>
-                        <button type="button" class="new-chat-btn danger-btn" onclick="resetAllMemory()">Reset Memory</button>
+                        <details class="clear-menu" id="clearMenu">
+                            <summary class="new-chat-btn" aria-label="Open clear menu">Clear <span aria-hidden="true">▾</span></summary>
+                            <div class="clear-menu-items" role="menu">
+                                <button type="button" role="menuitem" onclick="clearSession()">Clear Session</button>
+                                <button type="button" role="menuitem" class="danger-btn" onclick="clearSessionAndMemory()">Clear Session &amp; Memory</button>
+                            </div>
+                        </details>
                     </div>
                 </div>
             </header>

--- a/src/agent/internal/agent/web_ui/scripts/bootstrap.js
+++ b/src/agent/internal/agent/web_ui/scripts/bootstrap.js
@@ -25,7 +25,15 @@ inputEl.addEventListener('keydown', function(event) {
     }
 });
 
+document.addEventListener('click', function(event) {
+    const menu = document.getElementById('clearMenu');
+    if (menu && menu.open && !menu.contains(event.target)) closeClearMenu();
+});
+
 document.addEventListener('keydown', function(event) {
+    if (event.key === 'Escape') {
+        closeClearMenu();
+    }
     if (event.key === 'Escape' && activeStateMessageKey) {
         closeStateDetails();
     }

--- a/src/agent/internal/agent/web_ui/scripts/chat.js
+++ b/src/agent/internal/agent/web_ui/scripts/chat.js
@@ -451,30 +451,49 @@ function assistantStreamKey(value) {
     return value.request_id || value.episode_id || currentChatRequestId || '';
 }
 
-async function clearHistory() {
-    if (!confirm('Start a new chat and clear the current conversation?')) return;
-
-    try {
-        await fetch('/api/clear', { method: 'POST' });
-        clearDraftAttachments();
-        renderHistory([]);
-    } catch (err) {
-        console.error('Failed to clear history:', err);
-    }
+function closeClearMenu() {
+    const menu = document.getElementById('clearMenu');
+    if (menu) menu.removeAttribute('open');
 }
 
-async function resetAllMemory() {
-    if (!confirm('This will permanently delete ALL memory including long-term memories and user profile. Continue?')) return;
+document.addEventListener('click', (event) => {
+    const menu = document.getElementById('clearMenu');
+    if (menu && menu.open && !menu.contains(event.target)) closeClearMenu();
+});
+
+document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') closeClearMenu();
+});
+
+async function clearSession() {
+    closeClearMenu();
+    if (!confirm('Clear the current session? This will remove the current conversation.')) return;
 
     try {
-        const res = await fetch('/api/clear-all', { method: 'POST' });
+        const res = await fetch('/api/clear', { method: 'POST' });
         if (!res.ok) {
-            throw new Error(await res.text() || 'Failed to reset all memory.');
+            throw new Error(await res.text() || 'Failed to clear the session.');
         }
         clearDraftAttachments();
         renderHistory([]);
     } catch (err) {
-        console.error('Failed to reset all memory:', err);
+        console.error('Failed to clear the session:', err);
+    }
+}
+
+async function clearSessionAndMemory() {
+    closeClearMenu();
+    if (!confirm('Clear the current session and permanently delete ALL memory, including long-term memories and the user profile?')) return;
+
+    try {
+        const res = await fetch('/api/clear-all', { method: 'POST' });
+        if (!res.ok) {
+            throw new Error(await res.text() || 'Failed to clear the session and memory.');
+        }
+        clearDraftAttachments();
+        renderHistory([]);
+    } catch (err) {
+        console.error('Failed to clear the session and memory:', err);
     }
 }
 

--- a/src/agent/internal/agent/web_ui/scripts/chat.js
+++ b/src/agent/internal/agent/web_ui/scripts/chat.js
@@ -456,15 +456,6 @@ function closeClearMenu() {
     if (menu) menu.removeAttribute('open');
 }
 
-document.addEventListener('click', (event) => {
-    const menu = document.getElementById('clearMenu');
-    if (menu && menu.open && !menu.contains(event.target)) closeClearMenu();
-});
-
-document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') closeClearMenu();
-});
-
 async function clearSession() {
     closeClearMenu();
     if (!confirm('Clear the current session? This will remove the current conversation.')) return;

--- a/src/agent/internal/agent/web_ui/styles.css
+++ b/src/agent/internal/agent/web_ui/styles.css
@@ -350,6 +350,56 @@ textarea:focus-visible {
     border-left: 1px solid var(--line);
 }
 
+.clear-menu {
+    position: relative;
+}
+
+.clear-menu > summary {
+    gap: 6px;
+    list-style: none;
+    user-select: none;
+}
+
+.clear-menu > summary::-webkit-details-marker {
+    display: none;
+}
+
+.clear-menu-items {
+    position: absolute;
+    z-index: 20;
+    top: calc(100% + 6px);
+    right: 0;
+    display: grid;
+    min-width: 220px;
+    padding: 5px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    background: var(--panel);
+    box-shadow: var(--shadow-soft);
+}
+
+.clear-menu-items button {
+    width: 100%;
+    padding: 9px 10px;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text);
+    font: 12px ui-monospace, SFMono-Regular, Menlo, monospace;
+    text-align: left;
+    cursor: pointer;
+}
+
+.clear-menu-items button:hover,
+.clear-menu-items button:focus-visible {
+    background: var(--surface-soft);
+    outline: none;
+}
+
+.clear-menu-items .danger-btn {
+    color: var(--tool-error-text);
+}
+
 .danger-btn {
     border-color: #e0b0aa;
     color: #a0382a;


### PR DESCRIPTION
## Summary
- replace the separate New Chat and Reset Memory buttons with a Clear dropdown
- provide Clear Session and Clear Session & Memory actions with confirmation prompts
- close the dropdown on selection, outside click, or Escape
- add coverage for the WebUI controls and API wiring

## Testing
- `cd src/agent && go test ./internal/agent -run 'TestWebUIClearMenuUsesConfirmedSessionActions|TestWebUIIsEmbeddedFromStaticResource|TestServerServesEmbeddedWebUIAssets'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced separate chat and memory controls with an expandable **Clear** menu.
  * Added options to clear the current session or clear the session and memory.
  * Added confirmation prompts and clearer error feedback for both actions.
  * The menu now closes when clicking outside it or pressing Escape.

* **Bug Fixes**
  * Improved validation and handling of clear-session actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->