### PR TITLE
feat: Add phone bridge proxy mode for environment bridge

### DIFF
--- a/src/agent/internal/agent/phone_bridge.go
+++ b/src/agent/internal/agent/phone_bridge.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -161,6 +162,12 @@ type PhoneBridge struct {
 	bleCapabilityMu    sync.Mutex
 	bleCapabilityCache phoneBridgeBLECapabilities
 	bleCapabilityAt    time.Time
+
+	// Proxy mode fields
+	proxyMode     bool
+	proxyEndpoint string
+	proxyTaskID   string
+	proxyClient   *http.Client
 }
 
 func NewPhoneBridge(logger *Logger) *PhoneBridge {
@@ -173,7 +180,19 @@ func NewPhoneBridge(logger *Logger) *PhoneBridge {
 		hidConnectionState: readHIDConnectionState,
 		hidMonitorEnabled:  true,
 		hidMonitorStop:     make(chan struct{}),
+		proxyClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
 	}
+}
+
+// NewPhoneBridgeProxy creates a PhoneBridge in proxy mode that forwards to a remote agent.
+func NewPhoneBridgeProxy(endpoint, taskID string, logger *Logger) *PhoneBridge {
+	pb := NewPhoneBridge(logger)
+	pb.proxyMode = true
+	pb.proxyEndpoint = strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	pb.proxyTaskID = strings.TrimSpace(taskID)
+	return pb
 }
 
 // Close stops background Phone Bridge monitoring. It is safe to call more than
@@ -290,6 +309,13 @@ func (pb *PhoneBridge) notifyBLEWake(cmd BridgeCommand) {
 }
 
 func (pb *PhoneBridge) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
+	// Proxy mode: forward WebSocket to remote agent
+	if pb.proxyMode {
+		pb.handleWebSocketProxy(w, r)
+		return
+	}
+
+	// Local mode: handle WebSocket directly
 	// Leave origin verification on (the library default): a request with an
 	// empty Origin header — i.e. the native companion app — is accepted, while
 	// a cross-origin browser handshake is rejected. This blocks cross-site
@@ -791,6 +817,11 @@ func (pb *PhoneBridge) UpdateState() map[string]string {
 }
 
 func (pb *PhoneBridge) getStatus() PhoneBridgeStatus {
+	// Proxy mode: fetch status from remote agent
+	if pb.proxyMode {
+		return pb.getProxyStatus()
+	}
+
 	pb.refreshHIDConnection()
 	pb.mu.Lock()
 	defer pb.mu.Unlock()
@@ -1191,4 +1222,163 @@ func availableAppNames(apps []AvailableAppInfo, limit int) []string {
 		}
 	}
 	return names
