### PR TITLE
Remove dead conversation compaction token target

### DIFF
--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -1170,7 +1170,7 @@ func (r *Runtime) run(ctx context.Context, req RunRequest) (result RunResult, ru
 		maxResponseTokens = req.MaxTokens
 	}
 	usableInputBudget := toolResultUsableInputBudget(budgetContextWindow, maxResponseTokens)
-	compactionTrigger, _, compactionEnabled := toolResultCompactionBudgets(usableInputBudget)
+	compactionTrigger, compactionEnabled := conversationCompactionTrigger(usableInputBudget)
 	tokenUsage := tokencounter.EstimateMessagesTokens(r.contextManager.CloneMessageList())
 
 	// Historical state and tool-result pruning is deterministic and has its own

--- a/src/agent/internal/agent/tool_result_policy.go
+++ b/src/agent/internal/agent/tool_result_policy.go
@@ -28,7 +28,6 @@ const (
 	toolResultPreviewTargetToken = 1_200
 	toolResultMinimumObservation = 96
 	toolResultSoftLimitPercent   = 80
-	toolResultCompactionTarget   = 70
 	// Automatic historical pruning runs before conversation compaction. Keep
 	// the configured-threshold hysteresis ratio independent from these budget
 	// percentages so an explicit threshold remains predictable.
@@ -251,13 +250,16 @@ func toolResultSoftInputLimit(contextWindow, maxResponseTokens int) int {
 	return toolResultUsableInputBudget(contextWindow, maxResponseTokens) * toolResultSoftLimitPercent / 100
 }
 
-func toolResultCompactionBudgets(usableInputBudget int) (trigger int, target int, enabled bool) {
+// conversationCompactionTrigger returns the token usage at which conversation
+// compaction runs. Compaction has no token target: Compactor.Compact reduces
+// the transcript structurally via ProtectRule (head/tail retention plus an LLM
+// summary of the middle), so the resulting size follows from the summary rather
+// than from a budget.
+func conversationCompactionTrigger(usableInputBudget int) (trigger int, enabled bool) {
 	if usableInputBudget <= 0 {
-		return 0, 0, false
+		return 0, false
 	}
-	return usableInputBudget * toolResultSoftLimitPercent / 100,
-		usableInputBudget * toolResultCompactionTarget / 100,
-		true
+	return usableInputBudget * toolResultSoftLimitPercent / 100, true
 }
 
 // historicalPruneBudgets returns the independent trigger and target for

--- a/src/agent/internal/agent/tool_result_policy_test.go
+++ b/src/agent/internal/agent/tool_result_policy_test.go
@@ -46,13 +46,13 @@ func TestToolResultPolicyKeepsSmallResultInline(t *testing.T) {
 	}
 }
 
-func TestToolResultCompactionBudgetsRequirePositiveUsableInput(t *testing.T) {
-	if trigger, target, ok := toolResultCompactionBudgets(0); ok || trigger != 0 || target != 0 {
-		t.Fatalf("toolResultCompactionBudgets(0) = %d, %d, %v; want disabled", trigger, target, ok)
+func TestConversationCompactionTriggerRequiresPositiveUsableInput(t *testing.T) {
+	if trigger, ok := conversationCompactionTrigger(0); ok || trigger != 0 {
+		t.Fatalf("conversationCompactionTrigger(0) = %d, %v; want disabled", trigger, ok)
 	}
-	trigger, target, ok := toolResultCompactionBudgets(10_000)
-	if !ok || trigger != 8_000 || target != 7_000 {
-		t.Fatalf("toolResultCompactionBudgets(10000) = %d, %d, %v; want 8000, 7000, true", trigger, target, ok)
+	trigger, ok := conversationCompactionTrigger(10_000)
+	if !ok || trigger != 8_000 {
+		t.Fatalf("conversationCompactionTrigger(10000) = %d, %v; want 8000, true", trigger, ok)
 	}
 }
 
@@ -71,7 +71,7 @@ func TestHistoricalPruneBudgetsUseConfiguredThresholdIndependently(t *testing.T)
 	if !ok || trigger != 7_000 || target != 6_000 {
 		t.Fatalf("historicalPruneBudgets(10000, 0) = %d, %d, %v; want 7000, 6000, true", trigger, target, ok)
 	}
-	compactionTrigger, _, compactionOK := toolResultCompactionBudgets(10_000)
+	compactionTrigger, compactionOK := conversationCompactionTrigger(10_000)
 	if !compactionOK || trigger >= compactionTrigger {
 		t.Fatalf("automatic historical prune trigger = %d, compaction trigger = %d; prune must run first", trigger, compactionTrigger)
 	}


### PR DESCRIPTION
## Summary

`toolResultCompactionTarget = 70` computed a token target for conversation
compaction that nothing consumed. The only production call site in `runtime.go`
discarded it with `_`, and `Compactor.Compact` takes no target parameter at all.

Compaction is structural, not budget-driven: `DefaultProtectRule` keeps the
first 2 and last 3 messages (expanding to avoid splitting tool_call/tool_result
pairs and to keep the final user turn intact) and replaces the middle with one
LLM-generated summary bounded by `WithMaxTokens(800)`. The resulting size
follows from the summary, so a 70% target had no way to take effect.

This is a noise-reduction change with no behavior change. The alternative,
giving `Compact` a real token target so it converges to 70%, would change
compaction behavior and deserves separate evaluation.

## Changes

- Remove the `toolResultCompactionTarget` constant.
- Rename `toolResultCompactionBudgets` to `conversationCompactionTrigger` and
  narrow its return from `(trigger, target, enabled)` to `(trigger, enabled)`,
  with a comment explaining why this path has no target. The name previously
  implied symmetry with `historicalPruneBudgets` that did not exist.
- Simplify the `runtime.go` call site.
- Rename the test and drop the `target != 7_000` assertion.

`historicalPrune*` constants are untouched. `PruneHistorical` does accept and
honor `targetTokens`, so that path's target semantics are real. The trigger
threshold for conversation compaction stays at 80% of the usable input budget.

## Testing

- `go build ./...` and `go vet ./internal/agent/` clean.
- `go test ./internal/agent/ -run 'Compaction|Prune|ToolResult|ContextOverflow'` passes.
- All `./internal/agent/...` subpackages pass, including `compactor`.
- The invariant that automatic pruning triggers before compaction is still
  asserted in `TestHistoricalPruneBudgetsUseConfiguredThresholdIndependently`.

Pre-existing failures unrelated to this change: 14 tests in `internal/agent`
depending on audio devices (`TestAudioDialog*`, `TestPlayPromptSound*`,
`TestAudioClient*`, `TestWaitForPlaybackDrain*`, `TestStopPlayback*`) and on
file permissions (`TestLoadResolvedConfigRejectsSpecialFile`). Confirmed failing
on a clean tree via `git stash`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation compaction behavior by using a consistent trigger threshold.
  * Disabled compaction when no usable input is available, preventing unnecessary processing.
  * Updated compaction behavior to trigger at the expected threshold for larger conversations.

* **Tests**
  * Added coverage for disabled and threshold-based conversation compaction scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->