### PR TITLE
fix(agent): keep stable screen image out of tool result

### DIFF
--- a/src/agent/internal/agent/agent_loop_tool_result_test.go
+++ b/src/agent/internal/agent/agent_loop_tool_result_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"reflect"
 	"strings"
@@ -98,6 +99,54 @@ func TestAppendToolExecutionMessagesUsesSharedVisualActionFlowForScreenshot(t *t
 	content := stored[1].ToolResults[0].Content
 	if content != "ok" {
 		t.Fatalf("tool result = %q, want shared action_output", content)
+	}
+	if stored[2].Role != messages.MessageRoleState || len(stored[2].Attachments) != 1 {
+		t.Fatalf("third message = %#v, want state with one image attachment", stored[2])
+	}
+	if stored[2].Attachments[0].Source != messages.AttachmentSourceScreenshotObservation {
+		t.Fatalf("state attachment source = %q", stored[2].Attachments[0].Source)
+	}
+}
+
+func TestAppendToolExecutionMessagesKeepsWaitStableScreenshotOutOfToolResult(t *testing.T) {
+	manager, err := contextmanager.NewContextManagerFromMessageList(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("NewContextManagerFromMessageList() error = %v", err)
+	}
+	llmExecutor := executor.NewLLMExecutor(nil, manager)
+	encoded := "aW1nMQ=="
+	actionOutput := `{"ok":true,"stable":true,"elapsed_ms":250,"screen_changed":false}`
+	observation := fmt.Sprintf(
+		`{"action_output":%q,"ok":true,"stable":true,"elapsed_ms":250,"screen_changed":false,"width":800,"height":600,"format":"jpeg","size":4,"data":"%s"}`,
+		actionOutput,
+		encoded,
+	)
+	parser := &FunctionAgent{Tools: []langtools.Tool{&stubTool{name: "wait_for_stable_screen", visual: true}}}
+	step := schema.AgentStep{
+		Action:      schema.AgentAction{ToolID: "call_1", Tool: "wait_for_stable_screen"},
+		Observation: observation,
+	}
+	toolCall := messages.Message{
+		Role: messages.MessageRoleToolCall,
+		ToolCalls: []messages.ToolCall{{
+			ID: "call_1", Name: "wait_for_stable_screen", Arguments: `{}`,
+		}},
+	}
+
+	if err := appendToolExecutionMessages(llmExecutor, parser, toolCall, step, PreparedToolResult{Content: observation, Complete: true}); err != nil {
+		t.Fatalf("appendToolExecutionMessages() error = %v", err)
+	}
+
+	stored := manager.CloneMessageList()
+	if len(stored) != 3 {
+		t.Fatalf("stored messages = %#v, want tool call, tool result, and state", stored)
+	}
+	content := stored[1].ToolResults[0].Content
+	if content != actionOutput {
+		t.Fatalf("tool result = %q, want stable-screen action_output %q", content, actionOutput)
+	}
+	if strings.Contains(content, encoded) {
+		t.Fatalf("tool result contains screenshot base64: %q", content)
 	}
 	if stored[2].Role != messages.MessageRoleState || len(stored[2].Attachments) != 1 {
 		t.Fatalf("third message = %#v, want state with one image attachment", stored[2])

--- a/src/agent/internal/agent/function_agent_test.go
+++ b/src/agent/internal/agent/function_agent_test.go
@@ -744,7 +744,8 @@ func TestFunctionAgentWaitStableScreenDoesNotTreatMotionAsActionResult(t *testin
 	agent := &FunctionAgent{
 		Tools: []langtools.Tool{&stubTool{name: "wait_for_stable_screen", visual: true}},
 	}
-	observation := `{"ok":true,"stable":true,"elapsed_ms":250,"screen_changed":false,"width":800,"height":600,"format":"jpeg","size":4,"data":"` +
+	actionOutput := `{"ok":true,"stable":true,"elapsed_ms":250,"screen_changed":false}`
+	observation := fmt.Sprintf(`{"action_output":%q,"ok":true,"stable":true,"elapsed_ms":250,"screen_changed":false,"width":800,"height":600,"format":"jpeg","size":4,"data":"`, actionOutput) +
 		base64.StdEncoding.EncodeToString([]byte("img1")) + `"}`
 	step := schema.AgentStep{
 		Action:      schema.AgentAction{Tool: "wait_for_stable_screen"},
@@ -752,8 +753,11 @@ func TestFunctionAgentWaitStableScreenDoesNotTreatMotionAsActionResult(t *testin
 	}
 
 	toolContent, followups := agent.observationMessagesForStep(step, true)
-	if toolContent != observation {
-		t.Fatalf("toolContent = %q, want original observation", toolContent)
+	if toolContent != actionOutput {
+		t.Fatalf("toolContent = %q, want stable-screen action_output %q", toolContent, actionOutput)
+	}
+	if strings.Contains(toolContent, base64.StdEncoding.EncodeToString([]byte("img1"))) {
+		t.Fatalf("toolContent contains screenshot base64: %q", toolContent)
 	}
 	if len(followups) != 1 {
 		t.Fatalf("expected one followup screenshot message, got %#v", followups)

--- a/src/agent/internal/agent/tools_wait_stable.go
+++ b/src/agent/internal/agent/tools_wait_stable.go
@@ -88,6 +88,7 @@ type waitStableScreenResult struct {
 
 type waitStableScreenObservationResult struct {
 	screenshotResult
+	ActionOutput  string   `json:"action_output"`
 	OK            bool     `json:"ok"`
 	Stable        bool     `json:"stable"`
 	ElapsedMs     int64    `json:"elapsed_ms"`
@@ -152,8 +153,13 @@ func (t *WaitStableScreenTool) Call(ctx context.Context, input string) (string, 
 	}
 	stable := result.Stable
 	elapsed := result.ElapsedMs
-	out, _ := json.Marshal(waitStableScreenObservationResult{
+	actionOutput, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("marshal stable-screen result: %w", err)
+	}
+	out, err := json.Marshal(waitStableScreenObservationResult{
 		screenshotResult: screenshot,
+		ActionOutput:     string(actionOutput),
 		OK:               result.OK,
 		Stable:           result.Stable,
 		ElapsedMs:        result.ElapsedMs,
@@ -162,6 +168,9 @@ func (t *WaitStableScreenTool) Call(ctx context.Context, input string) (string, 
 		ScreenChanged:    result.ScreenChanged,
 		LastDiff:         result.LastDiff,
 	})
+	if err != nil {
+		return "", fmt.Errorf("marshal stable-screen screenshot observation: %w", err)
+	}
 	return string(out), nil
 }
 

--- a/src/agent/internal/agent/tools_wait_stable_test.go
+++ b/src/agent/internal/agent/tools_wait_stable_test.go
@@ -95,6 +95,20 @@ func TestWaitStableScreenToolReturnsScreenshotObservationJSON(t *testing.T) {
 	if result.StableWaitMs == nil || *result.StableWaitMs != result.ElapsedMs {
 		t.Fatalf("StableWaitMs = %#v, elapsed_ms=%d", result.StableWaitMs, result.ElapsedMs)
 	}
+	var toolResult map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(result.ActionOutput), &toolResult); err != nil {
+		t.Fatalf("action_output is not valid stable-screen result JSON: %v", err)
+	}
+	if _, ok := toolResult["data"]; ok {
+		t.Fatalf("action_output contains screenshot data: %s", result.ActionOutput)
+	}
+	var stableResult waitStableScreenResult
+	if err := json.Unmarshal([]byte(result.ActionOutput), &stableResult); err != nil {
+		t.Fatalf("decode action_output: %v", err)
+	}
+	if !stableResult.OK || !stableResult.Stable || stableResult.ElapsedMs != result.ElapsedMs {
+		t.Fatalf("action_output stable result = %#v, want top-level stable result", stableResult)
+	}
 	if result.Width != 2 || result.Height != 2 || result.Format != "jpeg" || result.Size != len(jpegData) {
 		t.Fatalf("unexpected screenshot metadata: %#v", result.screenshotResult)
 	}


### PR DESCRIPTION
## Summary
- add a compact `action_output` to `wait_for_stable_screen`, matching the visual-result flow used by `screenshot`
- keep stable-screen status fields in the tool result while delivering the image through the follow-up state attachment
- add tool, parser, and persisted-message regressions proving screenshot base64 is excluded from `tool_result`

## Testing
- `cd src/agent && go test ./internal/agent -run 'TestWaitStableScreenToolReturnsScreenshotObservationJSON|TestFunctionAgentWaitStableScreenDoesNotTreatMotionAsActionResult|TestAppendToolExecutionMessagesKeepsWaitStableScreenshotOutOfToolResult|TestAppendToolExecutionMessagesUsesSharedVisualActionFlowForScreenshot'`
- `cd src/agent && TMPDIR=/tmp go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stable-screen results so action details are returned separately from screenshot data.
  * Prevented screenshot-encoded data from being included in tool results, reducing unnecessary response size.
  * Preserved screenshots as state attachments for follow-up processing.
  * Improved error handling when stable-screen results cannot be serialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->