+}
+
+// handleWebSocketProxy forwards WebSocket connection to remote agent in proxy mode.
+func (pb *PhoneBridge) handleWebSocketProxy(w http.ResponseWriter, r *http.Request) {
+	// Accept connection from aiden app
+	appConn, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		if pb.logger != nil {
+			pb.logger.Error("phone-bridge-proxy: accept app connection failed: %v", err)
+		}
+		return
+	}
+
+	platform := r.URL.Query().Get("platform")
+	phoneID := r.URL.Query().Get("phone_id")
+
+	if pb.logger != nil {
+		pb.logger.Info("phone-bridge-proxy: app connected (platform=%s phone_id=%s)", platform, phoneID)
+	}
+
+	// Build remote agent WebSocket URL
+	remoteURL := pb.proxyEndpoint + "/api/phone-bridge"
+	if strings.HasPrefix(remoteURL, "http://") {
+		remoteURL = "ws://" + strings.TrimPrefix(remoteURL, "http://")
+	} else if strings.HasPrefix(remoteURL, "https://") {
+		remoteURL = "wss://" + strings.TrimPrefix(remoteURL, "https://")
+	}
+
+	// Add query parameters
+	if platform != "" || phoneID != "" {
+		params := url.Values{}
+		if platform != "" {
+			params.Set("platform", platform)
+		}
+		if phoneID != "" {
+			params.Set("phone_id", phoneID)
+		}
+		remoteURL = remoteURL + "?" + params.Encode()
+	}
+
+	// Connect to remote agent
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	agentConn, _, err := websocket.Dial(ctx, remoteURL, nil)
+	cancel()
+	if err != nil {
+		if pb.logger != nil {
+			pb.logger.Error("phone-bridge-proxy: connect to remote agent failed: %v", err)
+		}
+		appConn.Close(websocket.StatusInternalError, "failed to connect to remote agent")
+		return
+	}
+
+	if pb.logger != nil {
+		pb.logger.Info("phone-bridge-proxy: connected to remote agent %s", remoteURL)
+	}
+
+	// Bidirectional message forwarding
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	proxyCtx, proxyCancel := context.WithCancel(context.Background())
+	defer proxyCancel()
+
+	// Forward: app -> agent
+	go func() {
+		defer wg.Done()
+		pb.forwardWebSocketMessages(proxyCtx, "app->agent", appConn, agentConn)
+		proxyCancel()
+	}()
+
+	// Forward: agent -> app
+	go func() {
+		defer wg.Done()
+		pb.forwardWebSocketMessages(proxyCtx, "agent->app", agentConn, appConn)
+		proxyCancel()
+	}()
+
+	wg.Wait()
+
+	appConn.Close(websocket.StatusNormalClosure, "")
+	agentConn.Close(websocket.StatusNormalClosure, "")
+
+	if pb.logger != nil {
+		pb.logger.Info("phone-bridge-proxy: connection closed")
+	}
+}
+
+func (pb *PhoneBridge) forwardWebSocketMessages(ctx context.Context, direction string, from, to *websocket.Conn) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		// Read message from source
+		msgType, data, err := from.Read(context.Background())
+		if err != nil {
+			if websocket.CloseStatus(err) == -1 && pb.logger != nil {
+				pb.logger.Error("phone-bridge-proxy: [%s] read error: %v", direction, err)
+			}
+			return
+		}
+
+		// Forward message to destination
+		if err := to.Write(context.Background(), msgType, data); err != nil {
+			if pb.logger != nil {
+				pb.logger.Error("phone-bridge-proxy: [%s] write error: %v", direction, err)
+			}
+			return
+		}
+
+		if pb.logger != nil && msgType == websocket.MessageText {
+			// Log message for debugging (truncate if too long)
+			msg := string(data)
+			if len(msg) > 200 {
+				msg = msg[:200] + "..."
+			}
+			pb.logger.Info("phone-bridge-proxy: [%s] forwarded: %s", direction, msg)
+		}
+	}
+}
+
+// getProxyStatus fetches status from remote agent in proxy mode.
+func (pb *PhoneBridge) getProxyStatus() PhoneBridgeStatus {
+	req, err := http.NewRequest(http.MethodGet, pb.proxyEndpoint+"/api/phone-bridge/status", nil)
+	if err != nil {
+		if pb.logger != nil {
+			pb.logger.Error("phone-bridge-proxy: create status request failed: %v", err)
+		}
+		return PhoneBridgeStatus{Connected: false}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	if pb.proxyTaskID != "" {
+		req.Header.Set("benchmark-task-id", pb.proxyTaskID)
+	}
+
+	resp, err := pb.proxyClient.Do(req)
+	if err != nil {
+		if pb.logger != nil {
+			pb.logger.Error("phone-bridge-proxy: status request failed: %v", err)
+		}
+		return PhoneBridgeStatus{Connected: false}
+	}
+	defer resp.Body.Close()
+
+	var status PhoneBridgeStatus
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		if pb.logger != nil {
+			pb.logger.Error("phone-bridge-proxy: decode status failed: %v", err)
+		}
+		return PhoneBridgeStatus{Connected: false}
+	}
+
+	return status
 }

