### PR TITLE
refactor: flatten session chunk storage structure

### DIFF
--- a/src/agent/internal/agent/memory_tools_test.go
+++ b/src/agent/internal/agent/memory_tools_test.go
@@ -31,7 +31,7 @@ func writeTestChunk(t *testing.T, sessionFolder, sessionID string, msgs []messag
 	}
 	// Tags and entities are searchable index fields; set them on the entry the
 	// writer just appended.
-	indexPath := filepath.Join(sessionFolder, sessionID, "chunks", "index.yaml")
+	indexPath := filepath.Join(sessionFolder, "chunks", "index.yaml")
 	index, err := loadChunkIndexFromPath(indexPath)
 	if err != nil {
 		t.Fatalf("loadChunkIndexFromPath() error = %v", err)
@@ -66,7 +66,7 @@ func TestSessionChunkWriterDerivesSearchTermsFromContent(t *testing.T) {
 		t.Fatalf("WriteChunk() error = %v", err)
 	}
 
-	index, err := loadChunkIndexFromPath(filepath.Join(sessionFolder, "s_expense", "chunks", "index.yaml"))
+	index, err := loadChunkIndexFromPath(filepath.Join(sessionFolder, "chunks", "index.yaml"))
 	if err != nil {
 		t.Fatalf("loadChunkIndexFromPath() error = %v", err)
 	}
@@ -129,7 +129,7 @@ func TestSessionChunkWriterSerializesConcurrentWritersOnSameIndex(t *testing.T) 
 		}
 	}
 
-	index, err := loadChunkIndexFromPath(filepath.Join(sessionFolder, "s_shared", "chunks", "index.yaml"))
+	index, err := loadChunkIndexFromPath(filepath.Join(sessionFolder, "chunks", "index.yaml"))
 	if err != nil {
 		t.Fatalf("loadChunkIndexFromPath() error = %v", err)
 	}
@@ -142,11 +142,17 @@ func TestSessionChunkWriterSerializesConcurrentWritersOnSameIndex(t *testing.T) 
 			t.Fatalf("duplicate chunk id %q in index", chunk.ID)
 		}
 		ids[chunk.ID] = true
-		if _, err := os.Stat(filepath.Join(sessionFolder, "s_shared", "chunks", chunk.File)); err != nil {
+		if _, err := os.Stat(filepath.Join(sessionFolder, "chunks", chunk.File)); err != nil {
 			t.Fatalf("indexed chunk %q has no file: %v", chunk.ID, err)
+			}
+		}
+		// Verify all chunks belong to the correct session
+		for _, chunk := range index.Chunks {
+			if chunk.SessionID != "s_shared" {
+				t.Fatalf("chunk %q has session_id %q, want s_shared", chunk.ID, chunk.SessionID)
+			}
 		}
 	}
-}
 
 // If the context is canceled after the chunk file is written but before the
 // index is updated, the chunk file must be removed: recall expects every .jsonl
@@ -168,7 +174,7 @@ func TestSessionChunkWriterCleansUpOrphanedChunkOnContextCancel(t *testing.T) {
 
 	// The chunks directory may not exist if context was checked before MkdirAll,
 	// or it may exist but must contain no .jsonl files if checked after.
-	chunksDir := filepath.Join(sessionFolder, "s_canceled", "chunks")
+	chunksDir := filepath.Join(sessionFolder, "chunks")
 	entries, err := os.ReadDir(chunksDir)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -183,12 +189,15 @@ func TestSessionChunkWriterCleansUpOrphanedChunkOnContextCancel(t *testing.T) {
 		}
 	}
 
-	// The index should not exist or should be empty.
+	// The index should not exist or should have no chunks for s_canceled session.
 	indexPath := filepath.Join(chunksDir, "index.yaml")
 	if _, err := os.Stat(indexPath); err == nil {
 		index, _ := loadChunkIndexFromPath(indexPath)
-		if len(index.Chunks) > 0 {
-			t.Fatalf("index has %d chunks after context cancel, want 0", len(index.Chunks))
+		// Check if there are any chunks for the s_canceled session
+		for _, chunk := range index.Chunks {
+			if chunk.SessionID == "s_canceled" {
+				t.Fatalf("found chunk for s_canceled session after context cancel")
+			}
 		}
 	}
 }
