### PR TITLE
fix(agent): keep finished shell sessions pollable

### DIFF
--- a/src/agent/internal/agent/tools_shell.go
+++ b/src/agent/internal/agent/tools_shell.go
@@ -206,6 +206,7 @@ func shellStartBackground(ctx context.Context, arguments map[string]interface{},
 	return shellJSONString(map[string]interface{}{
 		"session_id": session.id,
 		"running":    true,
+		"completed":  false,
 		"pid":        session.processID(),
 		"command":    session.command,
 		"workdir":    session.workdir,
@@ -238,6 +239,7 @@ func shellPollBackground(ctx context.Context, arguments map[string]interface{}) 
 	payload := map[string]interface{}{
 		"session_id":       session.id,
 		"running":          running,
+		"completed":        !running,
 		"pid":              session.processID(),
 		"command":          session.command,
 		"workdir":          session.workdir,
@@ -248,9 +250,16 @@ func shellPollBackground(ctx context.Context, arguments map[string]interface{}) 
 		"exit_code":        session.exitCodeValue(),
 		"exit_error":       session.exitErrorText(),
 	}
+	if finished := session.finishedAtOr(); !finished.IsZero() {
+		payload["finished_at"] = finished.Format(time.RFC3339)
+	}
 
 	if !running && !session.output.hasUnread() {
-		globalShellSessionManager.delete(session.id)
+		// Keep the session so a repeated poll answers with this terminal payload
+		// instead of "session not found". Drop the bytes instead: every produced
+		// byte has been delivered, so nothing is lost, and the record stays small
+		// until evictIdle reclaims it on a fixed clock.
+		session.output.release()
 	}
 	return shellJSONString(payload), nil
 }

--- a/src/agent/internal/agent/tools_shell_session.go
+++ b/src/agent/internal/agent/tools_shell_session.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -41,6 +42,7 @@ type shellSession struct {
 
 	mu     sync.Mutex
 	closed bool
+	reaped bool
 }
 
 type shellRingBuffer struct {
@@ -154,6 +156,7 @@ func (s *shellSession) wait() {
 	var exitCode *int
 	if s.usePTY && s.ptyCmd != nil {
 		exitErr = s.ptyCmd.Wait()
+		s.markReaped()
 		if s.ptyCmd.ProcessState != nil {
 			code := s.ptyCmd.ProcessState.ExitCode()
 			exitCode = &code
@@ -167,6 +170,7 @@ func (s *shellSession) wait() {
 	}
 
 	exitErr = s.cmd.Wait()
+	s.markReaped()
 	if s.cmd.ProcessState != nil {
 		code := s.cmd.ProcessState.ExitCode()
 		exitCode = &code
@@ -181,6 +185,18 @@ func (s *shellSession) setExitState(exitErr error, exitCode *int) {
 	s.exitErr = exitErr
 	s.exitCode = exitCode
 	s.finishedAt = time.Now()
+}
+
+// markReaped records that Wait() has returned, which is the point from which the
+// OS may reuse the PID. It runs in the waiting goroutine immediately after Wait,
+// and stop() reads it under the same lock, so a session whose process is already
+// gone is never signalled. isRunning() is not a substitute: done closes only
+// after the PTY capture goroutine has drained, which can be long after the
+// process itself was reaped.
+func (s *shellSession) markReaped() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reaped = true
 }
 
 func (s *shellSession) isRunning() bool {
@@ -242,22 +258,28 @@ func (s *shellSession) stop() {
 	s.closeInputLocked()
 	done := s.done
 	var process *os.Process
-	if s.usePTY && s.ptyCmd != nil {
-		process = s.ptyCmd.Process
-	} else if s.cmd != nil {
-		process = s.cmd.Process
+	// Decide whether to signal under the same lock Wait() takes to record the
+	// reap. Signalling a reaped PID is what the process-group kill below must
+	// never do: the PID may already belong to something else.
+	if !s.reaped {
+		if s.usePTY && s.ptyCmd != nil {
+			process = s.ptyCmd.Process
+		} else if s.cmd != nil {
+			process = s.cmd.Process
+		}
 	}
 	s.mu.Unlock()
 
 	if process == nil {
 		return
 	}
-	// Wait() has already reaped a finished session's process, so its PID may
-	// since have been reused. Only interrupt a process that is still running.
-	if !s.isRunning() {
-		return
-	}
 	if err := process.Signal(os.Interrupt); err != nil {
+		// Wait() may have reaped the process since the check above; Go reports
+		// that as ErrProcessDone. Escalating to a process-group kill here would
+		// target a PID that may already be reused.
+		if errors.Is(err, os.ErrProcessDone) {
+			return
+		}
 		if killErr := shellKillProcessGroup(process); killErr != nil {
 			log.Printf("shell: kill after failed interrupt: %v", killErr)
 		}

--- a/src/agent/internal/agent/tools_shell_session.go
+++ b/src/agent/internal/agent/tools_shell_session.go
@@ -35,6 +35,7 @@ type shellSession struct {
 	cancel       context.CancelFunc
 	startedAt    time.Time
 	lastActivity time.Time
+	finishedAt   time.Time
 	exitErr      error
 	exitCode     *int
 
@@ -122,6 +123,18 @@ func (b *shellRingBuffer) hasUnread() bool {
 	return b.readPos < len(b.buf)
 }
 
+// release drops the buffered bytes once every produced byte has been read. A
+// finished session keeps answering polls, but it no longer needs the output.
+// Callers must only release after the process has exited, because a running
+// process can still append; at that point nothing is lost.
+func (b *shellRingBuffer) release() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = nil
+	b.readPos = 0
+	b.truncated = false
+}
+
 func (s *shellSession) capture(r io.Reader) {
 	buffer := make([]byte, 4096)
 	for {
@@ -167,6 +180,7 @@ func (s *shellSession) setExitState(exitErr error, exitCode *int) {
 	defer s.mu.Unlock()
 	s.exitErr = exitErr
 	s.exitCode = exitCode
+	s.finishedAt = time.Now()
 }
 
 func (s *shellSession) isRunning() bool {
@@ -176,6 +190,14 @@ func (s *shellSession) isRunning() bool {
 	default:
 		return true
 	}
+}
+
+// finishedAtOr reports when the session's process exited, or the zero time
+// while it is still running.
+func (s *shellSession) finishedAtOr() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.finishedAt
 }
 
 func (s *shellSession) processID() int {
@@ -228,6 +250,11 @@ func (s *shellSession) stop() {
 	s.mu.Unlock()
 
 	if process == nil {
+		return
+	}
+	// Wait() has already reaped a finished session's process, so its PID may
+	// since have been reused. Only interrupt a process that is still running.
+	if !s.isRunning() {
 		return
 	}
 	if err := process.Signal(os.Interrupt); err != nil {

--- a/src/agent/internal/agent/tools_shell_test.go
+++ b/src/agent/internal/agent/tools_shell_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
@@ -637,6 +638,12 @@ func TestShellToolBackgroundPollDrainsAndKeepsSession(t *testing.T) {
 			case <-time.After(5 * time.Second):
 				t.Fatal("background command did not finish")
 			}
+			// wait() records the reap the moment Wait returns, before the PTY
+			// capture goroutine drains and done closes. stop() depends on it to
+			// avoid signalling a PID the OS may already have reused.
+			if !session.reaped {
+				t.Fatal("wait() did not record the process reap")
+			}
 
 			pollArgs, _ := json.Marshal(map[string]interface{}{
 				"action":     "poll",
@@ -787,6 +794,39 @@ func TestShellToolPollAfterCompletionIsIdempotent(t *testing.T) {
 	}
 	if second.Output != "" {
 		t.Fatalf("repeat poll repeated already-delivered output: %q", second.Output)
+	}
+}
+
+// stop() must not signal a process that Wait() has already reaped: the OS may
+// have reused the PID, and the escalation path is a raw process-group kill.
+//
+// done stays open here, so a stop() that signals the process cannot return until
+// its interrupt timeout expires. A prompt return is therefore what distinguishes
+// "skipped the reap-aware check" from "signalled anyway"; asserting on the helper
+// still being alive does not work, because an unreaped child is a zombie and
+// signalling a zombie succeeds.
+func TestShellSessionStopSkipsReapedProcess(t *testing.T) {
+	skipOnWindows(t)
+	cmd := exec.Command("sleep", "30")
+	shellSetProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper process: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	session := &shellSession{
+		id:     "shell-reaped",
+		cmd:    cmd,
+		done:   make(chan struct{}),
+		reaped: true,
+	}
+	started := time.Now()
+	session.stop()
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("stop() took %v on a reaped session; it must not signal one", elapsed)
 	}
 }
 

--- a/src/agent/internal/agent/tools_shell_test.go
+++ b/src/agent/internal/agent/tools_shell_test.go
@@ -602,7 +602,7 @@ func TestShellRingBufferHasUnread(t *testing.T) {
 	}
 }
 
-func TestShellToolBackgroundPollDrainsBeforeDelete(t *testing.T) {
+func TestShellToolBackgroundPollDrainsAndKeepsSession(t *testing.T) {
 	skipOnWindows(t)
 	for _, usePTY := range []bool{false, true} {
 		t.Run(fmt.Sprintf("pty=%t", usePTY), func(t *testing.T) {
@@ -618,10 +618,16 @@ func TestShellToolBackgroundPollDrainsBeforeDelete(t *testing.T) {
 			}
 			var started struct {
 				SessionID string `json:"session_id"`
+				Completed bool   `json:"completed"`
 			}
 			if err := json.Unmarshal([]byte(startOut), &started); err != nil {
 				t.Fatalf("start unmarshal err: %v", err)
 			}
+			if started.Completed {
+				t.Fatalf("start reported completed=true: %s", startOut)
+			}
+			defer globalShellSessionManager.delete(started.SessionID)
+
 			session := globalShellSessionManager.get(started.SessionID)
 			if session == nil {
 				t.Fatalf("session %q not found after start", started.SessionID)
@@ -636,37 +642,36 @@ func TestShellToolBackgroundPollDrainsBeforeDelete(t *testing.T) {
 				"action":     "poll",
 				"session_id": started.SessionID,
 			})
-			pollOut, err := tool.Call(context.Background(), string(pollArgs))
-			if err != nil {
-				t.Fatalf("poll returned error: %v", err)
+			type shellPoll struct {
+				SessionID       string `json:"session_id"`
+				Running         bool   `json:"running"`
+				Completed       bool   `json:"completed"`
+				FinishedAt      string `json:"finished_at"`
+				Output          string `json:"output"`
+				OutputTruncated bool   `json:"output_truncated"`
 			}
 			var collected strings.Builder
+			var last shellPoll
 			firstPoll := true
 			firstPollSawTruncation := false
-			for i := 0; i < 10; i++ {
-				if strings.Contains(pollOut, "shell session not found") {
-					break
+			for i := 0; i < 12; i++ {
+				pollOut, err := tool.Call(context.Background(), string(pollArgs))
+				if err != nil {
+					t.Fatalf("poll returned error: %v", err)
 				}
-				var poll struct {
-					SessionID       string `json:"session_id"`
-					Running         bool   `json:"running"`
-					Output          string `json:"output"`
-					OutputTruncated bool   `json:"output_truncated"`
-				}
-				if err := json.Unmarshal([]byte(pollOut), &poll); err != nil {
+				if err := json.Unmarshal([]byte(pollOut), &last); err != nil {
 					t.Fatalf("poll unmarshal err: %v (raw=%q)", err, pollOut)
 				}
-				if poll.Running {
+				if last.Running {
 					t.Fatalf("session still running after done closed: %s", pollOut)
 				}
 				if firstPoll {
-					firstPollSawTruncation = poll.OutputTruncated
+					firstPollSawTruncation = last.OutputTruncated
 					firstPoll = false
 				}
-				collected.WriteString(poll.Output)
-				pollOut, err = tool.Call(context.Background(), string(pollArgs))
-				if err != nil {
-					t.Fatalf("poll returned error: %v", err)
+				collected.WriteString(last.Output)
+				if last.Output == "" {
+					break
 				}
 			}
 
@@ -679,10 +684,109 @@ func TestShellToolBackgroundPollDrainsBeforeDelete(t *testing.T) {
 			if !strings.Contains(collected.String(), "stdout-final") || !strings.Contains(collected.String(), "stderr-final") {
 				t.Fatalf("final stdout/stderr missing from %d captured bytes", collected.Len())
 			}
-			if !strings.Contains(pollOut, "shell session not found") {
-				t.Fatalf("expected session-not-found after drain, got %q", pollOut)
+			// Draining the last bytes must not drop the session: the follow-up poll
+			// reports the terminal state instead of "session not found".
+			if !last.Completed || last.FinishedAt == "" {
+				t.Fatalf("drained poll did not report completion: %+v", last)
+			}
+			if last.Output != "" {
+				t.Fatalf("drained poll repeated buffered output: %q", last.Output)
+			}
+			if globalShellSessionManager.get(started.SessionID) == nil {
+				t.Fatalf("session %q dropped after drain", started.SessionID)
 			}
 		})
+	}
+}
+
+// A finished, fully drained session used to be deleted, so the next poll answered
+// "shell session not found" — indistinguishable from a bogus session id, and it
+// invited the model to start a replacement session. The session now stays
+// pollable and reports its terminal state instead.
+func TestShellToolPollAfterCompletionIsIdempotent(t *testing.T) {
+	skipOnWindows(t)
+	tool := &ShellTool{}
+	startArgs, _ := json.Marshal(map[string]interface{}{
+		"action":  "start",
+		"command": `printf '23 24 25\nsum: 72\n'`,
+	})
+	startOut, err := tool.Call(context.Background(), string(startArgs))
+	if err != nil {
+		t.Fatalf("start returned error: %v", err)
+	}
+	var started struct {
+		SessionID string `json:"session_id"`
+		Completed bool   `json:"completed"`
+	}
+	if err := json.Unmarshal([]byte(startOut), &started); err != nil {
+		t.Fatalf("start unmarshal err: %v", err)
+	}
+	if started.SessionID == "" {
+		t.Fatalf("start returned no session_id: %s", startOut)
+	}
+	if started.Completed {
+		t.Fatalf("start reported completed=true: %s", startOut)
+	}
+	defer globalShellSessionManager.delete(started.SessionID)
+
+	pollArgs, _ := json.Marshal(map[string]interface{}{
+		"action":     "poll",
+		"session_id": started.SessionID,
+	})
+	type shellPoll struct {
+		SessionID  string `json:"session_id"`
+		Running    bool   `json:"running"`
+		Completed  bool   `json:"completed"`
+		FinishedAt string `json:"finished_at"`
+		ExitCode   *int   `json:"exit_code"`
+		Output     string `json:"output"`
+	}
+
+	var first shellPoll
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		pollOut, err := tool.Call(context.Background(), string(pollArgs))
+		if err != nil {
+			t.Fatalf("poll returned error: %v", err)
+		}
+		if err := json.Unmarshal([]byte(pollOut), &first); err != nil {
+			t.Fatalf("poll unmarshal err: %v (raw=%q)", err, pollOut)
+		}
+		if first.Completed {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("background command never reported completion: %+v", first)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if first.ExitCode == nil || *first.ExitCode != 0 {
+		t.Fatalf("poll exit_code = %v, want 0", first.ExitCode)
+	}
+	if !strings.Contains(first.Output, "sum: 72") {
+		t.Fatalf("poll output = %q, want the command result", first.Output)
+	}
+	if first.FinishedAt == "" {
+		t.Fatalf("completed poll reported no finished_at: %+v", first)
+	}
+
+	// Repeating the poll must keep answering, not report the session gone.
+	pollOut, err := tool.Call(context.Background(), string(pollArgs))
+	if err != nil {
+		t.Fatalf("repeat poll returned error: %v", err)
+	}
+	var second shellPoll
+	if err := json.Unmarshal([]byte(pollOut), &second); err != nil {
+		t.Fatalf("repeat poll is not a session payload: %q", pollOut)
+	}
+	if !second.Completed || second.Running {
+		t.Fatalf("repeat poll lost the terminal state: %+v", second)
+	}
+	if second.SessionID != started.SessionID {
+		t.Fatalf("repeat poll session_id = %q, want %q", second.SessionID, started.SessionID)
+	}
+	if second.Output != "" {
+		t.Fatalf("repeat poll repeated already-delivered output: %q", second.Output)
 	}
 }
 


### PR DESCRIPTION
## Problem

Polling an already-exited, fully drained background shell session **deleted** it, so the next poll answered:

```
shell session not found: shell-1
```

That string is indistinguishable from a bogus `session_id`, and it is returned with `CodeInvalidArguments` — so a model doing a redundant confirm-poll is told its *parameters* were wrong, and is invited to start a replacement session (which the prompt explicitly warns against).

Device log evidence, same session, 34s apart:

| # | call | result |
|---|---|---|
| `[293]` | `shell action=poll session_id=shell-1` | `{"exit_code":0,"output":"23 24 25\nsum: 72\n","running":false,…}` |
| `[295]` | `shell action=poll session_id=shell-1` | `shell session not found: shell-1` |

The first poll both delivered the output **and** destroyed the session, because the process had already exited and the poll drained the ring buffer:

```go
if !running && !session.output.hasUnread() {
    globalShellSessionManager.delete(session.id)
}
```

## Change

- Draining the last bytes now calls `session.output.release()` instead of deleting the session, so a repeated poll answers with the terminal payload. Release is only reachable once every produced byte has been read (the existing `!hasUnread()` guard means exactly that), so no output is lost.
- `start` and `poll` now report `completed`; `poll` adds `finished_at` once the process exits. "This will produce nothing more" is explicit instead of implied by `running=false`.
- Eviction is unchanged — the record is still reclaimed on the 30-minute idle timeout.
- `stop()` no longer signals a process that `Wait()` has already reaped. Retaining finished sessions means they now reach eviction, which calls `stop()`, and the reaped PID may since have been reused.

Retention drops the ring buffer (200 KB, eagerly allocated) and keeps only session metadata, so it does not hold output bytes.

## Verification

- `gofmt`, `go build ./...`, `go vet ./internal/agent/` — clean
- `go test -race -count=1 -run TestShell ./internal/agent/` — pass
- `TestShellToolPollAfterCompletionIsIdempotent` reproduces the log sequence: the first poll yields `sum: 72`, the repeat poll returns the terminal state instead of an error
- `TestShellToolBackgroundPollDrainsAndKeepsSession` replaces `TestShellToolBackgroundPollDrainsBeforeDelete`, which asserted the old drop-after-drain behaviour

No on-device or live-model validation performed.

## Not in this PR

`session not found` is still a bare string carrying `CodeInvalidArguments`. With sessions retained, that path now only fires for ids that never existed or have expired, so the misleading case is gone. Giving bare-string tool failures a structured channel is a follow-up that also covers the `web_search` backend-failure case (a rate-limited search is currently indistinguishable from "no results") and artifact re-reads being re-artifactized.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Background shell sessions now report completion status and, when available, the completion time.
  - Completed sessions remain available with stable identifiers for follow-up polling.

- **Bug Fixes**
  - Completed sessions no longer disappear immediately after their output is consumed.
  - Repeated polls provide consistent completion details without repeating previously retrieved output.
  - Stopping an already-completed session no longer risks affecting another process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->