### PR TITLE
fix(audio): reject playback writes after final chunk

### DIFF
--- a/src/audio_playback_session.cpp
+++ b/src/audio_playback_session.cpp
@@ -62,18 +62,29 @@ AidenServiceStatus AudioPlaybackSession::push_chunk(const uint8_t* data, size_t 
     if (stopped_.load()) return AidenServiceStatus::SESSION_NOT_FOUND;
 
     std::unique_lock<std::mutex> lock(mutex_);
+    if (final_received_) return AidenServiceStatus::SESSION_NOT_FOUND;
+
     if (queue_.size() >= kMaxQueueChunks) {
         // Apply back-pressure: wait for the queue to drain a bit.
         cv_.wait_for(lock, std::chrono::milliseconds(200),
-                     [this] { return queue_.size() < kMaxQueueChunks / 2 || stopped_.load(); });
-        if (stopped_.load()) return AidenServiceStatus::SESSION_NOT_FOUND;
+                     [this] {
+                         return queue_.size() < kMaxQueueChunks / 2 ||
+                                final_received_ || stopped_.load();
+                     });
+        if (final_received_ || stopped_.load()) {
+            return AidenServiceStatus::SESSION_NOT_FOUND;
+        }
     }
 
     if (data && len > 0) {
         queue_.push(std::vector<uint8_t>(data, data + len));
     }
     if (is_final) final_received_ = true;
-    cv_.notify_one();
+    if (is_final) {
+        cv_.notify_all();
+    } else {
+        cv_.notify_one();
+    }
     return AidenServiceStatus::OK;
 }
 

