### PR TITLE
feat(benchmark): seed session chunk recall fixture

### DIFF
--- a/benchmark/runner/agent_client.py
+++ b/benchmark/runner/agent_client.py
@@ -168,6 +168,18 @@ class AgentClient:
         body = _parse_json_response(body_bytes, "seed_episode")
         return body if isinstance(body, dict) else {}
 
+    def seed_session_chunk(self, chunk: dict[str, Any], timeout: int = 30) -> dict[str, Any]:
+        headers = {}
+        if self._benchmark_token:
+            headers["Authorization"] = f"Bearer {self._benchmark_token}"
+        status, body_bytes = self._post(
+            "/api/benchmark/seed_session_chunk", chunk, timeout=timeout, headers=headers
+        )
+        if status != 200:
+            raise AgentRequestError(f"seed_session_chunk returned {status}")
+        body = _parse_json_response(body_bytes, "seed_session_chunk")
+        return body if isinstance(body, dict) else {}
+
     def process_episode_memory(
         self, episode_id: str, timeout: int = 90
     ) -> dict[str, Any]:

--- a/benchmark/runner/reset.py
+++ b/benchmark/runner/reset.py
@@ -328,7 +328,7 @@ def _per_task_setup_seed_session_chunk(client: AgentClient, setup: dict[str, Any
     if setup.get("clear_history_after", False):
         try:
             client.clear_history()
-        except AgentRequestError as e:
+        except (AgentTimeoutError, AgentRequestError) as e:
             raise ResetError(f"seed_session_chunk clear_history failed: {e}") from e
 
 

--- a/benchmark/runner/reset.py
+++ b/benchmark/runner/reset.py
@@ -325,7 +325,7 @@ def _per_task_setup_seed_session_chunk(client: AgentClient, setup: dict[str, Any
         raise ResetError(f"seed_session_chunk timed out for {session_id!r}: {e}") from e
     except AgentRequestError as e:
         raise ResetError(f"seed_session_chunk failed for {session_id!r}: {e}") from e
-    if setup.get("clear_history_after", True):
+    if setup.get("clear_history_after", False):
         try:
             client.clear_history()
         except AgentRequestError as e:

--- a/benchmark/runner/reset.py
+++ b/benchmark/runner/reset.py
@@ -216,6 +216,9 @@ def per_task_setup(
             setup,
             consolidation_expectation=consolidation_expectation,
         )
+    if setup_type == "seed_session_chunk":
+        _per_task_setup_seed_session_chunk(client, setup)
+        return
     if setup_type == "seed_notification":
         _per_task_setup_seed_notification(client, setup)
         return
@@ -288,6 +291,45 @@ def _per_task_setup_seed_memory(client: AgentClient, setup: dict[str, Any]) -> N
             client.clear_history()
         except AgentRequestError as e:
             raise ResetError(f"seed_memory clear_history failed: {e}") from e
+
+
+def _per_task_setup_seed_session_chunk(client: AgentClient, setup: dict[str, Any]) -> None:
+    session_id = setup.get("session_id")
+    summary = setup.get("summary")
+    messages = setup.get("messages")
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise ResetError(f"seed_session_chunk setup missing session_id: {setup!r}")
+    if not isinstance(summary, str) or not summary.strip():
+        raise ResetError(f"seed_session_chunk setup missing summary: {setup!r}")
+    if not isinstance(messages, list) or not messages:
+        raise ResetError(f"seed_session_chunk setup requires non-empty messages list: {setup!r}")
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            raise ResetError(f"seed_session_chunk messages[{index}] must be a dict")
+        if not isinstance(message.get("role"), str) or not message["role"].strip():
+            raise ResetError(f"seed_session_chunk messages[{index}] missing role")
+        if not isinstance(message.get("content"), str) or not message["content"].strip():
+            raise ResetError(f"seed_session_chunk messages[{index}] missing content")
+    try:
+        timeout = int(setup.get("timeout_sec", 30))
+    except (ValueError, TypeError) as e:
+        raise ResetError(f"invalid timeout_sec: {setup.get('timeout_sec')!r}") from e
+    chunk = {
+        "session_id": session_id,
+        "summary": summary,
+        "messages": messages,
+    }
+    try:
+        client.seed_session_chunk(chunk, timeout=timeout)
+    except AgentTimeoutError as e:
+        raise ResetError(f"seed_session_chunk timed out for {session_id!r}: {e}") from e
+    except AgentRequestError as e:
+        raise ResetError(f"seed_session_chunk failed for {session_id!r}: {e}") from e
+    if setup.get("clear_history_after", True):
+        try:
+            client.clear_history()
+        except AgentRequestError as e:
+            raise ResetError(f"seed_session_chunk clear_history failed: {e}") from e
 
 
 def _per_task_setup_seed_episode(

--- a/benchmark/runner/suite.py
+++ b/benchmark/runner/suite.py
@@ -17,6 +17,7 @@ SETUP_KEYS = {
     "agent_prompt": {"type", "prompt", "timeout_sec", "clear_history_after", "expected_response"},
     "seed_memory": {"type", "memories", "timeout_sec", "clear_history_after"},
     "seed_episode": {"type", "episode", "consolidate", "timeout_sec", "consolidation_expectation"},
+    "seed_session_chunk": {"type", "session_id", "summary", "messages", "timeout_sec", "clear_history_after"},
     "seed_notification": {
         "type", "events", "consolidate", "timeout_sec",
         "expected_memory_count", "expected_memory_scope", "expected_memory_query",

--- a/benchmark/suites/memory_v1.json
+++ b/benchmark/suites/memory_v1.json
@@ -296,7 +296,8 @@
             "content": "这笔蓝海报销App记录的核销码是 ZX-91-ALPHA，项目代号是 海鸥计划。"
           }
         ],
-        "timeout_sec": 30
+        "timeout_sec": 30,
+        "clear_history_after": false
       },
       "prompt": "刚才蓝海报销App里提到的核销码和项目代号是什么？",
       "rubric": [

--- a/benchmark/suites/memory_v1.json
+++ b/benchmark/suites/memory_v1.json
@@ -282,6 +282,22 @@
       "id": "recall_session_chunk_details",
       "category": "memory",
       "description_for_judge": "Given a compressed session summary that points to chunk_000 but omits the exact details, the agent must call recall_session_chunks and answer using the recalled evidence.",
+      "setup": {
+        "type": "seed_session_chunk",
+        "session_id": "benchmark_reimbursement_details",
+        "summary": "蓝海报销App 对话详情：用户询问本次报销记录，助手从历史上下文确认核销码为 ZX-91-ALPHA，项目代号为 海鸥计划。",
+        "messages": [
+          {
+            "role": "user",
+            "content": "刚才在蓝海报销App里，这笔报销记录的核销码和项目代号分别是什么？"
+          },
+          {
+            "role": "assistant",
+            "content": "这笔蓝海报销App记录的核销码是 ZX-91-ALPHA，项目代号是 海鸥计划。"
+          }
+        ],
+        "timeout_sec": 30
+      },
       "prompt": "刚才蓝海报销App里提到的核销码和项目代号是什么？",
       "rubric": [
         {

--- a/benchmark/suites/memory_v1.json
+++ b/benchmark/suites/memory_v1.json
@@ -281,7 +281,7 @@
     {
       "id": "recall_session_chunk_details",
       "category": "memory",
-      "description_for_judge": "Given a compressed session summary that points to chunk_000 but omits the exact details, the agent must call recall_session_chunks and answer using the recalled evidence.",
+      "description_for_judge": "Given a compressed session summary that omits the exact details from the visible prompt, the agent must call recall_session_chunks and answer using the recalled seeded-session evidence.",
       "setup": {
         "type": "seed_session_chunk",
         "session_id": "benchmark_reimbursement_details",
@@ -306,8 +306,8 @@
           "check": "The tool trace contains at least one recall_session_chunks call."
         },
         {
-          "id": "recall_uses_chunk_000",
-          "check": "The recall_session_chunks call input references chunk_000 via chunk_ids, or otherwise searches for 蓝海报销App/核销码 and retrieves that chunk."
+          "id": "recall_searches_seeded_session",
+          "check": "The recall_session_chunks call searches for 蓝海报销App/核销码 or otherwise retrieves the seeded session chunk."
         },
         {
           "id": "answer_mentions_recalled_details",

--- a/benchmark/tests/test_agent_client.py
+++ b/benchmark/tests/test_agent_client.py
@@ -292,6 +292,24 @@ def test_seed_episode_sends_benchmark_token_header():
     assert result == {"status": "seeded", "id": "ep-1"}
 
 
+def test_seed_session_chunk_sends_benchmark_token_header():
+    seen = {}
+    client = AgentClient(base_url="http://test", benchmark_token="chunk-token")
+    chunk = {
+        "session_id": "s-1",
+        "summary": "old conversation",
+        "messages": [{"role": "user", "content": "remember this"}],
+    }
+    with patch("urllib.request.urlopen", _captured(seen, body={"status": "seeded", "session_id": "s-1"})):
+        result = client.seed_session_chunk(chunk, timeout=45)
+
+    assert seen["url"].endswith("/api/benchmark/seed_session_chunk")
+    assert seen["headers"]["authorization"] == "Bearer chunk-token"
+    assert json.loads(seen["body"]) == chunk
+    assert seen["timeout"] == 45
+    assert result == {"status": "seeded", "session_id": "s-1"}
+
+
 def test_process_episode_memory_sends_benchmark_token_header():
     seen = {}
     client = AgentClient(base_url="http://test", benchmark_token="episode-token")

--- a/benchmark/tests/test_reset.py
+++ b/benchmark/tests/test_reset.py
@@ -47,6 +47,10 @@ class RecordingSetupClient:
         self.calls.append(("seed_episode", episode, timeout))
         return {"status": "seeded", "id": episode["id"]}
 
+    def seed_session_chunk(self, chunk, timeout=30):
+        self.calls.append(("seed_session_chunk", chunk, timeout))
+        return {"status": "seeded", "session_id": chunk["session_id"]}
+
     def seed_memory(self, memory, timeout=30):
         self.calls.append(("seed_memory", memory, timeout))
         return {"status": "seeded", "id": memory["id"]}
@@ -155,6 +159,32 @@ def test_setup_sequence_runs_existing_primitives_in_order():
     assert client.calls == [
         ("seed_memory", memory, 30),
         ("seed_notification", [event], 30),
+    ]
+
+
+def test_seed_session_chunk_setup_writes_chunk_and_clears_history():
+    client = RecordingSetupClient()
+    setup = {
+        "type": "seed_session_chunk",
+        "session_id": "benchmark-session",
+        "summary": "Seeded chunk summary",
+        "messages": [{"role": "user", "content": "old question"}],
+        "timeout_sec": 45,
+    }
+
+    per_task_setup(client, setup)
+
+    assert client.calls == [
+        (
+            "seed_session_chunk",
+            {
+                "session_id": "benchmark-session",
+                "summary": "Seeded chunk summary",
+                "messages": [{"role": "user", "content": "old question"}],
+            },
+            45,
+        ),
+        ("clear_history",),
     ]
 
 

--- a/benchmark/tests/test_reset.py
+++ b/benchmark/tests/test_reset.py
@@ -162,7 +162,7 @@ def test_setup_sequence_runs_existing_primitives_in_order():
     ]
 
 
-def test_seed_session_chunk_setup_writes_chunk_and_clears_history():
+def test_seed_session_chunk_setup_writes_chunk_without_clearing_history_by_default():
     client = RecordingSetupClient()
     setup = {
         "type": "seed_session_chunk",
@@ -183,6 +183,31 @@ def test_seed_session_chunk_setup_writes_chunk_and_clears_history():
                 "messages": [{"role": "user", "content": "old question"}],
             },
             45,
+        )
+    ]
+
+
+def test_seed_session_chunk_setup_can_explicitly_clear_history_after_seed():
+    client = RecordingSetupClient()
+    setup = {
+        "type": "seed_session_chunk",
+        "session_id": "benchmark-session",
+        "summary": "Seeded chunk summary",
+        "messages": [{"role": "user", "content": "old question"}],
+        "clear_history_after": True,
+    }
+
+    per_task_setup(client, setup)
+
+    assert client.calls == [
+        (
+            "seed_session_chunk",
+            {
+                "session_id": "benchmark-session",
+                "summary": "Seeded chunk summary",
+                "messages": [{"role": "user", "content": "old question"}],
+            },
+            30,
         ),
         ("clear_history",),
     ]

--- a/benchmark/tests/test_reset.py
+++ b/benchmark/tests/test_reset.py
@@ -78,6 +78,11 @@ class RecordingSetupClient:
         )
 
 
+class TimeoutClearHistoryClient(RecordingSetupClient):
+    def clear_history(self):
+        raise AgentTimeoutError("clear timed out")
+
+
 def test_agent_prompt_setup_wraps_chat_errors_as_reset_error():
     setup = {"type": "agent_prompt", "prompt": "remember this", "timeout_sec": 5}
 
@@ -211,6 +216,19 @@ def test_seed_session_chunk_setup_can_explicitly_clear_history_after_seed():
         ),
         ("clear_history",),
     ]
+
+
+def test_seed_session_chunk_setup_wraps_clear_history_timeout_as_reset_error():
+    setup = {
+        "type": "seed_session_chunk",
+        "session_id": "benchmark-session",
+        "summary": "Seeded chunk summary",
+        "messages": [{"role": "user", "content": "old question"}],
+        "clear_history_after": True,
+    }
+
+    with pytest.raises(ResetError, match="seed_session_chunk clear_history failed"):
+        per_task_setup(TimeoutClearHistoryClient(), setup)
 
 
 def test_setup_sequence_preserves_consolidation_result_when_later_setup_returns_none():

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -927,6 +927,31 @@ def test_load_suite_rejects_non_string_setup_type(tmp_path: Path, setup_type):
         load_suite(p)
 
 
+def test_load_suite_accepts_seed_session_chunk_setup_keys(tmp_path: Path):
+    fixture = {
+        **FIXTURE,
+        "tasks": [
+            {
+                **FIXTURE["tasks"][0],
+                "setup": {
+                    "type": "seed_session_chunk",
+                    "session_id": "benchmark-session",
+                    "summary": "Seeded chunk summary",
+                    "messages": [{"role": "user", "content": "old question"}],
+                    "timeout_sec": 30,
+                    "clear_history_after": True,
+                },
+            }
+        ],
+    }
+    path = tmp_path / "seed-session-chunk-setup-keys.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    task = load_suite(path).tasks[0]
+    assert task.setup["type"] == "seed_session_chunk"
+    assert task.setup["session_id"] == "benchmark-session"
+
+
 def test_load_suite_rejects_invalid_expected_option_answer(tmp_path: Path):
     fixture = {
         **FIXTURE,

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -42,10 +42,11 @@ import (
 )
 
 const (
-	agentHTTPReadHeaderTimeout = 10 * time.Second
-	agentHTTPReadTimeout       = 30 * time.Second
-	agentHTTPIdleTimeout       = 120 * time.Second
-	agentHTTPShutdownTimeout   = 5 * time.Second
+	agentHTTPReadHeaderTimeout            = 10 * time.Second
+	agentHTTPReadTimeout                  = 30 * time.Second
+	agentHTTPIdleTimeout                  = 120 * time.Second
+	agentHTTPShutdownTimeout              = 5 * time.Second
+	benchmarkSeedSessionChunkMaxBodyBytes = 512 * 1024
 )
 
 // Server provides HTTP API for agent interactions
@@ -2753,7 +2754,7 @@ func (s *Server) handleBenchmarkSeedSessionChunk(w http.ResponseWriter, r *http.
 		return
 	}
 	var req benchmarkSeedSessionChunkRequest
-	decoder := json.NewDecoder(r.Body)
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, benchmarkSeedSessionChunkMaxBodyBytes))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&req); err != nil {
 		http.Error(w, "decode body: "+err.Error(), http.StatusBadRequest)

--- a/src/agent/internal/agent/server.go
+++ b/src/agent/internal/agent/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tmc/langchaingo/schema"
 	langtools "github.com/tmc/langchaingo/tools"
 
+	"aiden-agent/internal/agent/agentpath"
 	"aiden-agent/internal/agent/contextmanager"
 	"aiden-agent/internal/agent/messages"
 	"aiden-agent/internal/agent/mnk"
@@ -533,6 +534,7 @@ func (s *Server) Handler() http.Handler {
 	if s.benchmarkToken() != "" {
 		mux.HandleFunc("/api/benchmark/seed_memory", s.handleBenchmarkSeedMemory)
 		mux.HandleFunc("/api/benchmark/seed_episode", s.handleBenchmarkSeedEpisode)
+		mux.HandleFunc("/api/benchmark/seed_session_chunk", s.handleBenchmarkSeedSessionChunk)
 		mux.HandleFunc("/api/benchmark/episode-memory/process", s.handleBenchmarkProcessEpisodeMemory)
 		mux.HandleFunc("/api/benchmark/seed_notification", s.handleBenchmarkSeedNotification)
 		mux.HandleFunc("/api/benchmark/notification-memory/process", s.handleBenchmarkProcessNotificationMemory)
@@ -2681,6 +2683,12 @@ type benchmarkSeedMemoryRequest struct {
 	Priority     int               `json:"priority"`
 }
 
+type benchmarkSeedSessionChunkRequest struct {
+	SessionID string             `json:"session_id"`
+	Summary   string             `json:"summary"`
+	Messages  []messages.Message `json:"messages"`
+}
+
 func (s *Server) handleBenchmarkSeedEpisode(w http.ResponseWriter, r *http.Request) {
 	if !s.authorizeBenchmarkRequest(r) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
@@ -2732,6 +2740,74 @@ func (s *Server) handleBenchmarkSeedEpisode(w http.ResponseWriter, r *http.Reque
 	json.NewEncoder(w).Encode(map[string]string{
 		"status": "seeded",
 		"id":     id,
+	})
+}
+
+func (s *Server) handleBenchmarkSeedSessionChunk(w http.ResponseWriter, r *http.Request) {
+	if !s.authorizeBenchmarkRequest(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req benchmarkSeedSessionChunkRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		http.Error(w, "decode body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		http.Error(w, "decode body: expected exactly one JSON object", http.StatusBadRequest)
+		return
+	}
+	req.SessionID = strings.TrimSpace(req.SessionID)
+	req.Summary = strings.TrimSpace(req.Summary)
+	if req.SessionID == "" {
+		http.Error(w, "session_id is required", http.StatusBadRequest)
+		return
+	}
+	if req.Summary == "" {
+		http.Error(w, "summary is required", http.StatusBadRequest)
+		return
+	}
+	if len(req.Messages) == 0 {
+		http.Error(w, "messages are required", http.StatusBadRequest)
+		return
+	}
+	for index, msg := range req.Messages {
+		if msg.Role == "" {
+			http.Error(w, fmt.Sprintf("messages[%d].role is required", index), http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(msg.Content) == "" {
+			http.Error(w, fmt.Sprintf("messages[%d].content is required", index), http.StatusBadRequest)
+			return
+		}
+	}
+	if s.runtime == nil {
+		http.Error(w, "runtime is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	configDir := s.runtime.ConfigSnapshot().ConfigDir
+	if strings.TrimSpace(configDir) == "" {
+		http.Error(w, "config dir is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	writer := NewSessionChunkWriter(
+		agentpath.ContextManagerSessionFolder(configDir),
+		LoadMemoryExtractionConfig(configDir),
+	)
+	if err := writer.WriteChunk(r.Context(), req.SessionID, req.Messages, req.Summary); err != nil {
+		http.Error(w, "seed session chunk: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":     "seeded",
+		"session_id": req.SessionID,
 	})
 }
 

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -4689,6 +4689,44 @@ func TestHandleBenchmarkSeedMemorySucceeds(t *testing.T) {
 	}
 }
 
+func TestHandleBenchmarkSeedSessionChunkSucceeds(t *testing.T) {
+	server, configDir := newBenchmarkSeedMemoryServer(t)
+	body := `{
+		"session_id":"benchmark_expense_session",
+		"summary":"蓝海报销App 对话详情：核销码为 ZX-91-ALPHA，项目代号为 海鸥计划。",
+		"messages":[
+			{"role":"user","content":"刚才蓝海报销App里核销码和项目代号是什么？"},
+			{"role":"assistant","content":"核销码是 ZX-91-ALPHA，项目代号是 海鸥计划。"}
+		]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/benchmark/seed_session_chunk", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-benchmark-token")
+	rec := httptest.NewRecorder()
+
+	server.handleBenchmarkSeedSessionChunk(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["status"] != "seeded" || resp["session_id"] != "benchmark_expense_session" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+
+	tool := NewRecallSessionChunksTool(NewMultiSessionChunkStore(agentpath.ContextManagerSessionFolder(configDir)))
+	out, err := tool.Call(context.Background(), `{"entities":["蓝海报销App"],"limit":1}`)
+	if err != nil {
+		t.Fatalf("recall seeded chunk: %v", err)
+	}
+	if !strings.Contains(out, "ZX-91-ALPHA") || !strings.Contains(out, "海鸥计划") {
+		t.Fatalf("seeded chunk recall missing expected details: %s", out)
+	}
+}
+
 func TestHandleBenchmarkSeedNotificationWritesDurableFixture(t *testing.T) {
 	server, configDir := newBenchmarkSeedMemoryServerWithModel(t, &scriptedModel{responses: []*llms.ContentResponse{
 		contentResponse(`{"results":[{"context_id":"1","proposal":{"actions":[{"action":"ignore"}]}}]}`),

--- a/src/agent/internal/agent/server_test.go
+++ b/src/agent/internal/agent/server_test.go
@@ -4727,6 +4727,25 @@ func TestHandleBenchmarkSeedSessionChunkSucceeds(t *testing.T) {
 	}
 }
 
+func TestHandleBenchmarkSeedSessionChunkRejectsOversizedBody(t *testing.T) {
+	server, _ := newBenchmarkSeedMemoryServer(t)
+	oversizedSummary := strings.Repeat("x", benchmarkSeedSessionChunkMaxBodyBytes)
+	body := fmt.Sprintf(`{"session_id":"benchmark_expense_session","summary":%q,"messages":[{"role":"user","content":"hello"}]}`, oversizedSummary)
+	req := httptest.NewRequest(http.MethodPost, "/api/benchmark/seed_session_chunk", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-benchmark-token")
+	rec := httptest.NewRecorder()
+
+	server.handleBenchmarkSeedSessionChunk(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "request body too large") {
+		t.Fatalf("expected oversized-body error, got: %s", rec.Body.String())
+	}
+}
+
 func TestHandleBenchmarkSeedNotificationWritesDurableFixture(t *testing.T) {
 	server, configDir := newBenchmarkSeedMemoryServerWithModel(t, &scriptedModel{responses: []*llms.ContentResponse{
 		contentResponse(`{"results":[{"context_id":"1","proposal":{"actions":[{"action":"ignore"}]}}]}`),


### PR DESCRIPTION
Summary:
- Add a benchmark-only seed_session_chunk setup path.
- Seed recall_session_chunk_details with the Blue Ocean reimbursement code and project details.
- Cover the new setup path in runner, suite, client, and server tests.

Rationale:
- recall_session_chunk_details asks for details from a prior Blue Ocean reimbursement App session.
- The previous benchmark case did not seed a corresponding session chunk, so the recall target could be missing on a clean run.
- Seeding the chunk makes the case deterministic while preserving the intent to test recall_session_chunks.

Validation:
- PYTHONPATH=benchmark uv run pytest benchmark/tests/test_agent_client.py benchmark/tests/test_reset.py benchmark/tests/test_suite.py -k "seed_session_chunk or memory_suite_covers_representative_memory_behaviors or quick_capture_setup_keys"
- cd src/agent && go test ./internal/agent -run 'TestHandleBenchmarkSeedSessionChunkSucceeds|TestSessionChunkWriterDerivesSearchTermsFromContent|TestRecallSessionChunksToolReturnsMatchingChunk'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added benchmark support for seeding session memory with summaries and conversation messages before a task runs.
  - Benchmark tasks can optionally clear conversation history after seeding.
  - Added validation, authorization, request-size limits, and timeout handling for session-memory seeding requests.
  - Updated memory benchmarking with realistic pre-existing reimbursement details for recall testing.

- **Tests**
  - Added coverage for seeding, authorization, validation, memory recall, timeout handling, oversized requests, and optional history clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->