### PR TITLE
fix(tts): handle UTF-8 sentence boundaries in OpenRouter

### DIFF
--- a/src/agent/internal/agent/tts/adapters/openrouter/session.go
+++ b/src/agent/internal/agent/tts/adapters/openrouter/session.go
@@ -23,19 +23,19 @@ type session struct {
 	mu         sync.Mutex
 	textBuffer *bytes.Buffer
 	closed     bool
+	finalized  bool
 	lastErr    error
 }
 
 func (s *session) WriteText(text string) error {
-	if text == "" {
-		return nil
-	}
-
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.closed {
-		return fmt.Errorf("session closed")
+		return s.sessionErr()
+	}
+	if text == "" {
+		return nil
 	}
 
 	s.textBuffer.WriteString(text)
@@ -43,8 +43,14 @@ func (s *session) WriteText(text string) error {
 	// Find sentence boundary and synthesize only up to it, retaining remainder.
 	bufferedText := s.textBuffer.String()
 	if idx := lastSentenceBoundary(bufferedText); idx >= 0 {
-		_, boundarySize := utf8.DecodeRuneInString(bufferedText[idx:])
-		return s.synthesizeUpTo(idx + boundarySize)
+		endIdx, err := runeEndIndex(bufferedText, idx)
+		if err == nil {
+			err = s.synthesizeUpTo(endIdx)
+		}
+		if err != nil {
+			s.closed = true
+			return s.recordErr(err)
+		}
 	}
 	return nil
 }
@@ -53,29 +59,37 @@ func (s *session) Flush() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if s.closed {
+		return s.sessionErr()
+	}
 	if s.textBuffer.Len() == 0 {
 		return nil
 	}
-	return s.synthesizeAndClear()
+	if err := s.synthesizeAndClear(); err != nil {
+		s.closed = true
+		return s.recordErr(err)
+	}
+	return nil
 }
 
 func (s *session) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.closed {
+	if s.finalized {
 		return s.lastErr
 	}
 	s.closed = true
+	s.finalized = true
 
-	if s.textBuffer.Len() > 0 {
-		if err := s.synthesizeAndClear(); err != nil && s.lastErr == nil {
-			s.lastErr = err
+	if s.lastErr == nil && s.textBuffer.Len() > 0 {
+		if err := s.synthesizeAndClear(); err != nil {
+			s.recordErr(err)
 		}
 	}
 
-	if err := s.sink.Drain(s.ctx); err != nil && s.lastErr == nil {
-		s.lastErr = err
+	if err := s.sink.Drain(s.ctx); err != nil {
+		s.recordErr(err)
 	}
 
 	return s.lastErr
@@ -85,6 +99,24 @@ func (s *session) Err() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.lastErr
+}
+
+// recordErr stores and returns the first session error.
+// Must be called with s.mu held.
+func (s *session) recordErr(err error) error {
+	if err != nil && s.lastErr == nil {
+		s.lastErr = err
+	}
+	return s.lastErr
+}
+
+// sessionErr returns the stored failure, or the generic closed-session error.
+// Must be called with s.mu held.
+func (s *session) sessionErr() error {
+	if s.lastErr != nil {
+		return s.lastErr
+	}
+	return tts.ErrSessionClosed
 }
 
 // ResetBuffer drops any buffered text not yet synthesized.
@@ -111,7 +143,12 @@ func (s *session) synthesizeAndClear() error {
 // Must be called with s.mu held.
 func (s *session) synthesizeUpTo(endIdx int) error {
 	text := s.textBuffer.String()
-	if endIdx <= 0 || endIdx > len(text) {
+	if endIdx < 0 || endIdx > len(text) {
+		return nil
+	}
+	// Zero is a valid end index: it selects an empty prefix and leaves the
+	// entire buffer pending for a later synthesis.
+	if endIdx == 0 {
 		return nil
 	}
 
@@ -143,15 +180,13 @@ func (s *session) synthesize(text string) error {
 
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
-		s.lastErr = fmt.Errorf("marshal request: %w", err)
-		return s.lastErr
+		return s.recordErr(fmt.Errorf("marshal request: %w", err))
 	}
 
 	url := fmt.Sprintf("%s/audio/speech", s.adapter.endpoint)
 	req, err := http.NewRequestWithContext(s.ctx, "POST", url, bytes.NewReader(jsonData))
 	if err != nil {
-		s.lastErr = fmt.Errorf("create request: %w", err)
-		return s.lastErr
+		return s.recordErr(fmt.Errorf("create request: %w", err))
 	}
 
 	req.Header.Set("Authorization", "Bearer "+s.adapter.apiKey)
@@ -159,42 +194,39 @@ func (s *session) synthesize(text string) error {
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		s.lastErr = fmt.Errorf("send request: %w", err)
-		return s.lastErr
+		return s.recordErr(fmt.Errorf("send request: %w", err))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		s.lastErr = fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
-		return s.lastErr
+		return s.recordErr(fmt.Errorf("API error %d: %s", resp.StatusCode, string(body)))
 	}
 
 	// Response is raw PCM s16le audio stream.
 	pcmData, err := io.ReadAll(resp.Body)
 	if err != nil {
-		s.lastErr = fmt.Errorf("read audio: %w", err)
-		return s.lastErr
+		return s.recordErr(fmt.Errorf("read audio: %w", err))
 	}
 
 	if len(pcmData) > 0 {
 		if err := s.sink.WritePCM(pcmData); err != nil {
-			s.lastErr = err
-			return fmt.Errorf("write pcm: %w", err)
+			return s.recordErr(fmt.Errorf("write pcm: %w", err))
 		}
 	}
 
 	return nil
 }
 
-func containsSentenceBoundary(text string) bool {
-	for _, r := range text {
-		switch r {
-		case '.', '!', '?', '\n', '。', '！', '？', '；':
-			return true
-		}
+func runeEndIndex(text string, startIdx int) (int, error) {
+	if startIdx < 0 || startIdx >= len(text) {
+		return 0, fmt.Errorf("rune start index %d out of range", startIdx)
 	}
-	return false
+	r, size := utf8.DecodeRuneInString(text[startIdx:])
+	if r == utf8.RuneError && size == 1 {
+		return 0, fmt.Errorf("invalid UTF-8 at byte %d", startIdx)
+	}
+	return startIdx + size, nil
 }
 
 // lastSentenceBoundary returns the byte index of the last sentence boundary

--- a/src/agent/internal/agent/tts/adapters/openrouter/session.go
+++ b/src/agent/internal/agent/tts/adapters/openrouter/session.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"aiden-agent/internal/agent/tts"
 )
@@ -39,9 +40,11 @@ func (s *session) WriteText(text string) error {
 
 	s.textBuffer.WriteString(text)
 
-	// Find sentence boundary and synthesize only up to it, retaining remainder
-	if idx := lastSentenceBoundary(s.textBuffer.String()); idx >= 0 {
-		return s.synthesizeUpTo(idx + 1) // +1 to include the boundary char
+	// Find sentence boundary and synthesize only up to it, retaining remainder.
+	bufferedText := s.textBuffer.String()
+	if idx := lastSentenceBoundary(bufferedText); idx >= 0 {
+		_, boundarySize := utf8.DecodeRuneInString(bufferedText[idx:])
+		return s.synthesizeUpTo(idx + boundarySize)
 	}
 	return nil
 }
@@ -194,15 +197,17 @@ func containsSentenceBoundary(text string) bool {
 	return false
 }
 
-// lastSentenceBoundary returns the index of the last sentence boundary char in text, or -1 if none.
+// lastSentenceBoundary returns the byte index of the last sentence boundary
+// rune in text, or -1 if none.
 func lastSentenceBoundary(text string) int {
-	for i := len(text) - 1; i >= 0; i-- {
-		switch rune(text[i]) {
+	last := -1
+	for i, r := range text {
+		switch r {
 		case '.', '!', '?', '\n', '。', '！', '？', '；':
-			return i
+			last = i
 		}
 	}
-	return -1
+	return last
 }
 
 type speechRequest struct {

--- a/src/agent/internal/agent/tts/adapters/openrouter/session_test.go
+++ b/src/agent/internal/agent/tts/adapters/openrouter/session_test.go
@@ -1,0 +1,123 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"aiden-agent/internal/agent/tts"
+)
+
+func TestLastSentenceBoundaryHandlesUTF8Punctuation(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want int
+	}{
+		{name: "none", text: "没有结束符", want: -1},
+		{name: "ascii", text: "English. remainder", want: len("English")},
+		{name: "period", text: "第一句。后续", want: len("第一句")},
+		{name: "exclamation", text: "第一句！后续", want: len("第一句")},
+		{name: "question", text: "第一句？后续", want: len("第一句")},
+		{name: "semicolon", text: "第一句；后续", want: len("第一句")},
+		{name: "last boundary", text: "第一句。第二句！后续", want: len("第一句。第二句")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lastSentenceBoundary(tt.text); got != tt.want {
+				t.Fatalf("lastSentenceBoundary(%q) = %d, want %d", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionSynthesizesCompleteChineseSentences(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		inputs []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request speechRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		inputs = append(inputs, request.Input)
+		mu.Unlock()
+		_, _ = w.Write([]byte{0, 1, 2, 3})
+	}))
+	defer server.Close()
+
+	provider, err := New(tts.ProviderConfig{APIKey: "test-key", Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer provider.Close()
+
+	sink := &openRouterTestSink{}
+	session, err := provider.BeginStream(context.Background(), sink)
+	if err != nil {
+		t.Fatalf("BeginStream() error = %v", err)
+	}
+
+	if err := session.WriteText("第一句"); err != nil {
+		t.Fatalf("WriteText(first fragment) error = %v", err)
+	}
+	if err := session.WriteText("。第二句！第三句？第四句；余下"); err != nil {
+		t.Fatalf("WriteText(second fragment) error = %v", err)
+	}
+	mu.Lock()
+	gotInputs := append([]string(nil), inputs...)
+	mu.Unlock()
+	if len(gotInputs) != 1 || gotInputs[0] != "第一句。第二句！第三句？第四句；" {
+		t.Fatalf("synthesized inputs after WriteText = %#v, want complete Chinese sentences", gotInputs)
+	}
+
+	if err := session.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	mu.Lock()
+	gotInputs = append([]string(nil), inputs...)
+	mu.Unlock()
+	if len(gotInputs) != 2 || gotInputs[1] != "余下" {
+		t.Fatalf("synthesized inputs after Flush = %#v, want remainder %q", gotInputs, "余下")
+	}
+
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if !sink.drained {
+		t.Fatal("Close() did not drain the sink")
+	}
+}
+
+type openRouterTestSink struct {
+	mu      sync.Mutex
+	pcm     []byte
+	drained bool
+}
+
+func (s *openRouterTestSink) Format() tts.AudioFormat {
+	return tts.AudioFormat{SampleRate: 24000, Channels: 1, BitWidth: 16}
+}
+
+func (s *openRouterTestSink) WritePCM(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pcm = append(s.pcm, data...)
+	return nil
+}
+
+func (s *openRouterTestSink) Drain(context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.drained = true
+	return nil
+}
+
+func (s *openRouterTestSink) Stop() error { return nil }

--- a/src/agent/internal/agent/tts/adapters/openrouter/session_test.go
+++ b/src/agent/internal/agent/tts/adapters/openrouter/session_test.go
@@ -1,10 +1,13 @@
 package openrouter
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -35,64 +38,162 @@ func TestLastSentenceBoundaryHandlesUTF8Punctuation(t *testing.T) {
 	}
 }
 
-func TestSessionSynthesizesCompleteChineseSentences(t *testing.T) {
-	var (
-		mu     sync.Mutex
-		inputs []string
-	)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestSessionSentenceBuffering(t *testing.T) {
+	tests := []struct {
+		name       string
+		fragments  []string
+		flush      bool
+		wantInputs []string
+	}{
+		{name: "empty text", fragments: []string{""}},
+		{name: "whitespace only", fragments: []string{" \t", "\n"}},
+		{name: "punctuation only", fragments: []string{"。！？"}, wantInputs: []string{"。！？"}},
+		{name: "consecutive punctuation", fragments: []string{"你好！？继续"}, wantInputs: []string{"你好！？"}},
+		{name: "ends at boundary", fragments: []string{"完整句。"}, wantInputs: []string{"完整句。"}},
+		{name: "mixed punctuation", fragments: []string{"One.二！Three?四；尾巴"}, wantInputs: []string{"One.二！Three?四；"}},
+		{name: "single character and punctuation", fragments: []string{"啊。"}, wantInputs: []string{"啊。"}},
+		{name: "multiple fragments without boundary", fragments: []string{"多次", "写入", "仍无边界"}, flush: true, wantInputs: []string{"多次写入仍无边界"}},
+		{
+			name:       "complete sentences and remainder",
+			fragments:  []string{"第一句", "。第二句！第三句？第四句；余下"},
+			flush:      true,
+			wantInputs: []string{"第一句。第二句！第三句？第四句；", "余下"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := newOpenRouterRequestRecorder(t, http.StatusOK)
+			defer recorder.Close()
+
+			session, sink := newOpenRouterTestSession(t, recorder.URL)
+			for i, fragment := range tt.fragments {
+				if err := session.WriteText(fragment); err != nil {
+					t.Fatalf("WriteText(fragment %d) error = %v", i, err)
+				}
+			}
+			if tt.flush {
+				if err := session.Flush(); err != nil {
+					t.Fatalf("Flush() error = %v", err)
+				}
+			}
+
+			assertRecordedInputs(t, recorder.Inputs(), tt.wantInputs)
+
+			if err := session.Close(); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+			if !sink.isDrained() {
+				t.Fatal("Close() did not drain the sink")
+			}
+		})
+	}
+}
+
+func TestSessionWriteFailureClosesSessionAndPreservesFirstError(t *testing.T) {
+	recorder := newOpenRouterRequestRecorder(t, http.StatusInternalServerError)
+	defer recorder.Close()
+
+	session, sink := newOpenRouterTestSession(t, recorder.URL)
+	firstErr := session.WriteText("第一句。")
+	if firstErr == nil || !strings.Contains(firstErr.Error(), "API error 500") {
+		t.Fatalf("WriteText(first) error = %v, want API error 500", firstErr)
+	}
+
+	secondErr := session.WriteText("第二句。")
+	if !errors.Is(secondErr, firstErr) {
+		t.Fatalf("WriteText(second) error = %v, want first error %v", secondErr, firstErr)
+	}
+	assertRecordedInputs(t, recorder.Inputs(), []string{"第一句。"})
+
+	if closeErr := session.Close(); !errors.Is(closeErr, firstErr) {
+		t.Fatalf("Close() error = %v, want first error %v", closeErr, firstErr)
+	}
+	if !sink.isDrained() {
+		t.Fatal("Close() did not drain the sink after WriteText failure")
+	}
+}
+
+func TestRuneEndIndexRejectsInvalidUTF8(t *testing.T) {
+	_, err := runeEndIndex(string([]byte{0xff}), 0)
+	if err == nil {
+		t.Fatal("runeEndIndex() error = nil, want invalid UTF-8 error")
+	}
+}
+
+func TestSessionSynthesizeUpToAcceptsZeroIndex(t *testing.T) {
+	session := &session{textBuffer: bytes.NewBufferString("pending")}
+	if err := session.synthesizeUpTo(0); err != nil {
+		t.Fatalf("synthesizeUpTo(0) error = %v", err)
+	}
+	if got := session.textBuffer.String(); got != "pending" {
+		t.Fatalf("buffer after synthesizeUpTo(0) = %q, want %q", got, "pending")
+	}
+}
+
+type openRouterRequestRecorder struct {
+	*httptest.Server
+
+	mu     sync.Mutex
+	inputs []string
+}
+
+func newOpenRouterRequestRecorder(t *testing.T, status int) *openRouterRequestRecorder {
+	t.Helper()
+	recorder := &openRouterRequestRecorder{}
+	recorder.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var request speechRequest
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		mu.Lock()
-		inputs = append(inputs, request.Input)
-		mu.Unlock()
+		recorder.mu.Lock()
+		recorder.inputs = append(recorder.inputs, request.Input)
+		recorder.mu.Unlock()
+		if status != http.StatusOK {
+			http.Error(w, "synthesis failed", status)
+			return
+		}
 		_, _ = w.Write([]byte{0, 1, 2, 3})
 	}))
-	defer server.Close()
+	return recorder
+}
 
-	provider, err := New(tts.ProviderConfig{APIKey: "test-key", Endpoint: server.URL})
+func (r *openRouterRequestRecorder) Inputs() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.inputs...)
+}
+
+func newOpenRouterTestSession(t *testing.T, endpoint string) (tts.StreamSession, *openRouterTestSink) {
+	t.Helper()
+	provider, err := New(tts.ProviderConfig{APIKey: "test-key", Endpoint: endpoint})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
-	defer provider.Close()
+	t.Cleanup(func() {
+		if err := provider.Close(); err != nil {
+			t.Errorf("provider.Close() error = %v", err)
+		}
+	})
 
 	sink := &openRouterTestSink{}
-	session, err := provider.BeginStream(context.Background(), sink)
+	stream, err := provider.BeginStream(context.Background(), sink)
 	if err != nil {
 		t.Fatalf("BeginStream() error = %v", err)
 	}
+	return stream, sink
+}
 
-	if err := session.WriteText("第一句"); err != nil {
-		t.Fatalf("WriteText(first fragment) error = %v", err)
+func assertRecordedInputs(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("request count = %d, want %d; inputs = %#v", len(got), len(want), got)
 	}
-	if err := session.WriteText("。第二句！第三句？第四句；余下"); err != nil {
-		t.Fatalf("WriteText(second fragment) error = %v", err)
-	}
-	mu.Lock()
-	gotInputs := append([]string(nil), inputs...)
-	mu.Unlock()
-	if len(gotInputs) != 1 || gotInputs[0] != "第一句。第二句！第三句？第四句；" {
-		t.Fatalf("synthesized inputs after WriteText = %#v, want complete Chinese sentences", gotInputs)
-	}
-
-	if err := session.Flush(); err != nil {
-		t.Fatalf("Flush() error = %v", err)
-	}
-	mu.Lock()
-	gotInputs = append([]string(nil), inputs...)
-	mu.Unlock()
-	if len(gotInputs) != 2 || gotInputs[1] != "余下" {
-		t.Fatalf("synthesized inputs after Flush = %#v, want remainder %q", gotInputs, "余下")
-	}
-
-	if err := session.Close(); err != nil {
-		t.Fatalf("Close() error = %v", err)
-	}
-	if !sink.drained {
-		t.Fatal("Close() did not drain the sink")
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("request %d input = %q, want %q", i, got[i], want[i])
+		}
 	}
 }
 
@@ -118,6 +219,12 @@ func (s *openRouterTestSink) Drain(context.Context) error {
 	defer s.mu.Unlock()
 	s.drained = true
 	return nil
+}
+
+func (s *openRouterTestSink) isDrained() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.drained
 }
 
 func (s *openRouterTestSink) Stop() error { return nil }


### PR DESCRIPTION
## Summary

- Fix OpenRouter TTS sentence boundary detection for UTF-8 punctuation.
- Preserve complete multibyte punctuation when slicing buffered text.
- Add unit and HTTP integration coverage for Chinese sentence streaming.

## Tests

- `go test -race ./internal/agent/tts/adapters/openrouter`
- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text-to-speech sentence detection for multi-byte UTF-8 punctuation, including Chinese punctuation.
  - Ensured complete sentences are synthesized correctly when text is streamed or flushed.
  - Improved handling of pending audio when closing a text-to-speech session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->