### PR TITLE
fix(text-input): verify final candidate selection

### DIFF
--- a/src/agent/internal/agent/text_input_candidate_test.go
+++ b/src/agent/internal/agent/text_input_candidate_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -177,11 +178,18 @@ func TestCompositionCanReturnToFirstCandidateRow(t *testing.T) {
 	}
 }
 
-func TestCompletedCandidateSelectionSkipsPostActionVerification(t *testing.T) {
-	vision := &stubTextInputVision{analyses: []textInputScreenAnalysis{{
-		ObservedMode:       textInputModeComposition,
-		CompositionPending: true,
-	}}, actions: []textInputCandidateAction{{
+func TestCompletedCandidateSelectionRequiresPostActionVerification(t *testing.T) {
+	vision := &stubTextInputVision{analyses: []textInputScreenAnalysis{
+		{
+			ObservedMode:       textInputModeComposition,
+			CompositionPending: true,
+		},
+		{
+			ObservedMode:  textInputModeComposition,
+			FieldText:     "把自己",
+			TargetMatched: true,
+		},
+	}, actions: []textInputCandidateAction{{
 		Action:        textInputCandidateActionSelect,
 		Text:          "把自己",
 		CompletesPart: true,
@@ -206,20 +214,61 @@ func TestCompletedCandidateSelectionSkipsPostActionVerification(t *testing.T) {
 	if err != nil || !committed {
 		t.Fatalf("typeCompositionWithCandidateSelection() committed=%v err=%v", committed, err)
 	}
-	if vlmCalls != 2 {
-		t.Fatalf("vlmCalls=%d, want initial analysis plus candidate decision only", vlmCalls)
+	if vlmCalls != 3 {
+		t.Fatalf("vlmCalls=%d, want initial analysis, candidate decision, and post-selection verification", vlmCalls)
 	}
-	if len(screenshot.calls) != 2 {
-		t.Fatalf("screenshot calls=%d, want no post-selection verification screenshot", len(screenshot.calls))
+	if len(screenshot.calls) != 3 {
+		t.Fatalf("screenshot calls=%d, want post-selection verification screenshot", len(screenshot.calls))
 	}
-	initialCandidateSettleCount := 0
-	for _, delay := range sleeps {
-		if delay == textInputInitialCandidateDelay {
-			initialCandidateSettleCount++
-		}
+	if len(sleeps) < 2 {
+		t.Fatalf("delays=%v, want initial and post-selection candidate delays", sleeps)
 	}
-	if initialCandidateSettleCount != 1 {
-		t.Fatalf("initial candidate settle count=%d, want one pre-candidate settle and none after final selection; sleeps=%v", initialCandidateSettleCount, sleeps)
+	candidateDelays := sleeps[len(sleeps)-2:]
+	wantCandidateDelays := []time.Duration{
+		textInputInitialCandidateDelay,
+		textInputCandidateSettleDelay,
+	}
+	if !reflect.DeepEqual(candidateDelays, wantCandidateDelays) {
+		t.Fatalf("candidate delays=%v, want initial then post-selection delays %v; all sleeps=%v", candidateDelays, wantCandidateDelays, sleeps)
+	}
+}
+
+func TestCompletedCandidateSelectionDoesNotTrustModelPrediction(t *testing.T) {
+	vision := &stubTextInputVision{analyses: []textInputScreenAnalysis{
+		{
+			ObservedMode:       textInputModeComposition,
+			CompositionPending: true,
+		},
+		{
+			ObservedMode:       textInputModeComposition,
+			FieldText:          "ba zi ji",
+			CompositionPending: true,
+		},
+	}, actions: []textInputCandidateAction{
+		{
+			Action:        textInputCandidateActionSelect,
+			Text:          "把自己",
+			CompletesPart: true,
+		},
+		{Action: textInputCandidateActionNone},
+	}}
+	engine := newFastTextInputEngine(textInputHardwareDeps{
+		keyboardTap:  &recordingTextInputTool{name: "keyboard_tap", out: "ok"},
+		keyboardText: &recordingTextInputTool{name: "keyboard_text", out: "ok"},
+		screenshot:   textInputStubTool{name: "screenshot", out: `{"format":"jpeg","width":100,"height":100,"data":"abc"}`},
+	}, vision)
+
+	committed, _, _, _, err := engine.typeCompositionWithCandidateSelection(
+		context.Background(),
+		"ios",
+		textInputArgs{Text: "把自己", CurrentIMEPart: "把自己"},
+		[]string{"ba", "zi", "ji"},
+	)
+	if err != nil {
+		t.Fatalf("typeCompositionWithCandidateSelection() error=%v", err)
+	}
+	if committed {
+		t.Fatal("committed=true, want failure when post-selection analysis still shows a pending uncommitted candidate")
 	}
 }
 

--- a/src/agent/internal/agent/text_input_engine.go
+++ b/src/agent/internal/agent/text_input_engine.go
@@ -537,9 +537,11 @@ func (e *textInputEngine) analyzeActVerify(ctx context.Context, platform string,
 				selectedCandidateText += action.Text
 				candidateActions++
 				pageAttempts = 0
-				if action.CompletesPart {
-					return true, analysis.FieldText, false, vlmCalls, nil
-				}
+				// completes_part is the model's prediction, not proof that the
+				// keyboard committed the candidate. Always settle and inspect the
+				// field again, especially when this is the final IME part: an
+				// early return here bubbles up as enter_text success without
+				// verifying that the selection actually took effect.
 				if err := e.sleepFor(ctx, textInputCandidateSettleDelay); err != nil {
 					return false, analysis.FieldText, false, vlmCalls, err
 				}
@@ -750,7 +752,7 @@ func (e *textInputEngine) typeCompositionWithCandidateSelection(ctx context.Cont
 	}
 	// Do not commit the IME's default candidate blindly. Analyze the live
 	// candidate list first; analyzeActVerify will execute the model-selected
-	// candidate action. A selection that completes the part returns immediately.
+	// candidate action and verify the resulting committed field.
 	if err := e.sleepFor(ctx, textInputInitialCandidateDelay); err != nil {
 		return false, fieldText, false, vlmCalls, err
 	}


### PR DESCRIPTION
## Summary
- remove the early success return based only on `completes_part`
- settle and re-analyze the field after every candidate selection
- add regression coverage for uncommitted final candidates

## Verification
- `cd src/agent && go test ./internal/agent -run 'Test(TextInput|EnterText|RunSegmented|Composition|Candidate|CompletedCandidate)' -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved candidate selection reliability by verifying the live input field after a selection.
  * Added separate settling periods before and after selection to ensure the updated field is accurately analyzed.
  * Prevented completion from being reported when follow-up analysis still detects a pending candidate.
  * Improved handling of input methods that require additional processing before a candidate is committed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->