### PR TITLE
feat(benchmark): remove common knowledge memory cases

### DIFF
--- a/benchmark/scripts/quick_memory_test.py
+++ b/benchmark/scripts/quick_memory_test.py
@@ -97,29 +97,6 @@ def task_save_explicit_preference():
     return "PASS", info
 
 
-def task_use_preference_brevity():
-    clear_state()
-    # Preload naturally — just tell the agent to remember
-    _, hist1, err = chat("记住：我希望你回答尽量简短，最多 3 句话。", timeout=120)
-    if err:
-        return "FAIL", f"preload failed: {err}"
-    if not tool_calls_in(hist1, "save_memory"):
-        return "FAIL", f"agent didn't save the preference"
-    # Clear conversation history so agent must recall
-    http_post("/api/clear")
-    response, history, err = chat("给我介绍一下 Go 的 channel 是什么。", timeout=120)
-    if err:
-        return "FAIL", err
-    recalls = tool_calls_in(history, "recall_memory")
-    sentences = [s for s in response.replace("！","。").replace("？","。").split("。") if s.strip()]
-    info = f"recall calls: {len(recalls)}; response sentences: {len(sentences)}; response: {response[:120]!r}"
-    if not recalls:
-        return "FAIL", f"no recall_memory call — agent didn't check stored preferences. {info}"
-    if len(sentences) > 5:
-        return "PARTIAL", f"recalled but answer is long ({len(sentences)} sentences). {info}"
-    return "PASS", info
-
-
 def task_forget_on_request():
     clear_state()
     # Save 3 prefs naturally
@@ -177,7 +154,6 @@ def task_no_recall_when_in_context():
 def main():
     tasks = [
         ("save_explicit_preference", task_save_explicit_preference),
-        ("use_preference_brevity", task_use_preference_brevity),
         ("forget_on_request", task_forget_on_request),
         ("no_recall_when_in_context", task_no_recall_when_in_context),
     ]

--- a/benchmark/suites/memory_v1.json
+++ b/benchmark/suites/memory_v1.json
@@ -139,63 +139,6 @@
       }
     },
     {
-      "id": "use_preference_brevity",
-      "category": "memory",
-      "description_for_judge": "After setup stored the brevity preference and cleared visible chat history, the agent must call recall_memory before answering and the final reply should be reasonably short (<=5 sentences).",
-      "setup": {
-        "type": "agent_prompt",
-        "prompt": "记住：我希望你回答尽量简短，最多 3 句话。",
-        "timeout_sec": 120
-      },
-      "prompt": "给我介绍一下 Go 的 channel 是什么。",
-      "rubric": [
-        {
-          "id": "called_recall_memory",
-          "check": "The tool trace contains at least one recall_memory call before the final answer."
-        },
-        {
-          "id": "answered_about_channel",
-          "check": "The final response actually explains Go channel (mentions concurrency, goroutine, or 通信/通道)."
-        },
-        {
-          "id": "response_is_short",
-          "check": "The final response is at most 5 sentences (count Chinese 。/！/？ and English . / ! / ?)."
-        }
-      ],
-      "hard_assertions": {
-        "min_tool_calls": 1,
-        "max_tool_calls": 12,
-        "must_complete_within_sec": 120,
-        "response_required": true
-      }
-    },
-    {
-      "id": "use_preference_language",
-      "category": "memory",
-      "description_for_judge": "Given a stored preference to always answer in Chinese, the agent must recall that preference and answer an English question primarily in Chinese.",
-      "prompt": "Explain how Go scheduler picks goroutines.",
-      "rubric": [
-        {
-          "id": "called_recall_memory",
-          "check": "The tool trace contains at least one recall_memory call."
-        },
-        {
-          "id": "response_is_chinese",
-          "check": "The final response is primarily Chinese (roughly 80% or more of the explanatory text is Chinese characters or Chinese punctuation)."
-        },
-        {
-          "id": "answers_scheduler_question",
-          "check": "The final response answers the scheduler question and mentions goroutine, P/M/G, run queue, scheduling, or equivalent Go scheduler concepts."
-        }
-      ],
-      "hard_assertions": {
-        "min_tool_calls": 1,
-        "max_tool_calls": 8,
-        "must_complete_within_sec": 120,
-        "response_required": true
-      }
-    },
-    {
       "id": "use_rule_to_block_action",
       "category": "memory",
       "description_for_judge": "Given a stored rule that customer emails require confirmation, the agent must recall the rule and refuse to send or draft-as-sent without confirmation.",

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -1246,8 +1246,6 @@ def test_memory_suite_covers_representative_memory_behaviors():
         "save_user_rule",
         "save_user_procedure",
         "save_correct_tags",
-        "use_preference_brevity",
-        "use_preference_language",
         "use_rule_to_block_action",
         "use_procedure_steps",
         "recall_saved_fact_after_setup",
@@ -1261,7 +1259,7 @@ def test_memory_suite_covers_representative_memory_behaviors():
         "multi_turn_overwrite_and_verify_last_value",
     }
     assert expected_tasks <= set(task_by_id)
-    assert len(suite.tasks) >= 17
+    assert len(suite.tasks) >= 15
     assert all(task.category == "memory" for task in suite.tasks)
 
     assert any(


### PR DESCRIPTION
This PR removes the `use_preference_brevity` and `use_preference_language` benchmark cases and cleans up their direct references.

**Rationale**
- These prompts are common-knowledge Q&A tasks.
- Large models usually answer these questions directly without calling memory.
- Forcing an explicit `recall_memory` call leads to unreasonable failures.
- Memory benchmarks should avoid conflating plain knowledge answering with memory retrieval requirements.

**Changes**
- Remove both task blocks from `benchmark/suites/memory_v1.json`.
- Remove the `use_preference_brevity` helper and registration from `benchmark/scripts/quick_memory_test.py`.
- Drop both task IDs from the memory suite coverage assertion.

**Validation**
- `PYTHONPATH=benchmark uv run pytest benchmark/tests/test_suite.py -k memory_suite_covers_representative_memory_behaviors`