@@ -204,7 +213,7 @@ func TestMultiSessionChunkStoreLogsCorruptIndex(t *testing.T) {
 	}, "valid summary", []string{"valid"}, nil)
 
 	// Write a corrupt index for another session.
-	corruptDir := filepath.Join(sessionFolder, "s_corrupt", "chunks")
+	corruptDir := filepath.Join(sessionFolder, "chunks")
 	if err := os.MkdirAll(corruptDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
@@ -229,18 +238,15 @@ func TestMultiSessionChunkStoreLogsCorruptIndex(t *testing.T) {
 		t.Fatalf("RecallChunks() error = %v", err)
 	}
 
-	// Should return the valid session's chunk.
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result from valid session, got %d", len(results))
-	}
-	if results[0].SessionID != "s_valid" {
-		t.Fatalf("result session_id = %q, want s_valid", results[0].SessionID)
+	// Should return no results because the index is corrupt
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results due to corrupt index, got %d", len(results))
 	}
 
 	// Should have logged a warning about the corrupt index.
 	logOutput := logBuf.String()
-	if !strings.Contains(logOutput, "s_corrupt") || !strings.Contains(logOutput, "failed to load chunk index") {
-		t.Fatalf("expected warning about corrupt index for s_corrupt, got log output:\n%s", logOutput)
+	if !strings.Contains(logOutput, "failed to load global chunk index") {
+		t.Fatalf("expected warning about corrupt global index, got log output:\n%s", logOutput)
 	}
 }
 
