### PR TITLE
fix: decode escaped Wi-Fi SSIDs

### DIFF
--- a/src/agent/internal/configweb/configweb_test.go
+++ b/src/agent/internal/configweb/configweb_test.go
@@ -1056,7 +1056,7 @@ func TestParseWiFiScanOutputDecodesEscapedUTF8SSID(t *testing.T) {
 }
 
 func TestDecodeWiFiSSIDPreservesInvalidEscapes(t *testing.T) {
-	for _, value := range []string{`Office\xZZ`, `Office\xE9`} {
+	for _, value := range []string{`Office\xZZ`, `Office\xE9`, `Office\x41\xZZ`} {
 		if got := decodeWiFiSSID(value); got != value {
 			t.Errorf("decodeWiFiSSID(%q)=%q, want unchanged", value, got)
 		}

--- a/src/agent/internal/configweb/configweb_test.go
+++ b/src/agent/internal/configweb/configweb_test.go
@@ -1043,6 +1043,26 @@ func TestWiFiPublicValueUsesNetworkCollectionOnly(t *testing.T) {
 	}
 }
 
+func TestParseWiFiScanOutputDecodesEscapedUTF8SSID(t *testing.T) {
+	text := `BSS aa:bb:cc:dd:ee:ff(on wlan0)
+	SSID: \xe9\xa3\x9e\xe5\x88\xa9\xe7\x8c\xab\xe5\x93\x81\xe7\x89\x8cWiFi
+	Cell 02 - Address: 11:22:33:44:55:66
+		ESSID:"\xe9\xa3\x9e\xe5\x88\xa9\xe7\x8c\xab\xe5\x93\x81\xe7\x89\x8cWiFi"
+	`
+	want := []string{"飞利猫品牌WiFi"}
+	if got := parseWiFiScanOutput(text); len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("parseWiFiScanOutput()=%q, want %q", got, want)
+	}
+}
+
+func TestDecodeWiFiSSIDPreservesInvalidEscapes(t *testing.T) {
+	for _, value := range []string{`Office\xZZ`, `Office\xE9`} {
+		if got := decodeWiFiSSID(value); got != value {
+			t.Errorf("decodeWiFiSSID(%q)=%q, want unchanged", value, got)
+		}
+	}
+}
+
 func TestWiFiProxyRequestValidationAndPasswordRedaction(t *testing.T) {
 	customURL := "http://alice:secret@proxy.example:7890"
 	noProxy := "localhost,.example.com"

--- a/src/agent/internal/configweb/wifi.go
+++ b/src/agent/internal/configweb/wifi.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"aiden-agent/internal/wifiproxy"
 )
@@ -288,7 +289,7 @@ func (s *Server) queryWiFiStatusContext(ctx context.Context) map[string]any {
 			detail := strings.TrimRight(string(result.Output), "\r\n")
 			status["detail"] = detail
 			values := keyValueLines(detail)
-			status["state"], status["ssid"], status["ip_address"] = values["wpa_state"], values["ssid"], values["ip_address"]
+			status["state"], status["ssid"], status["ip_address"] = values["wpa_state"], decodeWiFiSSID(values["ssid"]), values["ip_address"]
 			status["connected"] = values["wpa_state"] == "COMPLETED" && values["ssid"] != ""
 			if status["connected"] == true && status["ip_address"] == "" {
 				status["ip_address"] = interfaceIPv4Context(ctx, s.options.WiFiInterface)
@@ -305,7 +306,7 @@ func (s *Server) queryWiFiStatusContext(ctx context.Context) map[string]any {
 		for _, line := range strings.Split(detail, "\n") {
 			line = strings.TrimSpace(line)
 			if strings.HasPrefix(line, "SSID:") {
-				status["ssid"] = strings.TrimSpace(strings.TrimPrefix(line, "SSID:"))
+				status["ssid"] = decodeWiFiSSID(strings.TrimSpace(strings.TrimPrefix(line, "SSID:")))
 				status["connected"], status["state"] = true, "COMPLETED"
 				status["ip_address"] = interfaceIPv4Context(ctx, s.options.WiFiInterface)
 			}
@@ -362,12 +363,12 @@ func parseWiFiScanOutput(text string) []string {
 		line = strings.TrimSpace(line)
 		name := ""
 		if strings.HasPrefix(line, "SSID:") {
-			name = strings.TrimSpace(strings.TrimPrefix(line, "SSID:"))
+			name = decodeWiFiSSID(strings.TrimSpace(strings.TrimPrefix(line, "SSID:")))
 		}
 		if position := strings.Index(line, `ESSID:"`); position >= 0 {
 			value := line[position+len(`ESSID:"`):]
 			if end := strings.IndexByte(value, '"'); end >= 0 {
-				name = value[:end]
+				name = decodeWiFiSSID(value[:end])
 			}
 		}
 		if name != "" && !seen[name] {
@@ -376,6 +377,48 @@ func parseWiFiScanOutput(text string) []string {
 		}
 	}
 	return result
+}
+
+// decodeWiFiSSID converts the \\xHH form emitted by some wireless-tools
+// versions back into the original SSID bytes. SSIDs are byte strings on the
+// wire, and UTF-8 is the common encoding for Chinese network names.
+func decodeWiFiSSID(value string) string {
+	if !strings.Contains(value, `\x`) {
+		return value
+	}
+	raw := make([]byte, 0, len(value))
+	changed := false
+	for i := 0; i < len(value); {
+		if i+3 < len(value) && value[i] == '\\' && value[i+1] == 'x' {
+			if high, ok := hexDigit(value[i+2]); ok {
+				if low, ok := hexDigit(value[i+3]); ok {
+					raw = append(raw, high<<4|low)
+					i += 4
+					changed = true
+					continue
+				}
+			}
+		}
+		raw = append(raw, value[i])
+		i++
+	}
+	if !changed || !utf8.Valid(raw) {
+		return value
+	}
+	return string(raw)
+}
+
+func hexDigit(value byte) (byte, bool) {
+	switch {
+	case value >= '0' && value <= '9':
+		return value - '0', true
+	case value >= 'a' && value <= 'f':
+		return value - 'a' + 10, true
+	case value >= 'A' && value <= 'F':
+		return value - 'A' + 10, true
+	default:
+		return 0, false
+	}
 }
 
 func (s *Server) handleWiFiScan(w http.ResponseWriter, _ *http.Request) {

--- a/src/agent/internal/configweb/wifi.go
+++ b/src/agent/internal/configweb/wifi.go
@@ -388,21 +388,27 @@ func decodeWiFiSSID(value string) string {
 	}
 	raw := make([]byte, 0, len(value))
 	changed := false
+	malformed := false
 	for i := 0; i < len(value); {
-		if i+3 < len(value) && value[i] == '\\' && value[i+1] == 'x' {
-			if high, ok := hexDigit(value[i+2]); ok {
+		if value[i] == '\\' && i+1 < len(value) && value[i+1] == 'x' {
+			if i+3 >= len(value) {
+				malformed = true
+			} else if high, ok := hexDigit(value[i+2]); ok {
 				if low, ok := hexDigit(value[i+3]); ok {
 					raw = append(raw, high<<4|low)
 					i += 4
 					changed = true
 					continue
 				}
+				malformed = true
+			} else {
+				malformed = true
 			}
 		}
 		raw = append(raw, value[i])
 		i++
 	}
-	if !changed || !utf8.Valid(raw) {
+	if !changed || malformed || !utf8.Valid(raw) {
 		return value
 	}
 	return string(raw)


### PR DESCRIPTION
The Wi-Fi scan endpoint exposed Chinese SSIDs as literal `\\xHH` byte escapes when wireless-tools returned escaped ESSID values. The config UI therefore showed names such as `\\xe9\\xa3...` and could not reliably match the actual network name.

This change decodes valid escaped UTF-8 SSID bytes during scan parsing and connected-status parsing, while preserving malformed or non-UTF-8 values unchanged. It adds regression coverage for `飞利猫品牌WiFi` and invalid escapes.

Validation:
- `go test ./internal/...`
- `./build.sh binaries`
- Verified live board Wi-Fi scan and `wpa_cli` status over SSH.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wi‑Fi status and scan results now correctly display SSIDs containing hexadecimal escape sequences.
  * Valid hexadecimal-encoded UTF‑8 characters are decoded for accurate display.
  * Malformed escape sequences, invalid UTF‑8 values, and mixed valid/invalid sequences are preserved unchanged rather than being incorrectly modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->