### PR TITLE
fix(benchmark): model memory overwrite as multi-turn

### DIFF
--- a/benchmark/suites/memory_v1.json
+++ b/benchmark/suites/memory_v1.json
@@ -462,7 +462,27 @@
       "id": "multi_turn_overwrite_and_verify_last_value",
       "category": "memory",
       "description_for_judge": "In one conversation, the user first asks the agent to remember a city, then overwrites it twice in the middle of the conversation, and finally asks what the remembered city is. The agent must keep updating the SAME memory (overwriting the value, not appending duplicate versions), and the final answer must equal the LAST modified value (成都), not the earlier values (杭州 or 深圳).",
-      "prompt": "下面我们边聊边更新一条记忆，请每一步都真实调用记忆工具去保存或召回，不要只在脑子里记。\n\n第 1 步：请记住「我的办公城市是杭州」。\n\n第 2 步：我改主意了，办公城市改成「深圳」。请把之前那条记忆更新成最新的值，别保留旧的杭州。\n\n第 3 步：又调整了一下，办公城市最终定为「成都」。请再次更新这条记忆。\n\n第 4 步：请用 recall_memory 查一下“办公城市”这条记忆，再问我现在的办公城市是什么？只按你最终保存的值回答，并说明这个值是经过前面几次修改后的最新值。",
+      "setup": [
+        {
+          "type": "agent_prompt",
+          "prompt": "请记住：我的办公城市是杭州。",
+          "timeout_sec": 120,
+          "clear_history_after": false
+        },
+        {
+          "type": "agent_prompt",
+          "prompt": "我改主意了，办公城市改成深圳。请更新办公城市这条记忆，不要继续保留杭州作为当前值。",
+          "timeout_sec": 120,
+          "clear_history_after": false
+        },
+        {
+          "type": "agent_prompt",
+          "prompt": "又调整了一下，办公城市最终定为成都。请再次更新办公城市这条记忆。",
+          "timeout_sec": 120,
+          "clear_history_after": false
+        }
+      ],
+      "prompt": "请用 recall_memory 查一下“办公城市”这条记忆，然后告诉我现在的办公城市是什么。只按你最终保存的值回答，并说明这个值是经过前面几次修改后的最新值。",
       "rubric": [
         {
           "id": "saved_initial_value",

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -1270,6 +1270,15 @@ def test_memory_suite_covers_representative_memory_behaviors():
     )
 
     overwrite_task = task_by_id["multi_turn_overwrite_and_verify_last_value"]
+    assert isinstance(overwrite_task.setup, list)
+    assert [item["prompt"] for item in overwrite_task.setup] == [
+        "请记住：我的办公城市是杭州。",
+        "我改主意了，办公城市改成深圳。请更新办公城市这条记忆，不要继续保留杭州作为当前值。",
+        "又调整了一下，办公城市最终定为成都。请再次更新办公城市这条记忆。",
+    ]
+    assert all(item["clear_history_after"] is False for item in overwrite_task.setup)
+    assert "第 1 步" not in overwrite_task.prompt
+    assert "recall_memory" in overwrite_task.prompt
     assert overwrite_task.hard_assertions.min_tool_calls == 4
     assert overwrite_task.hard_assertions.max_tool_calls == 4
     assert [item.tool for item in overwrite_task.hard_assertions.required_tool_calls] == [


### PR DESCRIPTION
Summary:
- Convert multi_turn_overwrite_and_verify_last_value into a true multi-turn benchmark flow.
- Use ordered setup prompts to save杭州, update to深圳, then update to成都 while preserving history.
- Keep the final task prompt focused on recalling and answering the latest value.
- Extend memory_suite_covers_representative_memory_behaviors to assert the multi-turn setup shape.

Validation:
- PYTHONPATH=benchmark uv run pytest benchmark/tests/test_suite.py -k memory_suite_covers_representative_memory_behaviors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage ensuring the memory benchmark verifies successive updates to an office city and recalls the most recently saved value.
  - Added checks confirming conversation history is retained throughout the multi-step setup and that the final prompt uses memory recall rather than step-specific wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->