@@ -312,6 +318,50 @@ func TestRecallSessionChunksToolSearchesAllSessions(t *testing.T) {
 	}
 	if !sessions["s_first"] || !sessions["s_second"] {
 		t.Fatalf("expected both sessions represented, got %#v", sessions)
+	}
+}
+
+// Chunks are returned in descending created_at order (newest first) when limit is applied.
+func TestRecallSessionChunksToolReturnsNewestFirst(t *testing.T) {
+	ctx := context.Background()
+	sessionFolder := t.TempDir()
+	
+	// Write chunks with delays to ensure different timestamps (RFC3339 has second precision)
+	writeTestChunk(t, sessionFolder, "s_old", []messages.Message{
+		{Role: messages.MessageRoleUser, Content: "old message"},
+	}, "Old chunk", []string{"test"}, nil)
+	time.Sleep(1100 * time.Millisecond)
+	
+	writeTestChunk(t, sessionFolder, "s_middle", []messages.Message{
+		{Role: messages.MessageRoleUser, Content: "middle message"},
+	}, "Middle chunk", []string{"test"}, nil)
+	time.Sleep(1100 * time.Millisecond)
+	
+	writeTestChunk(t, sessionFolder, "s_new", []messages.Message{
+		{Role: messages.MessageRoleUser, Content: "new message"},
+	}, "New chunk", []string{"test"}, nil)
+
+	tool := NewRecallSessionChunksTool(NewMultiSessionChunkStore(sessionFolder))
+	out, err := tool.Call(ctx, `{"tags":["test"],"limit":2}`)
+	if err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+
+	var decoded struct {
+		Results []ChunkRecallResult `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("decode output %q: %v", out, err)
+	}
+	if len(decoded.Results) != 2 {
+		t.Fatalf("expected 2 results (limit applied), got %d", len(decoded.Results))
+	}
+	// The newest two should be returned, in descending order
+	if decoded.Results[0].Summary != "New chunk" {
+		t.Fatalf("first result summary = %q, want New chunk", decoded.Results[0].Summary)
+	}
+	if decoded.Results[1].Summary != "Middle chunk" {
+		t.Fatalf("second result summary = %q, want Middle chunk", decoded.Results[1].Summary)
 	}
 }
 

--- a/src/agent/internal/agent/multi_session_chunk_store.go
+++ b/src/agent/internal/agent/multi_session_chunk_store.go
@@ -2,10 +2,10 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -19,66 +19,59 @@ func NewMultiSessionChunkStore(sessionFolder string) *MultiSessionChunkStore {
 	return &MultiSessionChunkStore{sessionFolder: sessionFolder}
 }
 
-// RecallChunks searches for chunks across all session directories.
+// RecallChunks searches for chunks in the global flat index.
 func (s *MultiSessionChunkStore) RecallChunks(ctx context.Context, query ChunkRecallQuery) ([]ChunkRecallResult, error) {
 	if s.sessionFolder == "" {
 		return nil, nil
 	}
 
-	// List all session directories
-	entries, err := os.ReadDir(s.sessionFolder)
+	// Load the global index from the flat chunks directory
+	chunksDir := filepath.Join(s.sessionFolder, "chunks")
+	indexPath := filepath.Join(chunksDir, "index.yaml")
+
+	// Skip if no chunks directory or index
+	if _, err := os.Stat(indexPath); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	// Load the global index
+	index, err := loadChunkIndexFromPath(indexPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read session folder: %w", err)
+		log.Printf("[WARN] [agent] [chunk_store] failed to load global chunk index: %v", err)
+		return nil, nil
+	}
+
+	// Build a map of chunk ID to created_at for efficient sorting
+	chunkCreatedAt := make(map[string]string, len(index.Chunks))
+	for _, chunk := range index.Chunks {
+		chunkCreatedAt[chunk.ID] = chunk.CreatedAt
 	}
 
 	var allResults []ChunkRecallResult
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		// Skip hidden directories and files
-		if strings.HasPrefix(entry.Name(), ".") {
-			continue
-		}
-
-		sessionID := entry.Name()
-		chunksDir := filepath.Join(s.sessionFolder, sessionID, "chunks")
-		indexPath := filepath.Join(chunksDir, "index.yaml")
-
-		// Skip if no chunks directory or index
-		if _, err := os.Stat(indexPath); os.IsNotExist(err) {
-			continue
-		}
-
-		// Load and search this session's chunks
-		index, err := loadChunkIndexFromPath(indexPath)
-		if err != nil {
-			// A corrupt index means this session's chunks are unreachable. Log it
-			// so the problem is visible rather than silently dropping history.
-			log.Printf("[WARN] [agent] [chunk_store] failed to load chunk index for session %q: %v", sessionID, err)
-			continue
-		}
-
-		for _, chunk := range index.Chunks {
-			if matchesChunkQuery(chunk, query) {
-				result := ChunkRecallResult{
-					ChunkID:   chunk.ID,
-					Source:    "session_" + sessionID,
-					SessionID: sessionID,
-					Summary:   chunk.Summary,
-				}
-				if chunk.Structured != nil {
-					result.Structured = chunk.Structured
-				}
-				allResults = append(allResults, result)
+	for _, chunk := range index.Chunks {
+		if matchesChunkQuery(chunk, query) {
+			result := ChunkRecallResult{
+				ChunkID:   chunk.ID,
+				Source:    "session_" + chunk.SessionID,
+				SessionID: chunk.SessionID,
+				Summary:   chunk.Summary,
 			}
+			if chunk.Structured != nil {
+				result.Structured = chunk.Structured
+			}
+			allResults = append(allResults, result)
 		}
 	}
 
-	// Apply limit
+	// Sort by created_at descending (newest first)
+	sort.Slice(allResults, func(i, j int) bool {
+		iCreatedAt := chunkCreatedAt[allResults[i].ChunkID]
+		jCreatedAt := chunkCreatedAt[allResults[j].ChunkID]
+		// Descending order: newer timestamps come first
+		return iCreatedAt > jCreatedAt
+	})
+
+	// Apply limit after sorting
 	if query.Limit > 0 && len(allResults) > query.Limit {
 		allResults = allResults[:query.Limit]
 	}

--- a/src/agent/internal/agent/session_chunk_writer.go
+++ b/src/agent/internal/agent/session_chunk_writer.go
@@ -84,7 +84,8 @@ func (w *SessionChunkWriter) WriteChunk(ctx context.Context, sessionID string, m
 		return err
 	}
 
-	chunksDir := filepath.Join(w.sessionFolder, sessionID, "chunks")
+	// All chunks go into a shared flat directory
+	chunksDir := filepath.Join(w.sessionFolder, "chunks")
 	if err := os.MkdirAll(chunksDir, 0o755); err != nil {
 		return fmt.Errorf("create chunks directory: %w", err)
 	}
@@ -159,9 +160,11 @@ func (w *SessionChunkWriter) WriteChunk(ctx context.Context, sessionID string, m
 	// chunk written without them would be reachable only by chunk_id.
 	tags, entities := w.chunkSearchTerms(msgs, summary)
 
-	// Create index entry
+	// Create index entry with session_id and created_at
+	now := time.Now().UTC().Format(time.RFC3339)
 	entry := chunkIndexEntry{
 		ID:         chunkID,
+		SessionID:  sessionID,
 		File:       chunkID + ".jsonl",
 		Status:     "active",
 		Summary:    summary,
@@ -169,10 +172,11 @@ func (w *SessionChunkWriter) WriteChunk(ctx context.Context, sessionID string, m
 		Entities:   entities,
 		EventCount: len(msgs),
 		Checksum:   checksum,
+		CreatedAt:  now,
 	}
 
 	index.Version = 1
-	index.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	index.UpdatedAt = now
 	index.Chunks = append(index.Chunks, entry)
 
 	// Write index as YAML

--- a/src/agent/internal/agent/session_memory.go
+++ b/src/agent/internal/agent/session_memory.go
@@ -47,7 +47,7 @@ type ChunkRecallResult struct {
 	Structured *ChunkStructuredSummary `json:"structured,omitempty"`
 }
 
-// chunkIndex is the on-disk `chunks/index.yaml` for one ContextManager session.
+// chunkIndex is the on-disk global `chunks/index.yaml` for all sessions.
 type chunkIndex struct {
 	Version   int               `yaml:"version"`
 	UpdatedAt string            `yaml:"updated_at"`
@@ -56,6 +56,7 @@ type chunkIndex struct {
 
 type chunkIndexEntry struct {
 	ID         string                  `yaml:"id"`
+	SessionID  string                  `yaml:"session_id"`
 	File       string                  `yaml:"file"`
 	Status     string                  `yaml:"status"`
 	Summary    string                  `yaml:"summary"`
@@ -64,4 +65,5 @@ type chunkIndexEntry struct {
 	Entities   []string                `yaml:"entities,omitempty"`
 	EventCount int                     `yaml:"event_count"`
 	Checksum   string                  `yaml:"checksum"`
+	CreatedAt  string                  `yaml:"created_at"`
 }


### PR DESCRIPTION
## 概述

将 session memory 的存储结构从按 session id 分目录改为扁平化存储，解决 context manager 每次 compaction 更新 session id 导致的文件组织问题。

## 主要变更

### 存储结构变化

**之前：**
```
session_folder/
  ├── session_id_1/chunks/
  ├── session_id_2/chunks/
  └── session_id_3/chunks/
```

**现在：**
```
session_folder/chunks/
  ├── index.yaml (全局索引)
  ├── chunk_xxx.jsonl
  ├── chunk_yyy.jsonl
  └── chunk_zzz.jsonl
```

### 数据结构变更

- `chunkIndexEntry` 新增 `session_id` 字段：记录 chunk 所属的 session
- `chunkIndexEntry` 新增 `created_at` 字段：RFC3339 格式的创建时间戳

### 功能改进

1. **目录数恒定**：不再随 session id 变化而增加目录
2. **召回效率提升**：只需读取一个 YAML 文件
3. **排序问题解决**：按 `created_at` 倒序排序，limit 返回最新的 N 个 chunks
4. **代码简化**：移除遍历多个目录的逻辑

## 修改的文件

- `session_memory.go`: 更新 `chunkIndexEntry` 结构
- `session_chunk_writer.go`: 写入扁平化目录并记录 session_id/created_at
- `multi_session_chunk_store.go`: 从全局索引读取并按时间排序
- `memory_tools_test.go`: 更新测试并添加排序测试

## 测试验证

所有相关测试通过：
- ✅ 并发写入序列化
- ✅ 搜索词提取
- ✅ 跨 session 召回
- ✅ 按时间倒序排序（新增）
- ✅ 错误处理和清理

## 兼容性说明

- 不支持旧文件迁移，新代码只处理扁平化结构
- 旧的分目录结构将被忽略

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Session memory recall now searches across stored chunks from all sessions.
  - Results are ordered from newest to oldest, with result limits applied after sorting.
  - Memory entries include session and creation-time details for more consistent retrieval.
  - Missing or unreadable memory indexes now fail gracefully without returning invalid recall results.
  - Canceled session operations clean up their own chunks without affecting memory from other sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->