### PR TITLE
fix(benchmark): use natural memory overwrite prompts

### DIFF
--- a/benchmark/suites/memory_v1.json
+++ b/benchmark/suites/memory_v1.json
@@ -414,18 +414,18 @@
         },
         {
           "type": "agent_prompt",
-          "prompt": "我改主意了，办公城市改成深圳。请更新办公城市这条记忆，不要继续保留杭州作为当前值。",
+          "prompt": "我改主意了，办公城市改成深圳。",
           "timeout_sec": 120,
           "clear_history_after": false
         },
         {
           "type": "agent_prompt",
-          "prompt": "又调整了一下，办公城市最终定为成都。请再次更新办公城市这条记忆。",
+          "prompt": "又调整了一下，办公城市最终定为成都",
           "timeout_sec": 120,
           "clear_history_after": false
         }
       ],
-      "prompt": "请用 recall_memory 查一下“办公城市”这条记忆，然后告诉我现在的办公城市是什么。只按你最终保存的值回答，并说明这个值是经过前面几次修改后的最新值。",
+      "prompt": "我现在的办公城市是什么？",
       "rubric": [
         {
           "id": "saved_initial_value",

--- a/benchmark/tests/test_suite.py
+++ b/benchmark/tests/test_suite.py
@@ -1271,12 +1271,14 @@ def test_memory_suite_covers_representative_memory_behaviors():
     assert isinstance(overwrite_task.setup, list)
     assert [item["prompt"] for item in overwrite_task.setup] == [
         "请记住：我的办公城市是杭州。",
-        "我改主意了，办公城市改成深圳。请更新办公城市这条记忆，不要继续保留杭州作为当前值。",
-        "又调整了一下，办公城市最终定为成都。请再次更新办公城市这条记忆。",
+        "我改主意了，办公城市改成深圳。",
+        "又调整了一下，办公城市最终定为成都",
     ]
     assert all(item["clear_history_after"] is False for item in overwrite_task.setup)
+    assert overwrite_task.prompt == "我现在的办公城市是什么？"
     assert "第 1 步" not in overwrite_task.prompt
-    assert "recall_memory" in overwrite_task.prompt
+    assert "recall_memory" not in overwrite_task.prompt
+    assert "记忆工具" not in overwrite_task.prompt
     assert overwrite_task.hard_assertions.min_tool_calls == 4
     assert overwrite_task.hard_assertions.max_tool_calls == 4
     assert [item.tool for item in overwrite_task.hard_assertions.required_tool_calls] == [


### PR DESCRIPTION
Summary:
- Simplify the multi-turn office city prompts to natural user messages.
- Remove explicit recall_memory and memory-tool wording from the final prompt.
- Update memory_suite_covers_representative_memory_behaviors to lock the natural prompt shape.

Validation:
- PYTHONPATH=benchmark uv run pytest benchmark/tests/test_suite.py -k memory_suite_covers_representative_memory_behaviors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated memory-handling benchmark scenarios with shorter, more natural prompts.
  - Continued validating that successive office-location updates are stored correctly and that the latest value is recalled accurately.
  - Preserved checks for the expected final response and required memory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->