### PR TITLE
fix(ble): log pairing start outcome

### DIFF
--- a/src/agent/internal/agent/bluetooth_http.go
+++ b/src/agent/internal/agent/bluetooth_http.go
@@ -71,14 +71,82 @@ func (s *Server) handleBluetoothPairingStart(w http.ResponseWriter, r *http.Requ
 		writeBluetoothError(w, http.StatusForbidden, "Bluetooth pairing control is available only over USB")
 		return
 	}
+	startedAt := time.Now()
+	if s.logger != nil {
+		s.logger.InfoEvent("bluetooth", "pairing_start_requested", bluetoothPairingRequestFields(r)...)
+	}
 	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
 	defer cancel()
 	status, err := s.bluetoothPairingStartRequest()(ctx, s.bluetoothServiceSocketPath())
 	if err != nil {
+		if s.logger != nil {
+			fields := bluetoothPairingRequestFields(r)
+			fields = append(fields,
+				LogField{Key: "duration_ms", Value: time.Since(startedAt).Milliseconds()},
+				LogField{Key: "error", Value: err},
+			)
+			s.logger.WarnEvent("bluetooth", "pairing_start_failed", fields...)
+		}
 		writeBluetoothRequestError(w, err)
 		return
 	}
+	if s.logger != nil {
+		fields := bluetoothPairingStatusFields(status)
+		fields = append(fields, LogField{Key: "duration_ms", Value: time.Since(startedAt).Milliseconds()})
+		s.logger.InfoEvent("bluetooth", "pairing_start_succeeded", fields...)
+	}
 	writeBluetoothJSON(w, http.StatusOK, bluetoothStatusResponse{OK: true, Bluetooth: status})
+}
+
+func bluetoothPairingRequestFields(r *http.Request) []LogField {
+	fields := []LogField{{Key: "transport", Value: "usb"}}
+	if r == nil {
+		return fields
+	}
+	if remoteIP, ok := addressIP(r.RemoteAddr); ok {
+		fields = append(fields, LogField{Key: "remote_ip", Value: remoteIP.String()})
+	}
+	return fields
+}
+
+func bluetoothPairingStatusFields(status ble.RuntimeStatus) []LogField {
+	fields := []LogField{
+		{Key: "backend_available", Value: status.BackendAvailable},
+		{Key: "adapter_powered", Value: status.AdapterPowered},
+		{Key: "gatt_registered", Value: status.GattRegistered},
+		{Key: "advertising", Value: status.Advertising},
+		{Key: "pairing_open", Value: status.PairingOpen},
+		{Key: "bonded_device_count", Value: status.BondedDeviceCount},
+		{Key: "connected", Value: status.Connected},
+		{Key: "paired", Value: status.Paired},
+		{Key: "services_resolved", Value: status.ServicesResolved},
+		{Key: "ancs_subscribed", Value: status.ANCSSubscribed},
+	}
+	if status.DeviceName != "" {
+		fields = append(fields, LogField{Key: "device_name", Value: status.DeviceName})
+	}
+	if status.BoardIdentity != "" {
+		fields = append(fields, LogField{Key: "board_identity", Value: status.BoardIdentity})
+	}
+	if status.PairingDeadline != "" {
+		fields = append(fields, LogField{Key: "pairing_deadline", Value: status.PairingDeadline})
+	}
+	if status.TrustedDeviceName != "" {
+		fields = append(fields, LogField{Key: "trusted_device_name", Value: status.TrustedDeviceName})
+	}
+	if status.TrustedDeviceAddr != "" {
+		fields = append(fields, LogField{Key: "trusted_device_address", Value: status.TrustedDeviceAddr})
+	}
+	if status.ConnectedDeviceName != "" {
+		fields = append(fields, LogField{Key: "connected_device_name", Value: status.ConnectedDeviceName})
+	}
+	if status.ConnectedDeviceAddr != "" {
+		fields = append(fields, LogField{Key: "connected_device_address", Value: status.ConnectedDeviceAddr})
+	}
+	if status.LastError != "" {
+		fields = append(fields, LogField{Key: "last_error", Value: status.LastError})
+	}
+	return fields
 }
 
 func (s *Server) handleBluetoothPairingReset(w http.ResponseWriter, r *http.Request) {

--- a/src/agent/internal/agent/bluetooth_http_test.go
+++ b/src/agent/internal/agent/bluetooth_http_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -32,9 +33,19 @@ func TestBluetoothHTTPStatus(t *testing.T) {
 }
 
 func TestBluetoothHTTPPairingActions(t *testing.T) {
+	var logs bytes.Buffer
 	server := &Server{
+		logger: &Logger{logger: log.New(&logs, "", 0)},
 		blePairingStartRequest: func(context.Context, string) (ble.RuntimeStatus, error) {
-			return ble.RuntimeStatus{PairingOpen: true}, nil
+			return ble.RuntimeStatus{
+				BackendAvailable:  true,
+				DeviceName:        "Aiden-1234",
+				AdapterPowered:    true,
+				GattRegistered:    true,
+				Advertising:       true,
+				PairingOpen:       true,
+				BondedDeviceCount: 1,
+			}, nil
 		},
 	}
 
@@ -42,6 +53,35 @@ func TestBluetoothHTTPPairingActions(t *testing.T) {
 	server.handleBluetoothPairingStart(recorder, bluetoothControlRequest(http.MethodPost))
 	if recorder.Code != http.StatusOK || !containsAll(recorder.Body.String(), `"pairing_open":true`) {
 		t.Fatalf("start code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !containsAll(logs.String(),
+		"pairing_start_requested",
+		"pairing_start_succeeded",
+		"backend_available=true",
+		"device_name=Aiden-1234",
+		"pairing_open=true",
+		"bonded_device_count=1",
+	) {
+		t.Fatalf("pairing logs = %s", logs.String())
+	}
+}
+
+func TestBluetoothHTTPPairingStartLogsFailure(t *testing.T) {
+	var logs bytes.Buffer
+	server := &Server{
+		logger: &Logger{logger: log.New(&logs, "", 0)},
+		blePairingStartRequest: func(context.Context, string) (ble.RuntimeStatus, error) {
+			return ble.RuntimeStatus{}, &ble.RequestError{Status: "SERVICE_UNAVAILABLE", Message: "adapter unavailable"}
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	server.handleBluetoothPairingStart(recorder, bluetoothControlRequest(http.MethodPost))
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("start code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !containsAll(logs.String(), "pairing_start_requested", "pairing_start_failed", "adapter unavailable") {
+		t.Fatalf("pairing failure logs = %s", logs.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- log BLE pairing start requests in the Agent log
- record pairing-start success state and service errors with duration
- add focused regression coverage for success and failure paths

## Verification
- `go test ./internal/agent -run 'TestBluetoothHTTP|TestConfiguredBLEServiceSocketPath' -count=1`\n- `go test ./internal/ble/... -count=1`\n\nThe Agent log covers the board-side pairing request and BLE service response. iOS-native scan, permission, or system dialog errors still require iOS Console logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Bluetooth pairing attempts now record request, success, and failure details, including connection type, client address, pairing status, errors, and duration.
  - Pairing failures caused by an unavailable adapter now return HTTP 503 responses with corresponding diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->