### PR TITLE
test(agent): avoid expired notification memory fixture

### DIFF
--- a/src/agent/internal/agent/notification_memory_processor_test.go
+++ b/src/agent/internal/agent/notification_memory_processor_test.go
@@ -204,7 +204,6 @@ func TestNotificationMemoryProcessorRetainsUserBillAndIgnoresPublicProductNews(t
   ]
 }`}}
 	processor := NewNotificationMemoryProcessor(ctxStore, root, nil, model)
-	processor.now = func() time.Time { return time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC) }
 	if _, err := processor.ProcessBatch(context.Background(), nil); err != nil {
 		t.Fatalf("ProcessBatch() error = %v", err)
 	}


### PR DESCRIPTION
## Summary
- remove the stale fixed clock from the notification memory classification test
- keep generated temporary memory expiry aligned with the store search clock

## Root cause
The test forced `processor.now` to 2026-08-27 while temporary memory search used the real clock. The default 7-day TTL made the expected bill memory expire after 2026-09-03, causing CI to return no memories.

## Validation
- `cd src/agent && TMPDIR=/tmp go test ./...`
- target test passed 10 consecutive runs

Unrelated pre-existing workspace deletions were not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a notification classification test to use the default time source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->