--- a/src/agent/internal/agent/phone_bridge.go
+++ b/src/agent/internal/agent/phone_bridge.go
@@ -1310,6 +1310,8 @@ func (pb *PhoneBridge) handleWebSocketProxy(w http.ResponseWriter, r *http.Reque
 }
 
 func (pb *PhoneBridge) forwardWebSocketMessages(ctx context.Context, direction string, from, to *websocket.Conn) {
+	defer to.Close(websocket.StatusNormalClosure, "forwarding stopped")
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -1318,7 +1320,7 @@ func (pb *PhoneBridge) forwardWebSocketMessages(ctx context.Context, direction s
 		}
 
 		// Read message from source
-		msgType, data, err := from.Read(context.Background())
+		msgType, data, err := from.Read(ctx)
 		if err != nil {
 			if websocket.CloseStatus(err) == -1 && pb.logger != nil {
 				pb.logger.Error("phone-bridge-proxy: [%s] read error: %v", direction, err)
@@ -1327,37 +1329,31 @@ func (pb *PhoneBridge) forwardWebSocketMessages(ctx context.Context, direction s
 		}
 
 		// Forward message to destination
-		if err := to.Write(context.Background(), msgType, data); err != nil {
+		if err := to.Write(ctx, msgType, data); err != nil {
 			if pb.logger != nil {
 				pb.logger.Error("phone-bridge-proxy: [%s] write error: %v", direction, err)
 			}
 			return
 		}
 
-		if pb.logger != nil && msgType == websocket.MessageText {
-			// Log message for debugging (truncate if too long)
-			msg := string(data)
-			if len(msg) > 200 {
-				msg = msg[:200] + "..."
-			}
-			pb.logger.Info("phone-bridge-proxy: [%s] forwarded: %s", direction, msg)
+		if pb.logger != nil {
+			pb.logger.Info("phone-bridge-proxy: [%s] forwarded %d bytes (type=%v)", direction, len(data), msgType)
 		}
 	}
 }
 
 // getProxyStatus fetches status from remote agent in proxy mode.
 func (pb *PhoneBridge) getProxyStatus() PhoneBridgeStatus {
-	req, err := http.NewRequest(http.MethodGet, pb.proxyEndpoint+"/api/phone-bridge/status", nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pb.proxyEndpoint+"/api/phone-bridge/status", nil)
 	if err != nil {
 		if pb.logger != nil {
 			pb.logger.Error("phone-bridge-proxy: create status request failed: %v", err)
 		}
 		return PhoneBridgeStatus{Connected: false}
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
 
 	if pb.proxyTaskID != "" {
 		req.Header.Set("benchmark-task-id", pb.proxyTaskID)
@@ -1371,6 +1367,13 @@ func (pb *PhoneBridge) getProxyStatus() PhoneBridgeStatus {
 		return PhoneBridgeStatus{Connected: false}
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if pb.logger != nil {
+			pb.logger.Error("phone-bridge-proxy: status request returned %d", resp.StatusCode)
+		}
+		return PhoneBridgeStatus{Connected: false}
+	}
 
 	var status PhoneBridgeStatus
 	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {

--- a/src/agent/internal/agent/phone_bridge_http.go
+++ b/src/agent/internal/agent/phone_bridge_http.go
@@ -1,10 +1,12 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -53,6 +55,12 @@ type GetResultResponse struct {
 func (pb *PhoneBridge) handleEnqueueCommand(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, `{"error":"Method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Proxy mode: forward to remote agent
+	if pb.proxyMode {
+		pb.proxyHTTPRequest(w, r, "/api/phone-bridge/commands")
 		return
 	}
 
@@ -130,6 +138,12 @@ func (pb *PhoneBridge) handleEnqueueCommand(w http.ResponseWriter, r *http.Reque
 func (pb *PhoneBridge) handlePollCommands(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, `{"error":"Method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Proxy mode: forward to remote agent
+	if pb.proxyMode {
+		pb.proxyHTTPRequest(w, r, "/api/phone-bridge/commands")
 		return
 	}
 
@@ -252,6 +266,12 @@ func (pb *PhoneBridge) handleSubmitResult(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// Proxy mode: forward to remote agent
+	if pb.proxyMode {
+		pb.proxyHTTPRequest(w, r, "/api/phone-bridge/results")
+		return
+	}
+
 	var req SubmitResultRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		if pb.logger != nil {
@@ -300,6 +320,12 @@ func (pb *PhoneBridge) handleQueryResult(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Proxy mode: forward to remote agent
+	if pb.proxyMode {
+		pb.proxyHTTPRequest(w, r, r.URL.Path)
+		return
+	}
+
 	// Extract command_id from path: /api/phone-bridge/results/:command_id
 	path := strings.TrimPrefix(r.URL.Path, "/api/phone-bridge/results/")
 	commandID := strings.TrimSpace(path)
@@ -328,4 +354,61 @@ func (pb *PhoneBridge) handleQueryResult(w http.ResponseWriter, r *http.Request)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
+}
+
+// proxyHTTPRequest forwards an HTTP request to the remote agent in proxy mode.
+func (pb *PhoneBridge) proxyHTTPRequest(w http.ResponseWriter, r *http.Request, path string) {
+	// Build remote URL
+	remoteURL := pb.proxyEndpoint + path
+	if r.URL.RawQuery != "" {
+		remoteURL = remoteURL + "?" + r.URL.RawQuery
+	}
+
+	// Read request body if present
+	var body io.Reader
+	if r.Body != nil {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			if pb.logger != nil {
+				pb.logger.Error("phone-bridge-proxy: read request body failed: %v", err)
+			}
+			http.Error(w, fmt.Sprintf(`{"error":"read request body: %v"}`, err), http.StatusBadGateway)
+			return
+		}
+		body = bytes.NewReader(bodyBytes)
+	}
+
+	// Create proxied request
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, remoteURL, body)
+	if err != nil {
+		if pb.logger != nil {
+			pb.logger.Error("phone-bridge-proxy: create request failed: %v", err)
+		}
+		http.Error(w, fmt.Sprintf(`{"error":"create request: %v"}`, err), http.StatusBadGateway)
+		return
+	}
+
+	// Copy relevant headers
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+	if pb.proxyTaskID != "" {
+		req.Header.Set("benchmark-task-id", pb.proxyTaskID)
+	}
+
+	// Send request
+	resp, err := pb.proxyClient.Do(req)
+	if err != nil {
+		if pb.logger != nil {
+			pb.logger.Error("phone-bridge-proxy: send request failed: %v", err)
+		}
+		http.Error(w, fmt.Sprintf(`{"error":"send request: %v"}`, err), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy response
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
 }

--- a/src/agent/internal/agent/phone_bridge_http.go
+++ b/src/agent/internal/agent/phone_bridge_http.go
@@ -330,7 +330,7 @@ func (pb *PhoneBridge) handleQueryResult(w http.ResponseWriter, r *http.Request)
 		
 		// Reject path separators and dot segments
 		if commandID == "" || strings.Contains(commandID, "/") || strings.Contains(commandID, "\\") || 
-			commandID == "." || commandID == ".." || strings.Contains(commandID, ".") {
+			commandID == "." || commandID == ".." {
 			http.Error(w, `{"error":"Invalid command ID"}`, http.StatusBadRequest)
 			return
 		}

--- a/src/agent/internal/agent/phone_bridge_http.go
+++ b/src/agent/internal/agent/phone_bridge_http.go
@@ -1,17 +1,19 @@
 package agent
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
 )
+
+const phoneBridgeProxyMaxBodyBytes = 1 << 20 // 1 MiB
 
 // EnqueueCommandRequest is the request body for POST /api/phone-bridge/commands
 type EnqueueCommandRequest struct {
@@ -322,7 +324,20 @@ func (pb *PhoneBridge) handleQueryResult(w http.ResponseWriter, r *http.Request)
 
 	// Proxy mode: forward to remote agent
 	if pb.proxyMode {
-		pb.proxyHTTPRequest(w, r, r.URL.Path)
+		// Extract and validate command ID to prevent path traversal
+		path := strings.TrimPrefix(r.URL.Path, "/api/phone-bridge/results/")
+		commandID := strings.TrimSpace(path)
+		
+		// Reject path separators and dot segments
+		if commandID == "" || strings.Contains(commandID, "/") || strings.Contains(commandID, "\\") || 
+			commandID == "." || commandID == ".." || strings.Contains(commandID, ".") {
+			http.Error(w, `{"error":"Invalid command ID"}`, http.StatusBadRequest)
+			return
+		}
+		
+		// Build safe path with validated ID
+		safePath := "/api/phone-bridge/results/" + url.PathEscape(commandID)
+		pb.proxyHTTPRequest(w, r, safePath)
 		return
 	}
 
@@ -364,18 +379,10 @@ func (pb *PhoneBridge) proxyHTTPRequest(w http.ResponseWriter, r *http.Request, 
 		remoteURL = remoteURL + "?" + r.URL.RawQuery
 	}
 
-	// Read request body if present
+	// Forward the request body without buffering it in memory
 	var body io.Reader
 	if r.Body != nil {
-		bodyBytes, err := io.ReadAll(r.Body)
-		if err != nil {
-			if pb.logger != nil {
-				pb.logger.Error("phone-bridge-proxy: read request body failed: %v", err)
-			}
-			http.Error(w, fmt.Sprintf(`{"error":"read request body: %v"}`, err), http.StatusBadGateway)
-			return
-		}
-		body = bytes.NewReader(bodyBytes)
+		body = http.MaxBytesReader(w, r.Body, phoneBridgeProxyMaxBodyBytes)
 	}
 
 	// Create proxied request

--- a/src/agent/internal/agent/phone_bridge_proxy_test.go
+++ b/src/agent/internal/agent/phone_bridge_proxy_test.go
@@ -1,0 +1,163 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+func TestPhoneBridgeProxyMode(t *testing.T) {
+	// Create a mock remote agent
+	remoteAgent := newPhoneBridgeForTest()
+	defer remoteAgent.queue.Stop()
+
+	remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/phone-bridge" {
+			remoteAgent.HandleWebSocket(w, r)
+		} else if r.URL.Path == "/api/phone-bridge/status" {
+			w.Header().Set("Content-Type", "application/json")
+			status := remoteAgent.getStatus()
+			json.NewEncoder(w).Encode(status)
+		} else if strings.HasPrefix(r.URL.Path, "/api/phone-bridge/") {
+			if r.Method == http.MethodPost && r.URL.Path == "/api/phone-bridge/commands" {
+				remoteAgent.handleEnqueueCommand(w, r)
+			} else if r.Method == http.MethodGet && r.URL.Path == "/api/phone-bridge/commands" {
+				remoteAgent.handlePollCommands(w, r)
+			} else if r.Method == http.MethodPost && r.URL.Path == "/api/phone-bridge/results" {
+				remoteAgent.handleSubmitResult(w, r)
+			} else if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/phone-bridge/results/") {
+				remoteAgent.handleQueryResult(w, r)
+			}
+		}
+	}))
+	defer remoteServer.Close()
+
+	// Create proxy bridge
+	proxyBridge := NewPhoneBridgeProxy(remoteServer.URL, "test-task", nil)
+	defer proxyBridge.queue.Stop()
+
+	if !proxyBridge.proxyMode {
+		t.Fatal("proxy bridge should be in proxy mode")
+	}
+
+	// Test getStatus proxies to remote agent
+	status := proxyBridge.getStatus()
+	if status.Connected {
+		t.Fatal("status.Connected should be false when no app is connected")
+	}
+
+	// Create proxy server
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/phone-bridge" {
+			proxyBridge.HandleWebSocket(w, r)
+		} else if r.URL.Path == "/api/phone-bridge/status" {
+			w.Header().Set("Content-Type", "application/json")
+			status := proxyBridge.getStatus()
+			json.NewEncoder(w).Encode(status)
+		}
+	}))
+	defer proxyServer.Close()
+
+	// Connect app to proxy
+	appURL := "ws" + strings.TrimPrefix(proxyServer.URL, "http") + "/api/phone-bridge?platform=ios&phone_id=test-phone"
+	appCtx, appCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer appCancel()
+
+	appConn, _, err := websocket.Dial(appCtx, appURL, nil)
+	if err != nil {
+		t.Fatalf("app dial failed: %v", err)
+	}
+	defer appConn.Close(websocket.StatusNormalClosure, "")
+
+	// Wait a bit for connections to establish
+	time.Sleep(100 * time.Millisecond)
+
+	// Send a message from app
+	msg := map[string]interface{}{
+		"id":     "test-msg",
+		"method": "test",
+	}
+	msgData, _ := json.Marshal(msg)
+	if err := appConn.Write(context.Background(), websocket.MessageText, msgData); err != nil {
+		t.Fatalf("app write failed: %v", err)
+	}
+
+	// The message should be forwarded to remote agent
+	// For a full test, we'd need to verify the remote agent received it
+	// For now, we just verify the proxy doesn't crash
+
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestPhoneBridgeProxyHTTPQueue(t *testing.T) {
+	// Create a mock remote agent
+	remoteAgent := newPhoneBridgeForTest()
+	defer remoteAgent.queue.Stop()
+
+	remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/phone-bridge/commands" {
+			remoteAgent.handleEnqueueCommand(w, r)
+		} else if r.Method == http.MethodGet && r.URL.Path == "/api/phone-bridge/commands" {
+			remoteAgent.handlePollCommands(w, r)
+		} else if r.Method == http.MethodPost && r.URL.Path == "/api/phone-bridge/results" {
+			remoteAgent.handleSubmitResult(w, r)
+		} else if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/phone-bridge/results/") {
+			remoteAgent.handleQueryResult(w, r)
+		}
+	}))
+	defer remoteServer.Close()
+
+	// Create proxy bridge
+	proxyBridge := NewPhoneBridgeProxy(remoteServer.URL, "test-task", nil)
+	defer proxyBridge.queue.Stop()
+
+	// Test enqueue command through proxy
+	cmdReq := EnqueueCommandRequest{
+		Command: BridgeCommand{
+			ID:      "test-cmd-1",
+			Type:    "open_app",
+			App:     "Calendar",
+			PhoneID: "test-phone",
+		},
+	}
+	cmdData, _ := json.Marshal(cmdReq)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/phone-bridge/commands", strings.NewReader(string(cmdData)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	proxyBridge.handleEnqueueCommand(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("enqueue command status = %d, want %d", w.Code, http.StatusAccepted)
+	}
+
+	// Test poll commands through proxy
+	pollReq := httptest.NewRequest(http.MethodGet, "/api/phone-bridge/commands?platform=ios&phone_id=test-phone", nil)
+	pollW := httptest.NewRecorder()
+
+	proxyBridge.handlePollCommands(pollW, pollReq)
+
+	if pollW.Code != http.StatusOK {
+		t.Fatalf("poll commands status = %d, want %d", pollW.Code, http.StatusOK)
+	}
+
+	var pollResp PollCommandsResponse
+	if err := json.NewDecoder(pollW.Body).Decode(&pollResp); err != nil {
+		t.Fatalf("decode poll response failed: %v", err)
+	}
+
+	if len(pollResp.Commands) != 1 {
+		t.Fatalf("poll commands count = %d, want 1", len(pollResp.Commands))
+	}
+
+	if pollResp.Commands[0].ID != "test-cmd-1" {
+		t.Fatalf("command ID = %q, want test-cmd-1", pollResp.Commands[0].ID)
+	}
+}

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -547,16 +547,17 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 	rt.storage.Start()
 
 	rt.screenState = screenState