--- a/src/audio_session_manager.cpp
+++ b/src/audio_session_manager.cpp
@@ -217,24 +217,24 @@ AidenServiceStatus AudioSessionManager::write_play_chunk(uint64_t session_id,
         // Move the session into a draining set so no further writes are
         // accepted, but stop_playback() can still interrupt the tail drain.
         std::shared_ptr<AudioPlaybackSession> owned;
-        std::shared_ptr<DrainingPlaybackState> draining_state;
+        const std::shared_ptr<DrainingPlaybackState> draining_state =
+            draining_playback_state_;
         {
             std::lock_guard<std::mutex> lock(mutex_);
             auto it = playback_sessions_.find(session_id);
             if (it != playback_sessions_.end()) {
                 owned = it->second;
+                // Publish the draining state before removing the active
+                // entry. start_playback() and stop_playback() both serialize
+                // on mutex_, so they cannot observe a partially moved session.
+                std::lock_guard<std::mutex> draining_lock(draining_state->mutex);
+                draining_state->sessions[session_id] = owned;
+                draining_state->count.fetch_add(1, std::memory_order_release);
                 playback_sessions_.erase(it);
-                draining_state = draining_playback_state_;
             }
             playback_last_active_.erase(session_id);
         }
         if (owned && draining_state) {
-            {
-                std::lock_guard<std::mutex> draining_lock(draining_state->mutex);
-                draining_state->sessions[session_id] = owned;
-            }
-            draining_state->count.fetch_add(1, std::memory_order_release);
-
             // Keep the draining session alive on a detached thread until the
             // playback thread exits or stop_playback() interrupts it.
             std::thread([session_id, owned, draining_state]() {

--- a/tests/audio_playback_session_test.cpp
+++ b/tests/audio_playback_session_test.cpp
@@ -57,15 +57,17 @@ TEST_CASE("backpressure writers fail when final state is published") {
 
     const size_t writer_count = 8;
     std::atomic<size_t> ready(0);
+    std::atomic<size_t> completed(0);
     std::vector<aiden::AidenServiceStatus> statuses(
         writer_count, aiden::AidenServiceStatus::INTERNAL_ERROR);
     std::unique_lock<std::mutex> session_lock(session.mutex_);
     std::vector<std::thread> writers;
     writers.reserve(writer_count);
     for (size_t i = 0; i < writer_count; ++i) {
-        writers.push_back(std::thread([&session, &chunk, &ready, &statuses, i]() {
+        writers.push_back(std::thread([&session, &chunk, &ready, &completed, &statuses, i]() {
             ready.fetch_add(1, std::memory_order_release);
             statuses[i] = session.push_chunk(chunk, sizeof(chunk), false);
+            completed.fetch_add(1, std::memory_order_release);
         }));
     }
     while (ready.load(std::memory_order_acquire) != writer_count) {
@@ -74,15 +76,27 @@ TEST_CASE("backpressure writers fail when final state is published") {
     session_lock.unlock();
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
-    // Publish the final state under the same mutex as push_chunk(). Removing
-    // one queued chunk models playback making room for the final chunk.
+    // Make room without notifying the waiting writers, then let a real final
+    // push publish final_received_ and wake them all.
     session_lock.lock();
     CHECK(session.queue_.size() == max_queue_chunks);
-    session.queue_.pop();
-    session.queue_.push(std::vector<uint8_t>(chunk, chunk + sizeof(chunk)));
-    session.final_received_ = true;
+    while (session.queue_.size() >= max_queue_chunks / 2) session.queue_.pop();
+    aiden::AidenServiceStatus final_status = aiden::AidenServiceStatus::INTERNAL_ERROR;
+    std::thread final_writer([&session, &chunk, &final_status]() {
+        final_status = session.push_chunk(chunk, sizeof(chunk), true);
+    });
     session_lock.unlock();
-    session.cv_.notify_all();
+
+    final_writer.join();
+    CHECK(final_status == aiden::AidenServiceStatus::OK);
+
+    const auto wake_deadline = std::chrono::steady_clock::now() +
+                               std::chrono::milliseconds(100);
+    while (completed.load(std::memory_order_acquire) != writer_count &&
+           std::chrono::steady_clock::now() < wake_deadline) {
+        std::this_thread::yield();
+    }
+    CHECK(completed.load(std::memory_order_acquire) == writer_count);
 
     for (size_t i = 0; i < writers.size(); ++i) writers[i].join();
 

--- a/tests/audio_playback_session_test.cpp
+++ b/tests/audio_playback_session_test.cpp
@@ -11,3 +11,21 @@ TEST_CASE("playback tail drain grace covers AO queued chunks") {
 
     CHECK(grace >= std::chrono::milliseconds(800));
 }
+
+TEST_CASE("playback session rejects chunks after final is received") {
+    aiden::AudioFormat fmt;
+    fmt.sample_rate = 16000;
+    fmt.channels = 1;
+    fmt.bit_width = 16;
+
+    aiden::AudioPlaybackSession session(1, fmt);
+    REQUIRE(session.start());
+
+    const uint8_t chunk[] = {1, 2, 3, 4};
+    REQUIRE(session.push_chunk(chunk, sizeof(chunk), true) ==
+            aiden::AidenServiceStatus::OK);
+    CHECK(session.push_chunk(chunk, sizeof(chunk), false) ==
+          aiden::AidenServiceStatus::SESSION_NOT_FOUND);
+
+    session.stop();
+}

--- a/tests/audio_playback_session_test.cpp
+++ b/tests/audio_playback_session_test.cpp
@@ -1,5 +1,13 @@
 #include "doctest.h"
+
+#define private public
 #include "audio_playback_session.h"
+#undef private
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
 
 TEST_CASE("playback tail drain grace covers AO queued chunks") {
     aiden::AudioFormat fmt;
@@ -28,4 +36,57 @@ TEST_CASE("playback session rejects chunks after final is received") {
           aiden::AidenServiceStatus::SESSION_NOT_FOUND);
 
     session.stop();
+}
+
+TEST_CASE("backpressure writers fail when final state is published") {
+    aiden::AudioFormat fmt;
+    fmt.sample_rate = 16000;
+    fmt.channels = 1;
+    fmt.bit_width = 16;
+
+    aiden::AudioPlaybackSession session(2, fmt);
+
+    const uint8_t chunk[] = {1, 2, 3, 4};
+    const size_t max_queue_chunks = 128;
+    {
+        std::lock_guard<std::mutex> lock(session.mutex_);
+        for (size_t i = 0; i < max_queue_chunks; ++i) {
+            session.queue_.push(std::vector<uint8_t>(chunk, chunk + sizeof(chunk)));
+        }
+    }
+
+    const size_t writer_count = 8;
+    std::atomic<size_t> ready(0);
+    std::vector<aiden::AidenServiceStatus> statuses(
+        writer_count, aiden::AidenServiceStatus::INTERNAL_ERROR);
+    std::unique_lock<std::mutex> session_lock(session.mutex_);
+    std::vector<std::thread> writers;
+    writers.reserve(writer_count);
+    for (size_t i = 0; i < writer_count; ++i) {
+        writers.push_back(std::thread([&session, &chunk, &ready, &statuses, i]() {
+            ready.fetch_add(1, std::memory_order_release);
+            statuses[i] = session.push_chunk(chunk, sizeof(chunk), false);
+        }));
+    }
+    while (ready.load(std::memory_order_acquire) != writer_count) {
+        std::this_thread::yield();
+    }
+    session_lock.unlock();
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    // Publish the final state under the same mutex as push_chunk(). Removing
+    // one queued chunk models playback making room for the final chunk.
+    session_lock.lock();
+    CHECK(session.queue_.size() == max_queue_chunks);
+    session.queue_.pop();
+    session.queue_.push(std::vector<uint8_t>(chunk, chunk + sizeof(chunk)));
+    session.final_received_ = true;
+    session_lock.unlock();
+    session.cv_.notify_all();
+
+    for (size_t i = 0; i < writers.size(); ++i) writers[i].join();
+
+    for (size_t i = 0; i < writer_count; ++i) {
+        CHECK(statuses[i] == aiden::AidenServiceStatus::SESSION_NOT_FOUND);
+    }
 }

--- a/tests/audio_session_manager_test.cpp
+++ b/tests/audio_session_manager_test.cpp
@@ -95,7 +95,7 @@ TEST_CASE("AudioSessionManager stops draining playback sessions") {
     CHECK(manager.stop_playback(session_id) == aiden::AidenServiceStatus::SESSION_NOT_FOUND);
 }
 
-TEST_CASE("AudioSessionManager publishes draining before removing active playback") {
+TEST_CASE("AudioSessionManager publishes draining before manager operations resume") {
     aiden::AudioSessionManager manager;
 
     aiden::AudioFormat fmt;
@@ -169,17 +169,33 @@ TEST_CASE("AudioSessionManager publishes draining before removing active playbac
         return;
     }
 
-    auto start_future = std::async(std::launch::async, [&manager, &fmt]() {
-        aiden::PlaybackStartResult out;
-        return manager.start_playback(fmt, &out);
-    });
-    CHECK(start_future.wait_for(std::chrono::milliseconds(50)) ==
-          std::future_status::timeout);
+    SUBCASE("start observes the draining session") {
+        auto start_future = std::async(std::launch::async, [&manager, &fmt]() {
+            aiden::PlaybackStartResult out;
+            return manager.start_playback(fmt, &out);
+        });
+        CHECK(start_future.wait_for(std::chrono::milliseconds(50)) ==
+              std::future_status::timeout);
 
-    draining_lock.unlock();
-    REQUIRE(final_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
-    CHECK(final_future.get() == aiden::AidenServiceStatus::OK);
-    REQUIRE(start_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
-    CHECK(start_future.get() == aiden::AidenServiceStatus::SERVICE_RECOVERING);
-    CHECK(manager.stop_playback(session_id) == aiden::AidenServiceStatus::OK);
+        draining_lock.unlock();
+        REQUIRE(final_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+        CHECK(final_future.get() == aiden::AidenServiceStatus::OK);
+        REQUIRE(start_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+        CHECK(start_future.get() == aiden::AidenServiceStatus::SERVICE_RECOVERING);
+        CHECK(manager.stop_playback(session_id) == aiden::AidenServiceStatus::OK);
+    }
+
+    SUBCASE("stop finds the draining session") {
+        auto stop_future = std::async(std::launch::async, [&manager, session_id]() {
+            return manager.stop_playback(session_id);
+        });
+        CHECK(stop_future.wait_for(std::chrono::milliseconds(50)) ==
+              std::future_status::timeout);
+
+        draining_lock.unlock();
+        REQUIRE(final_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+        CHECK(final_future.get() == aiden::AidenServiceStatus::OK);
+        REQUIRE(stop_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+        CHECK(stop_future.get() == aiden::AidenServiceStatus::OK);
+    }
 }

--- a/tests/audio_session_manager_test.cpp
+++ b/tests/audio_session_manager_test.cpp
@@ -4,6 +4,10 @@
 
 #include "doctest.h"
 
+#include <chrono>
+#include <future>
+#include <thread>
+
 TEST_CASE("AudioRecordSession captures at 16 kHz for a 24 kHz target") {
     aiden::AudioFormat fmt;
     fmt.sample_rate = 24000;
@@ -89,4 +93,93 @@ TEST_CASE("AudioSessionManager stops draining playback sessions") {
     CHECK(manager.stop_playback(session_id) == aiden::AidenServiceStatus::OK);
     CHECK(session->is_stopped());
     CHECK(manager.stop_playback(session_id) == aiden::AidenServiceStatus::SESSION_NOT_FOUND);
+}
+
+TEST_CASE("AudioSessionManager publishes draining before removing active playback") {
+    aiden::AudioSessionManager manager;
+
+    aiden::AudioFormat fmt;
+    fmt.sample_rate = 16000;
+    fmt.channels = 1;
+    fmt.bit_width = 16;
+
+    const uint64_t session_id = 100;
+    auto session = std::make_shared<aiden::AudioPlaybackSession>(session_id, fmt);
+    REQUIRE(session->start());
+    {
+        std::lock_guard<std::mutex> lock(manager.mutex_);
+        manager.playback_sessions_[session_id] = session;
+        manager.playback_last_active_[session_id] =
+            aiden::AudioSessionManager::Clock::now();
+    }
+
+    // Hold the draining lock so the migration must wait at its publication
+    // point. The manager lock must remain held until that publication is done.
+    std::unique_lock<std::mutex> draining_lock(manager.draining_playback_state_->mutex);
+    const uint8_t chunk[] = {1, 2, 3, 4};
+    auto final_future = std::async(std::launch::async, [&manager, session_id, &chunk]() {
+        return manager.write_play_chunk(session_id, chunk, sizeof(chunk), true);
+    });
+
+    bool final_received = false;
+    const auto final_deadline = std::chrono::steady_clock::now() +
+                                std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < final_deadline) {
+        {
+            std::lock_guard<std::mutex> lock(session->mutex_);
+            final_received = session->final_received_;
+        }
+        if (final_received) break;
+        std::this_thread::yield();
+    }
+    CHECK(final_received);
+    if (!final_received) {
+        draining_lock.unlock();
+        final_future.wait();
+        return;
+    }
+
+    // Once the migration starts, the manager lock must stay held while the
+    // draining lock is unavailable. The old ordering released it first.
+    bool migration_holds_manager = false;
+    const auto migration_deadline = std::chrono::steady_clock::now() +
+                                    std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < migration_deadline) {
+        if (manager.mutex_.try_lock()) {
+            manager.mutex_.unlock();
+            std::this_thread::yield();
+            continue;
+        }
+
+        migration_holds_manager = true;
+        for (int i = 0; i < 10; ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            if (manager.mutex_.try_lock()) {
+                manager.mutex_.unlock();
+                migration_holds_manager = false;
+                break;
+            }
+        }
+        if (migration_holds_manager) break;
+    }
+    CHECK(migration_holds_manager);
+    if (!migration_holds_manager) {
+        draining_lock.unlock();
+        final_future.wait();
+        return;
+    }
+
+    auto start_future = std::async(std::launch::async, [&manager, &fmt]() {
+        aiden::PlaybackStartResult out;
+        return manager.start_playback(fmt, &out);
+    });
+    CHECK(start_future.wait_for(std::chrono::milliseconds(50)) ==
+          std::future_status::timeout);
+
+    draining_lock.unlock();
+    REQUIRE(final_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+    CHECK(final_future.get() == aiden::AidenServiceStatus::OK);
+    REQUIRE(start_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+    CHECK(start_future.get() == aiden::AidenServiceStatus::SERVICE_RECOVERING);
+    CHECK(manager.stop_playback(session_id) == aiden::AidenServiceStatus::OK);
 }


### PR DESCRIPTION
## Summary

- reject playback chunks that race with or arrive after the final chunk
- wake back-pressured writers when the session becomes final so they fail explicitly instead of enqueueing unconsumed PCM
- add regression coverage for writes through a stale playback session reference

## Issue
- 播放会话结束与并发写入存在竞态，尾部音频可能被静默丢弃。
  src/audio_session_manager.cpp:214 在 is_final 写入后把会话移入 draining 集合，但其他已经拿到 shared_ptr 的并发写入仍可继续向该会话入队。src/
audio_playback_session.cpp:117 进入尾部
  等待后不会再消费新入队数据，因此并发到达的 PCM 可能被直接丢掉。

## Testing

- `ctest --test-dir build-host --output-on-failure`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented audio chunks from being accepted after a playback session has received its final chunk.
  * Improved concurrent playback handling so waiting operations stop promptly when a session is finalized.
  * Ensured finalized sessions transition reliably into draining state without race conditions.

* **Tests**
  * Added coverage for finalized-session writes, concurrent writers, and playback-session draining behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->