### PR TITLE
fix(audio): serialize playback player operations

### DIFF
--- a/src/audio_playback_session.cpp
+++ b/src/audio_playback_session.cpp
@@ -19,10 +19,13 @@ bool AudioPlaybackSession::start() {
     cfg.channels    = static_cast<int>(fmt_.channels);
     cfg.bit_width   = static_cast<int>(fmt_.bit_width);
 
-    if (!player_.init(cfg)) {
-        AIDEN_LOG_ERROR("playback", "player_init_failed", "session_id=%llu",
-                        static_cast<unsigned long long>(session_id_));
-        return false;
+    {
+        std::lock_guard<std::mutex> player_lock(player_mutex_);
+        if (!player_.init(cfg)) {
+            AIDEN_LOG_ERROR("playback", "player_init_failed", "session_id=%llu",
+                            static_cast<unsigned long long>(session_id_));
+            return false;
+        }
     }
 
     playback_thread_ = std::thread(&AudioPlaybackSession::playback_loop, this);
@@ -50,10 +53,13 @@ void AudioPlaybackSession::stop() {
 
 bool AudioPlaybackSession::set_volume(int volume) {
     if (stopped_.load()) return false;
+    std::lock_guard<std::mutex> player_lock(player_mutex_);
+    if (stopped_.load()) return false;
     return player_.set_volume(volume);
 }
 
 int AudioPlaybackSession::get_volume() const {
+    std::lock_guard<std::mutex> player_lock(player_mutex_);
     return player_.get_volume();
 }
 
@@ -99,6 +105,7 @@ void AudioPlaybackSession::playback_loop() {
             if (stopped_.load()) {
                 AIDEN_LOG_INFO("playback", "interrupted_before_drain", "session_id=%llu",
                                static_cast<unsigned long long>(session_id_));
+                std::lock_guard<std::mutex> player_lock(player_mutex_);
                 player_.stop();
                 return;
             }
@@ -122,6 +129,7 @@ void AudioPlaybackSession::playback_loop() {
             if (stopped_.load()) {
                 AIDEN_LOG_INFO("playback", "interrupted_during_final_drain", "session_id=%llu",
                                static_cast<unsigned long long>(session_id_));
+                std::lock_guard<std::mutex> player_lock(player_mutex_);
                 player_.stop();
                 return;
             }
@@ -132,6 +140,8 @@ void AudioPlaybackSession::playback_loop() {
 
         if (!chunk.empty()) {
             while (!stopped_.load()) {
+                std::lock_guard<std::mutex> player_lock(player_mutex_);
+                if (stopped_.load()) break;
                 if (player_.play(chunk.data(), static_cast<uint32_t>(chunk.size()))) {
                     last_played_chunk_bytes = chunk.size();
                     break;
@@ -147,7 +157,10 @@ void AudioPlaybackSession::playback_loop() {
     }
 
     // Tear down hardware from the same thread that called SendFrame — safe.
-    player_.stop();
+    {
+        std::lock_guard<std::mutex> player_lock(player_mutex_);
+        player_.stop();
+    }
 }
 
 }  // namespace aiden

--- a/src/audio_playback_session.h
+++ b/src/audio_playback_session.h
@@ -81,6 +81,9 @@ private:
     uint64_t session_id_;
     AudioFormat fmt_;
     AudioPlayer player_;
+    // AudioPlayer and its Rockit state are not thread-safe; serialize every
+    // hardware operation, including playback teardown and volume updates.
+    mutable std::mutex player_mutex_;
     std::thread playback_thread_;
     std::mutex mutex_;
     std::condition_variable cv_;

--- a/tests/aiden_sdk_audio_stub.cpp
+++ b/tests/aiden_sdk_audio_stub.cpp
@@ -1,12 +1,114 @@
 #include "aiden_sdk.h"
+#include "audio_player_test_hooks.h"
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
 
 namespace aiden {
+
+namespace {
+
+const size_t kAudioPlayerOperationCount = 3;
+
+size_t operation_index(test::AudioPlayerOperation operation) {
+    return static_cast<size_t>(operation);
+}
+
+struct AudioPlayerTestState {
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool blocked[kAudioPlayerOperationCount] = {};
+    size_t entries[kAudioPlayerOperationCount] = {};
+    int active_operations = 0;
+    int max_active_operations = 0;
+};
+
+AudioPlayerTestState& audio_player_test_state() {
+    static AudioPlayerTestState state;
+    return state;
+}
+
+class AudioPlayerOperationGuard {
+public:
+    explicit AudioPlayerOperationGuard(test::AudioPlayerOperation operation)
+        : operation_(operation) {
+        AudioPlayerTestState& state = audio_player_test_state();
+        std::unique_lock<std::mutex> lock(state.mutex);
+        const size_t index = operation_index(operation_);
+        ++state.entries[index];
+        ++state.active_operations;
+        state.max_active_operations =
+            std::max(state.max_active_operations, state.active_operations);
+        state.cv.notify_all();
+        state.cv.wait(lock, [&state, index] { return !state.blocked[index]; });
+    }
+
+    ~AudioPlayerOperationGuard() {
+        AudioPlayerTestState& state = audio_player_test_state();
+        std::lock_guard<std::mutex> lock(state.mutex);
+        --state.active_operations;
+        state.cv.notify_all();
+    }
+
+private:
+    test::AudioPlayerOperation operation_;
+};
+
+}  // namespace
+
+namespace test {
+
+void reset_audio_player_test_state() {
+    AudioPlayerTestState& state = audio_player_test_state();
+    std::lock_guard<std::mutex> lock(state.mutex);
+    for (size_t i = 0; i < kAudioPlayerOperationCount; ++i) {
+        state.blocked[i] = false;
+        state.entries[i] = 0;
+    }
+    state.active_operations = 0;
+    state.max_active_operations = 0;
+    state.cv.notify_all();
+}
+
+void block_audio_player_operation(AudioPlayerOperation operation) {
+    AudioPlayerTestState& state = audio_player_test_state();
+    std::lock_guard<std::mutex> lock(state.mutex);
+    state.blocked[operation_index(operation)] = true;
+}
+
+bool wait_for_audio_player_operation(AudioPlayerOperation operation,
+                                     std::chrono::milliseconds timeout) {
+    AudioPlayerTestState& state = audio_player_test_state();
+    std::unique_lock<std::mutex> lock(state.mutex);
+    const size_t index = operation_index(operation);
+    return state.cv.wait_for(lock, timeout, [&state, index] {
+        return state.entries[index] > 0;
+    });
+}
+
+void unblock_audio_player_operation(AudioPlayerOperation operation) {
+    AudioPlayerTestState& state = audio_player_test_state();
+    std::lock_guard<std::mutex> lock(state.mutex);
+    state.blocked[operation_index(operation)] = false;
+    state.cv.notify_all();
+}
+
+int max_concurrent_audio_player_operations() {
+    AudioPlayerTestState& state = audio_player_test_state();
+    std::lock_guard<std::mutex> lock(state.mutex);
+    return state.max_active_operations;
+}
+
+}  // namespace test
 
 class AudioCaptureImpl {};
 class AudioPlayerImpl {
 public:
-    int volume = 100;
-    bool initialized = false;
+    std::atomic<int> volume{100};
+    std::atomic<bool> initialized{false};
 };
 
 AudioCapture::AudioCapture() : impl_(new AudioCaptureImpl()) {}
@@ -23,22 +125,30 @@ AudioPlayer::AudioPlayer() : impl_(new AudioPlayerImpl()) {}
 AudioPlayer::~AudioPlayer() {}
 
 bool AudioPlayer::init(const AudioConfig&) {
-    impl_->initialized = true;
+    impl_->initialized.store(true);
     return true;
 }
 
-bool AudioPlayer::play(const void*, uint32_t) { return impl_->initialized; }
+bool AudioPlayer::play(const void*, uint32_t) {
+    AudioPlayerOperationGuard guard(test::AudioPlayerOperation::PLAY);
+    return impl_->initialized.load();
+}
 bool AudioPlayer::play(const AudioFrame& frame) { return play(frame.data, frame.length); }
-void AudioPlayer::stop() {}
+void AudioPlayer::stop() {
+    AudioPlayerOperationGuard guard(test::AudioPlayerOperation::STOP);
+    impl_->initialized.store(false);
+}
 void AudioPlayer::pause() {}
 void AudioPlayer::resume() {}
 
 bool AudioPlayer::set_volume(int volume) {
-    impl_->volume = volume;
+    AudioPlayerOperationGuard guard(test::AudioPlayerOperation::SET_VOLUME);
+    if (!impl_->initialized.load()) return false;
+    impl_->volume.store(volume);
     return true;
 }
 
-int AudioPlayer::get_volume() const { return impl_->volume; }
-bool AudioPlayer::is_initialized() const { return impl_->initialized; }
+int AudioPlayer::get_volume() const { return impl_->volume.load(); }
+bool AudioPlayer::is_initialized() const { return impl_->initialized.load(); }
 
 }  // namespace aiden

--- a/tests/audio_playback_session_test.cpp
+++ b/tests/audio_playback_session_test.cpp
@@ -1,5 +1,28 @@
 #include "doctest.h"
 #include "audio_playback_session.h"
+#include "audio_player_test_hooks.h"
+
+#include <chrono>
+#include <future>
+
+namespace {
+
+class ScopedAudioPlayerOperationBlock {
+public:
+    explicit ScopedAudioPlayerOperationBlock(aiden::test::AudioPlayerOperation operation)
+        : operation_(operation) {
+        aiden::test::block_audio_player_operation(operation_);
+    }
+
+    ~ScopedAudioPlayerOperationBlock() {
+        aiden::test::unblock_audio_player_operation(operation_);
+    }
+
+private:
+    aiden::test::AudioPlayerOperation operation_;
+};
+
+}  // namespace
 
 TEST_CASE("playback tail drain grace covers AO queued chunks") {
     aiden::AudioFormat fmt;
@@ -10,4 +33,91 @@ TEST_CASE("playback tail drain grace covers AO queued chunks") {
     const auto grace = aiden::playback_tail_drain_grace(fmt, 4096);
 
     CHECK(grace >= std::chrono::milliseconds(800));
+}
+
+TEST_CASE("volume updates are serialized with active playback") {
+    using aiden::test::AudioPlayerOperation;
+
+    aiden::test::reset_audio_player_test_state();
+
+    aiden::AudioFormat fmt;
+    fmt.sample_rate = 16000;
+    fmt.channels = 1;
+    fmt.bit_width = 16;
+
+    aiden::AudioPlaybackSession session(1, fmt);
+    REQUIRE(session.start());
+    std::future<bool> volume_result;
+    std::promise<void> volume_started;
+    std::future<void> volume_started_result = volume_started.get_future();
+    ScopedAudioPlayerOperationBlock blocked_play(AudioPlayerOperation::PLAY);
+
+    const uint8_t pcm[] = {0, 0};
+    REQUIRE(session.push_chunk(pcm, sizeof(pcm), false) == aiden::AidenServiceStatus::OK);
+    REQUIRE(aiden::test::wait_for_audio_player_operation(
+        AudioPlayerOperation::PLAY, std::chrono::seconds(1)));
+
+    volume_result = std::async(std::launch::async, [&session, &volume_started] {
+        volume_started.set_value();
+        return session.set_volume(42);
+    });
+    REQUIRE(volume_started_result.wait_for(std::chrono::seconds(1)) ==
+            std::future_status::ready);
+
+    CHECK_FALSE(aiden::test::wait_for_audio_player_operation(
+        AudioPlayerOperation::SET_VOLUME, std::chrono::milliseconds(100)));
+
+    aiden::test::unblock_audio_player_operation(AudioPlayerOperation::PLAY);
+    REQUIRE(volume_result.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
+    CHECK(volume_result.get());
+
+    session.stop();
+    CHECK(aiden::test::max_concurrent_audio_player_operations() == 1);
+}
+
+TEST_CASE("player stop is serialized with an active volume update") {
+    using aiden::test::AudioPlayerOperation;
+
+    aiden::test::reset_audio_player_test_state();
+
+    aiden::AudioFormat fmt;
+    fmt.sample_rate = 16000;
+    fmt.channels = 1;
+    fmt.bit_width = 16;
+
+    aiden::AudioPlaybackSession session(2, fmt);
+    REQUIRE(session.start());
+    std::future<bool> volume_result;
+    std::promise<void> volume_started;
+    std::future<void> volume_started_result = volume_started.get_future();
+    ScopedAudioPlayerOperationBlock blocked_volume(AudioPlayerOperation::SET_VOLUME);
+
+    volume_result = std::async(std::launch::async, [&session, &volume_started] {
+        volume_started.set_value();
+        return session.set_volume(37);
+    });
+    REQUIRE(volume_started_result.wait_for(std::chrono::seconds(1)) ==
+            std::future_status::ready);
+    REQUIRE(aiden::test::wait_for_audio_player_operation(
+        AudioPlayerOperation::SET_VOLUME, std::chrono::seconds(1)));
+
+    std::promise<void> stop_started;
+    std::future<void> stop_started_result = stop_started.get_future();
+    std::future<void> stop_result = std::async(std::launch::async, [&session, &stop_started] {
+        stop_started.set_value();
+        session.stop();
+    });
+    REQUIRE(stop_started_result.wait_for(std::chrono::seconds(1)) ==
+            std::future_status::ready);
+
+    CHECK_FALSE(aiden::test::wait_for_audio_player_operation(
+        AudioPlayerOperation::STOP, std::chrono::milliseconds(100)));
+
+    aiden::test::unblock_audio_player_operation(AudioPlayerOperation::SET_VOLUME);
+    REQUIRE(volume_result.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
+    CHECK(volume_result.get());
+    REQUIRE(stop_result.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
+    stop_result.get();
+
+    CHECK(aiden::test::max_concurrent_audio_player_operations() == 1);
 }

--- a/tests/audio_player_test_hooks.h
+++ b/tests/audio_player_test_hooks.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <chrono>
+
+namespace aiden {
+namespace test {
+
+enum class AudioPlayerOperation {
+    PLAY,
+    STOP,
+    SET_VOLUME,
+};
+
+void reset_audio_player_test_state();
+void block_audio_player_operation(AudioPlayerOperation operation);
+bool wait_for_audio_player_operation(AudioPlayerOperation operation,
+                                     std::chrono::milliseconds timeout);
+void unblock_audio_player_operation(AudioPlayerOperation operation);
+int max_concurrent_audio_player_operations();
+
+}  // namespace test
+}  // namespace aiden


### PR DESCRIPTION
## Problem

- 音量设置与播放/停止操作未同步，存在硬件调用和成员数据竞争。
  src/audio_session_manager.cpp:300 调用 AudioPlaybackSession::set_volume() 时，播放线程可能同时执行 player_.play()，另一个线程也可能执行 stop()。src/audio_playback_session.cpp:51 没有保护 AudioPlayer 的并发访问；在 C++ 中这属于未定义行为，设备上可能表现为音频中断或 Rockit API 异常。

`AudioPlaybackSession::set_volume()` could call `AudioPlayer::set_volume()` while the playback thread was inside `AudioPlayer::play()` or tearing the player down with `AudioPlayer::stop()`. `AudioPlayer` and its Rockit-backed member state are not thread-safe, so these overlaps caused C++ data races and could surface as interrupted audio or Rockit API failures.

No open pull request was found that modifies the affected playback session files.

## Changes

- Add a per-session mutex around every `AudioPlayer` operation: initialization, playback, teardown, and volume reads/writes.
- Recheck the stopped state after acquiring the player mutex so a waiting volume or playback call does not access hardware after shutdown begins.
- Extend the host audio stub with deterministic operation barriers and overlap tracking.
- Add regressions for volume changes racing with active playback and playback teardown. Both tests fail against the previous implementation because the stub observes two concurrent player operations.

## Validation

- `ctest --test-dir build-audio-race-tests --output-on-failure` — 15/15 passed.
- Ran both new concurrency tests 20 consecutive times — passed.
- `./build.sh binaries` — passed, including the ARM `audio_service` target.
- `git diff --check` — passed.

No hardware deployment was performed.