-	
+
 	// Create PhoneBridge in proxy mode if environment bridge is enabled
-	if cfg.EnvironmentBridge.Enabled && cfg.EnvironmentBridge.Endpoint != "" {
+	endpoint := strings.TrimSpace(cfg.EnvironmentBridge.Endpoint)
+	if cfg.EnvironmentBridge.Enabled && endpoint != "" {
 		rt.phoneBridge = NewPhoneBridgeProxy(
-			cfg.EnvironmentBridge.Endpoint,
+			endpoint,
 			cfg.EnvironmentBridge.BenchmarkTaskID,
 			logger,
 		)
 		if logger != nil {
-			logger.Info("phone-bridge: proxy mode enabled, endpoint=%s", cfg.EnvironmentBridge.Endpoint)
+			logger.Info("phone-bridge: proxy mode enabled, endpoint=%s", endpoint)
 		}
 	} else {
 		rt.phoneBridge = NewPhoneBridge(logger)

--- a/src/agent/internal/agent/runtime.go
+++ b/src/agent/internal/agent/runtime.go
@@ -547,7 +547,20 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 	rt.storage.Start()
 
 	rt.screenState = screenState
-	rt.phoneBridge = NewPhoneBridge(logger)
+	
+	// Create PhoneBridge in proxy mode if environment bridge is enabled
+	if cfg.EnvironmentBridge.Enabled && cfg.EnvironmentBridge.Endpoint != "" {
+		rt.phoneBridge = NewPhoneBridgeProxy(
+			cfg.EnvironmentBridge.Endpoint,
+			cfg.EnvironmentBridge.BenchmarkTaskID,
+			logger,
+		)
+		if logger != nil {
+			logger.Info("phone-bridge: proxy mode enabled, endpoint=%s", cfg.EnvironmentBridge.Endpoint)
+		}
+	} else {
+		rt.phoneBridge = NewPhoneBridge(logger)
+	}
 	rt.phoneBridge.SetConfiguredPlatform(cfg.DevicePlatformOrDefault())
 	rt.stateManager.RegisterUpdater(rt.phoneBridge)
 


### PR DESCRIPTION
## Summary

Add phone bridge proxy mode to forward aiden app connections to remote agent in environment bridge mode.

## Changes

- **phone_bridge.go**: Add proxy mode support with WebSocket forwarding
- **phone_bridge_http.go**: Add HTTP queue request forwarding
- **runtime.go**: Automatically create proxy PhoneBridge in environment bridge mode
- **phone_bridge_proxy_test.go**: Add unit tests for proxy functionality

## Features

### WebSocket Proxy (Foreground)
- Bidirectional message forwarding
- Automatic heartbeat handling
- Connection lifecycle management

### HTTP Queue Proxy (Background)
- Forward commands, results, and status queries
- Support iOS background mode

### Status Synchronization
- Proxy mode automatically fetches status from remote agent
- Correct connection state reflected in agent tools

## Usage

Start bridge agent with environment bridge mode:
```bash
./aiden-agent \
  --environment-bridge-mode \
  --environment-bridge-endpoint http://remote-agent:8080
```

Aiden app connects to bridge agent address - no changes needed!

## Architecture

```
Aiden App <--WebSocket/HTTP--> Bridge Agent <--WebSocket/HTTP--> Remote Agent
```

When environment bridge mode is enabled:
- MNK operations → proxied ✓
- Screen captures → proxied ✓
- **Phone Bridge connections → proxied ✓ (NEW)**

## Testing

- ✅ All unit tests pass
- ✅ Compilation successful
- ✅ Tested with benchmark webui - app status correctly displayed
- ✅ Backward compatible - local mode unaffected

## Benefits

- Fully transparent to aiden app
- Reuses environment bridge configuration
- Dual mode support (WebSocket + HTTP queue)
- Clean fallback when proxy unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for routing phone-bridge connections and commands through a remote agent.
  * Remote phone-bridge sessions now support WebSocket communication, status checks, command queuing, and result retrieval.
  * Environments automatically use the remote bridge when a valid proxy endpoint is configured.

* **Bug Fixes**
  * Remote connection failures now return appropriate error responses and report disconnected status when necessary.
  * Invalid command identifiers are rejected before remote requests are sent.
  * Large command payloads are handled through limited streaming instead of unrestricted buffering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->